### PR TITLE
refactor(signalk-options): make status fields signals and enable OnPush

### DIFF
--- a/src/app/core/components/options/signalk/signalk.component.html
+++ b/src/app/core/components/options/signalk/signalk.component.html
@@ -12,8 +12,8 @@
         </mat-form-field>
       </td>
       <td class="connect-cell">
-        <button mat-flat-button class="connect-btn" type="submit" [disabled]="!connectionForm.form.valid || isConnecting">
-          {{ isConnecting ? 'Validating...' : 'Connect' }}
+        <button mat-flat-button class="connect-btn" type="submit" [disabled]="!connectionForm.form.valid || isConnecting()">
+          {{ isConnecting() ? 'Validating...' : 'Connect' }}
         </button>
       </td>
     </tr>
@@ -55,8 +55,8 @@
     <div class="info-container">
       <pre>KIP: {{ app.appVersion() }}
 {{ app.browserVersion() }}, {{ app.osVersion() }}<br />
-{{ endpointServiceStatus.serverDescription }}
-{{ streamStatus.message }}, {{ isUserSession() ? 'Signed in' : 'Not signed in' }}
+{{ endpointServiceStatus().serverDescription }}
+{{ streamStatus().message }}, {{ isUserSession() ? 'Signed in' : 'Not signed in' }}
 Internet: {{ internetAvailabilityLabel() }}</pre>
     </div>
   </div>

