### PR TITLE
fix(iframe): validate postMessage origin/source and sandbox the iframe

### DIFF
--- a/src/app/widgets/widget-iframe/widget-iframe.component.html
+++ b/src/app/widgets/widget-iframe/widget-iframe.component.html
@@ -6,6 +6,7 @@
     height="100%"
     frameborder="0"
     class="widgetIframe"
+    sandbox="allow-same-origin allow-scripts allow-forms"
   ></iframe>
 } @else {
   <div style="padding: 15px;">

--- a/src/app/widgets/widget-iframe/widget-iframe.component.spec.ts
+++ b/src/app/widgets/widget-iframe/widget-iframe.component.spec.ts
@@ -1,0 +1,80 @@
+import { signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { WidgetIframeComponent } from './widget-iframe.component';
+import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
+import { DashboardService } from '../../core/services/dashboard.service';
+import type { IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
+
+const INSTANCE_ID = 'test-iframe-id';
+const EMBED_URL = `${window.location.origin}/embed`;
+
+function swipeDownFrom(source: MessageEventSource | null, origin: string): void {
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      data: { gesture: 'swipedown', eventData: { instanceId: INSTANCE_ID } },
+      origin,
+      source
+    })
+  );
+}
+
+function mount(url: string | null = EMBED_URL) {
+  const options = signal<IWidgetSvcConfig | undefined>({ widgetUrl: url, allowInput: true });
+  const dashboard = {
+    isDashboardStatic: () => true,
+    navigateToNextDashboard: vi.fn(),
+    navigateToPreviousDashboard: vi.fn()
+  };
+  TestBed.configureTestingModule({
+    imports: [WidgetIframeComponent],
+    providers: [
+      { provide: WidgetRuntimeDirective, useValue: { options } },
+      { provide: DashboardService, useValue: dashboard }
+    ]
+  });
+  const fixture = TestBed.createComponent(WidgetIframeComponent);
+  fixture.componentRef.setInput('id', INSTANCE_ID);
+  fixture.componentRef.setInput('type', 'widget-iframe');
+  fixture.componentRef.setInput('theme', null);
+  fixture.detectChanges();
+  return { fixture, dashboard };
+}
+
+function iframeWindow(fixture: ComponentFixture<WidgetIframeComponent>): Window {
+  const iframe = fixture.nativeElement.querySelector('iframe') as HTMLIFrameElement | null;
+  const win = iframe?.contentWindow ?? null;
+  expect(win).toBeTruthy();
+  return win as Window;
+}
+
+describe('WidgetIframeComponent', () => {
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('should create', () => {
+    expect(mount().fixture.componentInstance).toBeTruthy();
+  });
+
+  it('sandboxes the iframe to the minimal capabilities it needs', () => {
+    const iframe = mount().fixture.nativeElement.querySelector('iframe') as HTMLIFrameElement;
+    expect(iframe.getAttribute('sandbox')).toBe('allow-same-origin allow-scripts allow-forms');
+  });
+
+  it('acts on a gesture message from its own iframe', () => {
+    const { fixture, dashboard } = mount();
+    swipeDownFrom(iframeWindow(fixture), window.location.origin);
+    expect(dashboard.navigateToNextDashboard).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a gesture message from a foreign window source', () => {
+    const { dashboard } = mount();
+    swipeDownFrom(window, window.location.origin);
+    expect(dashboard.navigateToNextDashboard).not.toHaveBeenCalled();
+  });
+
+  it('ignores a gesture message whose origin is not the iframe origin', () => {
+    const { fixture, dashboard } = mount();
+    swipeDownFrom(iframeWindow(fixture), 'https://evil.invalid');
+    expect(dashboard.navigateToNextDashboard).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/widgets/widget-iframe/widget-iframe.component.ts
+++ b/src/app/widgets/widget-iframe/widget-iframe.component.ts
@@ -84,6 +84,19 @@ export class WidgetIframeComponent implements AfterViewInit, OnDestroy {
   private handleIframeGesture = (event: MessageEvent) => {
     if (!event.data) return;
 
+    // Only accept messages from this widget's own iframe; a foreign window that guessed the
+    // widget UUID must not drive navigation, toggle sidenavs, or inject synthetic key events.
+    let iframeWindow: Window | null = null;
+    try {
+      iframeWindow = this.iframe()?.nativeElement?.contentWindow ?? null;
+    } catch {
+      iframeWindow = null;
+    }
+    if (!iframeWindow || event.source !== iframeWindow) return;
+
+    const expectedOrigin = this.getExpectedIframeOrigin();
+    if (expectedOrigin && event.origin !== expectedOrigin) return;
+
     const instanceId = event.data?.eventData?.instanceId || event.data?.keyEventData?.instanceId;
     if (!instanceId || instanceId !== this.id()) return;
 
@@ -136,6 +149,16 @@ export class WidgetIframeComponent implements AfterViewInit, OnDestroy {
       iframeDocument.body.appendChild(script);
     } catch (e) {
       console.warn('[WidgetIframe] Failed to inject swipe script into iframe:', e);
+    }
+  }
+
+  private getExpectedIframeOrigin(): string | null {
+    const rawUrl = this.runtime.options()?.widgetUrl;
+    if (!rawUrl) return null;
+    try {
+      return new URL(rawUrl, window.location.origin).origin;
+    } catch {
+      return null;
     }
   }
 


### PR DESCRIPTION
## Why

The generic iframe widget handled `postMessage` events with no origin/source validation and rendered the iframe without a `sandbox` attribute (SEC-02) — any window could post to it, and embedded content ran with full privileges.

## What

- Validate incoming `postMessage` events by `event.source` (the iframe's `contentWindow`) and `event.origin` before handling, mirroring the existing guard in `widget-freeboardsk`.
- Add a `sandbox` attribute to the iframe with the minimal capabilities the embedded content needs.
- Spec asserts messages from a foreign source/origin are ignored.

**Accepted residual (P3):** once source/origin match, embedded content can still drive the widget — the same trust boundary the freeboard widget uses.

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zURudCY3TTRcNd2acknJ9
