### PR TITLE
fix(help-docs): point the Video Widget menu entry at the real file

### DIFF
--- a/src/assets/help-docs/menu.json
+++ b/src/assets/help-docs/menu.json
@@ -20,7 +20,7 @@
       },
       {
         "title": "The Video Widget",
-        "file": "videowidget.md"
+        "file": "video-widget.md"
       },
       {
         "title": "Video Recipes (step by step)",


### PR DESCRIPTION
`menu.json` referenced `videowidget.md`, but the help doc file is `video-widget.md`, so opening the "The Video Widget" help topic 404s. One-character fix to match the actual filename. Surfaced while integrating the video widget (#61).

🤖 Generated with [Claude Code](https://claude.com/claude-code)