### PR TITLE
Cut per-widget render and change-detection overhead (replicates mxtommy/Kip #1087)

### DIFF
--- a/src/app/core/services/ais-processing.service.spec.ts
+++ b/src/app/core/services/ais-processing.service.spec.ts
@@ -1,0 +1,185 @@
+import { TestBed } from '@angular/core/testing';
+import { Subject } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  AisProcessingService,
+  AisVessel,
+  AisAton,
+  AisTrack
+} from './ais-processing.service';
+import { DataService, IPathUpdateWithPath } from './data.service';
+
+/**
+ * These tests lock in the `applyAisUpdate` path-dispatch behavior after it was
+ * converted from a per-call `handlers` object literal to a `switch` statement.
+ *
+ * Events are driven through the real public entry point: the constructor
+ * subscribes to `subscribePathTree(...)` streams, so pushing an
+ * `IPathUpdateWithPath` through the mocked stream flows through
+ * `handleAisTreeUpdate` -> `matchAisContext` -> `applyAisUpdate`. We then assert
+ * the resulting track state the dispatch produced (see `trackByContext`).
+ */
+describe('AisProcessingService applyAisUpdate dispatch', () => {
+  // Shared stream the constructor's merged AIS-tree subscriptions read from.
+  let stream$: Subject<IPathUpdateWithPath>;
+  let service: AisProcessingService;
+
+  const VESSEL_CONTEXT = 'vessels.urn:mrn:imo:mmsi:123456789';
+  const ATON_CONTEXT = 'atons.urn:mrn:imo:mmsi:987654321';
+
+  function makeEvent(fullPath: string, value: unknown): IPathUpdateWithPath {
+    return {
+      path: fullPath,
+      update: {
+        data: { value, timestamp: new Date('2026-06-24T00:00:00Z') },
+        state: 'normal'
+      }
+    } as IPathUpdateWithPath;
+  }
+
+  /**
+   * Push a delta and flush the 250ms `targets` throttle so `targets()` updates.
+   * The service is zoneless, so we drive RxJS's async scheduler with vitest's
+   * fake timers (installed in beforeEach) instead of fakeAsync/tick.
+   */
+  function push(fullPath: string, value: unknown): void {
+    stream$.next(makeEvent(fullPath, value));
+    vi.advanceTimersByTime(300);
+  }
+
+  /**
+   * Resolve the track the dispatch wrote to, straight from the service's
+   * internal maps. We read internal state (not the public `targets()` signal)
+   * because `flushTargetsSignal` filters out tracks that have neither an mmsi
+   * nor a position - that filter is orthogonal to the dispatch under test, and
+   * reading the raw track lets us assert string-only / status-only updates too.
+   */
+  function trackByContext(context: string): AisTrack | undefined {
+    const internals = service as unknown as {
+      contextIndex: Map<string, string>;
+      tracks: Map<string, AisTrack>;
+    };
+    const id = internals.contextIndex.get(context);
+    return id ? internals.tracks.get(id) : undefined;
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    stream$ = new Subject<IPathUpdateWithPath>();
+
+    const dataServiceMock: Partial<DataService> = {
+      // Every prefix subscription shares the same stream; the merged pipeline
+      // forwards anything we push. The self-nav stream also reads this but our
+      // test paths only match AIS contexts, so they're routed correctly.
+      subscribePathTree: () => stream$.asObservable()
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        AisProcessingService,
+        { provide: DataService, useValue: dataServiceMock }
+      ]
+    });
+
+    service = TestBed.inject(AisProcessingService);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('sets a vessel string field (name)', () => {
+    push(`${VESSEL_CONTEXT}.name`, 'Test Vessel');
+
+    const track = trackByContext(VESSEL_CONTEXT);
+    expect(track).toBeDefined();
+    expect(track!.type).toBe('vessel');
+    expect(track!.name).toBe('Test Vessel');
+  });
+
+  it('sets a vessel numeric field gated by isVesselLike (speedOverGround)', () => {
+    push(`${VESSEL_CONTEXT}.navigation.speedOverGround`, 5.5);
+
+    const track = trackByContext(VESSEL_CONTEXT) as AisVessel;
+    expect(track).toBeDefined();
+    expect(track.speedOverGround).toBe(5.5);
+  });
+
+  it('sets a nested design field (design.length.overall)', () => {
+    push(`${VESSEL_CONTEXT}.design.length.overall`, 42);
+
+    const track = trackByContext(VESSEL_CONTEXT) as AisVessel;
+    expect(track).toBeDefined();
+    expect(track.design?.length?.overall).toBe(42);
+  });
+
+  it('merges nested design fields without clobbering siblings', () => {
+    push(`${VESSEL_CONTEXT}.design.length.overall`, 42);
+    push(`${VESSEL_CONTEXT}.design.beam`, 8);
+
+    const track = trackByContext(VESSEL_CONTEXT) as AisVessel;
+    expect(track.design?.length?.overall).toBe(42);
+    expect(track.design?.beam).toBe(8);
+  });
+
+  it('applies a position update (latitude + longitude)', () => {
+    push(`${VESSEL_CONTEXT}.navigation.position.latitude`, 48.5);
+    push(`${VESSEL_CONTEXT}.navigation.position.longitude`, -123.25);
+
+    const track = trackByContext(VESSEL_CONTEXT) as AisVessel;
+    expect(track.position?.latitude).toBe(48.5);
+    expect(track.position?.longitude).toBe(-123.25);
+    expect(track.lastPositionAt).toBe(new Date('2026-06-24T00:00:00Z').getTime());
+  });
+
+  it('ignores a non-numeric latitude (early-out path -> break)', () => {
+    push(`${VESSEL_CONTEXT}.navigation.position.latitude`, 'not-a-number');
+
+    const track = trackByContext(VESSEL_CONTEXT) as AisVessel;
+    // Track exists (created on resolve) but position was never set.
+    expect(track).toBeDefined();
+    expect(track.position).toBeUndefined();
+  });
+
+  it('sets an ATON field gated by isAton (atonType.name)', () => {
+    push(`${ATON_CONTEXT}.atonType.name`, 'Buoy 7');
+
+    const track = trackByContext(ATON_CONTEXT) as AisAton;
+    expect(track).toBeDefined();
+    expect(track.type).toBe('aton');
+    expect(track.typeName).toBe('Buoy 7');
+  });
+
+  it('does NOT set a vessel-only field on an ATON (guard holds)', () => {
+    // speedOverGround is gated by isVesselLike; an ATON must not receive it.
+    push(`${ATON_CONTEXT}.atonType.name`, 'Buoy 7');
+    push(`${ATON_CONTEXT}.navigation.speedOverGround`, 9);
+
+    const track = trackByContext(ATON_CONTEXT);
+    expect((track as AisAton).typeName).toBe('Buoy 7');
+    // Vessel-only field must remain absent on the ATON.
+    expect((track as unknown as AisVessel).speedOverGround).toBeUndefined();
+  });
+
+  it('removes the track when sensors.ais.status = "remove"', () => {
+    // First give the vessel a name + position so it shows up as a target.
+    push(`${VESSEL_CONTEXT}.name`, 'Doomed Vessel');
+    push(`${VESSEL_CONTEXT}.navigation.position.latitude`, 10);
+    push(`${VESSEL_CONTEXT}.navigation.position.longitude`, 20);
+    expect(trackByContext(VESSEL_CONTEXT)).toBeDefined();
+
+    push(`${VESSEL_CONTEXT}.sensors.ais.status`, 'remove');
+
+    expect(trackByContext(VESSEL_CONTEXT)).toBeUndefined();
+  });
+
+  it('sets a normal ais status without removing the track', () => {
+    push(`${VESSEL_CONTEXT}.name`, 'Live Vessel');
+    push(`${VESSEL_CONTEXT}.sensors.ais.status`, 'confirmed');
+
+    const track = trackByContext(VESSEL_CONTEXT);
+    expect(track).toBeDefined();
+    expect(track!.ais.status).toBe('confirmed');
+  });
+});

