### PR TITLE
fix(auth): preserve session on transient loginStatus probe failure

### DIFF
--- a/src/app/core/services/authentication.service.spec.ts
+++ b/src/app/core/services/authentication.service.spec.ts
@@ -114,6 +114,70 @@ describe('AuthenticationService', () => {
       }
     });
 
+    it('transport failure (no HTTP response) preserves the last known-good session', async () => {
+      const service = createService();
+      const httpTesting = TestBed.inject(HttpTestingController);
+
+      // Establish a known-good writable session.
+      const first = service.refreshLoginStatus();
+      expectLoginStatusRequest(httpTesting).flush({ status: 'loggedIn', userLevel: 'admin' });
+      await first;
+
+      // A transient network error carries no logout verdict: session state must survive it.
+      const second = service.refreshLoginStatus();
+      expectLoginStatusRequest(httpTesting).error(new ProgressEvent('network error'));
+      const result = await second;
+
+      expect(result).toEqual({ status: 'loggedIn', userLevel: 'admin' });
+      expect(await firstValueFrom(service.isLoggedIn$)).toBe(true);
+      expect(await firstValueFrom(service.isUserSession$)).toBe(true);
+      expect(await firstValueFrom(service.canWriteUserData$)).toBe(true);
+      httpTesting.verify();
+    });
+
+    it('transport timeout preserves the last known-good session', async () => {
+      vi.useFakeTimers();
+      try {
+        const service = createService();
+        const httpTesting = TestBed.inject(HttpTestingController);
+
+        const first = service.refreshLoginStatus();
+        expectLoginStatusRequest(httpTesting).flush({ status: 'loggedIn', userLevel: 'admin' });
+        await first;
+
+        const second = service.refreshLoginStatus();
+        expectLoginStatusRequest(httpTesting); // request opened, never flushed
+        await vi.advanceTimersByTimeAsync(5001);
+        const result = await second;
+
+        expect(result).toEqual({ status: 'loggedIn', userLevel: 'admin' });
+        expect(await firstValueFrom(service.isLoggedIn$)).toBe(true);
+        expect(await firstValueFrom(service.canWriteUserData$)).toBe(true);
+        httpTesting.verify();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('authoritative not-logged-in after a good session still clears it (not a transport blip)', async () => {
+      const service = createService();
+      const httpTesting = TestBed.inject(HttpTestingController);
+
+      const first = service.refreshLoginStatus();
+      expectLoginStatusRequest(httpTesting).flush({ status: 'loggedIn', userLevel: 'admin' });
+      await first;
+      expect(await firstValueFrom(service.isLoggedIn$)).toBe(true);
+
+      const second = service.refreshLoginStatus();
+      expectLoginStatusRequest(httpTesting).flush({ status: 'notLoggedIn' });
+      const result = await second;
+
+      expect(result).toEqual({ status: 'notLoggedIn' });
+      expect(await firstValueFrom(service.isLoggedIn$)).toBe(false);
+      expect(await firstValueFrom(service.isUserSession$)).toBe(false);
+      httpTesting.verify();
+    });
+
     it('not-logged-in: all session flags false; OIDC descriptors captured', async () => {
       const service = createService();
       const httpTesting = TestBed.inject(HttpTestingController);

--- a/src/app/core/services/authentication.service.ts
+++ b/src/app/core/services/authentication.service.ts
@@ -1,6 +1,6 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
-import { BehaviorSubject, lastValueFrom, timeout } from 'rxjs';
+import { BehaviorSubject, TimeoutError, lastValueFrom, timeout } from 'rxjs';
 import { distinctUntilChanged, map } from "rxjs/operators";
 
 /**
@@ -22,6 +22,7 @@ export interface ILoginStatus {
 
 const loginStatusPath = '/skServer/loginStatus'; // server-origin, not the /signalk/v1 API base
 const loginStatusTimeoutMs = 5000; // bounded so a hung endpoint cannot block the APP_INITIALIZER
+const noHttpResponseStatus = 0; // HttpErrorResponse.status is 0 when no response ever reached the client
 
 /**
  * Session authentication for the Signal K server. SKip is served same-origin by the SK server (behind
@@ -38,7 +39,7 @@ export class AuthenticationService {
   private _IsLoggedIn$ = new BehaviorSubject<boolean>(false);
   public isLoggedIn$ = this._IsLoggedIn$.asObservable();
 
-  // Latest parsed loginStatus (null until refreshed or on any failure).
+  // Latest parsed loginStatus (null until an authoritative probe; a transport blip leaves it unchanged).
   private _loginStatus$ = new BehaviorSubject<ILoginStatus | null>(null);
   public loginStatus$ = this._loginStatus$.asObservable();
 
@@ -69,19 +70,37 @@ export class AuthenticationService {
   /**
    * Query `GET /skServer/loginStatus` with credentials so the httpOnly session cookie authenticates
    * the probe, and derive session state from it (fail-closed). Returns the parsed status (including
-   * OIDC descriptors for the bootstrap redirect), or null on any failure. The request targets the
-   * served origin — the effective Signal K origin equals `window.location.origin` by definition — not
-   * the post-discovery `/signalk/v1` base.
+   * OIDC descriptors for the bootstrap redirect). An authoritative answer — a not-logged-in verdict,
+   * a non-2xx response, or an unparseable body — clears the session and returns null; a transport-layer
+   * failure (unreachable server or timeout) instead preserves the last known-good status so a transient
+   * drop cannot wedge a live cookie session into a false logged-out state. The request targets the served
+   * origin — the effective Signal K origin equals `window.location.origin` by definition — not the
+   * post-discovery `/signalk/v1` base.
    */
   public async refreshLoginStatus(): Promise<ILoginStatus | null> {
     const url = window.location.origin + loginStatusPath;
     try {
       const raw = await lastValueFrom(this.http.get<ILoginStatus>(url, { withCredentials: true }).pipe(timeout(loginStatusTimeoutMs)));
       return this.applyLoginStatus(raw);
-    } catch {
-      // Unreachable, non-2xx, or unparseable response: treat as not logged in.
+    } catch (error) {
+      if (this.isTransportFailure(error)) {
+        // A transient blip carries no logout verdict: keep the last known-good session so a brief
+        // connectivity drop cannot wedge the UI logged-out until a manual reload.
+        return this.loginStatusValue;
+      }
+      // The server answered but the response is not an authenticated session: treat as not logged in.
       return this.applyLoginStatus(null);
     }
+  }
+
+  /**
+   * Whether a failed probe is a transport-layer blip rather than an authoritative answer. A request
+   * that never reached the server surfaces as an HttpErrorResponse with no HTTP status, and a slow
+   * endpoint surfaces as an RxJS TimeoutError; neither implies the session ended.
+   */
+  private isTransportFailure(error: unknown): boolean {
+    return (error instanceof HttpErrorResponse && error.status === noHttpResponseStatus)
+      || error instanceof TimeoutError;
   }
 
   private applyLoginStatus(raw: unknown): ILoginStatus | null {

--- a/src/app/core/services/signalk-delta.service.spec.ts
+++ b/src/app/core/services/signalk-delta.service.spec.ts
@@ -103,6 +103,17 @@ describe('SignalKDeltaService', () => {
     });
   });
 
+  describe('loginStatus re-probe on WS open', () => {
+    it('re-probes loginStatus when the WebSocket opens so a reconnected session self-heals', () => {
+      const { service, auth } = setup();
+      auth.refreshLoginStatus.mockClear();
+
+      service.socketWSOpenEvent$.next({} as Event);
+
+      expect(auth.refreshLoginStatus).toHaveBeenCalled();
+    });
+  });
+
   describe('loginStatus re-check on WS drop', () => {
     it('re-checks loginStatus on a non-clean close', () => {
       const { service, auth } = setup();

--- a/src/app/core/services/signalk-delta.service.ts
+++ b/src/app/core/services/signalk-delta.service.ts
@@ -139,6 +139,10 @@ export class SignalKDeltaService implements OnDestroy {
 
         // Notify ConnectionStateMachine of successful WebSocket connection
         this.connectionStateMachine.onWebSocketConnected();
+
+        // The reconnected upgrade re-authenticated with the same session cookie; re-probe loginStatus
+        // so a session left stale by a failed probe during the drop self-heals without a page reload.
+        void this.auth.refreshLoginStatus();
       });
 
     // WebSocket closed Event Handling


### PR DESCRIPTION
## Why

A transient `loginStatus` probe failure (e.g. a brief WiFi drop) wedged a live cookie session into a false logged-out state, hiding write controls until a full reload (AUTH-01).

## What

- In `AuthenticationService.refreshLoginStatus`, distinguish transport/timeout failures (HTTP status 0 or an RxJS timeout) from an authoritative not-logged-in response, and on transport failure preserve the last known-good status instead of overwriting it with null.
- Re-probe `refreshLoginStatus` in the `SignalKDeltaService` WebSocket-open handler so session state self-heals after a reconnect.

**Noted (P3):** a non-2xx transient (e.g. a 503 during a server restart) is still classified as logout and momentarily clears the session, recovering on the WS-reconnect re-probe. This follows the issue's narrowed direction (preserve only status 0 / timeout); the primary WiFi-drop case surfaces as status 0 and is covered.

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zURudCY3TTRcNd2acknJ9
