### PR TITLE
fix(settings): trim the browser tab title before storing

### DIFF
--- a/src/app/core/services/settings.service.ts
+++ b/src/app/core/services/settings.service.ts
@@ -474,7 +474,9 @@ export class SettingsService {
   }
 
   public setBrowserTabTitle(title: string) {
-    this.browserTabTitle.next(title);
+    // Trim before storing so a padded/whitespace-only value isn't persisted (the resolver already
+    // trims for display; this keeps the saved config clean and blank values normalized to '').
+    this.browserTabTitle.next((title ?? '').trim());
     const appConf = this.buildAppStorageObject();
 
     if (this.useSharedConfig) {


### PR DESCRIPTION
Re-lands the trim fix from the content review of #63 (configurable browser tab title). #63 was merged at its pre-fix head (out of band), so its review fix — trimming the stored value — never reached main; this follow-up delivers it.

**What:** `setBrowserTabTitle` persisted the raw value; only the resolver trimmed for display, so a padded or whitespace-only tab title was stored verbatim. Trim on store and normalize blank to `''` (the resolver still falls back to the default `SKip`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)