### PR TITLE
Cut per-delta work on the data hot path (replicates mxtommy/Kip #1085)

### DIFF
--- a/src/app/core/directives/widget-runtime.directive.ts
+++ b/src/app/core/directives/widget-runtime.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, computed, effect, input, output, signal, untracked } from '@angular/core';
+import { Directive, computed, effect, input, signal, untracked } from '@angular/core';
 import { cloneDeep, merge } from 'lodash-es';
 import type { IWidgetSvcConfig } from '../interfaces/widgets-interface';
 
@@ -17,7 +17,6 @@ export class WidgetRuntimeDirective {
 
   // Default config input (typically from widget manifest DEFAULT_CONFIG)
   protected defaultConfig = signal<IWidgetSvcConfig | undefined>(undefined);
-  protected runtimeConfig = output<IWidgetSvcConfig | undefined>();
 
   // Internal runtime config
   private _runtimeConfig = signal<IWidgetSvcConfig | undefined>(undefined);
@@ -49,7 +48,6 @@ export class WidgetRuntimeDirective {
     this.lastBaseRef = base;
     this.lastUserRef = user;
     this.lastMergedRef = merged;
-    this.runtimeConfig.emit(merged);
     return merged;
   });
 

--- a/src/app/core/directives/widget-streams.directive.ts
+++ b/src/app/core/directives/widget-streams.directive.ts
@@ -119,17 +119,6 @@ export class WidgetStreamsDirective {
     const toUnit = (val: number) => convert ? this.unitsService.convertToUnit(convert, val) : val;
 
     let data$: Observable<IPathUpdate> = base$;
-    if (pathType === 'number') {
-      data$ = data$.pipe(
-        map(x => ({
-          data: {
-            value: x.data.value == null ? null : toUnit(x.data.value as number),
-            timestamp: x.data.timestamp
-          },
-          state: x.state
-        } as IPathUpdate))
-      );
-    }
     if (suppressBootstrapNull) {
       // Drop only the LEADING (bootstrap) null values. Once a real value has been seen, let
       // everything through - including a later null produced by a TTL timeout. The flag is
@@ -141,9 +130,24 @@ export class WidgetStreamsDirective {
         return seenNonNull;
       }));
     }
+    // Sample the RAW stream first, then convert units AFTER sampling. The unit conversion is a
+    // pure function of the value (and maps null -> null), so the emitted values are identical to
+    // converting upstream — but the conversion now runs only at the sampled rate (plus the fast
+    // first emission) instead of on every incoming delta.
     const initial$ = data$.pipe(take(1));
     const sampled$ = data$.pipe(sampleTime(sample));
     data$ = merge(initial$, sampled$);
+    if (pathType === 'number') {
+      data$ = data$.pipe(
+        map(x => ({
+          data: {
+            value: x.data.value == null ? null : toUnit(x.data.value as number),
+            timestamp: x.data.timestamp
+          },
+          state: x.state
+        } as IPathUpdate))
+      );
+    }
     if (enableTimeout) {
       data$ = data$.pipe(
         timeout({

--- a/src/app/core/services/data.service.spec.ts
+++ b/src/app/core/services/data.service.spec.ts
@@ -112,6 +112,30 @@ describe('DataService', () => {
     expect(latest!.state).toBe(States.Alert);
   });
 
+  it('exposes the value timestamp lazily as a memoized Date', () => {
+    let latest: IPathUpdate | undefined;
+
+    service
+      .subscribePath('self.navigation.speedThroughWater', 'default')
+      .subscribe(update => (latest = update));
+
+    dataPathUpdates$.next({
+      context: 'self',
+      path: 'navigation.speedThroughWater',
+      source: 'test-source',
+      timestamp: '2026-01-01T00:00:05.000Z',
+      value: 3.2,
+    });
+
+    expect(latest).toBeTruthy();
+    // The lazy getter returns the correct Date when a consumer reads it...
+    const ts = latest!.data.timestamp;
+    expect(ts).toBeInstanceOf(Date);
+    expect(ts!.toISOString()).toBe('2026-01-01T00:00:05.000Z');
+    // ...and is memoized: repeated reads return the same instance (no re-allocation).
+    expect(latest!.data.timestamp).toBe(ts);
+  });
+
   it('emits equivalent sequences for subscribePathTree and subscribePathTreeWithInitial', () => {
     dataPathUpdates$.next({
       context: 'self',

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -54,6 +54,26 @@ const typeFromUnits = (units: string): string => {
 };
 
 /**
+ * Builds an {@link IPathData} whose `timestamp` Date is created lazily and memoized on first
+ * access. This runs on the hot path (once per delta per registered path), and the large majority
+ * of consumers (numeric gauges, charts, text) only ever read `value` and never touch `timestamp`,
+ * so deferring the `new Date(...)` avoids a short-lived allocation per delta and the GC pressure it
+ * causes over long sessions on low-power devices. The public `Date | null` contract is preserved.
+ */
+const buildPathData = (value: unknown, rawTimestamp: string | number | Date | null | undefined): IPathData => {
+  let cached: Date | null | undefined;
+  return {
+    value,
+    get timestamp(): Date | null {
+      if (cached === undefined) {
+        cached = rawTimestamp ? new Date(rawTimestamp) : null;
+      }
+      return cached;
+    }
+  };
+};
+
+/**
  * The `IPathRegistration` interface represents a registration object used to track a path's Subjects.
  * Each registration is used to share the same Subject with multiple Observers.
  * The `subscribePath()` and `unsubscribePath()` methods return the registration's subject as an Observable.
@@ -441,10 +461,7 @@ export class DataService implements OnDestroy {
     // Update path register Subjects with new data
     const pathRegisterItems = this._pathRegisterByPath.get(updatePath) ?? [];
     if (pathRegisterItems.length) {
-      const pathData: IPathData = {
-        value: pathItem.pathValue,
-        timestamp: pathItem.pathTimestamp ? new Date(pathItem.pathTimestamp) : null
-      };
+      const pathData = buildPathData(pathItem.pathValue, pathItem.pathTimestamp);
 
       const defaultSource = pathRegisterItems.find(item => item.source === "default");
       if (defaultSource) {
@@ -656,10 +673,7 @@ export class DataService implements OnDestroy {
     const timestamp = useDefault ? pathItem.pathTimestamp : pathItem.sources?.[source]?.sourceTimestamp ?? null;
 
     return {
-      data: {
-        value,
-        timestamp: timestamp ? new Date(timestamp) : null
-      },
+      data: buildPathData(value, timestamp),
       state: pathItem.state || States.Normal
     };
   }


### PR DESCRIPTION
Replicates upstream PR https://github.com/mxtommy/Kip/pull/1085 ("Cut per-delta work on the data hot path") by dillan.

Method: commit-by-commit cherry-pick (linear history, single commit).

This is an experimental replica carried in the SKip fork for evaluation. It has not been independently tested in the fork context and needs a build + review before merge.
