### PR TITLE
Fix True Wind Angle offset in Wind/Sail Steer simple compass mode (#1066, #1063) (replicates mxtommy/Kip #1073)

### DIFF
--- a/src/app/widgets/widget-windsteer/widget-windsteer.component.spec.ts
+++ b/src/app/widgets/widget-windsteer/widget-windsteer.component.spec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { computeTrueWindBaseAngle } from './widget-windsteer.component';
+
+/**
+ * Regression tests for #1066 / #1063.
+ *
+ * In "simple" mode (enhanced/advanced compass mode OFF) the wind rose is bow-fixed, so the
+ * True Wind ANGLE (boat-relative angleTrueWater / angleTrueGround) must be shown as-is, exactly
+ * like Apparent Wind Angle. The previous code always added the boat heading to true wind,
+ * turning it into a compass-frame direction, which displaced TWA by the heading (~90° in the
+ * reports) only in simple mode. Enhanced mode rotates the dial by heading, so the offset is
+ * correct there and must be preserved.
+ */
+describe('computeTrueWindBaseAngle (#1066, #1063)', () => {
+  const TRUE_WATER = 'self.environment.wind.angleTrueWater';
+  const TRUE_GROUND = 'self.environment.wind.angleTrueGround';
+  const DIRECTION_TRUE = 'self.environment.wind.directionTrue';
+
+  it('keeps boat-relative true wind angle unchanged in simple mode (compass mode off)', () => {
+    // heading 90°, boat-relative TWA 45° -> must stay 45° in simple mode (NOT 135°)
+    expect(computeTrueWindBaseAngle(TRUE_WATER, 45, 90, false)).toBe(45);
+    expect(computeTrueWindBaseAngle(TRUE_GROUND, 45, 90, false)).toBe(45);
+  });
+
+  it('converts true wind angle to the compass frame (adds heading) in enhanced/compass mode', () => {
+    expect(computeTrueWindBaseAngle(TRUE_WATER, 45, 90, true)).toBe(135);
+  });
+
+  it('wraps the compass-frame result into 0..359 in enhanced/compass mode', () => {
+    expect(computeTrueWindBaseAngle(TRUE_WATER, 300, 90, true)).toBe(30); // 390 -> 30
+  });
+
+  it('passes through non boat-relative true wind paths (e.g. directionTrue) in both modes', () => {
+    expect(computeTrueWindBaseAngle(DIRECTION_TRUE, 200, 90, false)).toBe(200);
+    expect(computeTrueWindBaseAngle(DIRECTION_TRUE, 200, 90, true)).toBe(200);
+  });
+});

--- a/src/app/widgets/widget-windsteer/widget-windsteer.component.ts
+++ b/src/app/widgets/widget-windsteer/widget-windsteer.component.ts
@@ -432,13 +432,13 @@ function addHeadingDeg(h1: number, h2: number): number {
 /**
  * Resolves the base angle to display for the configured true-wind path.
  *
- * `angleTrueWater` / `angleTrueGround` are boat-relative (true wind ANGLE). The enhanced/compass
- * dial rotates with heading, so for those paths the heading is added to convert the angle into a
- * compass-frame true wind DIRECTION before rendering. Any other (direction-style) path is passed
- * through unchanged.
+ * `angleTrueWater` / `angleTrueGround` are boat-relative (true wind ANGLE). In enhanced/compass
+ * mode the dial rotates with heading, so for those paths the heading is added to convert the angle
+ * into a compass-frame true wind DIRECTION before rendering. In simple (bow-fixed) mode the dial
+ * does not rotate, so the angle must stay boat-relative - matching apparent wind - otherwise it is
+ * displaced by the heading (#1066, #1063). Direction-style paths are always passed through unchanged.
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars -- compassModeEnabled is honored by the fix for #1066/#1063
 export function computeTrueWindBaseAngle(path: string, value: number, heading: number, compassModeEnabled: boolean): number {
   const isBoatRelativeTrueWind = path.includes('angleTrueWater') || path.includes('angleTrueGround');
-  return isBoatRelativeTrueWind ? addHeadingDeg(heading, value) : value;
+  return isBoatRelativeTrueWind && compassModeEnabled ? addHeadingDeg(heading, value) : value;
 }

--- a/src/app/widgets/widget-windsteer/widget-windsteer.component.ts
+++ b/src/app/widgets/widget-windsteer/widget-windsteer.component.ts
@@ -280,7 +280,7 @@ export class WidgetWindComponent implements OnDestroy {
     if (u.data.value == null) u.data.value = 0;
     const cfg = this.runtime.options();
     const path = cfg?.paths['trueWindAngle'].path || '';
-    const base = (path.includes('angleTrueWater') || path.includes('angleTrueGround')) ? this.addHeading(this.currentHeading(), u.data.value) : u.data.value;
+    const base = computeTrueWindBaseAngle(path, u.data.value, this.currentHeading(), !!cfg?.compassModeEnabled);
     const next = this.normalizeAngle(base);
     if (!this.hasTWA || this.angleDelta(this.trueWindAngle(), next) >= this.DEG_EPSILON) {
       this.trueWindAngle.set(next); this.hasTWA = true; this.scheduleMarkForCheck();
@@ -408,7 +408,6 @@ export class WidgetWindComponent implements OnDestroy {
   }
 
   private normalizeAngle(a: number): number { return ((a % 360) + 360) % 360; }
-  private addHeading(h1: number, h2: number) { let h3 = (h1 + h2) % 360; if (h3 < 0) h3 += 360; return h3; }
   private angleDelta(from: number, to: number): number { const d = ((to - from + 540) % 360) - 180; return Math.abs(d); }
 
   private scheduleMarkForCheck() {
@@ -422,4 +421,24 @@ export class WidgetWindComponent implements OnDestroy {
       });
     });
   }
+}
+
+function addHeadingDeg(h1: number, h2: number): number {
+  let h3 = (h1 + h2) % 360;
+  if (h3 < 0) h3 += 360;
+  return h3;
+}
+
+/**
+ * Resolves the base angle to display for the configured true-wind path.
+ *
+ * `angleTrueWater` / `angleTrueGround` are boat-relative (true wind ANGLE). The enhanced/compass
+ * dial rotates with heading, so for those paths the heading is added to convert the angle into a
+ * compass-frame true wind DIRECTION before rendering. Any other (direction-style) path is passed
+ * through unchanged.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- compassModeEnabled is honored by the fix for #1066/#1063
+export function computeTrueWindBaseAngle(path: string, value: number, heading: number, compassModeEnabled: boolean): number {
+  const isBoatRelativeTrueWind = path.includes('angleTrueWater') || path.includes('angleTrueGround');
+  return isBoatRelativeTrueWind ? addHeadingDeg(heading, value) : value;
 }


### PR DESCRIPTION
Replicates upstream PR https://github.com/mxtommy/Kip/pull/1073 ("Fix True Wind Angle offset in Wind/Sail Steer simple compass mode (#1066, #1063)") by dillan.

Method: commit-by-commit cherry-pick (linear history, 2 commits).

This is an experimental replica carried in the SKip fork for evaluation. The change fixes True Wind Angle offset calculation in the Wind/Sail Steer widget when using simple compass mode — upstream issues #1066 and #1063. The PR includes a failing test (RED) followed by the fix (GREEN), preserving the TDD history.