--- a/src/app/core/components/options/signalk/signalk.component.spec.ts
+++ b/src/app/core/components/options/signalk/signalk.component.spec.ts
@@ -1,10 +1,15 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { SettingsSignalkComponent } from './signalk.component';
+import { SignalKConnectionService } from '../../../services/signalk-connection.service';
+import { SignalKDeltaService } from '../../../services/signalk-delta.service';
 
 describe('SettingsSignalkComponent', () => {
   let component: SettingsSignalkComponent;
   let fixture: ComponentFixture<SettingsSignalkComponent>;
+
+  const statusText = (): string =>
+    (fixture.nativeElement as HTMLElement).querySelector('pre')?.textContent ?? '';
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -21,5 +26,40 @@ describe('SettingsSignalkComponent', () => {
 
   it('should be created', () => {
     expect(component).toBeTruthy();
+  });
+
+  // The connection and delta services both re-emit the SAME mutated status object on each update.
+  // These tests emit a same-reference mutation (not a fresh literal) so they stay red unless the
+  // toSignal equal:()=>false override is present — a fresh-literal emit would pass either way.
+  it('updates the endpoint line on a same-reference status re-emit', () => {
+    const connection = TestBed.inject(SignalKConnectionService);
+    const status = {
+      operation: 2,
+      message: 'Connected',
+      serverDescription: 'signalk-server 2.5.0',
+      httpServiceUrl: 'http://localhost:3000',
+      WsServiceUrl: 'ws://localhost:3000'
+    };
+    connection.serverServiceEndpoint$.next(status);
+    fixture.detectChanges();
+    expect(statusText()).toContain('signalk-server 2.5.0');
+
+    status.serverDescription = 'signalk-server 2.6.0';
+    connection.serverServiceEndpoint$.next(status);
+    fixture.detectChanges();
+    expect(statusText()).toContain('signalk-server 2.6.0');
+  });
+
+  it('updates the stream line on a same-reference status re-emit', () => {
+    const delta = TestBed.inject(SignalKDeltaService);
+    const status = { operation: 2, message: 'Connected' };
+    delta.streamEndpoint$.next(status);
+    fixture.detectChanges();
+    expect(statusText()).toContain('Connected');
+
+    status.message = 'WebSocket closed';
+    delta.streamEndpoint$.next(status);
+    fixture.detectChanges();
+    expect(statusText()).toContain('WebSocket closed');
   });
 });

--- a/src/app/core/components/options/signalk/signalk.component.ts
+++ b/src/app/core/components/options/signalk/signalk.component.ts
@@ -1,12 +1,12 @@
-import { ElementRef, Component, OnInit, OnDestroy, AfterViewInit, viewChild, inject, DestroyRef, computed } from '@angular/core';
+import { ElementRef, Component, OnInit, OnDestroy, AfterViewInit, viewChild, inject, DestroyRef, computed, signal, ChangeDetectionStrategy } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { AppService } from '../../../services/app-service';
 import { ToastService } from '../../../services/toast.service';
 import { SettingsService } from '../../../services/settings.service';
 import { IConnectionConfig } from "../../../interfaces/app-settings.interfaces";
-import { SignalKConnectionService, IEndpointStatus } from '../../../services/signalk-connection.service';
+import { SignalKConnectionService } from '../../../services/signalk-connection.service';
 import { IDeltaUpdate, DataService } from '../../../services/data.service';
-import { SignalKDeltaService, IStreamStatus } from '../../../services/signalk-delta.service';
+import { SignalKDeltaService } from '../../../services/signalk-delta.service';
 import { AuthenticationService } from '../../../services/authentication.service';
 import { SsoRedirectService } from '../../../services/sso-redirect.service';
 import { ConnectionStateMachine } from '../../../services/connection-state-machine.service';
@@ -40,7 +40,8 @@ import { InternetReachabilityService } from '../../../services/internet-reachabi
     MatError,
     MatCheckbox,
     MatButton
-  ]
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 
 export class SettingsSignalkComponent implements OnInit, AfterViewInit, OnDestroy {
@@ -61,7 +62,7 @@ export class SettingsSignalkComponent implements OnInit, AfterViewInit, OnDestro
   protected readonly activityGraph = viewChild<ElementRef<HTMLCanvasElement>>('activityGraph');
 
   public connectionConfig: IConnectionConfig;
-  public isConnecting = false; // Loading state for connect button
+  protected readonly isConnecting = signal(false); // Loading state for connect button
 
   // The Connectivity tab shows the server session identity (SSO). These drive that identity block.
   protected readonly loginStatus = toSignal(this.auth.loginStatus$, { initialValue: null });
@@ -72,8 +73,14 @@ export class SettingsSignalkComponent implements OnInit, AfterViewInit, OnDestro
     this.ssoRedirect.manualSignIn();
   }
 
-  public endpointServiceStatus: IEndpointStatus;
-  public streamStatus: IStreamStatus;
+  // Both streams are BehaviorSubjects that replay their current value synchronously, so requireSync
+  // guarantees the view always has a status to render on first read. Both services re-emit the same
+  // mutated status object on each update, so equal:()=>false is required — the default Object.is
+  // equality would treat a same-reference re-emit as unchanged and drop the update under OnPush.
+  protected readonly endpointServiceStatus = toSignal(
+    this.signalKConnectionService.getServiceEndpointStatusAsO(), { requireSync: true, equal: () => false });
+  protected readonly streamStatus = toSignal(
+    this.deltaService.getDataStreamStatusAsO(), { requireSync: true, equal: () => false });
 
   protected readonly internetAvailabilityLabel = computed(() => {
     if (this.internetReachability.isChecking()) {
@@ -98,20 +105,6 @@ export class SettingsSignalkComponent implements OnInit, AfterViewInit, OnDestro
   ngOnInit() {
     // get Signal K connection configuration
     this.connectionConfig = this.settings.getConnectionConfig();
-
-    // get Signal K connection status
-    this.signalKConnectionService.getServiceEndpointStatusAsO().pipe(
-      takeUntilDestroyed(this.destroyRef)
-    ).subscribe((status: IEndpointStatus) => {
-      this.endpointServiceStatus = status;
-    });
-
-    // get Delta Service WebSocket stream status
-    this.deltaService.getDataStreamStatusAsO().pipe(
-      takeUntilDestroyed(this.destroyRef)
-    ).subscribe((status: IStreamStatus): void => {
-      this.streamStatus = status;
-    });
   }
 
   ngAfterViewInit(): void {
@@ -139,7 +132,7 @@ export class SettingsSignalkComponent implements OnInit, AfterViewInit, OnDestro
    */
   public async connectToServer() {
     // Start loading state
-    this.isConnecting = true;
+    this.isConnecting.set(true);
 
     try {
       console.log('[Settings-SignalK] Validating Signal K server before connecting...');
@@ -164,7 +157,7 @@ export class SettingsSignalkComponent implements OnInit, AfterViewInit, OnDestro
 
     } catch (error: unknown) {
       // Validation failed - show error and stay on current page
-      this.isConnecting = false;
+      this.isConnecting.set(false);
       const errorMessage = (error as Error)?.message || 'Unknown validation error';
       console.error('[Settings-SignalK] Server validation failed:', errorMessage);
       this.toast.show(`${errorMessage}`, 0, false, 'error');


### PR DESCRIPTION
## Why

The SignalK options component mutated two plain fields (`endpointServiceStatus`, `streamStatus`) inside RxJS subscribe callbacks. In the zoneless app that skips change detection, so the connectivity status block could render stale (ANG-01).

## What

- Convert `endpointServiceStatus` and `streamStatus` to `toSignal`, and `isConnecting` to a `signal`; add `ChangeDetectionStrategy.OnPush`.
- Both status streams re-emit the **same mutated object** on each update, so `toSignal` uses `equal: () => false` — the default `Object.is` equality would treat a same-reference re-emit as unchanged and drop it under OnPush.
- `isConnecting` had to become a signal too: OnPush otherwise strands its post-`await` reset, leaving the Connect button stuck on "Validating…" after a failed validation.
- Specs emit a same-reference mutation (not a fresh literal) so they stay red without the `equal` override.

The `equal:()=>false` and `isConnecting` handling address findings from the branch's own review pass. Verified locally: component spec green, lint + app build clean.

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zURudCY3TTRcNd2acknJ9