--- a/src/app/core/services/ais-processing.service.ts
+++ b/src/app/core/services/ais-processing.service.ts
@@ -274,239 +274,244 @@ export class AisProcessingService {
       track.closestApproach = {};
     }
 
-    let removed = false;
-    const handlers: Record<string, () => void> = {
-      mmsi: () => this.applyMmsi(track, update.value),
-      name: () => { track.name = this.toStringOrUndefined(update.value); },
-      'communication.callsignVhf': () => {
+    switch (update.path) {
+      case 'mmsi':
+        this.applyMmsi(track, update.value);
+        break;
+      case 'name':
+        track.name = this.toStringOrUndefined(update.value);
+        break;
+      case 'communication.callsignVhf':
         if (this.isVesselLike(track)) {
           track.callsign = this.toStringOrUndefined(update.value);
         }
-      },
-      'navigation.destination': () => {
+        break;
+      case 'navigation.destination':
+      case 'navigation.destination.commonName':
         if (this.isVesselLike(track)) {
           track.destination = this.toStringOrUndefined(update.value);
         }
-      },
-      'navigation.destination.commonName': () => {
-        if (this.isVesselLike(track)) {
-          track.destination = this.toStringOrUndefined(update.value);
-        }
-      },
-      'navigation.destination.eta': () => {
+        break;
+      case 'navigation.destination.eta':
         if (this.isVesselLike(track)) {
           track.eta = this.toStringOrUndefined(update.value);
         }
-      },
-      'design.beam': () => {
+        break;
+      case 'design.beam':
         if (this.isVesselLike(track)) {
           track.design = { ...(track.design ?? {}), beam: this.toNumberOrUndefined(update.value) };
         }
-      },
-      'design.length.overall': () => {
+        break;
+      case 'design.length.overall':
         if (this.isVesselLike(track)) {
           track.design = {
             ...(track.design ?? {}),
             length: { ...(track.design?.length ?? {}), overall: this.toNumberOrUndefined(update.value) }
           };
         }
-      },
-      'design.length.hull': () => {
+        break;
+      case 'design.length.hull':
         if (this.isVesselLike(track)) {
           track.design = {
             ...(track.design ?? {}),
             length: { ...(track.design?.length ?? {}), hull: this.toNumberOrUndefined(update.value) }
           };
         }
-      },
-      'design.length.waterline': () => {
+        break;
+      case 'design.length.waterline':
         if (this.isVesselLike(track)) {
           track.design = {
             ...(track.design ?? {}),
             length: { ...(track.design?.length ?? {}), waterline: this.toNumberOrUndefined(update.value) }
           };
         }
-      },
-      'design.draft.maximum': () => {
+        break;
+      case 'design.draft.maximum':
         if (this.isVesselLike(track)) {
           track.design = {
             ...(track.design ?? {}),
             draft: { ...(track.design?.draft ?? {}), maximum: this.toNumberOrUndefined(update.value) }
           };
         }
-      },
-      'design.draft.minimum': () => {
+        break;
+      case 'design.draft.minimum':
         if (this.isVesselLike(track)) {
           track.design = {
             ...(track.design ?? {}),
             draft: { ...(track.design?.draft ?? {}), minimum: this.toNumberOrUndefined(update.value) }
           };
         }
-      },
-      'design.draft.current': () => {
+        break;
+      case 'design.draft.current':
         if (this.isVesselLike(track)) {
           track.design = {
             ...(track.design ?? {}),
             draft: { ...(track.design?.draft ?? {}), current: this.toNumberOrUndefined(update.value) }
           };
         }
-      },
-      'design.draft.canoe': () => {
+        break;
+      case 'design.draft.canoe':
         if (this.isVesselLike(track)) {
           track.design = {
             ...(track.design ?? {}),
             draft: { ...(track.design?.draft ?? {}), canoe: this.toNumberOrUndefined(update.value) }
           };
         }
-      },
-      'registrations.imo': () => {
+        break;
+      case 'registrations.imo':
         if (this.isVesselLike(track)) {
           track.imo = this.toStringOrUndefined(update.value);
         }
-      },
-      'navigation.courseOverGroundTrue': () => {
+        break;
+      case 'navigation.courseOverGroundTrue':
         if (this.isVesselLike(track)) {
           track.courseOverGroundTrue = this.toNumberOrUndefined(update.value);
         }
-      },
-      'navigation.headingTrue': () => {
+        break;
+      case 'navigation.headingTrue':
         if (this.isVesselLike(track)) {
           track.headingTrue = this.toNumberOrUndefined(update.value);
         }
-      },
-      'navigation.rateOfTurn': () => {
+        break;
+      case 'navigation.rateOfTurn':
         if (this.isVesselLike(track)) {
           track.rateOfTurn = this.toNumberOrUndefined(update.value);
         }
-      },
-      'navigation.specialManeuver': () => {
+        break;
+      case 'navigation.specialManeuver':
         if (this.isVesselLike(track)) {
           track.specialManeuver = this.toStringOrUndefined(update.value);
         }
-      },
-      'navigation.speedOverGround': () => {
+        break;
+      case 'navigation.speedOverGround':
         if (this.isVesselLike(track)) {
           track.speedOverGround = this.toNumberOrUndefined(update.value);
         }
-      },
-      'navigation.state': () => {
+        break;
+      case 'navigation.state':
         if (this.isVesselLike(track)) {
           track.navState = this.toStringOrUndefined(update.value);
         }
-      },
-      'sensors.ais.class': () => {
+        break;
+      case 'sensors.ais.class':
         track.ais.class = this.normalizeAisClass(update.value);
-      },
-      'sensors.ais.status': () => {
-        const status = this.normalizeAisStatus(update.value);
-        if (!status) return;
-        if (status === 'remove') {
-          this.removeTrack(track);
-          removed = true;
-          return;
+        break;
+      case 'sensors.ais.status':
+        {
+          const status = this.normalizeAisStatus(update.value);
+          if (!status) break;
+          if (status === 'remove') {
+            this.removeTrack(track);
+            return;
+          }
+          track.ais.status = status;
         }
-        track.ais.status = status;
-      },
-      'sensors.ais.fromBow': () => {
+        break;
+      case 'sensors.ais.fromBow':
         if (this.isVesselLike(track)) {
           track.fromBow = this.toNumberOrUndefined(update.value);
         }
-      },
-      'sensors.ais.fromCenter': () => {
+        break;
+      case 'sensors.ais.fromCenter':
         if (this.isVesselLike(track)) {
           track.fromCenter = this.toNumberOrUndefined(update.value);
         }
-      },
-      'navigation.position.latitude': () => {
-        const latitude = this.toNumberOrUndefined(update.value);
-        if (latitude === undefined) return;
-        track.position = { ...(track.position ?? {}), latitude };
-        track.lastPositionAt = update.timestampMs;
-      },
-      'navigation.position.longitude': () => {
-        const longitude = this.toNumberOrUndefined(update.value);
-        if (longitude === undefined) return;
-        track.position = { ...(track.position ?? {}), longitude };
-        track.lastPositionAt = update.timestampMs;
-      },
-      'navigation.position.altitude': () => {
-        const altitude = this.toNumberOrUndefined(update.value);
-        if (track.position) {
-          track.position = { ...track.position, altitude };
-        }
-      },
-      'navigation.position': () => {
-        const position = this.readPositionValue(update.value);
-        if (position) {
-          track.position = position;
+        break;
+      case 'navigation.position.latitude':
+        {
+          const latitude = this.toNumberOrUndefined(update.value);
+          if (latitude === undefined) break;
+          track.position = { ...(track.position ?? {}), latitude };
           track.lastPositionAt = update.timestampMs;
         }
-      },
-      'atonType.id': () => {
+        break;
+      case 'navigation.position.longitude':
+        {
+          const longitude = this.toNumberOrUndefined(update.value);
+          if (longitude === undefined) break;
+          track.position = { ...(track.position ?? {}), longitude };
+          track.lastPositionAt = update.timestampMs;
+        }
+        break;
+      case 'navigation.position.altitude':
+        {
+          const altitude = this.toNumberOrUndefined(update.value);
+          if (track.position) {
+            track.position = { ...track.position, altitude };
+          }
+        }
+        break;
+      case 'navigation.position':
+        {
+          const position = this.readPositionValue(update.value);
+          if (position) {
+            track.position = position;
+            track.lastPositionAt = update.timestampMs;
+          }
+        }
+        break;
+      case 'atonType.id':
         if (this.isAton(track)) {
           track.typeId = this.toNumberOrUndefined(update.value);
         }
-      },
-      'atonType.name': () => {
+        break;
+      case 'atonType.name':
         if (this.isAton(track)) {
           track.typeName = this.toStringOrUndefined(update.value);
         }
-      },
-      virtual: () => {
+        break;
+      case 'virtual':
         if (this.isAton(track)) {
           track.virtual = Boolean(update.value);
         }
-      },
-      offPosition: () => {
+        break;
+      case 'offPosition':
         if (this.isAton(track)) {
           track.offPosition = Boolean(update.value);
         }
-      },
-      'design.aisShipType.id': () => {
+        break;
+      case 'design.aisShipType.id':
         if (this.isVesselLike(track)) {
           track.design = {
             ...(track.design ?? {}),
             aisShipType: { ...(track.design?.aisShipType ?? {}), id: this.toNumberOrUndefined(update.value) }
           };
         }
-      },
-      'design.aisShipType.name': () => {
+        break;
+      case 'design.aisShipType.name':
         if (this.isVesselLike(track)) {
           track.design = {
             ...(track.design ?? {}),
             aisShipType: { ...(track.design?.aisShipType ?? {}), name: this.toStringOrUndefined(update.value) }
           };
         }
-      },
-      'navigation.closestApproach.distance': () => {
+        break;
+      case 'navigation.closestApproach.distance':
         if (this.isVesselLike(track) && track.closestApproach) {
           track.closestApproach.distance = this.toNumberOrUndefined(update.value);
         }
-      },
-      'navigation.closestApproach.timeTo': () => {
+        break;
+      case 'navigation.closestApproach.timeTo':
         if (this.isVesselLike(track) && track.closestApproach) {
           track.closestApproach.timeTo = this.toNumberOrUndefined(update.value);
         }
-      },
-      'navigation.closestApproach.range': () => {
+        break;
+      case 'navigation.closestApproach.range':
         if (this.isVesselLike(track) && track.closestApproach) {
           track.closestApproach.range = this.toNumberOrUndefined(update.value);
         }
-      },
-      'navigation.closestApproach.bearing': () => {
+        break;
+      case 'navigation.closestApproach.bearing':
         if (this.isVesselLike(track) && track.closestApproach) {
           track.closestApproach.bearing = this.toNumberOrUndefined(update.value);
         }
-      },
-      'navigation.closestApproach.collisionRiskRating': () => {
+        break;
+      case 'navigation.closestApproach.collisionRiskRating':
         if (this.isVesselLike(track) && track.closestApproach) {
           track.closestApproach.collisionRiskRating = this.toNumberOrUndefined(update.value);
         }
-      }
-    };
-
-    handlers[update.path]?.();
-    if (removed) return;
+        break;
+    }
 
     this.updateTargetsSignal();
   }

--- a/src/app/core/services/canvas.service.spec.ts
+++ b/src/app/core/services/canvas.service.spec.ts
@@ -13,4 +13,28 @@ describe('CanvasService', () => {
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
+
+  it('memoizes calculateOptimalFontSize and skips the measureText search on repeat calls', () => {
+    let measureCalls = 0;
+    const ctx = {
+      font: '',
+      measureText(text: string): TextMetrics {
+        measureCalls++;
+        const px = parseInt(this.font, 10) || 10;
+        return { width: text.length * px * 0.5 } as TextMetrics;
+      }
+    } as unknown as CanvasRenderingContext2D;
+
+    const first = service.calculateOptimalFontSize(ctx, '12.3', 100, 40, 'normal');
+    const callsAfterFirst = measureCalls;
+    expect(callsAfterFirst).toBeGreaterThan(0); // binary search ran the first time
+
+    const second = service.calculateOptimalFontSize(ctx, '12.3', 100, 40, 'normal');
+    expect(second).toBe(first);                 // identical result
+    expect(measureCalls).toBe(callsAfterFirst); // cache hit: no extra measureText calls
+
+    // A different geometry/text is a cache miss and runs the search again.
+    service.calculateOptimalFontSize(ctx, '12.3', 120, 40, 'normal');
+    expect(measureCalls).toBeGreaterThan(callsAfterFirst);
+  });
 });

--- a/src/app/core/services/canvas.service.ts
+++ b/src/app/core/services/canvas.service.ts
@@ -14,10 +14,21 @@ export class CanvasService {
   private observedCanvases = new Map<HTMLCanvasElement, { autoRelease?: boolean }>();
   private dprMediaQuery: MediaQueryList | null = null;
   private resizeCallbacks = new WeakMap<HTMLCanvasElement, (w: number, h: number) => void>();
+  /**
+   * Memo of optimal font sizes keyed by (text, rounded maxWidth, rounded maxHeight, fontWeight).
+   * The binary search below runs a handful of measureText() calls on every value redraw of the
+   * numeric/text/position/race widgets, yet the geometry only changes on resize — so the result is
+   * highly repeatable. Cleared once web fonts load (fallback-font metrics differ), and bounded.
+   */
+  private readonly _fontSizeCache = new Map<string, number>();
+  private static readonly FONT_SIZE_CACHE_LIMIT = 600;
 
   constructor() {
     // Wait for font loading to complete
     this.fontsReadyPromise = this.createFontsReadyPromise();
+    // Fallback-font measurements differ from the loaded web font, so drop any sizes computed
+    // before the fonts settled; subsequent draws recompute with the correct metrics.
+    this.fontsReadyPromise.then(() => this._fontSizeCache.clear()).catch(() => this._fontSizeCache.clear());
   }
 
   private getDocumentFonts(): FontFaceSet | null {
@@ -447,6 +458,12 @@ export class CanvasService {
   * ensure the context transform so callers may pass CSS units).
    */
   public calculateOptimalFontSize(ctx: CanvasRenderingContext2D, text: string, maxWidth: number, maxHeight: number, fontWeight = 'normal'): number {
+    const cacheKey = `${fontWeight}|${Math.round(maxWidth)}|${Math.round(maxHeight)}|${text}`;
+    const cached = this._fontSizeCache.get(cacheKey);
+    if (cached !== undefined) {
+      return cached;
+    }
+
     let minFontSize = 1;
     let maxFontSize = maxHeight;
     let fontSize = maxFontSize;
@@ -463,6 +480,11 @@ export class CanvasService {
       }
     }
 
+    // Bound memory: a fresh value set easily caps out if every tick has a unique value string.
+    if (this._fontSizeCache.size >= CanvasService.FONT_SIZE_CACHE_LIMIT) {
+      this._fontSizeCache.clear();
+    }
+    this._fontSizeCache.set(cacheKey, maxFontSize);
     return maxFontSize;
   }
 

--- a/src/app/widgets/widget-boolean-switch/widget-boolean-switch.component.ts
+++ b/src/app/widgets/widget-boolean-switch/widget-boolean-switch.component.ts
@@ -1,4 +1,4 @@
-import { Component, effect, inject, input, signal, untracked, OnDestroy, ChangeDetectorRef, NgZone, computed, ChangeDetectionStrategy } from '@angular/core';
+import { Component, effect, inject, input, signal, untracked, OnDestroy, computed, ChangeDetectionStrategy } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { SignalkRequestsService } from '../../core/services/signalk-requests.service';
 import { ITheme } from '../../core/services/app-service';
@@ -48,8 +48,6 @@ export class WidgetBooleanSwitchComponent implements OnDestroy {
     multiChildCtrls: []
   };
 
-  private readonly cdr = inject(ChangeDetectorRef);
-  private readonly ngZone = inject(NgZone);
   protected readonly runtime = inject(WidgetRuntimeDirective, { optional: true });
   private readonly streams = inject(WidgetStreamsDirective, { optional: true });
 
@@ -106,14 +104,11 @@ export class WidgetBooleanSwitchComponent implements OnDestroy {
               ? ([0, 1, null].includes(val) ? Boolean(val) : ctrl.value)
               : val;
 
-            this.ngZone.run(() => {
-              this.switchControls.update(list => {
-                const i = list.findIndex(c => c.pathID === ctrl.pathID);
-                if (i === -1) return list;
-                const updated = { ...list[i], value: nextVal };
-                return [...list.slice(0, i), updated, ...list.slice(i + 1)];
-              });
-              this.cdr.markForCheck();
+            this.switchControls.update(list => {
+              const i = list.findIndex(c => c.pathID === ctrl.pathID);
+              if (i === -1) return list;
+              const updated = { ...list[i], value: nextVal };
+              return [...list.slice(0, i), updated, ...list.slice(i + 1)];
             });
           });
         });

--- a/src/app/widgets/widget-windsteer/widget-windsteer.component.ts
+++ b/src/app/widgets/widget-windsteer/widget-windsteer.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, NgZone, inject, ChangeDetectionStrategy, ChangeDetectorRef, input, effect, untracked, signal } from '@angular/core';
+import { Component, OnDestroy, inject, ChangeDetectionStrategy, input, effect, untracked, signal } from '@angular/core';
 import { Subscription, interval } from 'rxjs';
 import { IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
 import { SvgWindsteerComponent } from '../svg-windsteer/svg-windsteer.component';
@@ -155,8 +155,6 @@ export class WidgetWindComponent implements OnDestroy {
 
   public readonly runtime = inject(WidgetRuntimeDirective); // accessed in template
   private readonly stream = inject(WidgetStreamsDirective);
-  private zones = inject(NgZone);
-  private cdr = inject(ChangeDetectorRef);
 
   // Removed local registeredPaths guard; rely on WidgetStreamsDirective diff + idempotent observe() with stable callbacks
 
@@ -195,8 +193,6 @@ export class WidgetWindComponent implements OnDestroy {
   private lastUnwrapped: number | null = null;
   private lastSector: { min?: number; mid?: number; max?: number } = {};
 
-  private markScheduled = false;
-  private scheduleRafId: number | null = null;
   private readonly DEG_EPSILON = 1;      // degrees
   private readonly SPEED_EPSILON = 0.1;  // knots
 
@@ -220,35 +216,35 @@ export class WidgetWindComponent implements OnDestroy {
     if (u.data.value == null) u.data.value = 0;
     const next = this.normalizeAngle(u.data.value);
     if (!this.hasHeading || this.angleDelta(this.currentHeading(), next) >= this.DEG_EPSILON) {
-      this.currentHeading.set(next); this.hasHeading = true; this.scheduleMarkForCheck();
+      this.currentHeading.set(next); this.hasHeading = true;
     }
   };
   private onCOGUpdate = (u: IPathUpdate) => {
     if (u.data.value == null) u.data.value = 0;
     const next = this.normalizeAngle(u.data.value);
     if (!this.hasCOG || this.angleDelta(this.courseOverGroundAngle(), next) >= this.DEG_EPSILON) {
-      this.courseOverGroundAngle.set(next); this.hasCOG = true; this.scheduleMarkForCheck();
+      this.courseOverGroundAngle.set(next); this.hasCOG = true;
     }
   };
   private onDriftUpdate = (u: IPathUpdate) => {
     if (u.data.value == null) u.data.value = 0;
     const next = u.data.value;
     if (!this.hasDrift || Math.abs(this.driftFlow() - next) >= this.SPEED_EPSILON) {
-      this.driftFlow.set(next); this.hasDrift = true; this.scheduleMarkForCheck();
+      this.driftFlow.set(next); this.hasDrift = true;
     }
   };
   private onSetUpdate = (u: IPathUpdate) => {
     if (u.data.value == null) u.data.value = 0;
     const next = this.normalizeAngle(u.data.value);
     if (!this.hasSet || this.angleDelta(this.driftSet(), next) >= this.DEG_EPSILON) {
-      this.driftSet.set(next); this.hasSet = true; this.scheduleMarkForCheck();
+      this.driftSet.set(next); this.hasSet = true;
     }
   };
   private onWaypointUpdate = (u: IPathUpdate) => {
     const raw = u.data.value;
     const next = this.normalizeAngle(raw);
     if (!this.hasWPT || this.angleDelta(this.waypointAngle(), next) >= this.DEG_EPSILON) {
-      this.waypointAngle.set(next); this.hasWPT = true; this.scheduleMarkForCheck();
+      this.waypointAngle.set(next); this.hasWPT = true;
     }
   };
   private onAppWindAngle = (u: IPathUpdate) => {
@@ -259,21 +255,20 @@ export class WidgetWindComponent implements OnDestroy {
       this.appWindAngle.set(next); this.hasAWA = true;
       const cfg = this.runtime.options();
       if (cfg?.windSectorEnable) this.addHistoricalWindDirection(this.normalizeAngle(raw));
-      this.scheduleMarkForCheck();
     }
   };
   private onAppWindSpeed = (u: IPathUpdate) => {
     if (u.data.value == null) u.data.value = 0;
     const next = u.data.value;
     if (!this.hasAWS || Math.abs(this.appWindSpeed() - next) >= this.SPEED_EPSILON) {
-      this.appWindSpeed.set(next); this.hasAWS = true; this.scheduleMarkForCheck();
+      this.appWindSpeed.set(next); this.hasAWS = true;
     }
   };
   private onTrueWindSpeed = (u: IPathUpdate) => {
     if (u.data.value == null) u.data.value = 0;
     const next = u.data.value;
     if (!this.hasTWS || Math.abs(this.trueWindSpeed() - next) >= this.SPEED_EPSILON) {
-      this.trueWindSpeed.set(next); this.hasTWS = true; this.scheduleMarkForCheck();
+      this.trueWindSpeed.set(next); this.hasTWS = true;
     }
   };
   private onTrueWindAngle = (u: IPathUpdate) => {
@@ -283,32 +278,26 @@ export class WidgetWindComponent implements OnDestroy {
     const base = computeTrueWindBaseAngle(path, u.data.value, this.currentHeading(), !!cfg?.compassModeEnabled);
     const next = this.normalizeAngle(base);
     if (!this.hasTWA || this.angleDelta(this.trueWindAngle(), next) >= this.DEG_EPSILON) {
-      this.trueWindAngle.set(next); this.hasTWA = true; this.scheduleMarkForCheck();
+      this.trueWindAngle.set(next); this.hasTWA = true;
     }
   };
 
   private registerStreams() {
     const cfg = this.runtime.options();
     if (!cfg) return;
-    this.zones.runOutsideAngular(() => {
-      this.stream.observe('headingPath', this.onHeadingUpdate);
-      this.stream.observe('courseOverGround', this.onCOGUpdate);
-      this.stream.observe('drift', this.onDriftUpdate);
-      this.stream.observe('set', this.onSetUpdate);
-      this.stream.observe('nextWaypointBearing', this.onWaypointUpdate);
-      this.stream.observe('appWindAngle', this.onAppWindAngle);
-      this.stream.observe('appWindSpeed', this.onAppWindSpeed);
-      this.stream.observe('trueWindSpeed', this.onTrueWindSpeed);
-      this.stream.observe('trueWindAngle', this.onTrueWindAngle);
-    });
+    this.stream.observe('headingPath', this.onHeadingUpdate);
+    this.stream.observe('courseOverGround', this.onCOGUpdate);
+    this.stream.observe('drift', this.onDriftUpdate);
+    this.stream.observe('set', this.onSetUpdate);
+    this.stream.observe('nextWaypointBearing', this.onWaypointUpdate);
+    this.stream.observe('appWindAngle', this.onAppWindAngle);
+    this.stream.observe('appWindSpeed', this.onAppWindSpeed);
+    this.stream.observe('trueWindSpeed', this.onTrueWindSpeed);
+    this.stream.observe('trueWindAngle', this.onTrueWindAngle);
   }
 
   ngOnDestroy() {
     this.stopWindSectors();
-    if (this.scheduleRafId != null) {
-      cancelAnimationFrame(this.scheduleRafId);
-      this.scheduleRafId = null;
-    }
   }
 
   private startWindSectors() {
@@ -324,14 +313,11 @@ export class WidgetWindComponent implements OnDestroy {
       this.trueWindMidHistoric.set(undefined);
       this.trueWindMaxHistoric.set(undefined);
       this.lastSector = {};
-      this.scheduleMarkForCheck();
       return;
     }
 
-    this.zones.runOutsideAngular(() => {
-      this.windSectorObservableSub = interval(1000).subscribe(() => {
-        this.historicalCleanup();
-      });
+    this.windSectorObservableSub = interval(1000).subscribe(() => {
+      this.historicalCleanup();
     });
   }
 
@@ -366,7 +352,6 @@ export class WidgetWindComponent implements OnDestroy {
         this.trueWindMidHistoric.set(undefined);
         this.trueWindMaxHistoric.set(undefined);
         this.lastSector = {};
-        this.scheduleMarkForCheck();
       }
       return;
     }
@@ -386,7 +371,6 @@ export class WidgetWindComponent implements OnDestroy {
       this.trueWindMidHistoric.set(nextMid);
       this.trueWindMaxHistoric.set(nextMax);
       this.lastSector = { min: nextMin, mid: nextMid, max: nextMax };
-      this.scheduleMarkForCheck();
     }
   }
 
@@ -410,17 +394,6 @@ export class WidgetWindComponent implements OnDestroy {
   private normalizeAngle(a: number): number { return ((a % 360) + 360) % 360; }
   private angleDelta(from: number, to: number): number { const d = ((to - from + 540) % 360) - 180; return Math.abs(d); }
 
-  private scheduleMarkForCheck() {
-    if (this.markScheduled) return;
-    this.markScheduled = true;
-    this.zones.runOutsideAngular(() => {
-      this.scheduleRafId = requestAnimationFrame(() => {
-        this.zones.run(() => { this.cdr.markForCheck(); });
-        this.markScheduled = false;
-        this.scheduleRafId = null;
-      });
-    });
-  }
 }
 
 function addHeadingDeg(h1: number, h2: number): number {

--- a/src/app/widgets/widget-windtrends-chart/widget-windtrends-chart.component.ts
+++ b/src/app/widgets/widget-windtrends-chart/widget-windtrends-chart.component.ts
@@ -81,6 +81,8 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
   private chart: Chart<keyof ChartTypeRegistry, { x: number; y: number; }[], unknown>;
   private _dsDirectionSub: Subscription = null;
   private _dsSpeedSub: Subscription = null;
+  /** Pending coalesced chart recompute+repaint frame id (one per animation frame across both streams). */
+  private _chartUpdateRafId: number | null = null;
   private datasetConfig: IDatasetServiceDatasetConfig = null;
   private dataSourceInfo: IDatasetServiceDataSourceInfo = null;
   private xCenter: number | null = null;
@@ -723,8 +725,7 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
           for (let i = 0; i <= 4; i++) this.chart.data.datasets[i].data.shift();
         }
       }
-      this.updateChartAfterDataChange();
-      this.ngZone.runOutsideAngular(() => { this.chart?.update('none'); });
+      this.scheduleChartUpdate();
     });
 
     this._dsSpeedSub = batchThenLiveSpd$?.subscribe(dsPointOrBatch => {
@@ -736,8 +737,7 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
           for (let i = 5; i <= 9; i++) this.chart.data.datasets[i].data.shift();
         }
       }
-      this.updateChartAfterDataChange();
-      this.ngZone.runOutsideAngular(() => { this.chart?.update('none'); });
+      this.scheduleChartUpdate();
     });
   }
 
