### PR TITLE
fix(storage): surface config save failures to the user

### DIFF
--- a/src/app/core/services/settings.service.spec.ts
+++ b/src/app/core/services/settings.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { HttpTestingController } from '@angular/common/http/testing';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { SettingsService } from './settings.service';
@@ -162,6 +163,48 @@ describe('SettingsService — storage routing (server applicationData only)', ()
 
     expect(patchSpy).toHaveBeenCalledWith('IAppConfig', expect.objectContaining({ browserTabTitle: 'Helm' }));
     expect(localStorage.getItem('appConfig')).toBeNull();
+  });
+});
+
+describe('SettingsService — config save failure reporting', () => {
+  beforeEach(() => ensureLocalStorage());
+
+  it('surfaces a snackbar when a routine config save to the server fails', async () => {
+    const service = createService({ useSharedConfig: true, sharedConfigName: 'profileA' });
+    const storage = TestBed.inject(StorageService);
+    const http = TestBed.inject(HttpTestingController);
+    const snack = TestBed.inject(MatSnackBar);
+    const snackSpy = vi.spyOn(snack, 'open').mockImplementation(() => undefined as never);
+
+    storage.storageServiceReady$.next(true);
+    storage.activeConfigFileVersion = 11;
+    storage.sharedConfigName = 'profileA';
+
+    service.setThemeName('dark'); // fire-and-forget patchConfig write
+    http.expectOne((r) => r.method === 'POST').flush('boom', { status: 500, statusText: 'err' });
+    await Promise.resolve();
+
+    expect(snackSpy).toHaveBeenCalled();
+    http.verify();
+  });
+
+  it('does not raise the alarm toast for an expected read-only 401 save denial', async () => {
+    const service = createService({ useSharedConfig: true, sharedConfigName: 'profileA' });
+    const storage = TestBed.inject(StorageService);
+    const http = TestBed.inject(HttpTestingController);
+    const snack = TestBed.inject(MatSnackBar);
+    const snackSpy = vi.spyOn(snack, 'open').mockImplementation(() => undefined as never);
+
+    storage.storageServiceReady$.next(true);
+    storage.activeConfigFileVersion = 11;
+    storage.sharedConfigName = 'profileA';
+
+    service.setThemeName('dark');
+    http.expectOne((r) => r.method === 'POST').flush('denied', { status: 401, statusText: 'Unauthorized' });
+    await Promise.resolve();
+
+    expect(snackSpy).not.toHaveBeenCalled();
+    http.verify();
   });
 });
 

--- a/src/app/core/services/settings.service.ts
+++ b/src/app/core/services/settings.service.ts
@@ -1,5 +1,7 @@
 import { Injectable, inject, signal } from '@angular/core';
-import { BehaviorSubject, Observable } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { BehaviorSubject, Observable, filter } from 'rxjs';
+import { HttpErrorResponse } from '@angular/common/http';
 import { cloneDeep } from 'lodash-es';
 
 import { IDatasetServiceDatasetConfig } from './dataset-stream.service';
