### PR TITLE
refactor(signalk): remove dead IWidgetPath subscription-policy fields

### DIFF
--- a/src/app/core/interfaces/widgets-interface.ts
+++ b/src/app/core/interfaces/widgets-interface.ts
@@ -1,6 +1,6 @@
 import { ITheme } from '../services/app-service';
 import { TValidSkUnits } from '../services/units.service';
-import { TFormat, TPolicy, TScaleType } from './signalk-interfaces';
+import { TScaleType } from './signalk-interfaces';
 import type { IElectricalCardModeConfig } from '../contracts/electrical-topology-card.contract';
 
 /**
@@ -689,14 +689,6 @@ export interface IWidgetPath {
   suppressBootstrapNull?: boolean;
   /** Used as a reference ID when path is an Array and array index is not appropriate. */
   pathID?: string | null | '';
-  /** NOT IMPLEMENTED - Signal K - smoothingPeriod=[milliseconds] becomes the transmission rate, e.g. every smoothingPeriod/1000 seconds. Default: 1000 */
-  smoothingPeriod?: number;
-  /** NOT IMPLEMENTED - Signal K - format=[delta|full] specifies delta or full format. Default: delta */
-  format?: TFormat;
-  /** NOT IMPLEMENTED - Signal K - policy=[instant|ideal|fixed]. Default: ideal */
-  policy?: TPolicy;
-  /** NOT IMPLEMENTED - Signal K - minPeriod=[milliseconds] becomes the fastest message transmission rate allowed, e.g. every minPeriod/1000 seconds. This is only relevant for policy='instant' to avoid swamping the client or network. */
-  minPeriod?: number;
   /**
    * Optional: Indicates if the path control must have a path value or not.
    * - If true: The control is valid if the path is either a valid (non-empty) path or empty (null or '').

--- a/src/app/core/services/signalk-delta.service.ts
+++ b/src/app/core/services/signalk-delta.service.ts
@@ -52,7 +52,11 @@ export class SignalKDeltaService implements OnDestroy {
   }
   public streamEndpoint$: BehaviorSubject<IStreamStatus> = new BehaviorSubject<IStreamStatus>(this.streamEndpoint);
 
-  // Websocket config
+  // Websocket config.
+  // The stream opens a single coarse subscription (self or all) and receives the server's
+  // full delta firehose; path selection happens in DataService and per-widget rate limiting in
+  // WidgetStreamsDirective (sampleTime). We intentionally do not emit per-path SK subscribe/unsubscribe deltas or use
+  // SK subscription policies (policy/format/minPeriod), so no such controls exist in widget config.
   private endpointWS: string = null;
   private SubscriptionType = "self";
   private readonly WS_CONNECTION_SUBSCRIBE = "?subscribe=";


### PR DESCRIPTION
## Why

The app consumes the entire Signal K delta firehose and never uses SK's fine-grained subscribe/policies, yet `IWidgetPath` carried four dead fields — `policy`, `format`, `minPeriod`, `smoothingPeriod` — implying per-path subscription control that does not exist (SK-01).

## What

- Remove the four dead fields from `IWidgetPath` (grep-confirmed zero readers and zero writers — no member access, no object-literal writers, no HTML/config controls) and trim the now-unused `TFormat`/`TPolicy` imports.
- Document the firehose model in `signalk-delta.service.ts`: a single coarse subscription (self/all), path selection in `DataService`, per-widget rate limiting in `WidgetStreamsDirective` (`sampleTime`), and no per-path SK subscription policies. (The doc pointer was corrected per the branch review — the rate-limiting lives in `WidgetStreamsDirective`, not `DataService`.)

Pure type-level dead-field removal — no runtime behavior change. Verified locally: lint + `build:dev` clean.

## Deferred (the performance half of SK-01) → #101

Bounding `_skData` growth (pruning timed-out entries) and optional real per-path server-side subscriptions are perf optimizations not currently warranted on a small MFD — tracked in #101 so the concern isn't lost.

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zURudCY3TTRcNd2acknJ9
