### PR TITLE
fix(settings): deep-clone default config before returning

### DIFF
--- a/src/app/core/services/settings.service.spec.ts
+++ b/src/app/core/services/settings.service.spec.ts
@@ -4,6 +4,13 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { SettingsService } from './settings.service';
 import { StorageService } from './storage.service';
 import { ensureLocalStorage } from '../../../test-helpers/local-storage.test-helper';
+import { DefaultAppConfig, DefaultConnectionConfig } from '../../../default-config/config.blank.const';
+import { IAppConfig, IConnectionConfig } from '../interfaces/app-settings.interfaces';
+
+interface DefaultConfigGetters {
+  getDefaultAppConfig(): IAppConfig;
+  getDefaultConnectionConfig(): IConnectionConfig;
+}
 
 interface SeedOpts {
   sharedConfigName?: string;
@@ -290,5 +297,47 @@ describe('SettingsService', () => {
       expect(reloadSpy).not.toHaveBeenCalled();
       expect(snackSpy).toHaveBeenCalled();
     });
+  });
+});
+
+describe('SettingsService — default config isolation', () => {
+  beforeEach(() => ensureLocalStorage());
+
+  it('getDefaultAppConfig returns a fresh clone and never mutates the shared singleton', () => {
+    const service = createService({}) as unknown as DefaultConfigGetters;
+    // Capture the singleton's state up front rather than asserting an absolute value: other test
+    // files share this module singleton and one (app-initNetwork) mutates it, so the invariant to
+    // pin is that the getter itself leaves it unchanged, not what its value happens to be.
+    const titleBefore = DefaultAppConfig.browserTabTitle;
+    const notificationsBefore = DefaultAppConfig.notificationConfig.disableNotifications;
+
+    const first = service.getDefaultAppConfig();
+    first.browserTabTitle = 'mutated';
+    first.notificationConfig.disableNotifications = !first.notificationConfig.disableNotifications;
+
+    const second = service.getDefaultAppConfig();
+    expect(second).not.toBe(first);
+    expect(second.browserTabTitle).not.toBe('mutated');
+    // Nested defaults are cloned too (different reference), and mutating a result never reaches the singleton.
+    expect(first.notificationConfig).not.toBe(DefaultAppConfig.notificationConfig);
+    expect(DefaultAppConfig.browserTabTitle).toBe(titleBefore);
+    expect(DefaultAppConfig.notificationConfig.disableNotifications).toBe(notificationsBefore);
+  });
+
+  it('getDefaultConnectionConfig returns a fresh clone and never mutates the shared singleton', () => {
+    const service = createService({}) as unknown as DefaultConfigGetters;
+    const urlBefore = DefaultConnectionConfig.signalKUrl;
+    const uuidBefore = DefaultConnectionConfig.kipUUID;
+
+    const first = service.getDefaultConnectionConfig();
+    first.sharedConfigName = 'mutated';
+    first.signalKUrl = 'https://mutated.example';
+
+    const second = service.getDefaultConnectionConfig();
+    expect(second).not.toBe(first);
+    expect(second.signalKUrl).not.toBe('https://mutated.example');
+    // The getter clones, so mutating a returned result never reaches the shared singleton.
+    expect(DefaultConnectionConfig.signalKUrl).toBe(urlBefore);
+    expect(DefaultConnectionConfig.kipUUID).toBe(uuidBefore);
   });
 });

--- a/src/app/core/services/settings.service.ts
+++ b/src/app/core/services/settings.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, inject, signal } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
+import { cloneDeep } from 'lodash-es';
 
 import { IDatasetServiceDatasetConfig } from './dataset-stream.service';
 import { IWidget } from '../interfaces/widgets-interface';
@@ -709,16 +710,16 @@ export class SettingsService {
 
   // Creates config from defaults and saves to LocalStorage
   private getDefaultAppConfig(): IAppConfig {
-    const config: IAppConfig = DefaultAppConfig;
-    config.notificationConfig = DefaultNotificationConfig;
-    config.unitDefaults = DefaultUnitsConfig;
-    config['configVersion'] = latestConfigVersion;
+    const config: IAppConfig = cloneDeep(DefaultAppConfig);
+    config.notificationConfig = cloneDeep(DefaultNotificationConfig);
+    config.unitDefaults = cloneDeep(DefaultUnitsConfig);
+    config.configVersion = latestConfigVersion;
     localStorage.setItem('appConfig', JSON.stringify(config));
     return config;
   }
 
   private getDefaultConnectionConfig(): IConnectionConfig {
-    const config: IConnectionConfig = DefaultConnectionConfig;
+    const config: IConnectionConfig = cloneDeep(DefaultConnectionConfig);
     config.kipUUID = UUID.create();
     config.signalKUrl = window.location.origin;
     localStorage.setItem('connectionConfig', JSON.stringify(config));

--- a/src/default-config/config.blank.const.ts
+++ b/src/default-config/config.blank.const.ts
@@ -3,7 +3,9 @@ import { DefaultNotificationConfig } from './config.blank.notification.const';
 import { DefaultUnitsConfig } from "./config.blank.units.const";
 import { UUID } from "../app/core/utils/uuid.util";
 
-export const DefaultAppConfig: IAppConfig = {
+// Immutable defaults: the settings getters and profile-import validation read these as a shared
+// baseline, so callers must clone before mutating rather than corrupt the singleton in place.
+export const DefaultAppConfig: Readonly<IAppConfig> = {
   "configVersion": 12,
   "autoNightMode": true,
   "redNightMode": false,
@@ -24,7 +26,7 @@ export const defaultConfig: IConfig = {
   "dashboards": []
 }
 
-export const DefaultConnectionConfig: IConnectionConfig = {
+export const DefaultConnectionConfig: Readonly<IConnectionConfig> = {
   "configVersion": 13,
   "kipUUID": UUID.create(),
   "signalKUrl": null, // get's overwritten with host at getDefaultConnectionConfig()


### PR DESCRIPTION
## Why

`getDefaultAppConfig()` / `getDefaultConnectionConfig()` assigned the module-level `DefaultAppConfig` / `DefaultConnectionConfig` singletons **by reference** and then mutated them, corrupting the shared defaults across calls — `profile.service` reads `defaultConfig.app.configVersion` as its import-validation baseline (PCS-05).

## What

- Deep-clone the constant (`cloneDeep` from `lodash-es`, matching `profile.service`) before mutating/returning, so the singleton is never mutated at runtime.
- Mark the two leaf constants `Readonly<…>` in `config.blank.const.ts` to make the immutability contract explicit. Scoped to the two leaves; the `defaultConfig` composite stays mutable because `profile.service` cloneDeeps-and-mutates it.
- New `default config isolation` specs assert each getter returns a fresh pristine object and that mutating a result never leaks into the singleton or a later call.

## Note

Review surfaced a **sibling instance** of the same anti-pattern in `app-initNetwork.service.ts:369` (`this.config = DefaultConnectionConfig; this.config.signalKUrl = …`) that the `Readonly` type can't catch (it's laundered through a mutable alias). Out of this PR's footprint — filed as a follow-up.

Verified locally: lint + `build:dev` clean, settings spec green (21 tests).

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zURudCY3TTRcNd2acknJ9
