### PR TITLE
[codex] Fix autopilot standby button label (replicates mxtommy/Kip #1068)

### DIFF
--- a/src/app/widgets/widget-autopilot/widget-autopilot.component.html
+++ b/src/app/widgets/widget-autopilot/widget-autopilot.component.html
@@ -15,7 +15,7 @@
         <svg width="100%" height="100%" viewBox="0 0 100 14" preserveAspectRatio="xMidYMid meet" class="svg-element svg-modes">
           <text xml:space="preserve"
             x="50.090435"
-            y="10.743966">Disengage</text>
+            y="10.743966">{{ standbyButtonLabel() }}</text>
         </svg>
       </mat-icon>
     </button>

--- a/src/app/widgets/widget-autopilot/widget-autopilot.component.spec.ts
+++ b/src/app/widgets/widget-autopilot/widget-autopilot.component.spec.ts
@@ -1,0 +1,102 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClient } from '@angular/common/http';
+import { EMPTY, of } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { WidgetAutopilotComponent } from './widget-autopilot.component';
+import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
+import { WidgetStreamsDirective } from '../../core/directives/widget-streams.directive';
+import { SignalkRequestsService } from '../../core/services/signalk-requests.service';
+import { DashboardService } from '../../core/services/dashboard.service';
+import { UnitsService } from '../../core/services/units.service';
+import { DataService } from '../../core/services/data.service';
+
+describe('WidgetAutopilotComponent', () => {
+  let component: WidgetAutopilotComponent;
+
+  const runtimeOptions = {
+    autopilot: {
+      apiVersion: 'v2' as 'v1' | 'v2',
+      instanceId: 'test-autopilot',
+      pluginId: 'autopilot',
+      modes: ['auto', 'wind', 'route'],
+      invertRudder: true,
+      headingDirectionTrue: false,
+      courseDirectionTrue: false
+    }
+  };
+
+  const runtimeMock = {
+    options: () => runtimeOptions
+  };
+
+  const streamsMock = {
+    observe: vi.fn()
+  };
+
+  const requestsMock = {
+    subscribeRequest: () => EMPTY,
+    putRequest: vi.fn()
+  };
+
+  const httpMock = {
+    post: vi.fn(() => of({ statusCode: 200 })),
+    put: vi.fn(() => of({ statusCode: 200 })),
+    delete: vi.fn(() => of({ statusCode: 200 }))
+  };
+
+  const dashboardMock = {
+    isDashboardStatic: () => true
+  };
+
+  const unitsMock = {
+    convertToUnit: (_unit: string, value: unknown) => value
+  };
+
+  const dataMock = {
+    subscribePath: vi.fn(() => EMPTY)
+  };
+
+  beforeEach(async () => {
+    runtimeOptions.autopilot.apiVersion = 'v2';
+    streamsMock.observe.mockClear();
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: WidgetRuntimeDirective, useValue: runtimeMock },
+        { provide: WidgetStreamsDirective, useValue: streamsMock },
+        { provide: SignalkRequestsService, useValue: requestsMock },
+        { provide: HttpClient, useValue: httpMock },
+        { provide: DashboardService, useValue: dashboardMock },
+        { provide: UnitsService, useValue: unitsMock },
+        { provide: DataService, useValue: dataMock }
+      ]
+    });
+
+    component = TestBed.runInInjectionContext(() => new WidgetAutopilotComponent());
+  });
+
+  it('labels the v2 standby toggle as Engage when autopilot is not engaged', () => {
+    (component as unknown as { apEngaged: { set: (value: boolean) => void } }).apEngaged.set(false);
+
+    const label = (component as unknown as { standbyButtonLabel: () => string }).standbyButtonLabel();
+
+    expect(label).toBe('Engage');
+  });
+
+  it('labels the v2 standby toggle as Disengage when autopilot is engaged', () => {
+    (component as unknown as { apEngaged: { set: (value: boolean) => void } }).apEngaged.set(true);
+
+    const label = (component as unknown as { standbyButtonLabel: () => string }).standbyButtonLabel();
+
+    expect(label).toBe('Disengage');
+  });
+
+  it('keeps the v1 standby command label as Disengage', () => {
+    runtimeOptions.autopilot.apiVersion = 'v1';
+    (component as unknown as { apEngaged: { set: (value: boolean) => void } }).apEngaged.set(false);
+
+    const label = (component as unknown as { standbyButtonLabel: () => string }).standbyButtonLabel();
+
+    expect(label).toBe('Disengage');
+  });
+});

--- a/src/app/widgets/widget-autopilot/widget-autopilot.component.spec.ts
+++ b/src/app/widgets/widget-autopilot/widget-autopilot.component.spec.ts
@@ -91,6 +91,16 @@ describe('WidgetAutopilotComponent', () => {
     expect(label).toBe('Disengage');
   });
 
+  it('labels the v2 standby toggle as Engage before the engaged state is known (null)', () => {
+    runtimeOptions.autopilot.apiVersion = 'v2';
+    (component as unknown as { apEngaged: { set: (value: boolean | null) => void } }).apEngaged.set(null);
+
+    const label = (component as unknown as { standbyButtonLabel: () => string }).standbyButtonLabel();
+
+    // A click in this state POSTs engage (apEngaged() is falsy), so the label must read Engage, not Disengage.
+    expect(label).toBe('Engage');
+  });
+
   it('keeps the v1 standby command label as Disengage', () => {
     runtimeOptions.autopilot.apiVersion = 'v1';
     (component as unknown as { apEngaged: { set: (value: boolean) => void } }).apEngaged.set(false);

--- a/src/app/widgets/widget-autopilot/widget-autopilot.component.ts
+++ b/src/app/widgets/widget-autopilot/widget-autopilot.component.ts
@@ -311,6 +311,15 @@ export class WidgetAutopilotComponent implements OnInit, OnDestroy {
 
   // Keypad buttons & layout
   protected apGrid = computed(() => this.apMode() ? 'grid' : 'none');
+  protected readonly standbyButtonLabel = computed(() => {
+    const apiVersion = this.runtime.options().autopilot.apiVersion;
+
+    if (apiVersion === "v2" && this.apEngaged() === false) {
+      return "Engage";
+    }
+
+    return "Disengage";
+  });
   protected readonly apEngageBtnDisabled = computed(() => {
     const state = this.apState();
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/app/widgets/widget-autopilot/widget-autopilot.component.ts
+++ b/src/app/widgets/widget-autopilot/widget-autopilot.component.ts
@@ -314,7 +314,7 @@ export class WidgetAutopilotComponent implements OnInit, OnDestroy {
   protected readonly standbyButtonLabel = computed(() => {
     const apiVersion = this.runtime.options().autopilot.apiVersion;
 
-    if (apiVersion === "v2" && this.apEngaged() === false) {
+    if (apiVersion === "v2" && !this.apEngaged()) {
       return "Engage";
     }
 


### PR DESCRIPTION
Replicates upstream PR https://github.com/mxtommy/Kip/pull/1068 ("[codex] Fix autopilot standby button label") by macjl.

Method: commit-by-commit cherry-pick (the upstream PR had a linear history with no merge commits).

This is an experimental replica carried in the SKip fork for evaluation. The change fixes the autopilot standby button label and adds a unit test for the widget-autopilot component.
