### PR TITLE
Restore TTL reset to dashes after a data timeout (#1069) (replicates mxtommy/Kip #1076)

### DIFF
--- a/src/app/core/directives/widget-streams.directive.spec.ts
+++ b/src/app/core/directives/widget-streams.directive.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
-import { Subject, Observable } from 'rxjs';
+import { Subject, BehaviorSubject, Observable } from 'rxjs';
 import { WidgetStreamsDirective } from './widget-streams.directive';
 import { DataService, IPathUpdate } from '../services/data.service';
 import { UnitsService } from '../services/units.service';
@@ -476,5 +476,85 @@ describe('WidgetStreamsDirective', () => {
         subj.next({ data: { value: 'F', timestamp: new Date() }, state: 'normal' } as IPathUpdate);
         await vi.advanceTimersByTimeAsync(35);
         expect(hits).toEqual(['A', 'C', 'D', 'E', 'F']);
+    });
+});
+
+/**
+ * Faithful-to-DataService fake: path values live in a BehaviorSubject (so the current value is
+ * replayed on re-subscription), and timeoutPathObservable() resets the value to null - exactly
+ * like the real service does on a TTL timeout.
+ */
+class TtlFakeDataService {
+    subjects = new Map<string, BehaviorSubject<IPathUpdate>>();
+    timeoutCalls: { path: string; pathType: string }[] = [];
+
+    private keyFor(path: string, source?: string): string {
+        return `${path}|${source?.trim() || 'default'}`;
+    }
+
+    subscribePath(path: string, source?: string): Observable<IPathUpdate> {
+        const key = this.keyFor(path, source);
+        if (!this.subjects.has(key)) {
+            this.subjects.set(key, new BehaviorSubject<IPathUpdate>(
+                { data: { value: null, timestamp: null }, state: 'normal' } as IPathUpdate
+            ));
+        }
+        return this.subjects.get(key)!.asObservable();
+    }
+
+    timeoutPathObservable(path: string, pathType: string): void {
+        this.timeoutCalls.push({ path, pathType });
+        // Mirror the real DataService: a TTL timeout resets the path value to null.
+        this.subjects.get(this.keyFor(path))?.next(
+            { data: { value: null, timestamp: null }, state: 'normal' } as IPathUpdate
+        );
+    }
+}
+
+describe('WidgetStreamsDirective TTL value reset (#1069)', () => {
+    let directive: WidgetStreamsDirective;
+    let dataSvc: TtlFakeDataService;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [
+                WidgetStreamsDirective,
+                { provide: DataService, useClass: TtlFakeDataService },
+                { provide: UnitsService, useClass: FakeUnitsService }
+            ]
+        });
+        directive = TestBed.inject(WidgetStreamsDirective);
+        dataSvc = TestBed.inject(DataService) as unknown as TtlFakeDataService;
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    it('resets the value to null after a TTL timeout even with suppressBootstrapNull enabled', async () => {
+        vi.useFakeTimers();
+        vi.spyOn(console, 'log'); // silence timeout/retry logs
+        const cfg = makeCfg({
+            path: 'env.ttl', source: null, pathType: 'number', sampleTime: 50,
+            suppressBootstrapNull: true, enableTimeout: true, dataTimeout: 0.02
+        });
+        directive.setStreamsConfig(cfg);
+
+        const hits: (number | null)[] = [];
+        directive.observe('p', u => hits.push((u?.data?.value as number | null) ?? null));
+
+        const subj = dataSvc.subjects.get('env.ttl|default')!;
+        // A real value arrives (e.g. engine running).
+        subj.next({ data: { value: 500, timestamp: new Date() }, state: 'normal' } as IPathUpdate);
+        await vi.advanceTimersByTimeAsync(10);
+        expect(hits).toEqual([500]);
+
+        // Engine stops: no more data. Let the TTL fire and the retry resubscribe (retryDelay = 5s).
+        await vi.advanceTimersByTimeAsync(5100);
+
+        expect(dataSvc.timeoutCalls.length).toBeGreaterThanOrEqual(1);
+        // The widget must be reset to null ("--"), not left showing the stale 500.
+        expect(hits[hits.length - 1]).toBeNull();
     });
 });

--- a/src/app/core/directives/widget-streams.directive.ts
+++ b/src/app/core/directives/widget-streams.directive.ts
@@ -2,7 +2,7 @@ import { Directive, DestroyRef, inject, signal } from '@angular/core';
 import { DataService, IPathUpdate } from '../services/data.service';
 import { UnitsService } from '../services/units.service';
 import { IWidgetSvcConfig } from '../interfaces/widgets-interface';
-import { Observable, Observer, Subject, delayWhen, map, retryWhen, sampleTime, skipWhile, tap, throwError, timeout, timer, takeUntil, take, merge, Subscription } from 'rxjs';
+import { Observable, Observer, Subject, delayWhen, filter, map, retryWhen, sampleTime, tap, throwError, timeout, timer, takeUntil, take, merge, Subscription } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Directive({
@@ -131,7 +131,15 @@ export class WidgetStreamsDirective {
       );
     }
     if (suppressBootstrapNull) {
-      data$ = data$.pipe(skipWhile(x => x?.data?.value == null));
+      // Drop only the LEADING (bootstrap) null values. Once a real value has been seen, let
+      // everything through - including a later null produced by a TTL timeout. The flag is
+      // captured here, outside the operator, so it survives the timeout/retry resubscription
+      // below; a plain skipWhile would reset on every retry and swallow the timeout null (#1069).
+      let seenNonNull = false;
+      data$ = data$.pipe(filter(x => {
+        if (x?.data?.value != null) seenNonNull = true;
+        return seenNonNull;
+      }));
     }
     const initial$ = data$.pipe(take(1));
     const sampled$ = data$.pipe(sampleTime(sample));


### PR DESCRIPTION
Replicates upstream PR https://github.com/mxtommy/Kip/pull/1076 ("Restore TTL reset to dashes after a data timeout (#1069)") by dillan.

Method: commit-by-commit cherry-pick (linear upstream history, no merge commits).

This is an experimental replica carried in the SKip fork for evaluation. It restores the behaviour where widget values reset to dashes (the "bootstrap-null" display) after a data timeout has elapsed, fixing a regression introduced in a prior refactor. The change adds a failing regression test first (RED) and then makes the bootstrap-null suppression stateful so it is only applied on the very first bootstrap, not on subsequent timeout-driven null values (GREEN).
