### PR TITLE
fix(connection): escalate WebSocket retry backoff instead of fixed interval

### DIFF
--- a/src/app/core/services/connection-state-machine.service.spec.ts
+++ b/src/app/core/services/connection-state-machine.service.spec.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ConnectionStateMachine } from './connection-state-machine.service';
 
 describe('ConnectionStateMachine', () => {
@@ -21,5 +22,33 @@ describe('ConnectionStateMachine', () => {
     const retryWindowMs = service.getHttpRetryWindowMs(2000);
 
     expect(retryWindowMs).toBe(12000);
+  });
+
+  it('escalates WebSocket retry backoff through the configured intervals and then holds', () => {
+    vi.useFakeTimers();
+    try {
+      const retry = vi.fn();
+      service.setWebSocketRetryCallback(retry);
+      service.enableWebSocketMode();
+      service.startHTTPDiscovery();
+      service.onHTTPDiscoverySuccess();
+
+      // Delays follow retryIntervals (2s, 3s, 5s) and clamp to the longest once exhausted,
+      // proving the backoff escalates rather than repeating a fixed interval.
+      const expectedDelays = [2000, 3000, 5000, 5000];
+
+      expectedDelays.forEach((delay, attempt) => {
+        service.onWebSocketError('socket dropped');
+
+        vi.advanceTimersByTime(delay - 1);
+        expect(retry).toHaveBeenCalledTimes(attempt);
+
+        vi.advanceTimersByTime(1);
+        expect(retry).toHaveBeenCalledTimes(attempt + 1);
+      });
+    } finally {
+      service.ngOnDestroy();
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/app/core/services/connection-state-machine.service.ts
+++ b/src/app/core/services/connection-state-machine.service.ts
@@ -218,6 +218,10 @@ export class ConnectionStateMachine implements OnDestroy {
       return;
     }
 
+    // Unlike HTTP discovery, WebSocket reconnection is intentionally unbounded: a
+    // marine display must keep reaching for a boat server that may be intermittently
+    // offline rather than give up into PermanentFailure. Backoff escalates through
+    // retryIntervals and holds at the longest interval once exhausted.
     this._webSocketRetryCount++;
     this.setState(
       ConnectionState.WebSocketRetrying,
@@ -356,8 +360,10 @@ export class ConnectionStateMachine implements OnDestroy {
 
   private scheduleWebSocketRetry(): void {
     this.clearRetryTimer();
+    const retryIndex = Math.min(this._webSocketRetryCount - 1, this.config.retryIntervals.length - 1);
+    const delay = this.config.retryIntervals[retryIndex];
 
-    console.log(`[ConnectionStateMachine] Scheduling WebSocket retry in ${this.config.retryIntervals[1]}ms`);
+    console.log(`[ConnectionStateMachine] Scheduling WebSocket retry in ${delay}ms`);
     this._retryTimeout = setTimeout(() => {
       // Trigger WebSocket reconnection attempt via callback
       // Don't change state here - let the WebSocket result determine the new state
@@ -374,7 +380,7 @@ export class ConnectionStateMachine implements OnDestroy {
           this.config.webSocketRetryCount
         );
       }
-    }, this.config.retryIntervals[1]);
+    }, delay);
   }
 
   private clearRetryTimer(): void {


### PR DESCRIPTION
## Why

WebSocket reconnection used a hard-coded `retryIntervals[1]` (a fixed backoff), while the HTTP discovery path escalates and caps (ARCH-02).

## What

Drive the WebSocket retry delay from `retryIntervals` indexed by a clamped `_webSocketRetryCount`, so it escalates through the configured intervals and holds at the longest once exhausted. The spec asserts escalating delays `[2s, 3s, 5s, 5s]` via fake timers.

**Design decision (needs your eyes):** WebSocket reconnection stays **indefinite** — a marine display should keep reaching for a boat server that may be intermittently offline — rather than capping to `PermanentFailure` like the HTTP path. The `webSocketRetryCount` / `maxRetries` fields are retained as informational display values, not enforced caps. If you'd rather cap it, say so.

**Known cosmetic follow-up:** the retry log still prints `N/webSocketRetryCount` (e.g. `N/5`), now misleading under unbounded retry. Left out of scope to keep the change minimal.

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zURudCY3TTRcNd2acknJ9
