### PR TITLE
fix(bootstrap): trigger recovery when Signal K returns an empty config

### DIFF
--- a/src/app/core/services/app-initNetwork.service.spec.ts
+++ b/src/app/core/services/app-initNetwork.service.spec.ts
@@ -60,9 +60,11 @@ describe('AppNetworkInitService', () => {
         navigate: vi.fn().mockResolvedValue(true)
     };
 
+    const validRemoteConfig = (): IConfig => ({ app: { configVersion: 11 }, theme: null, dashboards: [] } as unknown as IConfig);
+
     const mockStorage = {
         waitUntilReady: vi.fn().mockResolvedValue(true),
-        getConfig: vi.fn().mockResolvedValue({}),
+        getConfig: vi.fn().mockResolvedValue(validRemoteConfig()),
         bootstrapRemoteContext: vi.fn()
     };
 
@@ -92,6 +94,8 @@ describe('AppNetworkInitService', () => {
         mockConnectionStateMachine.isHTTPConnected.mockClear();
         mockConnectionStateMachine.enableWebSocketMode.mockClear();
         mockConnectionStateMachine.startWebSocketConnection.mockClear();
+        mockStorage.getConfig.mockReset().mockResolvedValue(validRemoteConfig());
+        mockStorage.bootstrapRemoteContext.mockClear();
         mockAuth.loginStatusValue = null;
         mockAuth.refreshLoginStatus.mockClear();
         mockRouter.navigate.mockClear();
@@ -314,6 +318,17 @@ describe('AppNetworkInitService', () => {
             await service.initNetworkServices();
 
             expect(mockSsoRedirect.resetBudget).toHaveBeenCalled();
+        });
+
+        it('logged-in with an appless 200 {} config raises missing-shared-config, not a clean bootstrap', async () => {
+            mockAuth.refreshLoginStatus.mockImplementation(async () => { isLoggedIn$.next(true); return { status: 'loggedIn' }; });
+            mockStorage.getConfig.mockResolvedValue({} as IConfig);
+
+            await service.initNetworkServices();
+
+            expect(latestIssue().reason).toBe('missing-shared-config');
+            expect(mockStorage.bootstrapRemoteContext).not.toHaveBeenCalled();
+            expect(mockSsoRedirect.resetBudget).not.toHaveBeenCalled();
         });
 
         it('does not double-start the WebSocket when a connect is already in flight at the finally', async () => {

--- a/src/app/core/services/app-initNetwork.service.ts
+++ b/src/app/core/services/app-initNetwork.service.ts
@@ -153,6 +153,20 @@ export class AppNetworkInitService implements OnDestroy {
           throw new Error('[AppInit Network Service] StorageService did not become ready in time. Cannot bootstrap remote configuration.');
         } else {
           remoteConfig = await this.storage.getConfig('user', this.config.sharedConfigName, configFileVersion);
+          if (!remoteConfig?.app) {
+            // SK answers a never-created slot with 200 {} rather than a 404, so an appless config is
+            // the real "no shared configuration yet" signal. Surface recovery here; the 404 catch
+            // branch below remains only for servers that genuinely answer 404.
+            startupDegraded = true;
+            const legacyUpgradeAvailable = await this.probeLegacyUpgradeAvailability(this.config.sharedConfigName);
+            this._bootstrapIssue$.next({
+              reason: 'missing-shared-config',
+              sharedConfigName: this.config.sharedConfigName,
+              legacyUpgradeAvailable
+            });
+            this._bootstrapStatus$.next('degraded');
+            return;
+          }
           const bootstrapContext: IStorageRemoteBootstrapContext = {
             sharedConfigName: this.config.sharedConfigName,
             configFileVersion,

--- a/src/app/core/services/storage.service.spec.ts
+++ b/src/app/core/services/storage.service.spec.ts
@@ -135,6 +135,27 @@ describe('StorageService', () => {
       await expect(second).resolves.toBeUndefined();
     });
   });
+
+  describe('bootstrapRemoteContext appless-config guard', () => {
+    it('rejects an appless config (SK 200 {}) as an absent bootstrap', () => {
+      expect(() => service.bootstrapRemoteContext({
+        sharedConfigName: 'cockpit',
+        configFileVersion: 11,
+        initConfig: blankConfig()
+      })).toThrow(/invalid remote bootstrap/i);
+      expect(service.isRemoteContextBootstrapped()).toBe(false);
+    });
+
+    it('accepts a config that carries an app section', () => {
+      service.bootstrapRemoteContext({
+        sharedConfigName: 'cockpit',
+        configFileVersion: 11,
+        initConfig: { app: { configVersion: 11 }, theme: null, dashboards: [] } as unknown as IConfig
+      });
+      expect(service.isRemoteContextBootstrapped()).toBe(true);
+      expect(service.initConfig?.app).toBeTruthy();
+    });
+  });
 });
 
 interface StoragePrivate { serverEndpoint: string }

--- a/src/app/core/services/storage.service.ts
+++ b/src/app/core/services/storage.service.ts
@@ -605,7 +605,9 @@ export class StorageService {
    * });
    */
   public bootstrapRemoteContext(context: IStorageRemoteBootstrapContext): void {
-    if (!context?.sharedConfigName || context.configFileVersion == null || !context.initConfig) {
+    // An appless config (SK returns 200 {} for a never-created slot) is an absent bootstrap, not a
+    // successful one — reject it so callers route to recovery instead of booting a blank app.
+    if (!context?.sharedConfigName || context.configFileVersion == null || !context.initConfig?.app) {
       throw new Error('[StorageService] Invalid remote bootstrap context');
     }
 


### PR DESCRIPTION
## Why

When Signal K returned `200 {}` (an empty/appless config) rather than a 404, the missing-config recovery prompt never fired — first-run or wiped-config users were left with a silent broken state (PCS-01).

## What

- In `app-initNetwork.service.ts`, after `getConfig()` resolves, detect an empty/appless config and emit `IBootstrapIssue{ reason: 'missing-shared-config' }`, keeping the existing 404 catch branch as a defensive fallback.
- In `storage.service.ts`, tighten `bootstrapRemoteContext`'s truthy `initConfig` check so `{}` is treated as an absent config rather than a successful bootstrap.

The consumers (`app.component` bootstrap-issue effect, `settings.service` startup) already handle the `missing-shared-config` reason, so no change there.

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zURudCY3TTRcNd2acknJ9