@@ -827,6 +827,21 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
     const base = step / Math.pow(10, exp);
     const chosen = mantissas.find(m => base <= m) ?? mantissas[mantissas.length - 1];
     return chosen * Math.pow(10, exp);
+  }
+
+  /**
+   * Coalesce the chart recompute + repaint into a single animation frame. The direction (-twd) and
+   * speed (-tws) streams frequently emit in the same frame; without this, each emission runs the
+   * full 10-dataset y recompute and a chart.update('none'), doing that work twice per frame.
+   */
+  private scheduleChartUpdate(): void {
+    if (this._chartUpdateRafId != null) return;
+    this._chartUpdateRafId = requestAnimationFrame(() => {
+      this._chartUpdateRafId = null;
+      if (!this.chart) return;
+      this.updateChartAfterDataChange();
+      this.ngZone.runOutsideAngular(() => this.chart?.update('none'));
+    });
   }
 
   private updateChartAfterDataChange() {
@@ -1121,6 +1136,10 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
   ngOnDestroy(): void {
     this._dsDirectionSub?.unsubscribe();
     this._dsSpeedSub?.unsubscribe();
+    if (this._chartUpdateRafId != null) {
+      cancelAnimationFrame(this._chartUpdateRafId);
+      this._chartUpdateRafId = null;
+    }
     // we need to destroy when moving Pages to remove Chart Objects
     this.chart?.destroy();
     const canvas = this.widgetDataChart?.()?.nativeElement as HTMLCanvasElement | undefined;

--- a/src/app/widgets/widget-zones-state-panel/widget-zones-state-panel.component.ts
+++ b/src/app/widgets/widget-zones-state-panel/widget-zones-state-panel.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, NgZone, computed, effect, inject, input, signal, untracked, ChangeDetectionStrategy } from '@angular/core';
+import { Component, computed, effect, inject, input, signal, untracked, ChangeDetectionStrategy } from '@angular/core';
 import { ITheme } from '../../core/services/app-service';
 import { IWidgetSvcConfig, IDynamicControl, IWidgetPath } from '../../core/interfaces/widgets-interface';
 import { DashboardService } from '../../core/services/dashboard.service';
@@ -43,8 +43,6 @@ export class WidgetZonesStatePanelComponent {
     multiChildCtrls: []
   };
 
-  private readonly cdr = inject(ChangeDetectorRef);
-  private readonly ngZone = inject(NgZone);
   protected readonly runtime = inject(WidgetRuntimeDirective, { optional: true });
   private readonly notificationsService = inject(NotificationsService);
   protected readonly dashboard = inject(DashboardService);
@@ -80,7 +78,6 @@ export class WidgetZonesStatePanelComponent {
       untracked(() => {
         this.labelColor.set(getColors(cfg.color, theme).dim);
       });
-      this.cdr.markForCheck()
     });
 
     // Effect: rebuild controls and paths when config changes
