### PR TITLE
Await server writes before reload/refresh (fix misused-promise bugs) (replicates mxtommy/Kip #1089)

### DIFF
--- a/src/app/core/components/options/display/display.component.spec.ts
+++ b/src/app/core/components/options/display/display.component.spec.ts
@@ -41,8 +41,8 @@ class SettingsServiceMock {
     public getSplitShellSide() { return 'left' as const; }
     public getSplitShellSwipeDisabled() { return false; }
     public getWidgetHistoryDisabled() { return false; }
+    public getBrowserTabTitle() { return 'KIP'; }
     public getDisablePathValidation() { return false; }
-    public setDisablePathValidation(): void { }
     public setAutoNightMode(): void { }
     public setRedNightMode(): void { }
     public setNightModeBrightness(): void { }
@@ -53,6 +53,8 @@ class SettingsServiceMock {
     public setSplitShellSide(): void { }
     public setSplitShellSwipeDisabled(): void { }
     public setWidgetHistoryDisabled(): void { }
+    public setBrowserTabTitle(): void { }
+    public setDisablePathValidation(): void { }
 }
 
 class PluginConfigClientServiceMock {
@@ -142,6 +144,29 @@ describe('SettingsNotificationsComponent', () => {
         await flushPromises();
 
         expect(toast.show).toHaveBeenCalledWith("To enable Automatic Night Mode, the Derived Data plugin must be enabled. Do you wish to enable the plugin?", 0, false, 'warn', 'Ok');
+    });
+
+    it('shows an error and not a success toast when the KIP plugin config save fails', async () => {
+        const pluginService = TestBed.inject(PluginConfigClientService) as unknown as PluginConfigClientServiceMock;
+        pluginService.savePluginConfig.mockResolvedValue({ ok: false, error: { message: 'server rejected' } });
+
+        // Auto night mode is off -> straight to applyAndSaveSettings (the server save path).
+        component['saveAllSettings']();
+        await flushPromises();
+        await flushPromises();
+
+        expect(toast.show).toHaveBeenCalledWith('Failed to save KIP plugin configuration on server.', 0, false, 'error');
+        expect(toast.show).not.toHaveBeenCalledWith('Configuration saved', 1000, true, 'message');
+    });
+
+    it('shows the success toast when the KIP plugin config save succeeds', async () => {
+        // Default savePluginConfig mock resolves { ok: true }.
+        component['saveAllSettings']();
+        await flushPromises();
+        await flushPromises();
+
+        expect(toast.show).toHaveBeenCalledWith('Configuration saved', 1000, true, 'message');
+        expect(toast.show).not.toHaveBeenCalledWith('Failed to save KIP plugin configuration on server.', 0, false, 'error');
     });
 
     it('shows prompt for configuring sun flag only when plugin is enabled but sun flag is false', async () => {

--- a/src/app/core/components/options/display/display.component.ts
+++ b/src/app/core/components/options/display/display.component.ts
@@ -100,10 +100,10 @@ export class SettingsDisplayComponent implements OnInit {
       return;
     }
 
-    this.applyAndSaveSettings();
+    void this.applyAndSaveSettings();
   }
 
-  private applyAndSaveSettings(): void {
+  private async applyAndSaveSettings(): Promise<void> {
     this.settings.setAutoNightMode(this.autoNightMode());
     this.settings.setRedNightMode(this.isRedNightMode());
     this.settings.setNightModeBrightness(this.nightBrightness());
@@ -128,10 +128,15 @@ export class SettingsDisplayComponent implements OnInit {
     this.settings.setSplitShellSwipeDisabled(this.splitShellSwipeDisabled());
     this.settings.setWidgetHistoryDisabled(this.widgetHistoryDisabled());
     this.settings.setDisablePathValidation(this.isPathValidationDisabled());
-    if (!this.setKipPluginConfig()) {
-      this.toast.show('Failed to save KIP plugin configuration on server.', 0, false, 'error');
-    }
+    // Await the server write; setKipPluginConfig() returns a Promise, so the old
+    // `if (!this.setKipPluginConfig())` was always false (a Promise is truthy) —
+    // the error branch was dead and "Configuration saved" lied on failure.
+    const ok = await this.setKipPluginConfig();
     this.displayForm()?.form.markAsPristine();
+    if (!ok) {
+      this.toast.show('Failed to save KIP plugin configuration on server.', 0, false, 'error');
+      return;
+    }
     this.toast.show("Configuration saved", 1000, true, 'message');
   }
 
@@ -140,7 +145,7 @@ export class SettingsDisplayComponent implements OnInit {
     if (seq !== this._pluginCheckSeq) return;
 
     if (isValid) {
-      this.applyAndSaveSettings();
+      await this.applyAndSaveSettings();
     } else {
       // Reset toggle and abort save
       this.autoNightMode.set(false);

--- a/src/app/core/services/configuration-upgrade.service.spec.ts
+++ b/src/app/core/services/configuration-upgrade.service.spec.ts
@@ -50,4 +50,25 @@ describe('ConfigurationUpgradeService', () => {
         expect(mockStorage.listConfigs).toHaveBeenCalledWith(9);
         expect(service.error()).toBeNull();
     });
+
+    it('startFresh retires BOTH global and user legacy configs via an awaited write before resetting', async () => {
+        mockStorage.initConfig = null; // remote (Signal K) path
+        mockStorage.listConfigs.mockResolvedValueOnce([
+            { scope: 'global', name: 'gconf' },
+            { scope: 'user', name: 'uconf' }
+        ]);
+        mockStorage.getConfig.mockImplementation(async () => ({ app: { configVersion: 10 } }));
+
+        service.startFresh();
+
+        // The reset (which reloads the page) must run only after retiring completes.
+        await vi.waitFor(() => expect(mockAppSettings.resetSettings).toHaveBeenCalled());
+
+        // Global must be retired via an awaited setConfig (not a deferred fire-and-forget),
+        // to legacy file version 9 with configVersion 0 — same as the user scope.
+        expect(mockStorage.setConfig).toHaveBeenCalledWith(
+            'global', 'gconf', expect.objectContaining({ app: expect.objectContaining({ configVersion: 0 }) }), 9);
+        expect(mockStorage.setConfig).toHaveBeenCalledWith(
+            'user', 'uconf', expect.objectContaining({ app: expect.objectContaining({ configVersion: 0 }) }), 9);
+    });
 });

--- a/src/app/core/services/configuration-upgrade.service.ts
+++ b/src/app/core/services/configuration-upgrade.service.ts
@@ -206,22 +206,16 @@ export class ConfigurationUpgradeService {
           for (const rootConfig of rootConfigs) {
             const oldConfiguration = await this._storage.getConfig(rootConfig.scope, rootConfig.name, this.legacyFileVersion) as unknown as IConfig;
             oldConfiguration.app.configVersion = 0; // retire
-            if (rootConfig.scope === 'global') {
-              try {
-                setTimeout(() => {
-                  this._storage.patchGlobal(rootConfig.name, rootConfig.scope, oldConfiguration, 'replace', this.legacyFileVersion);
-                  this.pushMsg(`[Retired] Configuration ${rootConfig.scope}/${rootConfig.name} patched to version 0.`);
-                }, 750);
-              } catch {
-                this.pushError(`[Upgrade] Error saving configuration for ${rootConfig.name}.`);
-              }
-            } else {
-              try {
-                await this._storage.setConfig(rootConfig.scope, rootConfig.name, oldConfiguration, this.legacyFileVersion);
-                this.pushMsg(`[Retired] Configuration ${rootConfig.scope}/${rootConfig.name} patched to version 0.`);
-              } catch {
-                this.pushError(`[Upgrade] Error saving configuration for ${rootConfig.name}.`);
-              }
+            try {
+              // Await the retire write for BOTH scopes so it completes before the
+              // finally() block runs resetSettings() and reloads the page. The old
+              // 'global' branch scheduled a deferred, un-awaited patchGlobal (via
+              // setTimeout) that the reload aborted, leaving the legacy global config
+              // un-retired. Mirror the awaited setConfig pattern used by runUpgrade().
+              await this._storage.setConfig(rootConfig.scope, rootConfig.name, oldConfiguration, this.legacyFileVersion);
+              this.pushMsg(`[Retired] Configuration ${rootConfig.scope}/${rootConfig.name} patched to version 0.`);
+            } catch {
+              this.pushError(`[Upgrade] Error saving configuration for ${rootConfig.name}.`);
             }
           }
         })

--- a/src/app/core/services/dashboard-history-series-sync.service.spec.ts
+++ b/src/app/core/services/dashboard-history-series-sync.service.spec.ts
@@ -339,6 +339,49 @@ describe('DashboardHistorySeriesSyncService', () => {
         expect(windSpeed?.path).toBe('self.environment.wind.speedTrue');
     });
 
+    it('retries on the next cycle when a reconcile fails (resolves null instead of throwing)', async () => {
+        vi.useFakeTimers();
+        TestBed.inject(DashboardHistorySeriesSyncService);
+        connectionStub.serverServiceEndpoint$.next({
+            operation: 2,
+            message: 'Connected',
+            serverDescription: 'Signal K',
+            httpServiceUrl: 'http://localhost:3000/signalk/v1/api/',
+            WsServiceUrl: 'ws://localhost:3000/signalk/v1/stream'
+        });
+
+        // First reconcile attempt "fails": reconcileSeries returns null (it does not throw).
+        reconcileSpy.mockResolvedValueOnce(null);
+
+        dashboardStub.dashboards.set([
+            {
+                id: 'dash-1',
+                name: 'Dashboard 1',
+                icon: 'dashboard-dashboard',
+                configuration: [
+                    createAutomaticNode('widget-numeric-1', 'widget-numeric', { source: 'default', period: 10 })
+                ]
+            }
+        ]);
+        await vi.advanceTimersByTimeAsync(800);
+        expect(reconcileSpy).toHaveBeenCalledTimes(1);
+
+        // Re-emit the SAME series content (new array reference). Because the prior attempt
+        // failed, the signature must NOT have been marked submitted, so this retries.
+        dashboardStub.dashboards.set([
+            {
+                id: 'dash-1',
+                name: 'Dashboard 1',
+                icon: 'dashboard-dashboard',
+                configuration: [
+                    createAutomaticNode('widget-numeric-1', 'widget-numeric', { source: 'default', period: 10 })
+                ]
+            }
+        ]);
+        await vi.advanceTimersByTimeAsync(800);
+        expect(reconcileSpy).toHaveBeenCalledTimes(2);
+    });
+
     it('should skip reconcile when history series service mode is disabled', async () => {
         vi.useFakeTimers();
         TestBed.inject(DashboardHistorySeriesSyncService);

--- a/src/app/core/services/dashboard-history-series-sync.service.ts
+++ b/src/app/core/services/dashboard-history-series-sync.service.ts
@@ -127,8 +127,15 @@ export class DashboardHistorySeriesSyncService {
     }
 
     try {
-      await this.kipSeries.reconcileSeries(nextSeries);
-      this.lastSubmittedSignature = nextSignature;
+      // reconcileSeries resolves to null on failure (it swallows errors and does
+      // NOT throw), so we must inspect the result. Only mark the signature as
+      // submitted on a real success; otherwise leave it unset so the next cycle retries.
+      const result = await this.kipSeries.reconcileSeries(nextSeries);
+      if (result) {
+        this.lastSubmittedSignature = nextSignature;
+      } else {
+        console.warn('[DashboardHistorySeriesSyncService] Reconcile did not complete; will retry on next cycle');
+      }
     } catch (error) {
       console.error('[DashboardHistorySeriesSyncService] Reconcile failed:', error);
       // Don't update lastSubmittedSignature so next cycle will retry

--- a/src/app/core/services/profile.service.spec.ts
+++ b/src/app/core/services/profile.service.spec.ts
@@ -22,7 +22,7 @@ function makeStorageMock(userNames: string[] = ['default', 'profileA']) {
     ),
     getConfig: vi.fn<(scope: string, name: string) => Promise<IConfig>>(() => Promise.resolve(cfg('fromGet'))),
     setConfig: vi.fn<(scope: string, name: string, config: IConfig) => Promise<null>>(() => Promise.resolve(null)),
-    removeItem: vi.fn<(scope: string, name: string) => void>(() => undefined),
+    removeItem: vi.fn<(scope: string, name: string) => Promise<void>>(() => Promise.resolve()),
     awaitQueueDrain: vi.fn<() => Promise<boolean>>(() => Promise.resolve(true))
   };
 }

--- a/src/app/core/services/profile.service.ts
+++ b/src/app/core/services/profile.service.ts
@@ -129,7 +129,8 @@ export class ProfileService {
       }
       await this.storage.setConfig(PROFILE_SCOPE, normalized, sourceConfig);
 
-      this.storage.removeItem(PROFILE_SCOPE, oldName);
+      // Failure is surfaced via awaitQueueDrain() below; swallow the per-write rejection.
+      void this.storage.removeItem(PROFILE_SCOPE, oldName).catch(() => undefined);
       const drained = await this.storage.awaitQueueDrain();
       if (!drained) {
         console.warn(`[ProfileService] Old profile slot "${oldName}" may not have been removed; an orphan copy could remain until the next refresh.`);
@@ -156,7 +157,8 @@ export class ProfileService {
       if (this.existingNames().length <= 1) {
         throw new Error('The last remaining profile cannot be deleted.');
       }
-      this.storage.removeItem(PROFILE_SCOPE, name);
+      // Failure is surfaced via awaitQueueDrain() below; swallow the per-write rejection.
+      void this.storage.removeItem(PROFILE_SCOPE, name).catch(() => undefined);
       const drained = await this.storage.awaitQueueDrain();
       await this.refresh();
       if (!drained) {

--- a/src/app/core/services/settings.service.spec.ts
+++ b/src/app/core/services/settings.service.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { SettingsService } from './settings.service';
 import { StorageService } from './storage.service';
 import { ensureLocalStorage } from '../../../test-helpers/local-storage.test-helper';
@@ -244,9 +245,50 @@ describe('SettingsService', () => {
       const service = createService({ useSharedConfig: true, sharedConfigName: 'profileA' });
       const storage = TestBed.inject(StorageService);
       storage.storageServiceReady$.next(true);
-      const setSpy = vi.spyOn(storage, 'setConfig').mockImplementation(() => undefined);
+      const setSpy = vi.spyOn(storage, 'setConfig').mockResolvedValue(undefined);
+      vi.spyOn(service, 'reloadApp').mockImplementation(() => undefined);
       service.loadDemoConfig();
       expect(setSpy).toHaveBeenCalledWith('user', 'profileA', expect.objectContaining({ app: expect.anything() }));
+    });
+
+    it('reloads only after the demo config save resolves', async () => {
+      const service = createService({ useSharedConfig: true, sharedConfigName: 'profileA' });
+      const storage = TestBed.inject(StorageService);
+      storage.storageServiceReady$.next(true);
+      let resolveSave!: (value: unknown) => void;
+      vi.spyOn(storage, 'setConfig').mockReturnValue(
+        new Promise((resolve) => { resolveSave = resolve; })
+      );
+      const reloadSpy = vi.spyOn(service, 'reloadApp').mockImplementation(() => undefined);
+
+      service.loadDemoConfig();
+      await Promise.resolve();
+
+      // Reload must wait for the write, not race it.
+      expect(reloadSpy).not.toHaveBeenCalled();
+
+      resolveSave(null);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(reloadSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not reload and surfaces an error when the demo config save fails', async () => {
+      const service = createService({ useSharedConfig: true, sharedConfigName: 'profileA' });
+      const storage = TestBed.inject(StorageService);
+      storage.storageServiceReady$.next(true);
+      vi.spyOn(storage, 'setConfig').mockRejectedValue(new Error('network down'));
+      const reloadSpy = vi.spyOn(service, 'reloadApp').mockImplementation(() => undefined);
+      const snack = TestBed.inject(MatSnackBar);
+      const snackSpy = vi.spyOn(snack, 'open').mockImplementation(() => undefined as never);
+
+      service.loadDemoConfig();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(reloadSpy).not.toHaveBeenCalled();
+      expect(snackSpy).toHaveBeenCalled();
     });
   });
 });

--- a/src/app/core/services/settings.service.ts
+++ b/src/app/core/services/settings.service.ts
@@ -675,8 +675,24 @@ export class SettingsService {
         theme: DemoThemeConfig
       };
       console.log("[AppSettings Service] Loading Demo configuration settings as remote config: " + this.useServerStorage + " and reloading app.");
-      this.storage.setConfig('user', this.sharedConfigName, demoConfig);
-      this.reloadApp();
+      // Wait for the server write to land before reloading; reloading mid-request
+      // aborts the POST and leaves the previous configuration in place. Storage
+      // readiness is already guaranteed by the guard above.
+      this.storage.setConfig('user', this.sharedConfigName, demoConfig)
+        .then(() => {
+          this.reloadApp();
+        })
+        .catch(error => {
+          console.error("[AppSettings Service] Error saving demo configuration to the server", error);
+          this.snackBar.open(
+            'Problem saving configuration to the server. Resolve this issue before KIP can be used reliably.',
+            'Close',
+            {
+              duration: 0,
+              verticalPosition: 'top'
+            }
+          );
+        });
     } else {
       console.log("[AppSettings Service] Loading Demo configuration settings to LocalStorage");
       this.replaceConfig("appConfig", DemoAppConfig);

--- a/src/app/core/services/storage.service.spec.ts
+++ b/src/app/core/services/storage.service.spec.ts
@@ -1,3 +1,4 @@
+import { TestBed } from '@angular/core/testing';
 import { HttpTestingController } from '@angular/common/http/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { StorageService } from './storage.service';

--- a/src/app/core/services/storage.service.spec.ts
+++ b/src/app/core/services/storage.service.spec.ts
@@ -1,4 +1,3 @@
-import { TestBed } from '@angular/core/testing';
 import { HttpTestingController } from '@angular/common/http/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { StorageService } from './storage.service';
@@ -93,6 +92,43 @@ describe('StorageService', () => {
       http.expectOne(() => true).flush(null);
       await expect(drain).resolves.toBe(true);
       http.verify();
+    });
+  });
+
+  describe('removeItem completion', () => {
+    beforeEach(() => {
+      service.storageServiceReady$.next(true);
+      service.activeConfigFileVersion = 11;
+      service.sharedConfigName = 'p';
+    });
+
+    afterEach(() => http.verify());
+
+    it('resolves only after the queued delete request completes', async () => {
+      let resolved = false;
+      const done = service.removeItem('user', 'race-config').then(() => { resolved = true; });
+
+      // The request is dispatched synchronously through the patch queue...
+      const req = http.expectOne((r) => r.method === 'POST');
+      // ...but the promise must not resolve until the server responds.
+      await Promise.resolve();
+      expect(resolved).toBe(false);
+
+      req.flush(null);
+      await done;
+
+      expect(resolved).toBe(true);
+    });
+
+    it('rejects on failure yet the patch queue keeps processing', async () => {
+      const first = service.removeItem('user', 'first');
+      http.expectOne((r) => r.method === 'POST').flush('boom', { status: 500, statusText: 'err' });
+      await expect(first).rejects.toBeTruthy();
+
+      // A failed delete must not kill the sequential queue for later operations.
+      const second = service.removeItem('user', 'second');
+      http.expectOne((r) => r.method === 'POST').flush(null);
+      await expect(second).resolves.toBeUndefined();
     });
   });
 });

--- a/src/app/core/services/storage.service.ts
+++ b/src/app/core/services/storage.service.ts
@@ -25,7 +25,10 @@ export interface IStorageRemoteBootstrapContext {
 interface IPatchAction {
   url: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  document: any
+  document: any,
+  // Optional deferred handlers so callers can await a queued patch's completion.
+  resolve?: () => void,
+  reject?: (error: unknown) => void
 }
 
 @Injectable({
@@ -56,8 +59,21 @@ export class StorageService {
     //console.log(`[Storage Service] Send patch request:\n${JSON.stringify(arg.document)}`);
     return this.http.post(arg.url, arg.document)
       .pipe(
-        tap(() => console.log("[Storage Service] Remote config patch request completed successfully")),
-        catchError((error) => this.handleError(error))
+        tap({
+          next: () => console.log("[Storage Service] Remote config patch request completed successfully"),
+          // Settle on completion (not on the value emission) so the deferred
+          // promise resolves whenever the request terminates successfully, even
+          // if the response body is empty.
+          complete: () => arg.resolve?.()
+        }),
+        catchError((error) => {
+          this.logError(error);
+          arg.reject?.(error);
+          // Rethrow so the queue's outer catchError can count the failure
+          // (_patchFailures) and keep the sequential queue alive. Swallowing
+          // here would hide failures from awaitQueueDrain.
+          throw error;
+        })
       );
   }
 
@@ -536,7 +552,7 @@ export class StorageService {
    *
    * @memberof StorageService
    */
-  public removeItem(scope: string, name: string, forceConfigFileVersion?: number) {
+  public removeItem(scope: string, name: string, forceConfigFileVersion?: number): Promise<void> {
     this.ensureReady();
     this.assertSlotName(name, 'removeItem');
     let url = this.serverEndpoint + scope + "/kip/" + this.configFileVersion;
@@ -550,8 +566,14 @@ export class StorageService {
           "path": `/${name}`
         }
       ]
-    const patch: IPatchAction = { url, document };
-    this.enqueuePatch(patch);
+    // Resolve only once the queued delete patch has actually run on the server,
+    // so callers can refresh their config list against the post-delete state.
+    // Route through enqueuePatch to preserve the pending-patch accounting that
+    // awaitQueueDrain relies on.
+    return new Promise<void>((resolve, reject) => {
+      const patch: IPatchAction = { url, document, resolve, reject };
+      this.enqueuePatch(patch);
+    });
   }
 
   /**
@@ -608,7 +630,7 @@ export class StorageService {
     return this._isRemoteContextBootstrapped;
   }
 
-  private handleError(error: HttpErrorResponse) {
+  private logError(error: HttpErrorResponse) {
     if (error.status === 0) {
       // A client-side or network error occurred. Handle it accordingly.
       console.error('[Storage Service] An error occurred:', error.error);
@@ -617,7 +639,11 @@ export class StorageService {
       // The response body may contain clues as to what went wrong.
       console.error(`[Storage Service] Backend returned error: `, error.message);
     }
-    // Return an observable with a user-facing error message.
+  }
+
+  private handleError(error: HttpErrorResponse) {
+    this.logError(error);
+    // Rethrow so awaiting callers (get/set/list) observe the failure.
     throw error;
   }
 


### PR DESCRIPTION
Replicates upstream PR https://github.com/mxtommy/Kip/pull/1089 ("Await server writes before reload/refresh (fix misused-promise bugs)") by dillan.

**Method:** commit-by-commit cherry-pick (the upstream PR is linear, no merge commits), preserving each original author.

This is an experimental replica carried in the fork for evaluation. It has not been built or test-run here; treat it as a candidate for review rather than a finished change.

## ⚠️ Conflict resolution applied

SKip has diverged substantially from upstream in the config/storage write path (profile-based configuration UI, a reworked patch queue with pending/failure accounting). The following files required hand-resolution:

- **src/app/core/services/storage.service.ts** — Kept SKip's existing patch queue (`_pendingPatches$` / `_patchFailures` / `enqueuePatch` / `awaitQueueDrain`) and layered the PR's per-patch deferred `resolve`/`reject` on top. Critically, the PR's `patch()` `catchError` swallowed the error with `of(null)`; that would have hidden failures from SKip's outer queue `catchError`, leaving `_patchFailures` stuck at 0 and making `awaitQueueDrain` falsely report success. Changed it to fire `arg.reject` then **re-throw**, so SKip's outer layer still counts the failure and keeps the queue alive. `removeItem` now returns `Promise<void>` but routes through `enqueuePatch` (not raw `patchQueue$.next`) to preserve the pending-patch accounting.
- **src/app/core/components/options/configuration/config.component.ts** — Kept SKip's version entirely. SKip replaced the upstream `saveConfig`/`deleteConfig`/restore flow with a profile-based service that already `await`s every server operation before reload/refresh, so the PR's intent is already satisfied here by different means; the methods the PR patched no longer exist in SKip.
- **src/app/core/components/options/configuration/config.component.spec.ts** — Kept SKip's version (the PR's new tests target the removed `saveConfig`/`deleteConfig` methods).
- **src/app/core/services/settings.service.ts** — Applied the PR's await-then-reload intent to `loadDemoConfig`, keeping SKip's `useServerStorage` naming and dropping the PR's now-redundant inner readiness check (SKip already early-returns when storage is not ready).
- **src/app/core/services/settings.service.spec.ts** — Kept SKip's existing `loadDemoConfig` tests, fixed SKip's "writes when ready" test whose `setConfig` mock returned `undefined` (now broken because `loadDemoConfig` chains `.then`), and ported the PR's await-sequencing tests in SKip's `createService`/real-`StorageService`-spy style (adapted `useSharedConfig` → driven via `createService`).
- **src/app/core/services/storage.service.spec.ts** — Kept SKip's `HttpTestingController` harness and re-added the PR's two `removeItem` completion tests adapted to that harness (the PR used a different `HttpClient` mock setup incompatible with SKip's).
- **src/app/core/components/options/display/display.component.spec.ts** — Resolved a `SettingsServiceMock` overlap so `getDisablePathValidation`/`setDisablePathValidation`/`getBrowserTabTitle`/`setBrowserTabTitle` each appear exactly once.

Needs a build + review before merge.

The remaining commits (history-series reconcile retry, configuration-upgrade start-fresh, display.component result reporting) applied cleanly against SKip.
