### PR TITLE
docs(readme): add SKip logo to the header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="./src/assets/skip-logo.svg" alt="SKip logo" width="120">
+</p>
+
 # SKip – Signal K Multi-Function Display (MFD) and Marine Instrument Panel
 
 > **SKip** is an experimental [Hat Labs](https://hatlabs.fi) fork of [Kip](https://github.com/mxtommy/Kip) by Thomas St.Pierre and David Godin, maintained for [HaLOS](https://halos.fi). It adds standard Signal K session/SSO authentication and account-independent named profiles, and may diverge from upstream as it evolves. The webapp is served at `/@halos-org/skip/`. Licensed under MIT (see [LICENSE](LICENSE)).


### PR DESCRIPTION
Adds the SKip compass logo (`src/assets/skip-logo.svg`) centered above the README title.

This is a repo-level identity we *can* control — unlike the `owner / repo` breadcrumb avatar, which is the halos-org org avatar and shared across all org repos. The logo's colored fills (blue/gold) render on both light and dark GitHub themes, and the H1 stays a markdown heading so anchors are unaffected.

Doc-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)