### PR TITLE
Lazy-load widget components and the history chart dialog (replicates mxtommy/Kip #1088)

### DIFF
--- a/src/app/core/components/widget-embedded/widget-embedded.component.html
+++ b/src/app/core/components/widget-embedded/widget-embedded.component.html
@@ -1,3 +1,9 @@
 <mat-card appearance="raised" class="widget-container kip-widget-card-colors" style="border: 1px dashed transparent">
   <ng-container #childOutlet></ng-container>
+  @if (loadFailed()) {
+    <button type="button" class="widget-load-error" (click)="retryWidgetLoad()">
+      <span class="widget-load-error__title">Widget failed to load</span>
+      <span class="widget-load-error__hint">Tap to retry</span>
+    </button>
+  }
 </mat-card>

--- a/src/app/core/components/widget-embedded/widget-embedded.component.scss
+++ b/src/app/core/components/widget-embedded/widget-embedded.component.scss
@@ -15,3 +15,25 @@
 .kip-widget-card-colors {
   background-color: var(--kip-widget-card-background-color);
 }
+
+.widget-load-error {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  padding: 8px;
+  border: none;
+  background: transparent;
+  color: var(--mat-sys-error);
+  font: inherit;
+  text-align: center;
+  cursor: pointer;
+}
+
+.widget-load-error__hint {
+  opacity: 0.7;
+  font-size: 0.85em;
+}

--- a/src/app/core/components/widget-embedded/widget-embedded.component.spec.ts
+++ b/src/app/core/components/widget-embedded/widget-embedded.component.spec.ts
@@ -1,5 +1,80 @@
+import { Component, Type, input } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { of } from 'rxjs';
+import { WidgetEmbeddedComponent } from './widget-embedded.component';
+import { WidgetService } from '../../services/widget.service';
+import { AppService } from '../../services/app-service';
+import { DataService } from '../../services/data.service';
+import { UnitsService } from '../../services/units.service';
+import type { IWidget } from '../../interfaces/widgets-interface';
+
+// A trivial stand-in widget the embedded host will lazy-load and render.
+@Component({
+  selector: 'test-lazy-widget',
+  standalone: true,
+  template: '<span class="test-lazy-widget">loaded</span>'
+})
+class TestLazyWidgetComponent {
+  public id = input<string>();
+  public type = input<string>();
+  public theme = input<unknown>();
+  public static readonly DEFAULT_CONFIG = { displayName: 'Test' };
+}
+
 describe('WidgetEmbeddedComponent', () => {
-	it('placeholder', () => {
-		expect(true).toBe(true);
-	});
+  let fixture: ComponentFixture<WidgetEmbeddedComponent>;
+  const getComponentType = vi.fn();
+
+  const setup = async () => {
+    await TestBed.configureTestingModule({
+      imports: [WidgetEmbeddedComponent],
+      providers: [
+        { provide: WidgetService, useValue: { getComponentType, getDefaultConfig: vi.fn().mockReturnValue(undefined) } },
+        { provide: AppService, useValue: { cssThemeColorRoles$: of({ contrast: '#fff' }) } },
+        // Mocked so the streams/metadata host directives don't construct the real DataService chain.
+        { provide: DataService, useValue: {} },
+        { provide: UnitsService, useValue: { convertToUnit: (_u: string, v: unknown) => v } }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(WidgetEmbeddedComponent);
+    fixture.componentRef.setInput('widgetProperties', {
+      uuid: 'embedded-1',
+      type: 'test-lazy-widget',
+      config: {}
+    } as IWidget);
+  };
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    TestBed.resetTestingModule();
+  });
+
+  it('lazily resolves the widget component and renders it once the chunk loads', async () => {
+    getComponentType.mockResolvedValue(TestLazyWidgetComponent as Type<unknown>);
+    await setup();
+
+    fixture.detectChanges(); // ngOnInit kicks off the async load
+    // Not rendered synchronously: resolution is async (the import has not resolved yet).
+    expect(fixture.nativeElement.querySelector('.test-lazy-widget')).toBeNull();
+
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    // After the (mocked) import resolves, the child widget is created and rendered.
+    expect(getComponentType).toHaveBeenCalledWith('test-lazy-widget');
+    expect(fixture.nativeElement.querySelector('.test-lazy-widget')?.textContent).toContain('loaded');
+  });
+
+  it('does not create a child when the component type fails to resolve', async () => {
+    getComponentType.mockResolvedValue(undefined);
+    await setup();
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.test-lazy-widget')).toBeNull();
+  });
 });

--- a/src/app/core/components/widget-embedded/widget-embedded.component.ts
+++ b/src/app/core/components/widget-embedded/widget-embedded.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, Type, ViewChild, ViewContainerRef, Input, effect, ComponentRef, OnInit } from '@angular/core';
+import { Component, inject, Type, ViewChild, ViewContainerRef, Input, effect, ComponentRef, OnInit, OnDestroy } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { MatCardModule } from '@angular/material/card';
 import { IWidget, IWidgetSvcConfig } from '../../interfaces/widgets-interface';
@@ -74,7 +74,7 @@ interface WidgetViewComponentBase { defaultConfig?: IWidgetSvcConfig }
  * In the parent component template use:
  *   <widget-embedded [widgetProperties]="xteWidgetProps"></widget-embedded>
  */
-export class WidgetEmbeddedComponent implements OnInit {
+export class WidgetEmbeddedComponent implements OnInit, OnDestroy {
   @Input({ required: true }) protected widgetProperties!: IWidget;
   // Mark static:true so the outlet is available during ngOnInit allowing
   // runtime initialization + child creation before the first stability check.
@@ -87,6 +87,7 @@ export class WidgetEmbeddedComponent implements OnInit {
   protected theme = toSignal(this._app.cssThemeColorRoles$, { requireSync: true });
   private childRef: ComponentRef<WidgetViewComponentBase>;
   private compType: Type<WidgetViewComponentBase>
+  private _destroyed = false;
 
   constructor() {
     effect(() => {
@@ -100,7 +101,17 @@ export class WidgetEmbeddedComponent implements OnInit {
   ngOnInit(): void {
     const type = this.widgetProperties.type;
     if (!type) return;
-    this.compType = this._widgetService.getComponentType(type) as Type<WidgetViewComponentBase> | undefined;
+    // Widget components are lazy-loaded, so resolution is async.
+    void this.loadAndCreateChild(type);
+  }
+
+  ngOnDestroy(): void {
+    this._destroyed = true;
+  }
+
+  private async loadAndCreateChild(type: string): Promise<void> {
+    this.compType = await this._widgetService.getComponentType(type) as Type<WidgetViewComponentBase> | undefined;
+    if (this._destroyed) return; // host torn down while the chunk loaded
 
     // Initialize runtime
     this._runtime?.initialize?.(undefined, this.widgetProperties.config);
@@ -110,13 +121,14 @@ export class WidgetEmbeddedComponent implements OnInit {
     this._streams?.applyStreamsConfigDiff?.(merged);
     this._meta?.applyMetaConfigDiff?.(merged);
 
-    // Create the child component BEFORE first change detection completes so its
     if (this.outlet && this.compType) {
       this.childRef = this.outlet.createComponent(this.compType);
       this.childRef.setInput('id', this.widgetProperties.uuid);
       this.childRef.setInput('type', this.widgetProperties.type);
       // Pass current theme value; ongoing updates handled by effect in ctor.
       this.childRef.setInput('theme', this.theme());
+      // Created after the import resolved (outside the initial CD pass), so render it now.
+      this.childRef.changeDetectorRef.detectChanges();
     }
   }
 }

--- a/src/app/core/components/widget-embedded/widget-embedded.component.ts
+++ b/src/app/core/components/widget-embedded/widget-embedded.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, Type, ViewChild, ViewContainerRef, Input, effect, ComponentRef, OnInit, OnDestroy } from '@angular/core';
+import { Component, inject, Type, ViewChild, ViewContainerRef, Input, effect, ComponentRef, OnInit, OnDestroy, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { MatCardModule } from '@angular/material/card';
 import { IWidget, IWidgetSvcConfig } from '../../interfaces/widgets-interface';
@@ -85,6 +85,8 @@ export class WidgetEmbeddedComponent implements OnInit, OnDestroy {
   private readonly _widgetService = inject(WidgetService);
   private readonly _app = inject(AppService);
   protected theme = toSignal(this._app.cssThemeColorRoles$, { requireSync: true });
+  // True when the widget's lazy chunk could not be resolved, so the template shows a retry affordance.
+  protected readonly loadFailed = signal(false);
   private childRef: ComponentRef<WidgetViewComponentBase>;
   private compType: Type<WidgetViewComponentBase>
   private _destroyed = false;
@@ -121,6 +123,8 @@ export class WidgetEmbeddedComponent implements OnInit, OnDestroy {
     this._streams?.applyStreamsConfigDiff?.(merged);
     this._meta?.applyMetaConfigDiff?.(merged);
 
+    this.loadFailed.set(!this.compType);
+
     if (this.outlet && this.compType) {
       this.childRef = this.outlet.createComponent(this.compType);
       this.childRef.setInput('id', this.widgetProperties.uuid);
@@ -130,5 +134,13 @@ export class WidgetEmbeddedComponent implements OnInit, OnDestroy {
       // Created after the import resolved (outside the initial CD pass), so render it now.
       this.childRef.changeDetectorRef.detectChanges();
     }
+  }
+
+  /** Re-attempt a failed lazy chunk load (the import promise is dropped on failure, so this re-imports). */
+  protected retryWidgetLoad(): void {
+    const type = this.widgetProperties.type;
+    if (!type || this._destroyed) return;
+    this.loadFailed.set(false);
+    void this.loadAndCreateChild(type);
   }
 }

--- a/src/app/core/components/widget-host2/widget-host2.component.html
+++ b/src/app/core/components/widget-host2/widget-host2.component.html
@@ -6,4 +6,10 @@
   (press)="openBottomSheet($event)"
   (contextmenu)="openWidgetHistoryDialog($event)">
   <ng-container #childOutlet></ng-container>
+  @if (loadFailed()) {
+    <button type="button" class="widget-load-error" (click)="retryWidgetLoad()">
+      <span class="widget-load-error__title">Widget failed to load</span>
+      <span class="widget-load-error__hint">Tap to retry</span>
+    </button>
+  }
 </mat-card>

--- a/src/app/core/components/widget-host2/widget-host2.component.scss
+++ b/src/app/core/components/widget-host2/widget-host2.component.scss
@@ -16,3 +16,25 @@
 .kip-widget-card-colors {
   background-color: var(--kip-widget-card-background-color);
 }
+
+.widget-load-error {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  padding: 8px;
+  border: none;
+  background: transparent;
+  color: var(--mat-sys-error);
+  font: inherit;
+  text-align: center;
+  cursor: pointer;
+}
+
+.widget-load-error__hint {
+  opacity: 0.7;
+  font-size: 0.85em;
+}

--- a/src/app/core/components/widget-host2/widget-host2.component.spec.ts
+++ b/src/app/core/components/widget-host2/widget-host2.component.spec.ts
@@ -352,6 +352,7 @@ describe('WidgetHost2Component', () => {
 
         fixture.detectChanges();
         await Promise.resolve();
+        await Promise.resolve();
 
         expect(dialogServiceMock.openWidgetOptions).toHaveBeenCalledTimes(1);
         expect(testWidget.autoOpenOptionsOnCreate).toBeUndefined();
@@ -374,6 +375,7 @@ describe('WidgetHost2Component', () => {
         dialogServiceMock.openWidgetOptions.mockReturnValue({ afterClosed: () => of(null) });
 
         fixture.detectChanges();
+        await Promise.resolve();
         await Promise.resolve();
 
         expect(dialogServiceMock.openWidgetOptions).toHaveBeenCalledTimes(1);

--- a/src/app/core/components/widget-host2/widget-host2.component.ts
+++ b/src/app/core/components/widget-host2/widget-host2.component.ts
@@ -80,6 +80,7 @@ export class WidgetHost2Component extends BaseWidget implements OnInit, OnDestro
   private childRef: ComponentRef<WidgetViewComponentBase> | null = null;
   private compType: Type<WidgetViewComponentBase>
   private _hasInitialized = false;
+  private _destroyed = false;
   private readonly openOverlays = new Set<TOverlayGate>();
   // Debug helper gated by the same localStorage flag used by gestures directive
   private isDebugEnabled(): boolean {
@@ -122,7 +123,19 @@ export class WidgetHost2Component extends BaseWidget implements OnInit, OnDestro
     if (shouldAutoOpenOptions) {
       delete this.widgetProperties.autoOpenOptionsOnCreate;
     }
-    this.compType = this.widgetService.getComponentType(type) as Type<WidgetViewComponentBase> | undefined;
+    // Widget components are lazy-loaded, so resolution is async. Kick it off; the child is created
+    // once its chunk resolves (instant for an already-loaded type, a fetch on first use).
+    void this.loadAndCreateChild(type, shouldAutoOpenOptions);
+  }
+
+  /**
+   * Resolve (lazy-import) the widget component, initialize the runtime/streams from its default +
+   * saved config, and create the child view. Awaiting the import means this runs after the initial
+   * render, so it guards against the host being destroyed mid-load and explicitly renders the child.
+   */
+  private async loadAndCreateChild(type: string, shouldAutoOpenOptions: boolean): Promise<void> {
+    this.compType = await this.widgetService.getComponentType(type) as Type<WidgetViewComponentBase> | undefined;
+    if (this._destroyed) return; // host was torn down while the chunk loaded
 
     // Resolve default configuration for this component type using helper
     const defaultCfg = this.getDefaultConfig();
@@ -135,7 +148,6 @@ export class WidgetHost2Component extends BaseWidget implements OnInit, OnDestro
     this.streams?.applyStreamsConfigDiff?.(merged);
     this.meta?.applyMetaConfigDiff?.(merged);
 
-    // Create the child component BEFORE first change detection completes so its
     if (this.outlet && this.compType) {
       this.childRef = this.outlet.createComponent(this.compType, {
         bindings: [
@@ -144,6 +156,8 @@ export class WidgetHost2Component extends BaseWidget implements OnInit, OnDestro
           inputBinding('theme', this.theme)
         ]
       });
+      // Created outside the initial CD pass (after the import resolved), so render it now.
+      this.childRef.changeDetectorRef.detectChanges();
     }
     this._hasInitialized = true;
 
@@ -153,6 +167,7 @@ export class WidgetHost2Component extends BaseWidget implements OnInit, OnDestro
   }
 
   ngOnDestroy(): void {
+    this._destroyed = true;
     this.childRef?.destroy();
     this.childRef = null;
     this.openOverlays.clear();
@@ -407,11 +422,12 @@ export class WidgetHost2Component extends BaseWidget implements OnInit, OnDestro
         || familyDescriptor?.displayTitle
         || 'Widget Data History';
 
-      this.dialog.openWidgetHistoryDialog({
+      const dialogRef = await this.dialog.openWidgetHistoryDialog({
         title,
         widget: this.widgetProperties,
         seriesDefinitions
-      }).afterClosed().subscribe(() => {
+      });
+      dialogRef.afterClosed().subscribe(() => {
         this.releaseOverlay('history');
       });
     } catch (error) {

--- a/src/app/core/components/widget-host2/widget-host2.component.ts
+++ b/src/app/core/components/widget-host2/widget-host2.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, Type, ViewChild, ViewContainerRef, Input, effect, ComponentRef, OnDestroy, OnInit, untracked, ChangeDetectionStrategy, inputBinding, computed } from '@angular/core';
+import { Component, inject, Type, ViewChild, ViewContainerRef, Input, effect, ComponentRef, OnDestroy, OnInit, untracked, ChangeDetectionStrategy, inputBinding, computed, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { MatCardModule } from '@angular/material/card';
 import { GestureDirective } from '../../directives/gesture.directive';
@@ -77,6 +77,9 @@ export class WidgetHost2Component extends BaseWidget implements OnInit, OnDestro
 
   protected theme = toSignal(this.app.cssThemeColorRoles$, { requireSync: true });
   protected readonly dashboardStaticView = computed(() => this.dashboard.isDashboardStatic());
+  // True when the widget's lazy chunk could not be resolved, so the template shows a retry affordance
+  // instead of a silent blank tile.
+  protected readonly loadFailed = signal(false);
   private childRef: ComponentRef<WidgetViewComponentBase> | null = null;
   private compType: Type<WidgetViewComponentBase>
   private _hasInitialized = false;
@@ -148,6 +151,8 @@ export class WidgetHost2Component extends BaseWidget implements OnInit, OnDestro
     this.streams?.applyStreamsConfigDiff?.(merged);
     this.meta?.applyMetaConfigDiff?.(merged);
 
+    this.loadFailed.set(!this.compType);
+
     if (this.outlet && this.compType) {
       this.childRef = this.outlet.createComponent(this.compType, {
         bindings: [
@@ -164,6 +169,14 @@ export class WidgetHost2Component extends BaseWidget implements OnInit, OnDestro
     if (shouldAutoOpenOptions) {
       queueMicrotask(() => this.openWidgetOptions(new Event('kip:auto-open-options')));
     }
+  }
+
+  /** Re-attempt a failed lazy chunk load (the import promise is dropped on failure, so this re-imports). */
+  protected retryWidgetLoad(): void {
+    const type = this.widgetProperties.type;
+    if (!type || this._destroyed) return;
+    this.loadFailed.set(false);
+    void this.loadAndCreateChild(type, false);
   }
 
   ngOnDestroy(): void {

--- a/src/app/core/services/dashboard-history-series-sync.service.spec.ts
+++ b/src/app/core/services/dashboard-history-series-sync.service.spec.ts
@@ -172,6 +172,7 @@ describe('DashboardHistorySeriesSyncService', () => {
     };
     let widgetServiceMock: {
         getComponentType: Mock;
+        getDefaultConfig: Mock;
     };
     let reconcileSpy: Mock;
 
@@ -192,7 +193,8 @@ describe('DashboardHistorySeriesSyncService', () => {
         });
 
         widgetServiceMock = {
-            getComponentType: vi.fn().mockReturnValue(undefined)
+            getComponentType: vi.fn().mockResolvedValue(undefined),
+            getDefaultConfig: vi.fn().mockReturnValue(undefined)
         };
 
         TestBed.configureTestingModule({
@@ -936,33 +938,31 @@ describe('DashboardHistorySeriesSyncService', () => {
     });
 
     it('resolves numeric paths from widget DEFAULT_CONFIG when saved config is partial', () => {
-        widgetServiceMock.getComponentType.mockImplementation((selector: string) => {
+        widgetServiceMock.getDefaultConfig.mockImplementation((selector: string) => {
             if (selector !== 'widget-horizon') {
                 return undefined;
             }
 
             return {
-                DEFAULT_CONFIG: {
-                    supportAutomaticHistoricalSeries: true,
-                    timeScale: 'minute',
-                    period: 30,
-                    paths: {
-                        gaugePitchPath: {
-                            description: 'Pitch',
-                            path: 'self.navigation.attitude.pitch',
-                            source: 'default',
-                            pathType: 'number',
-                            isPathConfigurable: true,
-                            sampleTime: 1000
-                        },
-                        gaugeRollPath: {
-                            description: 'Roll',
-                            path: 'self.navigation.attitude.roll',
-                            source: 'default',
-                            pathType: 'number',
-                            isPathConfigurable: true,
-                            sampleTime: 1000
-                        }
+                supportAutomaticHistoricalSeries: true,
+                timeScale: 'minute',
+                period: 30,
+                paths: {
+                    gaugePitchPath: {
+                        description: 'Pitch',
+                        path: 'self.navigation.attitude.pitch',
+                        source: 'default',
+                        pathType: 'number',
+                        isPathConfigurable: true,
+                        sampleTime: 1000
+                    },
+                    gaugeRollPath: {
+                        description: 'Roll',
+                        path: 'self.navigation.attitude.roll',
+                        source: 'default',
+                        pathType: 'number',
+                        isPathConfigurable: true,
+                        sampleTime: 1000
                     }
                 }
             };

--- a/src/app/core/services/dashboard-history-series-sync.service.spec.ts
+++ b/src/app/core/services/dashboard-history-series-sync.service.spec.ts
@@ -241,6 +241,38 @@ describe('DashboardHistorySeriesSyncService', () => {
         expect(reconcileSpy).not.toHaveBeenCalled();
     });
 
+    it('loads in-use widget DEFAULT_CONFIG before reconciling (deterministic across dashboards)', async () => {
+        vi.useFakeTimers();
+        TestBed.inject(DashboardHistorySeriesSyncService);
+        connectionStub.serverServiceEndpoint$.next({
+            operation: 2,
+            message: 'Connected',
+            serverDescription: 'Signal K',
+            httpServiceUrl: 'http://localhost:3000/signalk/v1/api/',
+            WsServiceUrl: 'ws://localhost:3000/signalk/v1/stream'
+        });
+
+        dashboardStub.dashboards.set([
+            {
+                id: 'dash-1',
+                name: 'Dashboard 1',
+                icon: 'dashboard-dashboard',
+                configuration: [
+                    createAutomaticNode('widget-numeric-1', 'widget-numeric', {
+                        numericPath: 'navigation.speedThroughWater'
+                    })
+                ]
+            }
+        ]);
+
+        await vi.advanceTimersByTimeAsync(800);
+
+        // The reconcile warms each in-use widget type's DEFAULT_CONFIG (via getComponentType),
+        // independently of which dashboard is rendered, before extracting series.
+        expect(widgetServiceMock.getComponentType).toHaveBeenCalledWith('widget-numeric');
+        expect(reconcileSpy).toHaveBeenCalledTimes(1);
+    });
+
     it('should extract numeric path series and reconcile once after debounce', async () => {
         vi.useFakeTimers();
         TestBed.inject(DashboardHistorySeriesSyncService);

--- a/src/app/core/services/dashboard-history-series-sync.service.ts
+++ b/src/app/core/services/dashboard-history-series-sync.service.ts
@@ -215,12 +215,11 @@ export class DashboardHistorySeriesSyncService {
   }
 
   private getDefaultConfigForType(widgetType: string): IWidgetSvcConfig | undefined {
-    try {
-      const comp = this.widgetService.getComponentType(widgetType) as { DEFAULT_CONFIG?: IWidgetSvcConfig } | undefined;
-      return comp?.DEFAULT_CONFIG;
-    } catch {
-      return undefined;
-    }
+    // Reads the widget's static DEFAULT_CONFIG from WidgetService's cache, which is populated when
+    // the widget component is lazy-loaded (i.e. rendered). Returns undefined for widgets whose chunk
+    // has not been fetched yet; the saved config alone is then used, and a later reconcile picks up
+    // the defaults once the widget has loaded.
+    return this.widgetService.getDefaultConfig(widgetType);
   }
 
   private collectSeriesFromNodes(nodes: IGridWidgetNode[], sink: IKipSeriesDefinition[]): void {

--- a/src/app/core/services/dashboard-history-series-sync.service.ts
+++ b/src/app/core/services/dashboard-history-series-sync.service.ts
@@ -63,8 +63,7 @@ export class DashboardHistorySeriesSyncService {
   private readonly AUTO_RETENTION_MS = 24 * 60 * 60 * 1000;
   private reconcileTimer: number | null = null;
   private lastSubmittedSignature: string | null = null;
-  private pendingSignature: string | null = null;
-  private pendingSeries: IKipSeriesDefinition[] = [];
+  private pendingDashboards: Dashboard[] | null = null;
 
   constructor() {
     effect(() => {
@@ -75,12 +74,7 @@ export class DashboardHistorySeriesSyncService {
         return;
       }
 
-      try {
-        const desiredSeries = this.extractSeriesFromDashboards(dashboards);
-        this.scheduleReconcile(desiredSeries);
-      } catch (error) {
-        console.error('[DashboardHistorySeriesSyncService] Error extracting series from dashboards:', error);
-      }
+      this.scheduleReconcile(dashboards);
     });
 
     this.destroyRef.onDestroy(() => {
@@ -91,14 +85,8 @@ export class DashboardHistorySeriesSyncService {
     });
   }
 
-  private scheduleReconcile(seriesDefinitions: IKipSeriesDefinition[]): void {
-    const signature = this.getCanonicalSeriesSignature(seriesDefinitions);
-    if (signature === this.lastSubmittedSignature) {
-      return;
-    }
-
-    this.pendingSeries = seriesDefinitions;
-    this.pendingSignature = signature;
+  private scheduleReconcile(dashboards: Dashboard[]): void {
+    this.pendingDashboards = dashboards;
 
     if (this.reconcileTimer !== null) {
       clearTimeout(this.reconcileTimer);
@@ -110,19 +98,35 @@ export class DashboardHistorySeriesSyncService {
   }
 
   private async flushReconcile(): Promise<void> {
-    if (!this.pendingSignature) {
+    this.reconcileTimer = null;
+    const dashboards = this.pendingDashboards;
+    this.pendingDashboards = null;
+    if (!dashboards) {
       return;
     }
 
-    const nextSignature = this.pendingSignature;
-    const nextSeries = this.pendingSeries;
-    this.pendingSignature = null;
-    this.reconcileTimer = null;
+    // Load every in-use widget type's static DEFAULT_CONFIG before extracting series, so history
+    // registration is deterministic regardless of which dashboard is currently rendered. Runs after
+    // first paint, so it does not affect the initial bundle/first-paint the lazy loading targets.
+    await this.ensureWidgetDefaultsLoaded(dashboards);
+
+    let desiredSeries: IKipSeriesDefinition[];
+    try {
+      desiredSeries = this.extractSeriesFromDashboards(dashboards);
+    } catch (error) {
+      console.error('[DashboardHistorySeriesSyncService] Error extracting series from dashboards:', error);
+      return;
+    }
+
+    const signature = this.getCanonicalSeriesSignature(desiredSeries);
+    if (signature === this.lastSubmittedSignature) {
+      return;
+    }
 
     const modeConfig = await this.pluginConfig.getKipRuntimeModeConfigCached('kip');
     if (!modeConfig.historySeriesServiceEnabled) {
       console.warn('[DashboardHistorySeriesSyncService] Reconcile skipped because history series service mode is disabled');
-      this.lastSubmittedSignature = nextSignature;
+      this.lastSubmittedSignature = signature;
       return;
     }
 
@@ -130,9 +134,9 @@ export class DashboardHistorySeriesSyncService {
       // reconcileSeries resolves to null on failure (it swallows errors and does
       // NOT throw), so we must inspect the result. Only mark the signature as
       // submitted on a real success; otherwise leave it unset so the next cycle retries.
-      const result = await this.kipSeries.reconcileSeries(nextSeries);
+      const result = await this.kipSeries.reconcileSeries(desiredSeries);
       if (result) {
-        this.lastSubmittedSignature = nextSignature;
+        this.lastSubmittedSignature = signature;
       } else {
         console.warn('[DashboardHistorySeriesSyncService] Reconcile did not complete; will retry on next cycle');
       }
@@ -140,6 +144,29 @@ export class DashboardHistorySeriesSyncService {
       console.error('[DashboardHistorySeriesSyncService] Reconcile failed:', error);
       // Don't update lastSubmittedSignature so next cycle will retry
     }
+  }
+
+  private async ensureWidgetDefaultsLoaded(dashboards: Dashboard[]): Promise<void> {
+    const types = new Set<string>();
+    dashboards.forEach(dashboard => {
+      this.collectWidgetTypes(this.coerceNodeList(dashboard.configuration), types);
+    });
+    await Promise.all(
+      [...types].map(type => this.widgetService.getComponentType(type).catch(() => undefined))
+    );
+  }
+
+  private collectWidgetTypes(nodes: IGridWidgetNode[], sink: Set<string>): void {
+    nodes.forEach(node => {
+      const type = node?.input?.widgetProperties?.type;
+      if (type) {
+        sink.add(type);
+      }
+      const children = this.coerceNodeList(node?.subGridOpts?.children);
+      if (children.length > 0) {
+        this.collectWidgetTypes(children, sink);
+      }
+    });
   }
 
   private extractSeriesFromDashboards(dashboards: Dashboard[]): IKipSeriesDefinition[] {
@@ -215,10 +242,9 @@ export class DashboardHistorySeriesSyncService {
   }
 
   private getDefaultConfigForType(widgetType: string): IWidgetSvcConfig | undefined {
-    // Reads the widget's static DEFAULT_CONFIG from WidgetService's cache, which is populated when
-    // the widget component is lazy-loaded (i.e. rendered). Returns undefined for widgets whose chunk
-    // has not been fetched yet; the saved config alone is then used, and a later reconcile picks up
-    // the defaults once the widget has loaded.
+    // Reads the widget's static DEFAULT_CONFIG from WidgetService's cache. flushReconcile() awaits
+    // ensureWidgetDefaultsLoaded() before extracting series, so the cache is warm here for every
+    // in-use widget type, independently of which dashboard is currently rendered.
     return this.widgetService.getDefaultConfig(widgetType);
   }
 

--- a/src/app/core/services/dialog.service.ts
+++ b/src/app/core/services/dialog.service.ts
@@ -10,7 +10,7 @@ import { WidgetsListComponent } from '../components/widgets-list/widgets-list.co
 import { UpgradeConfigComponent } from '../components/upgrade-config/upgrade-config.component';
 import { DialogDashboardPageEditorComponent } from '../components/dialog-dashboard-page-editor/dialog-dashboard-page-editor.component';
 import { DialogAisTargetComponent } from '../../widgets/widget-ais-radar/dialog-ais-target/dialog-ais-target.component';
-import { IWidgetHistoryChartDialogData, WidgetHistoryChartDialogComponent } from '../components/widget-history-chart-dialog/widget-history-chart-dialog.component';
+import type { IWidgetHistoryChartDialogData, WidgetHistoryChartDialogComponent } from '../components/widget-history-chart-dialog/widget-history-chart-dialog.component';
 
 @Injectable({
   providedIn: 'root'
@@ -104,12 +104,16 @@ export class DialogService {
    * Opens a history-only chart dialog for a widget.
    *
    * @param {IWidgetHistoryChartDialogData} data Widget history dialog payload.
-   * @returns {MatDialogRef<WidgetHistoryChartDialogComponent>} Dialog reference.
+   * @returns {Promise<MatDialogRef<WidgetHistoryChartDialogComponent>>} Dialog reference.
+   *
+   * @remarks The history chart dialog (and its chart.js dependency) is lazy-loaded so it stays out
+   * of the initial bundle and is only fetched the first time a user opens widget history.
    *
    * @example
-   * const ref = dialogService.openWidgetHistoryDialog({ title: 'History', widget, seriesDefinitions });
+   * const ref = await dialogService.openWidgetHistoryDialog({ title: 'History', widget, seriesDefinitions });
    */
-  public openWidgetHistoryDialog(data: IWidgetHistoryChartDialogData): MatDialogRef<WidgetHistoryChartDialogComponent> {
+  public async openWidgetHistoryDialog(data: IWidgetHistoryChartDialogData): Promise<MatDialogRef<WidgetHistoryChartDialogComponent>> {
+    const { WidgetHistoryChartDialogComponent } = await import('../components/widget-history-chart-dialog/widget-history-chart-dialog.component');
     return this.dialog.open(WidgetHistoryChartDialogComponent,
       {
         data,

--- a/src/app/core/services/widget.service.spec.ts
+++ b/src/app/core/services/widget.service.spec.ts
@@ -21,4 +21,28 @@ describe('WidgetService', () => {
     expect(selectors).toContain('widget-solar-charger');
     expect(selectors).toContain('widget-charger');
   });
+
+  it('lazily resolves a component type as a promise and dedupes concurrent lookups', async () => {
+    const p1 = service.getComponentType('widget-text');
+    const p2 = service.getComponentType('widget-text');
+    expect(p1).toBeInstanceOf(Promise);
+    expect(p1).toBe(p2); // same in-flight promise reused (single import())
+
+    const type = await p1;
+    expect(type).toBeTruthy();
+  });
+
+  it('resolves undefined for an unknown selector without attempting an import', async () => {
+    await expect(service.getComponentType('widget-does-not-exist')).resolves.toBeUndefined();
+  });
+
+  it('exposes DEFAULT_CONFIG only after the component has been loaded', async () => {
+    // Not fetched yet: config-only consumers get undefined and fall back to saved config.
+    expect(service.getDefaultConfig('widget-text')).toBeUndefined();
+
+    await service.getComponentType('widget-text');
+
+    // Once the chunk has loaded, the static DEFAULT_CONFIG is cached for synchronous reads.
+    expect(service.getDefaultConfig('widget-text')).toBeDefined();
+  });
 });

--- a/src/app/core/services/widget.service.ts
+++ b/src/app/core/services/widget.service.ts
@@ -1,41 +1,11 @@
 import { inject, Injectable } from '@angular/core';
 import { Type } from '@angular/core';
 import { PluginConfigClientService } from './plugin-config-client.service';
-import { WidgetNumericComponent } from '../../widgets/widget-numeric/widget-numeric.component';
-import { WidgetTextComponent } from '../../widgets/widget-text/widget-text.component';
-import { WidgetWindTrendsChartComponent } from '../../widgets/widget-windtrends-chart/widget-windtrends-chart.component';
-import { WidgetWindComponent } from '../../widgets/widget-windsteer/widget-windsteer.component';
-import { WidgetTutorialComponent } from '../../widgets/widget-tutorial/widget-tutorial.component';
-import { WidgetSliderComponent } from '../../widgets/widget-slider/widget-slider.component';
-import { WidgetSimpleLinearComponent } from '../../widgets/widget-simple-linear/widget-simple-linear.component';
-import { WidgetRacesteerComponent } from '../../widgets/widget-racesteer/widget-racesteer.component';
-import { WidgetRacerTimerComponent } from '../../widgets/widget-racer-timer/widget-racer-timer.component';
-import { WidgetRacerLineComponent } from '../../widgets/widget-racer-line/widget-racer-line.component';
-import { WidgetRaceTimerComponent } from '../../widgets/widget-race-timer/widget-race-timer.component';
-import { WidgetPositionComponent } from '../../widgets/widget-position/widget-position.component';
-import { WidgetAisRadarComponent } from '../../widgets/widget-ais-radar/widget-ais-radar.component';
-import { WidgetLabelComponent } from '../../widgets/widget-label/widget-label.component';
-import { WidgetIframeComponent } from '../../widgets/widget-iframe/widget-iframe.component';
-import { WidgetHorizonComponent } from '../../widgets/widget-horizon/widget-horizon.component';
-import { WidgetHeelGaugeComponent } from '../../widgets/widget-heel-gauge/widget-heel-gauge.component';
-import { WidgetSteelGaugeComponent } from '../../widgets/widget-gauge-steel/widget-gauge-steel.component';
-import { WidgetGaugeNgRadialComponent } from '../../widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component';
-import { WidgetGaugeNgLinearComponent } from '../../widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component';
-import { WidgetGaugeNgCompassComponent } from '../../widgets/widget-gauge-ng-compass/widget-gauge-ng-compass.component';
-import { WidgetFreeboardskComponent } from '../../widgets/widget-freeboardsk/widget-freeboardsk.component';
-import { WidgetAnchorAlarmComponent } from '../../widgets/widget-anchor-alarm/widget-anchor-alarm.component';
-import { WidgetDatetimeComponent } from '../../widgets/widget-datetime/widget-datetime.component';
-import { WidgetDataChartComponent } from '../../widgets/widget-data-chart/widget-data-chart.component';
-import { WidgetBooleanSwitchComponent } from '../../widgets/widget-boolean-switch/widget-boolean-switch.component';
-import { WidgetMultiStateSwitchComponent } from '../../widgets/widget-multi-state-switch/widget-multi-state-switch.component';
-import { WidgetZonesStatePanelComponent } from '../../widgets/widget-zones-state-panel/widget-zones-state-panel.component';
-import { WidgetAutopilotComponent } from '../../widgets/widget-autopilot/widget-autopilot.component';
-import { WidgetBmsComponent } from '../../widgets/widget-bms/widget-bms.component';
-import { WidgetSolarChargerComponent } from '../../widgets/widget-solar-charger/widget-solar-charger.component';
-import { WidgetChargerComponent } from '../../widgets/widget-charger/widget-charger.component';
-import { WidgetInverterComponent } from '../../widgets/widget-inverter/widget-inverter.component';
-import { WidgetAlternatorComponent } from '../../widgets/widget-alternator/widget-alternator.component';
-import { WidgetAcComponent } from '../../widgets/widget-ac/widget-ac.component';
+import type { IWidgetSvcConfig } from '../interfaces/widgets-interface';
+// Widget view components are NOT imported statically. They are loaded on demand through the lazy
+// loader map below so each widget's code (and its heavy vendor deps: chart.js, d3, canvas-gauges,
+// etc.) ships in its own chunk and is only downloaded when that widget type is actually placed on a
+// dashboard. See `_componentTypeMap` and `getComponentType()`.
 
 export const WIDGET_CATEGORIES = ['Core', 'Gauge', 'Component', 'Racing'] as const;
 export type TWidgetCategories = typeof WIDGET_CATEGORIES[number];
@@ -138,45 +108,49 @@ export class WidgetService {
   private readonly _pluginConfig = inject(PluginConfigClientService);
   private readonly _widgetCategories = [...WIDGET_CATEGORIES];
   // Cache for selector -> component Type resolutions to avoid repeated definition scans
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private readonly _componentTypeCache = new Map<string, Type<any> | undefined>();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private readonly _componentTypeMap: Record<string, Type<any>> = {
-    WidgetNumericComponent: WidgetNumericComponent,
-    WidgetTextComponent: WidgetTextComponent,
-    WidgetWindTrendsChartComponent: WidgetWindTrendsChartComponent,
-    WidgetWindComponent: WidgetWindComponent,
-    WidgetTutorialComponent: WidgetTutorialComponent,
-    WidgetSliderComponent: WidgetSliderComponent,
-    WidgetSimpleLinearComponent: WidgetSimpleLinearComponent,
-    WidgetRacesteerComponent: WidgetRacesteerComponent,
-    WidgetRacerTimerComponent: WidgetRacerTimerComponent,
-    WidgetRacerLineComponent: WidgetRacerLineComponent,
-    WidgetRaceTimerComponent: WidgetRaceTimerComponent,
-    WidgetPositionComponent: WidgetPositionComponent,
-    WidgetAisRadarComponent: WidgetAisRadarComponent,
-    WidgetLabelComponent: WidgetLabelComponent,
-    WidgetIframeComponent: WidgetIframeComponent,
-    WidgetHorizonComponent: WidgetHorizonComponent,
-    WidgetHeelGaugeComponent: WidgetHeelGaugeComponent,
-    WidgetSteelGaugeComponent: WidgetSteelGaugeComponent,
-    WidgetGaugeNgRadialComponent: WidgetGaugeNgRadialComponent,
-    WidgetGaugeNgLinearComponent: WidgetGaugeNgLinearComponent,
-    WidgetGaugeNgCompassComponent: WidgetGaugeNgCompassComponent,
-    WidgetFreeboardskComponent: WidgetFreeboardskComponent,
-    WidgetAnchorAlarmComponent: WidgetAnchorAlarmComponent,
-    WidgetDatetimeComponent: WidgetDatetimeComponent,
-    WidgetDataChartComponent: WidgetDataChartComponent,
-    WidgetBooleanSwitchComponent: WidgetBooleanSwitchComponent,
-    WidgetMultiStateSwitchComponent: WidgetMultiStateSwitchComponent,
-    WidgetZonesStatePanelComponent: WidgetZonesStatePanelComponent,
-    WidgetAutopilotComponent: WidgetAutopilotComponent,
-    WidgetBmsComponent: WidgetBmsComponent,
-    WidgetSolarChargerComponent: WidgetSolarChargerComponent,
-    WidgetChargerComponent: WidgetChargerComponent,
-    WidgetInverterComponent: WidgetInverterComponent,
-    WidgetAlternatorComponent: WidgetAlternatorComponent,
-    WidgetAcComponent: WidgetAcComponent
+  // Resolved component-type promises, deduped per selector so repeat/concurrent lookups reuse one import().
+  private readonly _componentTypePromise = new Map<string, Promise<Type<unknown> | undefined>>();
+  // Static DEFAULT_CONFIG captured when a widget loads, so config-only consumers (historical-series
+  // reconciliation) can read it synchronously without forcing a chunk download.
+  private readonly _defaultConfigCache = new Map<string, IWidgetSvcConfig | undefined>();
+  // Lazy loaders: each value dynamically imports its widget component on first use, so the widget's
+  // code + vendor deps live in a separate chunk fetched only when that widget type is instantiated.
+  private readonly _componentTypeMap: Record<string, () => Promise<Type<unknown>>> = {
+    WidgetNumericComponent: () => import('../../widgets/widget-numeric/widget-numeric.component').then(m => m.WidgetNumericComponent),
+    WidgetTextComponent: () => import('../../widgets/widget-text/widget-text.component').then(m => m.WidgetTextComponent),
+    WidgetWindTrendsChartComponent: () => import('../../widgets/widget-windtrends-chart/widget-windtrends-chart.component').then(m => m.WidgetWindTrendsChartComponent),
+    WidgetWindComponent: () => import('../../widgets/widget-windsteer/widget-windsteer.component').then(m => m.WidgetWindComponent),
+    WidgetTutorialComponent: () => import('../../widgets/widget-tutorial/widget-tutorial.component').then(m => m.WidgetTutorialComponent),
+    WidgetSliderComponent: () => import('../../widgets/widget-slider/widget-slider.component').then(m => m.WidgetSliderComponent),
+    WidgetSimpleLinearComponent: () => import('../../widgets/widget-simple-linear/widget-simple-linear.component').then(m => m.WidgetSimpleLinearComponent),
+    WidgetRacesteerComponent: () => import('../../widgets/widget-racesteer/widget-racesteer.component').then(m => m.WidgetRacesteerComponent),
+    WidgetRacerTimerComponent: () => import('../../widgets/widget-racer-timer/widget-racer-timer.component').then(m => m.WidgetRacerTimerComponent),
+    WidgetRacerLineComponent: () => import('../../widgets/widget-racer-line/widget-racer-line.component').then(m => m.WidgetRacerLineComponent),
+    WidgetRaceTimerComponent: () => import('../../widgets/widget-race-timer/widget-race-timer.component').then(m => m.WidgetRaceTimerComponent),
+    WidgetPositionComponent: () => import('../../widgets/widget-position/widget-position.component').then(m => m.WidgetPositionComponent),
+    WidgetAisRadarComponent: () => import('../../widgets/widget-ais-radar/widget-ais-radar.component').then(m => m.WidgetAisRadarComponent),
+    WidgetLabelComponent: () => import('../../widgets/widget-label/widget-label.component').then(m => m.WidgetLabelComponent),
+    WidgetIframeComponent: () => import('../../widgets/widget-iframe/widget-iframe.component').then(m => m.WidgetIframeComponent),
+    WidgetHorizonComponent: () => import('../../widgets/widget-horizon/widget-horizon.component').then(m => m.WidgetHorizonComponent),
+    WidgetHeelGaugeComponent: () => import('../../widgets/widget-heel-gauge/widget-heel-gauge.component').then(m => m.WidgetHeelGaugeComponent),
+    WidgetSteelGaugeComponent: () => import('../../widgets/widget-gauge-steel/widget-gauge-steel.component').then(m => m.WidgetSteelGaugeComponent),
+    WidgetGaugeNgRadialComponent: () => import('../../widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component').then(m => m.WidgetGaugeNgRadialComponent),
+    WidgetGaugeNgLinearComponent: () => import('../../widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component').then(m => m.WidgetGaugeNgLinearComponent),
+    WidgetGaugeNgCompassComponent: () => import('../../widgets/widget-gauge-ng-compass/widget-gauge-ng-compass.component').then(m => m.WidgetGaugeNgCompassComponent),
+    WidgetFreeboardskComponent: () => import('../../widgets/widget-freeboardsk/widget-freeboardsk.component').then(m => m.WidgetFreeboardskComponent),
+    WidgetAnchorAlarmComponent: () => import('../../widgets/widget-anchor-alarm/widget-anchor-alarm.component').then(m => m.WidgetAnchorAlarmComponent),
+    WidgetDatetimeComponent: () => import('../../widgets/widget-datetime/widget-datetime.component').then(m => m.WidgetDatetimeComponent),
+    WidgetDataChartComponent: () => import('../../widgets/widget-data-chart/widget-data-chart.component').then(m => m.WidgetDataChartComponent),
+    WidgetBooleanSwitchComponent: () => import('../../widgets/widget-boolean-switch/widget-boolean-switch.component').then(m => m.WidgetBooleanSwitchComponent),
+    WidgetMultiStateSwitchComponent: () => import('../../widgets/widget-multi-state-switch/widget-multi-state-switch.component').then(m => m.WidgetMultiStateSwitchComponent),
+    WidgetZonesStatePanelComponent: () => import('../../widgets/widget-zones-state-panel/widget-zones-state-panel.component').then(m => m.WidgetZonesStatePanelComponent),
+    WidgetAutopilotComponent: () => import('../../widgets/widget-autopilot/widget-autopilot.component').then(m => m.WidgetAutopilotComponent),
+    WidgetBmsComponent: () => import('../../widgets/widget-bms/widget-bms.component').then(m => m.WidgetBmsComponent),
+    WidgetSolarChargerComponent: () => import('../../widgets/widget-solar-charger/widget-solar-charger.component').then(m => m.WidgetSolarChargerComponent),
+    WidgetChargerComponent: () => import('../../widgets/widget-charger/widget-charger.component').then(m => m.WidgetChargerComponent),
+    WidgetInverterComponent: () => import('../../widgets/widget-inverter/widget-inverter.component').then(m => m.WidgetInverterComponent),
+    WidgetAlternatorComponent: () => import('../../widgets/widget-alternator/widget-alternator.component').then(m => m.WidgetAlternatorComponent),
+    WidgetAcComponent: () => import('../../widgets/widget-ac/widget-ac.component').then(m => m.WidgetAcComponent)
 };
   private readonly _widgetDefinition: readonly WidgetDescription[] = [
     {
@@ -647,41 +621,67 @@ export class WidgetService {
   }
 
   /**
-   * Resolves a widget's runtime component Type from its selector.
+   * Resolves a widget's runtime component Type from its selector by dynamically importing the
+   * widget's chunk on demand.
    *
    * Flow:
    *  1. Locate the widget definition whose `selector` matches the provided string.
-   *  2. Look up the definition's `componentClassName` inside `_componentTypeMap`.
-   *  3. Return the component Type if the widget has been migrated; otherwise `undefined`.
+   *  2. Look up the definition's lazy loader inside `_componentTypeMap` and `import()` it.
+   *  3. Resolve with the component Type (and cache its DEFAULT_CONFIG), or `undefined` if unknown.
    *
-   * Host2 will fall back to a safe default (currently Numeric) when `undefined` is returned.
-   * This allows incremental migration without breaking existing dashboard configs.
-   *
-   * NOTE: We intentionally keep this lightweight instead of using dynamic `import()` to
-   * preserve tree‑shaking.
+   * The returned promise is cached per selector so repeat/concurrent lookups reuse a single import.
+   * Host2 (and widget-embedded) await this before creating the child; they fall back to a safe
+   * default when it resolves `undefined`.
    *
    * @param selector Dashboard widget type / selector (e.g. `widget-numeric`).
-   * @returns Angular component Type or undefined if not yet migrated.
+   * @returns Promise resolving to the Angular component Type, or undefined if unknown / failed to load.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public getComponentType(selector: string): Type<any> | undefined {
-    // Only return cached value if it's a defined component Type; avoid sticky undefined caching
-    const cached = this._componentTypeCache.get(selector);
-    if (cached) return cached;
+  public getComponentType(selector: string): Promise<Type<unknown> | undefined> {
+    const existing = this._componentTypePromise.get(selector);
+    if (existing) return existing;
 
     const def = this._widgetDefinition.find(w => w.selector === selector);
-    if (!def) return undefined;
+    if (!def) return Promise.resolve(undefined);
 
-    const resolved = this._componentTypeMap[def.componentClassName];
-    if (!resolved) {
-      // Do NOT cache undefined so that adding a new mapping later in dev picks it up without reload
+    const loader = this._componentTypeMap[def.componentClassName];
+    if (!loader) {
       if (typeof ngDevMode !== 'undefined' && ngDevMode) {
         console.warn('[WidgetService] No component mapping for', def.componentClassName);
       }
-      return undefined;
+      return Promise.resolve(undefined);
     }
-    this._componentTypeCache.set(selector, resolved);
-    return resolved;
+
+    const promise = loader()
+      .then(componentType => {
+        // Capture the static DEFAULT_CONFIG so config-only consumers can read it without re-loading.
+        this._defaultConfigCache.set(
+          selector,
+          (componentType as { DEFAULT_CONFIG?: IWidgetSvcConfig }).DEFAULT_CONFIG
+        );
+        return componentType;
+      })
+      .catch((error: unknown) => {
+        // Drop the cached promise so a later attempt can retry the import after a transient failure.
+        this._componentTypePromise.delete(selector);
+        console.error('[WidgetService] Failed to load component for', def.componentClassName, error);
+        return undefined;
+      });
+
+    this._componentTypePromise.set(selector, promise);
+    return promise;
+  }
+
+  /**
+   * Synchronously returns a widget type's static DEFAULT_CONFIG IF its component has already been
+   * loaded (e.g. it is rendered on a dashboard). Returns `undefined` for widgets whose chunk has not
+   * been fetched yet — config-only callers should treat that as "not yet known" and fall back to the
+   * saved config rather than force a chunk download.
+   *
+   * @param selector Dashboard widget type / selector (e.g. `widget-numeric`).
+   * @returns The cached DEFAULT_CONFIG, or undefined if the component has not been loaded.
+   */
+  public getDefaultConfig(selector: string): IWidgetSvcConfig | undefined {
+    return this._defaultConfigCache.get(selector);
   }
 
   /**


### PR DESCRIPTION
Replicates upstream PR https://github.com/mxtommy/Kip/pull/1088 ("Lazy-load widget components and the history chart dialog") by dillan.

**Method:** commit-by-commit cherry-pick onto `origin/main` (linear upstream history, single commit, no conflicts).

This is an experimental replica carried in the fork for evaluation. It has not been built or runtime-tested here; treat it as a candidate for review before merge.
