### PR TITLE
Fix pre-existing client test-suite failures (54 to 0) (replicates mxtommy/Kip #1083)

### DIFF
--- a/src/app/core/components/options/display/display.component.spec.ts
+++ b/src/app/core/components/options/display/display.component.spec.ts
@@ -31,6 +31,7 @@ class ToastServiceMock {
 }
 
 class SettingsServiceMock {
+    public getDisablePathValidation() { return false; }
     public getNightModeBrightness() { return 0.27; }
     public getAutoNightMode() { return false; }
     public getThemeName() { return ''; }

--- a/src/app/core/services/settings.service.ts
+++ b/src/app/core/services/settings.service.ts
@@ -174,6 +174,8 @@ export class SettingsService {
    * @memberof SettingsService
    */
   public loadConfigFromLocalStorage(type: string) {
+    // A missing key returns null; JSON.parse('') would throw, so fall back to the string 'null'
+    // which parses to null and triggers the default-loading branch below (the intended behavior).
     let config = JSON.parse(localStorage.getItem(type) ?? 'null');
 
     if (config === null) {

--- a/src/app/core/services/widget.service.spec.ts
+++ b/src/app/core/services/widget.service.spec.ts
@@ -20,5 +20,11 @@ describe('WidgetService', () => {
     // widget-alternator/-inverter/-ac are commented out in widget.service.ts pending readiness.
     expect(selectors).toContain('widget-solar-charger');
     expect(selectors).toContain('widget-charger');
+    // The Alternator, Inverter and AC Monitor widget definitions are currently commented out in
+    // widget.service.ts (see the /* ... */ block around the electrical family entries), so they are
+    // not registered yet. Re-enable these assertions when those definitions are uncommented.
+    // expect(selectors).toContain('widget-inverter');
+    // expect(selectors).toContain('widget-alternator');
+    // expect(selectors).toContain('widget-ac');
   });
 });

--- a/src/app/widget-config/path-control-config/path-control-config.component.spec.ts
+++ b/src/app/widget-config/path-control-config/path-control-config.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { EMPTY } from 'rxjs';
 import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
+import { BehaviorSubject } from 'rxjs';
 import { IDynamicControl } from '../../core/interfaces/widgets-interface';
 
 import { PathControlConfigComponent } from './path-control-config.component';
@@ -17,7 +17,18 @@ describe('PathControlConfigComponent', () => {
     await TestBed.configureTestingModule({
       imports: [PathControlConfigComponent],
       providers: [
-        { provide: SignalKConnectionService, useValue: { skServerVersion: '2.14.0', serverServiceEndpoint$: EMPTY, serverVersion$: EMPTY } },
+        {
+          // Real AuthenticationService/StorageService get pulled in via the DI HTTP interceptor and
+          // subscribe to these streams, so mirror the global connection stub (plus skServerVersion).
+          provide: SignalKConnectionService,
+          useValue: {
+            skServerVersion: '2.14.0',
+            serverServiceEndpoint$: new BehaviorSubject({ operation: 0, httpServiceUrl: '', WsServiceUrl: '', subscribeAll: false }),
+            serverVersion$: new BehaviorSubject(null),
+            signalKURL: { url: 'http://localhost' },
+            getServiceEndpointStatusAsO(): unknown { return this.serverServiceEndpoint$.asObservable(); }
+          }
+        },
         {
           provide: DataService,
           useValue: {

--- a/src/test.ts
+++ b/src/test.ts
@@ -4,6 +4,29 @@ import { cwd } from 'node:process';
 // Mark global test flag before anything else so app code can detect test context
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (window as any).__KIP_TEST__ = true;
+
+// jsdom in this unit-test runner ships WITHOUT Web Storage, so `localStorage`/`sessionStorage`
+// are undefined. Any service that reads localStorage in its constructor (AuthenticationService,
+// SettingsService, StorageService, …) throws "Cannot read properties of undefined (reading
+// 'getItem')" and every spec that builds that real service fails. Provide an in-memory polyfill.
+if (typeof globalThis.localStorage === 'undefined') {
+  class MemoryStorage implements Storage {
+    private store = new Map<string, string>();
+    get length(): number { return this.store.size; }
+    clear(): void { this.store.clear(); }
+    getItem(key: string): string | null { return this.store.has(key) ? this.store.get(key)! : null; }
+    key(index: number): string | null { return Array.from(this.store.keys())[index] ?? null; }
+    removeItem(key: string): void { this.store.delete(key); }
+    setItem(key: string, value: string): void { this.store.set(key, String(value)); }
+  }
+  for (const name of ['localStorage', 'sessionStorage']) {
+    const value = new MemoryStorage();
+    Object.defineProperty(globalThis, name, { configurable: true, value });
+    if (typeof window !== 'undefined') {
+      Object.defineProperty(window, name, { configurable: true, value });
+    }
+  }
+}
 // Neutralize hard navigation that break Karma connection
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const loc: any = window.location;
@@ -456,6 +479,8 @@ class SettingsServiceStub {
   public setSplitShellSwipeDisabled(v: boolean): void { this.splitShellSwipeDisabledSubject.next(v); }
   public getNotificationServiceConfigAsO(): Observable<import('./app/core/interfaces/app-settings.interfaces').INotificationConfig> { return this._notificationConfig.asObservable(); }
   public getNotificationConfig(): import('./app/core/interfaces/app-settings.interfaces').INotificationConfig { return this._notificationConfig.value; }
+  // Used by SettingsDisplayComponent at field init (model<boolean>(this.settings.getDisablePathValidation())).
+  public getDisablePathValidation(): boolean { return false; }
 }
 
 // Lightweight runtime directive stub so components can inject it in tests


### PR DESCRIPTION
Replicates upstream PR https://github.com/mxtommy/Kip/pull/1083 ("Fix pre-existing client test-suite failures (54 to 0)") by dillan.

**Method:** Commit-by-commit cherry-pick (PR history was linear, no merge commits). All three upstream commits were replayed onto `origin/main`, preserving the original author.

## ⚠️ Conflict resolution applied

Three files required hand-resolution because SKip's tree had diverged from the upstream base:

- `src/app/core/services/settings.service.ts` — SKip already carried the `JSON.parse(... ?? 'null')` safety fix; the PR only adds an explanatory comment above it. Kept SKip's code and took the PR's comment.
- `src/app/widget-config/path-control-config/path-control-config.component.spec.ts` — Took the PR's completed `SignalKConnectionService` mock (the substance of the P2b commit, replacing the simpler `EMPTY`-based stub) and removed the now-unused `EMPTY` import.
- `src/app/core/services/widget.service.spec.ts` — Purely additive; took the PR's commented-out assertions and explanatory note for the commented-out electrical widget definitions.

Needs a build + review before merge.

---

This is an experimental replica carried in the fork for evaluation. It has not been built or test-run here (no npm/build steps were executed during replication).
