### PR TITLE
Fix resize, data-inspector and race-timer hot spots (replicates mxtommy/Kip #1086)

### DIFF
--- a/src/app/core/components/dashboard/dashboard.component.html
+++ b/src/app/core/components/dashboard/dashboard.component.html
@@ -7,7 +7,6 @@
   (swipeup)="previousDashboard()"
   (swipedown)="nextDashboard()"
   (press)="addNewWidget($event)"
-  (window:resize)="resizeGridColumns()"
 >
 </gridstack>
 @if (gridIsEmpty()) {

--- a/src/app/core/components/data-inspector/data-inspector.component.ts
+++ b/src/app/core/components/data-inspector/data-inspector.component.ts
@@ -8,9 +8,9 @@ import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
 import { MatSort, MatSortModule } from '@angular/material/sort';
 import { DataInspectorRowComponent } from '../data-inspector-row/data-inspector-row.component';
 import { PageHeaderComponent } from '../page-header/page-header.component';
-import { Subject } from 'rxjs';
+import { Subject, asyncScheduler } from 'rxjs';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
-import { map, debounceTime } from 'rxjs/operators';
+import { map, debounceTime, throttleTime } from 'rxjs/operators';
 import { BreakpointObserver, Breakpoints, BreakpointState } from '@angular/cdk/layout';
 import { Clipboard } from '@angular/cdk/clipboard';
 
@@ -87,6 +87,10 @@ export class DataInspectorComponent implements AfterViewInit, OnDestroy {
   ngAfterViewInit() {
     this.dataService.startSkDataFullTree()
       .pipe(
+        // Diagnostic-only screen: the full path tree can emit up to ~5x/sec. Rate-limit the
+        // rebuild of the whole table to ~2x/sec. Leading so the first snapshot renders
+        // immediately; trailing so the final state is never missed when updates stop.
+        throttleTime(500, asyncScheduler, { leading: true, trailing: true }),
         map((paths: ISkPathData[]) =>
           paths
             .filter(path => Object.keys(path.sources || {}).length > 0)

--- a/src/app/widgets/widget-race-timer/widget-race-timer.component.spec.ts
+++ b/src/app/widgets/widget-race-timer/widget-race-timer.component.spec.ts
@@ -1,0 +1,84 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { WidgetRaceTimerComponent } from './widget-race-timer.component';
+import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
+import { TimersService } from '../../core/services/timers.service';
+import { CanvasService } from '../../core/services/canvas.service';
+import type { ITheme } from '../../core/services/app-service';
+
+const themeMock = {
+  contrast: '#fff', dim: '#ccc', dimmer: '#999', color: '#fff',
+  zoneNominal: '#0f0', zoneWarn: '#fa0', zoneAlarm: '#f00', zoneAlert: '#f0f'
+} as unknown as ITheme;
+
+// The 'race' timer is a shared singleton subject. ensureTimer() is invoked from the config effect
+// (on every options() change) and from resetTimer(), so without lifecycle management each re-arm
+// would stack another subscription on the same subject and none would be removed when the widget is
+// destroyed. These tests pin that behaviour: exactly one active subscription, torn down on destroy.
+describe('WidgetRaceTimerComponent timer subscription lifecycle', () => {
+  let fixture: ComponentFixture<WidgetRaceTimerComponent>;
+  let component: WidgetRaceTimerComponent;
+  let timers: TimersService;
+
+  const runtimeMock = { options: vi.fn() };
+  const canvasMock = {
+    registerCanvas: vi.fn(),
+    unregisterCanvas: vi.fn(),
+    clearCanvas: vi.fn(),
+    calculateOptimalFontSize: vi.fn().mockReturnValue(10),
+    drawRectangle: vi.fn(),
+    drawText: vi.fn()
+  };
+
+  const setup = async (options: Record<string, unknown> = { timerLength: -300, color: 'contrast' }) => {
+    runtimeMock.options.mockReturnValue(options);
+    await TestBed.configureTestingModule({
+      imports: [WidgetRaceTimerComponent],
+      providers: [
+        { provide: WidgetRuntimeDirective, useValue: runtimeMock },
+        { provide: CanvasService, useValue: canvasMock },
+        TimersService
+      ]
+    }).compileComponents();
+
+    timers = TestBed.inject(TimersService);
+    fixture = TestBed.createComponent(WidgetRaceTimerComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('id', 'w-race-1');
+    fixture.componentRef.setInput('type', 'widget-race-timer');
+    fixture.componentRef.setInput('theme', themeMock);
+    fixture.detectChanges();
+  };
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+    vi.clearAllMocks();
+  });
+
+  const observerCount = (): number =>
+    (timers as unknown as { kipTimers: Record<string, { currentValue: { observers: unknown[] } }> })
+      .kipTimers['race']?.currentValue.observers.length ?? 0;
+
+  it('keeps a single timer subscription when the timer is re-armed', async () => {
+    await setup();
+    expect(observerCount()).toBe(1);
+
+    // Re-arm several times, as the config effect would on each options() change.
+    const comp = component as unknown as { ensureTimer: (n: number) => void };
+    comp.ensureTimer(-280);
+    comp.ensureTimer(-260);
+    comp.ensureTimer(-240);
+
+    // Without lifecycle management this would be 4 (one per subscribe, none removed).
+    expect(observerCount()).toBe(1);
+  });
+
+  it('tears down the timer subscription when the widget is destroyed', async () => {
+    await setup();
+    expect(observerCount()).toBe(1);
+
+    fixture.destroy();
+
+    expect(observerCount()).toBe(0);
+  });
+});

--- a/src/app/widgets/widget-race-timer/widget-race-timer.component.ts
+++ b/src/app/widgets/widget-race-timer/widget-race-timer.component.ts
@@ -1,4 +1,6 @@
-import { Component, OnDestroy, ElementRef, viewChild, inject, effect, signal, untracked, input, AfterViewInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnDestroy, ElementRef, viewChild, inject, effect, signal, untracked, input, AfterViewInit, ChangeDetectionStrategy, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Subscription } from 'rxjs';
 import { TimersService } from '../../core/services/timers.service';
 import { States } from '../../core/interfaces/signalk-interfaces';
 import { CanvasService } from '../../core/services/canvas.service';
@@ -25,6 +27,9 @@ export class WidgetRaceTimerComponent implements AfterViewInit, OnDestroy {
   protected readonly runtime = inject(WidgetRuntimeDirective);
   private readonly timers = inject(TimersService);
   private readonly canvas = inject(CanvasService);
+  private readonly destroyRef = inject(DestroyRef);
+  /** Active subscription to the shared race timer; replaced on re-arm, torn down on destroy. */
+  private timerSub?: Subscription;
 
   // Static config
   public static readonly DEFAULT_CONFIG: IWidgetSvcConfig = {
@@ -94,9 +99,13 @@ export class WidgetRaceTimerComponent implements AfterViewInit, OnDestroy {
   }
 
   private ensureTimer(initial: number) {
-    // subscribe only once per widget id
+    // The race timer is a shared singleton subject, so re-arming (config effect / reset) would
+    // otherwise stack a new subscription on top of the old ones. Tear down any previous
+    // subscription first, and bind the new one to the widget lifecycle so it cannot outlive the
+    // widget (the callback draws to the canvas and emits beeps).
+    this.timerSub?.unsubscribe();
     const obs = this.timers.createTimer(this.timeName, initial, 1000);
-    obs.subscribe(newValue => {
+    this.timerSub = obs.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(newValue => {
       this.dataValue = newValue;
       this.timerRunning.set(this.timers.isRunning(this.timeName));
       // zone & beeps


### PR DESCRIPTION
Replicates upstream PR https://github.com/mxtommy/Kip/pull/1086 ("Fix resize, data-inspector and race-timer hot spots") by dillan.

Method: commit-by-commit cherry-pick (linear history, no merge commits in the upstream PR).

This is an experimental replica carried in the SKip fork for evaluation. It has not been independently verified against the SKip build — a build and functional review are required before merging.
