### PR TITLE
fix(windsteer): recompute TWA base immediately on compass-mode toggle

### DIFF
--- a/src/app/widgets/widget-windsteer/widget-windsteer.component.spec.ts
+++ b/src/app/widgets/widget-windsteer/widget-windsteer.component.spec.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect } from 'vitest';
-import { computeTrueWindBaseAngle } from './widget-windsteer.component';
+import { WritableSignal, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { WidgetWindComponent, computeTrueWindBaseAngle } from './widget-windsteer.component';
+import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
+import { WidgetStreamsDirective } from '../../core/directives/widget-streams.directive';
+import { IPathUpdate } from '../../core/services/data.service';
+import { IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
 
 /**
  * Regression tests for #1066 / #1063.
@@ -33,5 +39,59 @@ describe('computeTrueWindBaseAngle (#1066, #1063)', () => {
   it('passes through non boat-relative true wind paths (e.g. directionTrue) in both modes', () => {
     expect(computeTrueWindBaseAngle(DIRECTION_TRUE, 200, 90, false)).toBe(200);
     expect(computeTrueWindBaseAngle(DIRECTION_TRUE, 200, 90, true)).toBe(200);
+  });
+});
+
+/**
+ * Regression test for #73.
+ *
+ * Toggling compass mode live must recompute the displayed TWA base immediately from the last
+ * received sample. The wind stream does not re-emit on an options change, so before the fix the
+ * dial kept the previous base and showed a one-frame heading-offset transient until the next
+ * sample arrived.
+ */
+describe('WidgetWindComponent live compass-mode toggle (#73)', () => {
+  let component: WidgetWindComponent;
+  let options: WritableSignal<IWidgetSvcConfig | undefined>;
+  let callbacks: Map<string, (u: IPathUpdate) => void>;
+
+  const makeConfig = (compassModeEnabled: boolean): IWidgetSvcConfig => ({
+    ...WidgetWindComponent.DEFAULT_CONFIG,
+    compassModeEnabled,
+    windSectorEnable: false
+  });
+
+  const update = (value: number): IPathUpdate => ({ data: { value, timestamp: null }, state: 'normal' });
+
+  const twa = (): number => (component as unknown as { trueWindAngle: () => number }).trueWindAngle();
+
+  beforeEach(() => {
+    options = signal<IWidgetSvcConfig | undefined>(makeConfig(false));
+    callbacks = new Map<string, (u: IPathUpdate) => void>();
+
+    const streamsMock = {
+      observe: (pathName: string, next: (u: IPathUpdate) => void) => { callbacks.set(pathName, next); }
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: WidgetRuntimeDirective, useValue: { options } },
+        { provide: WidgetStreamsDirective, useValue: streamsMock }
+      ]
+    });
+
+    component = TestBed.runInInjectionContext(() => new WidgetWindComponent());
+    TestBed.tick(); // flush the options effect so streams register and callbacks are captured
+  });
+
+  it('recomputes the TWA base on a live compass-mode toggle without a new wind sample', () => {
+    callbacks.get('headingPath')!(update(90));
+    callbacks.get('trueWindAngle')!(update(45));
+    expect(twa()).toBe(45); // simple mode: boat-relative angle shown as-is
+
+    options.set(makeConfig(true));
+    TestBed.tick();
+
+    expect(twa()).toBe(135); // compass mode: heading (90) added to the cached angle (45)
   });
 });

--- a/src/app/widgets/widget-windsteer/widget-windsteer.component.ts
+++ b/src/app/widgets/widget-windsteer/widget-windsteer.component.ts
@@ -167,6 +167,7 @@ export class WidgetWindComponent implements OnDestroy {
   private hasSet = false;
   private hasDrift = false;
   private hasWPT = false;
+  private lastRawTrueWindAngle: number | null = null;
 
   protected currentHeading = signal(0);
   protected courseOverGroundAngle = signal(0);
@@ -207,6 +208,11 @@ export class WidgetWindComponent implements OnDestroy {
         this.registerStreams();
         this.stopWindSectors();
         this.startWindSectors();
+        // A live compass-mode or TWA-path change does not re-fire the wind stream, so recompute
+        // the displayed base from the cached sample here; otherwise the dial keeps a stale heading
+        // offset until the next sample arrives (#73). currentHeading is read untracked to avoid
+        // re-running this effect on every heading tick.
+        this.applyTrueWindBase();
       });
     });
   }
@@ -273,14 +279,23 @@ export class WidgetWindComponent implements OnDestroy {
   };
   private onTrueWindAngle = (u: IPathUpdate) => {
     if (u.data.value == null) u.data.value = 0;
-    const cfg = this.runtime.options();
-    const path = cfg?.paths['trueWindAngle'].path || '';
-    const base = computeTrueWindBaseAngle(path, u.data.value, this.currentHeading(), !!cfg?.compassModeEnabled);
-    const next = this.normalizeAngle(base);
+    this.lastRawTrueWindAngle = u.data.value;
+    const next = this.normalizeAngle(this.computeTrueWindBase(u.data.value));
     if (!this.hasTWA || this.angleDelta(this.trueWindAngle(), next) >= this.DEG_EPSILON) {
       this.trueWindAngle.set(next); this.hasTWA = true;
     }
   };
+
+  private computeTrueWindBase(rawAngle: number): number {
+    const cfg = this.runtime.options();
+    const path = cfg?.paths['trueWindAngle'].path || '';
+    return computeTrueWindBaseAngle(path, rawAngle, this.currentHeading(), !!cfg?.compassModeEnabled);
+  }
+
+  private applyTrueWindBase() {
+    if (this.lastRawTrueWindAngle == null) return;
+    this.trueWindAngle.set(this.normalizeAngle(this.computeTrueWindBase(this.lastRawTrueWindAngle)));
+  }
 
   private registerStreams() {
     const cfg = this.runtime.options();


### PR DESCRIPTION
## Why

Toggling compass mode live left the True Wind Angle needle showing a transient wrong value until the next wind sample arrived (#73, follow-up to #43).

## What

Cache the last raw boat-relative TWA in `onTrueWindAngle`. In the existing `runtime.options()` effect (which already re-runs when `compassModeEnabled` changes), recompute the true-wind base via `computeTrueWindBaseAngle` using an `untracked` read of `currentHeading()` and set `trueWindAngle` — so a live toggle recomputes the base immediately instead of waiting for the next sample. The child `svg-windsteer` already reacts to the input.

**Informational (P3):** an unrelated options save after the heading drifted will recompute against the live heading (a self-correcting one-frame shift, arguably more current) — noted, no change needed.

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zURudCY3TTRcNd2acknJ9
