### PR TITLE
refactor(data): remove unsafe unused unsubscribePath

### DIFF
--- a/src/app/core/services/data.service.spec.ts
+++ b/src/app/core/services/data.service.spec.ts
@@ -42,6 +42,33 @@ describe('DataService', () => {
     expect(service).toBeTruthy();
   });
 
+  it('shares one live subject per (path, source) so co-subscribers cannot tear each other down', () => {
+    const first$ = service.subscribePath('self.electrical.batteries.10.voltage', 'default');
+    const second$ = service.subscribePath('self.electrical.batteries.10.voltage', 'default');
+    const otherSource$ = service.subscribePath('self.electrical.batteries.10.voltage', 'test-source');
+
+    // Deduplication is keyed by (path, source): identical pairs share one subject, distinct sources do not.
+    expect(second$).toBe(first$);
+    expect(otherSource$).not.toBe(first$);
+
+    const firstValues: unknown[] = [];
+    const secondValues: unknown[] = [];
+    first$.subscribe(update => firstValues.push(update.data.value));
+    second$.subscribe(update => secondValues.push(update.data.value));
+
+    dataPathUpdates$.next({
+      context: 'self',
+      path: 'electrical.batteries.10.voltage',
+      source: 'test-source',
+      timestamp: '2026-01-01T00:00:01.000Z',
+      value: 12.5,
+    });
+
+    // Both co-subscribers keep receiving from the shared stream; there is no teardown that could complete it.
+    expect(firstValues.at(-1)).toBe(12.5);
+    expect(secondValues.at(-1)).toBe(12.5);
+  });
+
   it('applies notification state to path value updates', () => {
     let latest: IPathUpdate | undefined;
 

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -1,5 +1,5 @@
 import { DestroyRef, inject, Injectable, OnDestroy } from '@angular/core';
-import { Observable, BehaviorSubject, ReplaySubject, Subject, map, combineLatest, of, interval, Subscription, filter } from 'rxjs';
+import { Observable, BehaviorSubject, ReplaySubject, Subject, map, combineLatest, of, interval, filter } from 'rxjs';
 import { ISkPathData, IPathValueData, IPathMetaData, IMeta, IPathUpdateEvent } from "../interfaces/app-interfaces";
 import { ISignalKDataValueUpdate, ISkMetadata, ISignalKNotification, States, TState } from '../interfaces/signalk-interfaces'
 import { SignalKDeltaService } from './signalk-delta.service';
@@ -76,7 +76,12 @@ const buildPathData = (value: unknown, rawTimestamp: string | number | Date | nu
 /**
  * The `IPathRegistration` interface represents a registration object used to track a path's Subjects.
  * Each registration is used to share the same Subject with multiple Observers.
- * The `subscribePath()` and `unsubscribePath()` methods return the registration's subject as an Observable.
+ * The `subscribePath()` method returns the registration's subject as an Observable.
+ *
+ * Registrations are app-lifetime objects, bounded by the unique `(path, source)` pairs a session
+ * encounters, and are intentionally never torn down individually: a subject is shared across every
+ * co-subscriber of a `(path, source)` pair, so completing one would terminate the stream for the
+ * others. Consumers scope their own subscriptions with `takeUntilDestroyed`/`finalize` instead.
  *
  * @property {string} path - A Signal K path.
  * @property {string} source - The Signal K data path source. This is used when multiple sources exist for the same path. If set, the Signal K default source will be ignored.
@@ -94,7 +99,6 @@ interface IPathRegistration {
   _pathState$: BehaviorSubject<TState>;
   pathDataUpdate$: BehaviorSubject<IPathUpdate>;
   pathMeta$: BehaviorSubject<ISkMetadata | null>;
-  combinedSub?: Subscription; // explicit subscription for combined$ to allow manual teardown
 }
 
 export interface IDeltaUpdate {
@@ -228,35 +232,6 @@ export class DataService implements OnDestroy {
     this._isReset.next(true);
   }
 
-  public unsubscribePath(path: string): void {
-    const index = this._pathRegister.findIndex(registration => registration.path === path);
-
-    if (index !== -1) {
-      const registration = this._pathRegister[index];
-
-      // Ensure all observables are completed to avoid memory leaks
-      registration.combinedSub?.unsubscribe();
-      registration._pathData$?.complete();
-      registration._pathState$?.complete();
-      registration.pathDataUpdate$?.complete();
-      registration.pathMeta$?.complete();
-
-      // Use splice to remove the item without changing the entire
-      // array reference.
-      this._pathRegister.splice(index, 1);
-
-      const registrations = this._pathRegisterByPath.get(path);
-      if (registrations) {
-        const updated = registrations.filter(item => item !== registration);
-        if (updated.length) {
-          this._pathRegisterByPath.set(path, updated);
-        } else {
-          this._pathRegisterByPath.delete(path);
-        }
-      }
-    }
-  }
-
   public subscribePath(path: string, source: string): Observable<IPathUpdate> {
     const registrations = this._pathRegisterByPath.get(path);
     const matchingPaths = registrations?.find(item => item.path === path && item.source === source);
@@ -309,7 +284,7 @@ export class DataService implements OnDestroy {
       map(([d, s]) => ({ data: d, state: s } as IPathUpdate))
     );
 
-    newPathSubject.combinedSub = combined$.subscribe(value => newPathSubject.pathDataUpdate$.next(value));
+    combined$.subscribe(value => newPathSubject.pathDataUpdate$.next(value));
 
     this._pathRegister.push(newPathSubject);
     if (registrations) {
@@ -773,7 +748,7 @@ export class DataService implements OnDestroy {
    * Notes:
    * - The path must already be registered via {@link subscribePath}; otherwise this returns an Observable that emits `null`.
    * - If multiple registrations exist for the same path (e.g. different sources), this returns the first match by path.
-   * - The returned Observable completes when the path is unsubscribed via {@link unsubscribePath} (subjects are completed).
+   * - Registrations are app-lifetime, so the returned Observable stays live for the session and does not complete on its own.
    */
   public getPathMetaObservable(path: string): Observable<ISkMetadata | null> {
     const registration = this._pathRegisterByPath.get(path)?.[0];


### PR DESCRIPTION
## Why

`DataService.unsubscribePath` destructively `.complete()`d the shared per-`(path, source)` subjects — terminating the stream for **every** co-subscriber of that path — and it was called by nobody (ARCH-07). `WidgetStreamsDirective` uses `takeUntilDestroyed`/`finalize` instead.

## What

- Delete `unsubscribePath` entirely (KISS/YAGNI — no reference-counting for an uncalled method). A repo-wide grep confirmed zero callers.
- Remove the now-dead supporting code it alone required: the `IPathRegistration.combinedSub` field and its assignment (the `combined$` subscription is now anonymous — identical runtime behavior, it was never unsubscribed in practice) and the unused `Subscription` import.
- Update the two stale JSDoc references; document that path registrations are app-lifetime objects, bounded by unique `(path, source)` pairs, intentionally never torn down individually.
- Spec pins the fan-out invariant: the same `(path, source)` returns one shared subject, distinct sources return distinct subjects, and co-subscribers both keep receiving from the shared stream.

## Note

The spec is an **invariant guard**, not a regression test: because the removed method had zero callers there's no buggy behavior to fail against, so it locks in the fan-out property that would make any reintroduced destructive teardown unsafe.

Verified locally: lint + `build:dev` clean, data spec green (7 tests).

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zURudCY3TTRcNd2acknJ9