@@ -64,6 +66,24 @@ export class SettingsService {
   constructor() {
     console.log("[AppSettings Service] Service startup...");
     this.storage.activeConfigFileVersion = configFileVersion;
+
+    // Routine saves go through the fire-and-forget patchConfig queue, so a failed server write is
+    // otherwise invisible: the setting applies in memory but reverts on the next reload. Surface it.
+    this.storage.patchFailure$
+      .pipe(
+        // A read-only session (no SK write scope) returns 401/403 on every save — expected, not a
+        // fault — so it must not raise the alarming persistent toast; only genuine failures do.
+        filter(({ error }) => !(error instanceof HttpErrorResponse && (error.status === 401 || error.status === 403))),
+        takeUntilDestroyed()
+      )
+      .subscribe(() => this.snackBar.open(
+        'Problem saving configuration to the server. Resolve this issue before KIP can be used reliably.',
+        'Close',
+        {
+          duration: 0,
+          verticalPosition: 'top'
+        }
+      ));
 
     if (!window.localStorage) {
       // REQUIRED BY APP - localStorage support

--- a/src/app/core/services/storage.service.spec.ts
+++ b/src/app/core/services/storage.service.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { HttpTestingController } from '@angular/common/http/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { BehaviorSubject } from 'rxjs';
-import { StorageService } from './storage.service';
+import { StorageService, IPatchFailure } from './storage.service';
 import { IConfig } from '../interfaces/app-settings.interfaces';
 import { SignalKConnectionService, IEndpointStatus } from './signalk-connection.service';
 import { AuthenticationService } from './authentication.service';
@@ -58,6 +58,48 @@ describe('StorageService', () => {
       // JSON Patch op path is namespaced by the active slot name
       expect(req.request.body[0].path).toBe('/cockpit/dashboards');
       req.flush(null);
+    });
+  });
+
+  describe('patch-failure reporting', () => {
+    beforeEach(() => {
+      service.storageServiceReady$.next(true);
+      service.activeConfigFileVersion = 11;
+      service.sharedConfigName = 'p';
+    });
+
+    afterEach(() => http.verify());
+
+    it('emits on patchFailure$ when a routine patch fails, naming the target', () => {
+      const failures: IPatchFailure[] = [];
+      const sub = service.patchFailure$.subscribe((f) => failures.push(f));
+      service.patchConfig('IThemeConfig', { themeName: 'dark' });
+      http.expectOne((r) => r.method === 'POST').flush('boom', { status: 500, statusText: 'err' });
+      sub.unsubscribe();
+      expect(failures).toHaveLength(1);
+      expect(failures[0].key).toBe('IThemeConfig');
+      expect(failures[0].error).toBeTruthy();
+    });
+
+    it('reports the unset-slot refusal on patchFailure$ without POSTing', () => {
+      service.sharedConfigName = undefined as unknown as string;
+      const failures: IPatchFailure[] = [];
+      const sub = service.patchFailure$.subscribe((f) => failures.push(f));
+      service.patchConfig('Dashboards', []);
+      sub.unsubscribe();
+      expect(failures).toHaveLength(1);
+      expect(failures[0].key).toBe('Dashboards');
+      http.expectNone(() => true);
+    });
+
+    it('stays silent on patchFailure$ for a deferred patch (removeItem settles its own promise)', async () => {
+      const failures: IPatchFailure[] = [];
+      const sub = service.patchFailure$.subscribe((f) => failures.push(f));
+      const removal = service.removeItem('user', 'slot');
+      http.expectOne((r) => r.method === 'POST').flush('boom', { status: 500, statusText: 'err' });
+      await expect(removal).rejects.toBeTruthy();
+      sub.unsubscribe();
+      expect(failures).toHaveLength(0);
     });
   });
 

--- a/src/app/core/services/storage.service.ts
+++ b/src/app/core/services/storage.service.ts
@@ -16,6 +16,12 @@ export interface Config {
   scope: string
 }
 
+export interface IPatchFailure {
+  // Config target that failed to persist — patchConfig's ObjType, when known.
+  key?: string;
+  error: unknown;
+}
+
 export interface IStorageRemoteBootstrapContext {
   sharedConfigName: string;
   configFileVersion: number;
@@ -26,6 +32,8 @@ interface IPatchAction {
   url: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   document: any,
+  // Config target of the patch, carried into patchFailure$ so a failed save names what was lost.
+  key?: string,
   // Optional deferred handlers so callers can await a queued patch's completion.
   resolve?: () => void,
   reject?: (error: unknown) => void
@@ -55,6 +63,11 @@ export class StorageService {
   private patchQueue$ = new Subject();  // REST call queue to force sequential calls
   private _pendingPatches$ = new BehaviorSubject<number>(0); // in-flight + queued patch count, for awaitQueueDrain
   private _patchFailures = 0; // monotonic count of failed patches, so awaitQueueDrain can report failure (not just emptiness)
+  private readonly _patchFailure$ = new Subject<IPatchFailure>();
+  // Surfaces fire-and-forget patch failures so a caller that did not await the write can still tell
+  // the user their save was lost; deferred patches settle their own promise and are excluded here to
+  // avoid a double report.
+  public readonly patchFailure$ = this._patchFailure$.asObservable();
   private patch = function (arg: IPatchAction) { // http JSON Patch function
     //console.log(`[Storage Service] Send patch request:\n${JSON.stringify(arg.document)}`);
     return this.http.post(arg.url, arg.document)
@@ -112,6 +125,9 @@ export class StorageService {
             catchError((err) => {
               console.error('[Storage Service] Config patch failed; keeping the queue alive:', err);
               this._patchFailures++;
+              if (!arg.reject) {
+                this._patchFailure$.next({ key: arg.key, error: err });
+              }
               return of(null);
             }),
             finalize(() => this._pendingPatches$.next(Math.max(0, this._pendingPatches$.value - 1)))
@@ -375,7 +391,9 @@ export class StorageService {
   public patchConfig(ObjType: string, value: any, forceConfigFileVersion?: number) {
     this.ensureReady();
     if (!this.sharedConfigName) {
-      console.error('[StorageService] Refusing patchConfig: active config slot name is unset.');
+      const error = new Error('[StorageService] Refusing patchConfig: active config slot name is unset.');
+      console.error(error.message);
+      this._patchFailure$.next({ key: ObjType, error });
       return;
     }
     const ver = forceConfigFileVersion ?? this.configFileVersion;
@@ -468,7 +486,7 @@ export class StorageService {
         break;
     }
 
-    const patch: IPatchAction = { url, document };
+    const patch: IPatchAction = { url, document, key: ObjType };
     if (this._logIO) {
       const appVer = ObjType === 'IAppConfig' ? (value?.configVersion) : undefined;
       const touchesConfigVersion = ObjType === 'IAppConfig' && (typeof appVer !== 'undefined');


### PR DESCRIPTION
## Why

Routine config saves (SettingsService's ~10 `set*` methods → `StorageService.patchConfig`) were fire-and-forget and silent on failure: the JSON-Patch queue's `catchError` only bumped a private counter, and a `patchConfig` call with `sharedConfigName` unset silently early-returned (a no-op). A failed dashboard/theme/unit save was invisible until a reload reverted it (PCS-03).

## What

- StorageService now exposes a `patchFailure$` stream (`Subject<IPatchFailure>` = `{ key?, error }`). The queue's `catchError` emits on it — but **only for fire-and-forget patches**; deferred/profile ops settle their own promise and are excluded to avoid double-reporting. The unset-`sharedConfigName` refusal now emits too, instead of a silent no-op. `patchConfig`'s `void` signature and its ~10 call sites are untouched.
- SettingsService subscribes once at construction and shows a MatSnackBar on failure, reusing the existing reset/demo snackbar pattern.
- **Read-only sessions are not alarmed:** expected 401/403 write-denials are filtered out (they mean "no write access," not "broken") — only genuine failures (network / 5xx) raise the persistent toast. (Addresses the branch review's P3.)

## Tests

Failed routine patch emits on the stream naming the target key and triggers the snackbar end-to-end; unset-slot reported without POSTing; a deferred `removeItem` failure stays silent on the stream (rejects its promise); and a **401 denial does not raise the toast**.

Verified locally: lint + `build:dev` clean, settings + storage specs green (55 tests).

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zURudCY3TTRcNd2acknJ9
