### PR TITLE
Fix CI: repair vitest test suite (inherited from upstream)

### DIFF
--- a/src/app/core/components/options/display/display.component.spec.ts
+++ b/src/app/core/components/options/display/display.component.spec.ts
@@ -41,6 +41,8 @@ class SettingsServiceMock {
     public getSplitShellSide() { return 'left' as const; }
     public getSplitShellSwipeDisabled() { return false; }
     public getWidgetHistoryDisabled() { return false; }
+    public getDisablePathValidation() { return false; }
+    public setDisablePathValidation(): void { }
     public setAutoNightMode(): void { }
     public setRedNightMode(): void { }
     public setNightModeBrightness(): void { }

--- a/src/app/core/services/settings.service.ts
+++ b/src/app/core/services/settings.service.ts
@@ -174,7 +174,7 @@ export class SettingsService {
    * @memberof SettingsService
    */
   public loadConfigFromLocalStorage(type: string) {
-    let config = JSON.parse(localStorage.getItem(type) ?? '');
+    let config = JSON.parse(localStorage.getItem(type) ?? 'null');
 
     if (config === null) {
       console.log(`[AppSettings Service] Error loading ${type} config. Force loading ${type} defaults`);

--- a/src/app/core/services/widget.service.spec.ts
+++ b/src/app/core/services/widget.service.spec.ts
@@ -14,12 +14,11 @@ describe('WidgetService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('registers new electrical family widgets in definitions', () => {
+  it('registers the available electrical family widgets in definitions', () => {
     const selectors = service.kipWidgets.map(widget => widget.selector);
 
+    // widget-alternator/-inverter/-ac are commented out in widget.service.ts pending readiness.
+    expect(selectors).toContain('widget-solar-charger');
     expect(selectors).toContain('widget-charger');
-    expect(selectors).toContain('widget-inverter');
-    expect(selectors).toContain('widget-alternator');
-    expect(selectors).toContain('widget-ac');
   });
 });

--- a/src/app/widget-config/path-control-config/path-control-config.component.spec.ts
+++ b/src/app/widget-config/path-control-config/path-control-config.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { beforeEach, describe, expect, it } from 'vitest';
+import { EMPTY } from 'rxjs';
 import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
 import { IDynamicControl } from '../../core/interfaces/widgets-interface';
 
@@ -16,7 +17,7 @@ describe('PathControlConfigComponent', () => {
     await TestBed.configureTestingModule({
       imports: [PathControlConfigComponent],
       providers: [
-        { provide: SignalKConnectionService, useValue: { skServerVersion: '2.14.0' } },
+        { provide: SignalKConnectionService, useValue: { skServerVersion: '2.14.0', serverServiceEndpoint$: EMPTY, serverVersion$: EMPTY } },
         {
           provide: DataService,
           useValue: {

--- a/src/app/widgets/widget-login/login.component.spec.ts
+++ b/src/app/widgets/widget-login/login.component.spec.ts
@@ -1,5 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { beforeEach, describe, expect, it } from 'vitest';
+import { MatDialog } from '@angular/material/dialog';
+import { of } from 'rxjs';
 import { WidgetLoginComponent } from './widget-login.component';
 
 describe('WidgetLoginComponent', () => {
@@ -8,7 +10,10 @@ describe('WidgetLoginComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-    imports: [WidgetLoginComponent]
+    imports: [WidgetLoginComponent],
+    providers: [
+      { provide: MatDialog, useValue: { open: () => ({ afterClosed: () => of(undefined) }) } }
+    ]
 })
     .compileComponents();
   });

--- a/src/test.ts
+++ b/src/test.ts
@@ -448,6 +448,12 @@ class SettingsServiceStub {
   public getConnectionConfig() { return this._connectionConfig; }
   public setConnectionConfig(v: typeof this._connectionConfig) { this._connectionConfig = { ...v }; }
   public getNightModeBrightness(): number { return this.nightModeBrightnessSubject.value; }
+  public setNightModeBrightness(v: number): void { this.nightModeBrightnessSubject.next(v); }
+  public getDisablePathValidation(): boolean { return false; }
+  public setDisablePathValidation(): void { /* noop */ }
+  public getWidgetHistoryDisabled(): boolean { return false; }
+  public setWidgetHistoryDisabled(): void { /* noop */ }
+  public setSplitShellSwipeDisabled(v: boolean): void { this.splitShellSwipeDisabledSubject.next(v); }
   public getNotificationServiceConfigAsO(): Observable<import('./app/core/interfaces/app-settings.interfaces').INotificationConfig> { return this._notificationConfig.asObservable(); }
   public getNotificationConfig(): import('./app/core/interfaces/app-settings.interfaces').INotificationConfig { return this._notificationConfig.value; }
 }


### PR DESCRIPTION
## Why
CI on the fork is red. Investigation shows the failures are **inherited from upstream** (mxtommy/kip's own master CI is red since ~2026-05-13) — the karma→vitest migration left the suite broken. None are caused by the fork, the rebrand, or the logo.

## Root causes & fixes
1. **Real bug** — `SettingsService.loadConfigFromLocalStorage` did `JSON.parse(localStorage.getItem(type) ?? '')`; `JSON.parse('')` throws instead of yielding `null`, so an empty/missing config slot crashed `SettingsService` construction (cascading into ~16 "should create" failures, and affecting real first-run users). Fixed → `?? 'null'`, matching the sibling at line 744. Upstreamable.
2. **Stub drift** — `SettingsServiceStub` (test.ts) lacked methods the real service gained (`get/setDisablePathValidation`, `get/setWidgetHistoryDisabled`, `setNightModeBrightness`, `setSplitShellSwipeDisabled`) → display & path-control specs hit "is not a function". Added them.
3. **widget.service.spec** asserted `widget-inverter/-alternator/-ac`, which are commented out in `widget.service.ts`. Aligned the test to the registered set (solar-charger, charger).
4. **login.component.spec** — `ngOnInit` opens a credential dialog; with no `MatDialog` mock, `afterClosed()` was undefined. Mocked `MatDialog`.

None of these change application behaviour (except fix 1, which is a genuine robustness fix).

## Verification
Local env can't reproduce CI (its jsdom lacks `localStorage` due to a lockfile-drift version mismatch), so CI is the oracle — see the checks on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)