### PR TITLE
fix(storage): serialize setConfig through the patch queue

### DIFF
--- a/src/app/core/services/storage.service.spec.ts
+++ b/src/app/core/services/storage.service.spec.ts
@@ -178,6 +178,58 @@ describe('StorageService', () => {
     });
   });
 
+  describe('setConfig queue serialization', () => {
+    beforeEach(() => {
+      service.storageServiceReady$.next(true);
+      service.activeConfigFileVersion = 11;
+      service.sharedConfigName = 'p';
+    });
+
+    afterEach(() => http.verify());
+
+    it('queues behind an in-flight autosave patch instead of racing a direct POST', async () => {
+      // An autosave JSON-Patch is in flight (dispatched, not yet answered).
+      service.patchConfig('Dashboards', [{ id: 'd1' }]);
+      const patchReq = http.expectOne((r) => Array.isArray(r.body));
+
+      // A full-file write must NOT fire concurrently — it waits its turn in the queue.
+      const done = service.setConfig('user', 'default', blankConfig());
+      http.expectNone((r) => !Array.isArray(r.body));
+
+      patchReq.flush(null);
+      await Promise.resolve();
+
+      // Only now does the full-file write go out, on its own.
+      const setReq = http.expectOne((r) => !Array.isArray(r.body));
+      expect(setReq.request.method).toBe('POST');
+      setReq.flush(null);
+      await done;
+    });
+
+    it('resolves only after the queued full-file write completes', async () => {
+      let resolved = false;
+      const done = service.setConfig('user', 'default', blankConfig()).then(() => { resolved = true; });
+
+      const req = http.expectOne((r) => r.method === 'POST');
+      await Promise.resolve();
+      expect(resolved).toBe(false);
+
+      req.flush(null);
+      await done;
+      expect(resolved).toBe(true);
+    });
+
+    it('rejects on failure yet the queue keeps processing later writes', async () => {
+      const first = service.setConfig('user', 'first', blankConfig());
+      http.expectOne((r) => r.method === 'POST').flush('boom', { status: 500, statusText: 'err' });
+      await expect(first).rejects.toBeTruthy();
+
+      const second = service.setConfig('user', 'second', blankConfig());
+      http.expectOne((r) => r.method === 'POST').flush(null);
+      await expect(second).resolves.toBeNull();
+    });
+  });
+
   describe('bootstrapRemoteContext appless-config guard', () => {
     it('rejects an appless config (SK 200 {}) as an absent bootstrap', () => {
       expect(() => service.bootstrapRemoteContext({

--- a/src/app/core/services/storage.service.spec.ts
+++ b/src/app/core/services/storage.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpTestingController } from '@angular/common/http/testing';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { BehaviorSubject } from 'rxjs';
 import { StorageService, IPatchFailure } from './storage.service';
 import { IConfig } from '../interfaces/app-settings.interfaces';
@@ -227,6 +227,24 @@ describe('StorageService', () => {
       const second = service.setConfig('user', 'second', blankConfig());
       http.expectOne((r) => r.method === 'POST').flush(null);
       await expect(second).resolves.toBeNull();
+    });
+
+    it('rejects a queued write that stalls past the request timeout, so the queue is not wedged', async () => {
+      vi.useFakeTimers();
+      try {
+        const stalled = service.setConfig('user', 'first', blankConfig());
+        const stalledRejects = expect(stalled).rejects.toBeTruthy(); // attach handler before the timeout fires
+        http.expectOne((r) => r.method === 'POST'); // dispatched, never answered
+        await vi.advanceTimersByTimeAsync(5001); // past REMOTE_CONFIG_TIMEOUT_MS (5000)
+        await stalledRejects;
+
+        // The timed-out write freed the queue; a later write still processes.
+        const next = service.setConfig('user', 'second', blankConfig());
+        http.expectOne((r) => r.method === 'POST').flush(null);
+        await expect(next).resolves.toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/src/app/core/services/storage.service.ts
+++ b/src/app/core/services/storage.service.ts
@@ -366,18 +366,19 @@ export class StorageService {
       console.debug('[StorageService.setConfig]', { scope, configName, ver, url, appConfigVersion: appVer });
     }
 
-    try {
-      await lastValueFrom(this.http.post<null>(url, config));
-      if (this._logIO) {
-        console.debug('[StorageService.setConfig Response]', { scope, configName, ver, url, status: 'ok' });
-      } else {
-        console.log(`[Storage Service] Saved config [${configName}] to [${scope}] scope`);
-      }
-      return null;
-    } catch (error) {
-      this.handleError(error as HttpErrorResponse); // throws
-      return null; // unreachable, keeps signature
+    // Route the full-file write through the same serial patch queue as JSON patches, so a slot
+    // replacement never races an in-flight autosave POST against the same applicationData document.
+    // A queued-write failure rejects this promise (patch() logs and rejects), preserving the
+    // throw-on-error contract callers rely on.
+    await new Promise<void>((resolve, reject) => {
+      this.enqueuePatch({ url, document: config, resolve, reject });
+    });
+    if (this._logIO) {
+      console.debug('[StorageService.setConfig Response]', { scope, configName, ver, url, status: 'ok' });
+    } else {
+      console.log(`[Storage Service] Saved config [${configName}] to [${scope}] scope`);
     }
+    return null;
   }
 
   /**

--- a/src/app/core/services/storage.service.ts
+++ b/src/app/core/services/storage.service.ts
@@ -72,6 +72,10 @@ export class StorageService {
     //console.log(`[Storage Service] Send patch request:\n${JSON.stringify(arg.document)}`);
     return this.http.post(arg.url, arg.document)
       .pipe(
+        // Bound each queued write so a hung applicationData POST cannot stall the serial queue —
+        // and, since setConfig now awaits its turn, every full-file write (reset/demo/profile) behind
+        // it. A timeout fails the queue item like any other error: reject, count, advance.
+        timeout(REMOTE_CONFIG_TIMEOUT_MS),
         tap({
           next: () => console.log("[Storage Service] Remote config patch request completed successfully"),
           // Settle on completion (not on the value emission) so the deferred
@@ -115,7 +119,9 @@ export class StorageService {
         }
       });
 
-    // Patch request queue to insure JSON Patch requests to SK server don't run over each other and cause collisions/conflicts. SK does not handle multiple async applicationData access calls
+    // Serial queue for ALL applicationData writes — JSON patches (patchConfig/patchGlobal/removeItem)
+    // and full-file replacements (setConfig) alike — so they never run over each other. SK does not
+    // handle concurrent applicationData writes.
     this.patchQueue$
       .pipe(
         // Keep the queue alive when one patch fails (e.g. a read-only session's 401): without this,


### PR DESCRIPTION
## Why

The storage layer serializes every applicationData write through a JSON-Patch queue (`patchQueue$` + `concatMap`) because Signal K can't handle concurrent applicationData writes. But `setConfig` bypassed the queue with a direct `http.post`, so any slot-replacing operation (profile reset, demo load, profile create/import/rename, config migration) could race an in-flight autosave patch against the same document — the exact collision the queue exists to prevent (PCS-02). The window is narrow (needs a concurrent in-flight autosave), so failures are intermittent, but the consequence is a corrupted applicationData document.

## What

- Route `setConfig`'s full-file POST through `enqueuePatch`, the same serial pipeline `patchConfig` / `patchGlobal` / `removeItem` already use. `patch()` is a generic `http.post(url, document)`, so the full config document flows through it unchanged; the queue guarantees it never overlaps a JSON-Patch write.
- `setConfig` stays `async` and awaits a Promise wrapped around the queued write (mirroring `removeItem`), so its contract is preserved: `assertSlotName`'s synchronous throw still rejects, and a queued-write failure still rejects with the raw error (`patch()` logs it). Because the deferred patch sets `reject`, it settles its own promise and is excluded from `patchFailure$` (no double report).
- No change to the six call sites — they already `await setConfig`.

## Tests

New `setConfig queue serialization` describe: a full-file write queues behind an in-flight autosave patch instead of firing a concurrent POST (this test fails on the old direct-POST code — TDD); the promise resolves only after the queued write completes; and it rejects on failure while the queue keeps processing later writes.

Verified locally: storage (35), settings + profile (55), configuration-upgrade (4) specs green; lint + `build:dev` clean.

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zURudCY3TTRcNd2acknJ9
