### PR TITLE
chore: rename brand "SKip" to "Skip"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this is
 
-SKip — an Angular 21 (zoneless, signals, new control flow) Signal K marine multi-function display. A **standalone fork** of `mxtommy/kip` (not a GitHub fork object), rebranded `@halos-org/skip`, maintained for HaLOS. It's a Signal K webapp the SK server serves at the path `/@halos-org/skip/` (its own npm package name). The `upstream` remote points at `mxtommy/kip` for occasional cherry-picking. The fork's reason to exist is its auth + profiles work (below), which upstream did not accept.
+Skip — an Angular 21 (zoneless, signals, new control flow) Signal K marine multi-function display. A **standalone fork** of `mxtommy/kip` (not a GitHub fork object), rebranded `@halos-org/skip`, maintained for HaLOS. It's a Signal K webapp the SK server serves at the path `/@halos-org/skip/` (its own npm package name). The `upstream` remote points at `mxtommy/kip` for occasional cherry-picking. The fork's reason to exist is its auth + profiles work (below), which upstream did not accept.
 
 **Staying rebaseable on upstream is an explicit non-goal.** Pulling an upstream feature in may mean partially reimplementing it. Design decisions weigh correctness and our own maintenance cost — never rebase risk or whether code is upstream-maintained vs. fork-added. When upstream *is* pulled in, the CI re-apply notes (see "Testing reality" and "Fork-specific gotchas") still apply opportunistically, but they never constrain what we choose to change or remove.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
 Copyright (c) 2023 mxtommy
-Copyright (c) 2026 Hat Labs Ltd. and SKip contributors
+Copyright (c) 2026 Hat Labs Ltd. and Skip contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
 Copyright (c) 2023 mxtommy
-Copyright (c) 2026 Hat Labs Ltd. and Skip contributors
+Copyright (c) 2026 Hat Labs Oy and Skip contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Skip – Signal K Multi-Function Display (MFD) and Marine Instrument Panel
 
-> **Skip** is an experimental [Hat Labs](https://hatlabs.fi) fork of [Kip](https://github.com/mxtommy/Kip) by Thomas St.Pierre and David Godin, maintained for [HaLOS](https://halos.fi). It adds standard Signal K session/SSO authentication and account-independent named profiles, and may diverge from upstream as it evolves. The webapp is served at `/@halos-org/skip/`. Licensed under MIT (see [LICENSE](LICENSE)).
+> **Skip** is an experimental [HaLOS](https://halos.fi) fork of [Kip](https://github.com/mxtommy/Kip) by Thomas St.Pierre and David Godin. It adds standard Signal K session/SSO authentication and account-independent named profiles, and may diverge from upstream as it evolves. The webapp is served at `/@halos-org/skip/`. Licensed under MIT (see [LICENSE](LICENSE)).
 
 *Original Kip readme follows.*
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <p align="center">
-  <img src="./src/assets/skip-logo.svg" alt="SKip logo" width="120">
+  <img src="./src/assets/skip-logo.svg" alt="Skip logo" width="120">
 </p>
 
-# SKip – Signal K Multi-Function Display (MFD) and Marine Instrument Panel
+# Skip – Signal K Multi-Function Display (MFD) and Marine Instrument Panel
 
-> **SKip** is an experimental [Hat Labs](https://hatlabs.fi) fork of [Kip](https://github.com/mxtommy/Kip) by Thomas St.Pierre and David Godin, maintained for [HaLOS](https://halos.fi). It adds standard Signal K session/SSO authentication and account-independent named profiles, and may diverge from upstream as it evolves. The webapp is served at `/@halos-org/skip/`. Licensed under MIT (see [LICENSE](LICENSE)).
+> **Skip** is an experimental [Hat Labs](https://hatlabs.fi) fork of [Kip](https://github.com/mxtommy/Kip) by Thomas St.Pierre and David Godin, maintained for [HaLOS](https://halos.fi). It adds standard Signal K session/SSO authentication and account-independent named profiles, and may diverge from upstream as it evolves. The webapp is served at `/@halos-org/skip/`. Licensed under MIT (see [LICENSE](LICENSE)).
 
 *Original Kip readme follows.*
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   ],
   "signalk": {
     "appIcon": "assets/icon-72x72.png",
-    "displayName": "SKip Instrument MFD"
+    "displayName": "Skip Instrument MFD"
   },
   "main": "plugin/index.js",
   "files": [

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" name="viewport" content="user-scalable=no, width=device-width, initial-scale=1, maximum-scale=1">
-    <title>SKip</title>
+    <title>Skip</title>
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,8 +5,8 @@
   "display": "fullscreen",
   "scope": "/@halos-org/skip/",
   "start_url": "/@halos-org/skip/",
-  "name": "SKip Instrument MFD",
-  "short_name": "SKip",
+  "name": "Skip Instrument MFD",
+  "short_name": "Skip",
   "description": "An advanced and versatile marine instrumentation package to display Signal K data.",
   "orientation": "landscape",
   "icons": [


### PR DESCRIPTION
Executive decision: the `SKip` capitalization is awkward — use **Skip** everywhere.

Case-sensitive replacement of the brand token `SKip` → `Skip` across the 6 files that contained it (README, CLAUDE.md, LICENSE, `package.json` `displayName`, `src/manifest.json` name/short_name, `src/index.html` title). 9 occurrences total.

Also in this PR:
- Reframes the README description to characterize Skip as an experimental **HaLOS** fork (rather than a "Hat Labs" fork), dropping the now-redundant "maintained for HaLOS" clause.
- Corrects the LICENSE copyright holder from "Hat Labs Ltd." to **"Hat Labs Oy"** (the company's actual Finnish Osakeyhtiö registration; "Ltd." was a copy-propagated error).

Deliberately unchanged:
- The npm package name and serving path `@halos-org/skip` / `/@halos-org/skip/` (already lowercase).
- Upstream `Kip` / `mxtommy/kip` references.
- The `skip-logo.svg` asset filename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