@@ -109,7 +106,6 @@ export class WidgetZonesStatePanelComponent {
         // immediately (no need to wait for the next notification delta).
         this.applyNotificationsSnapshot(this.notifications());
       });
-      this.cdr.markForCheck()
     });
 
     // Effect: update controls from notifications as they change
@@ -128,41 +124,35 @@ export class WidgetZonesStatePanelComponent {
       if (n?.path) notifByPath.set(n.path, n);
     }
 
-    this.ngZone.run(() => {
-      let didChange = false;
+    // The update callback returns the SAME list reference when nothing changed, so the signal
+    // (and therefore change detection) only fires when a control's state/message actually changes.
+    this.zonesControls.update(list => {
+      let nextList: IDynamicControl[] | null = null;
 
-      this.zonesControls.update(list => {
-        let nextList: IDynamicControl[] | null = null;
+      for (let i = 0; i < list.length; i++) {
+        const ctrl = list[i];
+        const notificationPath = this.pathIdToNotificationPath.get(ctrl.pathID);
+        const notification = notificationPath ? notifByPath.get(notificationPath) : undefined;
+        if (!notification) continue;
 
-        for (let i = 0; i < list.length; i++) {
-          const ctrl = list[i];
-          const notificationPath = this.pathIdToNotificationPath.get(ctrl.pathID);
-          const notification = notificationPath ? notifByPath.get(notificationPath) : undefined;
-          if (!notification) continue;
+        const state = notification.value?.['state'] as string | undefined;
+        const message = notification.value?.['message'] as string | undefined;
 
-          const state = notification.value?.['state'] as string | undefined;
-          const message = notification.value?.['message'] as string | undefined;
+        if (ctrl.notificationState === state && ctrl.notificationMessage === message) continue;
 
-          if (ctrl.notificationState === state && ctrl.notificationMessage === message) continue;
+        if (!nextList) nextList = [...list];
+        nextList[i] = {
+          ...ctrl,
+          notificationState: state,
+          notificationMessage: message,
+        };
+      }
 
-          if (!nextList) nextList = [...list];
-          nextList[i] = {
-            ...ctrl,
-            notificationState: state,
-            notificationMessage: message,
-          };
-          didChange = true;
-        }
-
-        return nextList ?? list;
-      });
-
-      if (didChange) this.cdr.markForCheck();
+      return nextList ?? list;
     });
   }
 
   onResized(event: ResizeObserverEntry): void {
     this.hostSize.set({ width: event.contentRect.width, height: event.contentRect.height });
-    this.cdr.markForCheck();
   }
 }


### PR DESCRIPTION
Replicates upstream PR https://github.com/mxtommy/Kip/pull/1087 ("Cut per-widget render and change-detection overhead") by dillan.

Method: commit-by-commit cherry-pick (the upstream PR had a linear, single-commit history).

This is an experimental replica carried in the SKip fork for evaluation. It has not been tested against the SKip build and should be reviewed before merge.
