### PR TITLE
fix(auth): stop unbounded sign-in loop under hash routing

### DIFF
--- a/src/app/core/utils/login-redirect.util.spec.ts
+++ b/src/app/core/utils/login-redirect.util.spec.ts
@@ -43,6 +43,15 @@ describe('isSafeReturnTo', () => {
   it('rejects the login self-route (avoids a redirect loop)', () => {
     expect(isSafeReturnTo('/login')).toBe(false);
   });
+
+  it('rejects the hash-routed login self-route (hash routing puts /login in the fragment)', () => {
+    expect(isSafeReturnTo('/#/login')).toBe(false);
+    expect(isSafeReturnTo('/#/login?returnTo=%2Fdashboard')).toBe(false);
+  });
+
+  it('accepts a non-login hash route', () => {
+    expect(isSafeReturnTo('/#/dashboard/0')).toBe(true);
+  });
 });
 
 describe('buildLoginRedirectUrl', () => {

--- a/src/app/core/utils/login-redirect.util.ts
+++ b/src/app/core/utils/login-redirect.util.ts
@@ -2,6 +2,19 @@
 // SSO bounce instead of returning the user to real content.
 const SELF_ROUTE_PATHS = ['/login'];
 
+// The app uses hash-based routing (main.ts withHashLocation), so KIP's own routes live in the URL
+// fragment: /#/login resolves to pathname '/' with hash '#/login'. Checking only the pathname would
+// let /#/login pass as a safe returnTo and loop the SSO bounce, so the fragment's route is checked too.
+function isSelfRoute(resolved: URL): boolean {
+  if (SELF_ROUTE_PATHS.includes(resolved.pathname)) {
+    return true;
+  }
+  const fragment = resolved.hash.startsWith('#') ? resolved.hash.slice(1) : '';
+  const queryIndex = fragment.indexOf('?');
+  const fragmentPath = queryIndex >= 0 ? fragment.slice(0, queryIndex) : fragment;
+  return SELF_ROUTE_PATHS.includes(fragmentPath);
+}
+
 /**
  * Validates a returnTo target for the SSO redirect. Accepts only site-relative paths on the app's
  * own origin; rejects protocol-relative (`//host`), backslash (normalized to `/` by browsers),
@@ -38,7 +51,7 @@ export function isSafeReturnTo(target: string | null | undefined): boolean {
   if (resolved.pathname.startsWith('//')) {
     return false;
   }
-  return !SELF_ROUTE_PATHS.includes(resolved.pathname);
+  return !isSelfRoute(resolved);
 }
 
 /**

--- a/src/app/widgets/widget-login/login.component.spec.ts
+++ b/src/app/widgets/widget-login/login.component.spec.ts
@@ -2,32 +2,42 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { WidgetLoginComponent } from './widget-login.component';
 import { SsoRedirectService } from '../../core/services/sso-redirect.service';
+import { AuthenticationService, ILoginStatus } from '../../core/services/authentication.service';
 
 describe('WidgetLoginComponent', () => {
-  let component: WidgetLoginComponent;
   let fixture: ComponentFixture<WidgetLoginComponent>;
   const manualSignIn = vi.fn();
 
-  beforeEach(async () => {
-    manualSignIn.mockClear();
+  async function createComponent(loginStatusValue: ILoginStatus | null = null) {
     await TestBed.configureTestingModule({
       imports: [WidgetLoginComponent],
       providers: [
-        { provide: SsoRedirectService, useValue: { manualSignIn } }
+        { provide: SsoRedirectService, useValue: { manualSignIn } },
+        { provide: AuthenticationService, useValue: { loginStatusValue } }
       ]
-    })
-      .compileComponents();
-  });
+    }).compileComponents();
+    fixture = TestBed.createComponent(WidgetLoginComponent);
+    fixture.detectChanges();
+    return fixture.componentInstance;
+  }
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(WidgetLoginComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+    manualSignIn.mockClear();
+    TestBed.resetTestingModule();
   });
 
-  it('should create and redirect to the SK/SSO login', () => {
+  it('redirects to the SK/SSO login when not authenticated', async () => {
+    const component = await createComponent();
+
     expect(component).toBeTruthy();
     expect(component.redirecting).toBe(true);
     expect(manualSignIn).toHaveBeenCalledOnce();
+  });
+
+  it('skips the sign-in redirect when already logged in (breaks the /#/login loop)', async () => {
+    const component = await createComponent({ status: 'loggedIn' });
+
+    expect(component.redirecting).toBe(false);
+    expect(manualSignIn).not.toHaveBeenCalled();
   });
 });

--- a/src/app/widgets/widget-login/widget-login.component.ts
+++ b/src/app/widgets/widget-login/widget-login.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, inject } from '@angular/core';
 import { ChangeDetectionStrategy } from '@angular/core';
 import { SsoRedirectService } from '../../core/services/sso-redirect.service';
+import { AuthenticationService } from '../../core/services/authentication.service';
 
 
 @Component({
@@ -11,10 +12,16 @@ import { SsoRedirectService } from '../../core/services/sso-redirect.service';
 })
 export class WidgetLoginComponent implements OnInit {
   private ssoRedirect = inject(SsoRedirectService);
+  private auth = inject(AuthenticationService);
 
   public redirecting = false;
 
   ngOnInit(): void {
+    // Reaching /login while already authenticated (bookmark, or an SSO bounce with a live IdP session)
+    // must not re-trigger the sign-in redirect, or the bounce returns here and loops indefinitely.
+    if (this.auth.loginStatusValue?.status === 'loggedIn') {
+      return;
+    }
     // Same-origin only: SKip has no credential form. Redirect to the SK/SSO login (explicit sign-in:
     // resets the redirect budget and disables auto-login so this is not immediately auto-bounced).
     this.redirecting = true;


### PR DESCRIPTION
## Why

Under hash routing the self-route loop guard was ineffective, so a sign-in could loop unboundedly (AUTH-02).

## What

- Make `isSafeReturnTo` hash-aware so KIP's own `/#/login` route is recognized as a self-route and not treated as an external return target.
- Guard `WidgetLoginComponent.ngOnInit` to skip `manualSignIn()` when the session is already logged in (e.g. a bookmarked `/login`).

Either fix alone breaks the loop; both are included for defense in depth.

**Theoretical residual (P3):** the self-route fragment match is exact-string, so a matrix-param or trailing-slash `/#/login` variant would evade it — not reachable in practice, since `returnTo` is self-generated and the logged-in case is covered by the `ngOnInit` guard.

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zURudCY3TTRcNd2acknJ9
