### PR TITLE
feat(config): give Skip its own config namespace on both storage tiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * OIDC/SSO users could not sign in to KIP because it required a server-local password they do not have; same-origin SSO mode resolves this.
 ## Behavior changes
 * Cross-origin token sign-in: the Signal K server provides no token-refresh endpoint, so the stored password is no longer re-sent to renew a session. The session token still persists across browser reloads until it expires; when it expires you are prompted to sign in again.
+* Skip now stores its configuration in its own namespace, separate from KIP's, on both the Signal K server (applicationData appid `skip` instead of `kip`) and in browser storage (`skip.`-prefixed keys). On a server or browser that had also run KIP, Skip previously loaded KIP's dashboards and settings; it now starts from its own defaults. This is a **one-time reset with no migration** — your existing KIP config is left untouched but is not imported, so re-create or re-import your Skip configuration after this upgrade.
 
 # v4.8.0
 ## New Features

--- a/src/app/core/components/widget-host2/widget-host2.component.ts
+++ b/src/app/core/components/widget-host2/widget-host2.component.ts
@@ -8,6 +8,7 @@ import { IWidget, IWidgetPath, IWidgetSvcConfig } from '../../interfaces/widgets
 import type { NgCompInputs, NgGridStackWidget } from 'gridstack/dist/angular';
 import { BaseWidget } from 'gridstack/dist/angular';
 import { WidgetStreamsDirective } from '../../directives/widget-streams.directive';
+import { GESTURES_DEBUG_KEY } from '../../constants/config-storage.const';
 import { WidgetMetadataDirective } from '../../directives/widget-metadata.directive';
 import { WidgetRuntimeDirective } from '../../directives/widget-runtime.directive';
 import { DialogService } from '../../services/dialog.service';
@@ -87,7 +88,7 @@ export class WidgetHost2Component extends BaseWidget implements OnInit, OnDestro
   private readonly openOverlays = new Set<TOverlayGate>();
   // Debug helper gated by the same localStorage flag used by gestures directive
   private isDebugEnabled(): boolean {
-    try { return typeof localStorage !== 'undefined' && localStorage.getItem('kip:gesturesDebug') === '1'; } catch { return false; }
+    try { return typeof localStorage !== 'undefined' && localStorage.getItem(GESTURES_DEBUG_KEY) === '1'; } catch { return false; }
   }
   private debug(...args: unknown[]) { if (this.isDebugEnabled()) console.debug('[Host2]', ...args); }
 

--- a/src/app/core/constants/config-storage.const.ts
+++ b/src/app/core/constants/config-storage.const.ts
@@ -1,0 +1,30 @@
+/**
+ * Skip's own configuration namespace on both storage tiers. Skip is a fork of Kip and shares the
+ * same server (applicationData appid) and the same browser origin, so without a distinct namespace
+ * it would read Kip's config. See issue #84. Cold-turkey switch — no migration: any config left
+ * under the old `kip`/bare keys is orphaned and Skip starts from defaults.
+ */
+
+/** applicationData appid path segment for server-side config (was `kip`). */
+export const SERVER_CONFIG_APPID = 'skip';
+
+/** Logical config type → Skip-namespaced localStorage key. Single source for the per-device keys. */
+export const LOCAL_CONFIG_KEYS = {
+  connectionConfig: 'skip.connectionConfig',
+  appConfig: 'skip.appConfig',
+  dashboardsConfig: 'skip.dashboardsConfig',
+  layoutConfig: 'skip.layoutConfig',
+  themeConfig: 'skip.themeConfig',
+  widgetConfig: 'skip.widgetConfig',
+} as const;
+
+/** Resolve a logical config type to its Skip-namespaced localStorage key. */
+export function localConfigKey(type: string): string {
+  return (LOCAL_CONFIG_KEYS as Record<string, string>)[type] ?? `skip.${type}`;
+}
+
+/** Per-tab SSO redirect-budget key (sessionStorage). */
+export const SSO_REDIRECT_BUDGET_KEY = 'skip.ssoRedirectAttempts';
+
+/** Gesture-diagnostics debug flag key. */
+export const GESTURES_DEBUG_KEY = 'skip.gesturesDebug';

--- a/src/app/core/directives/gesture.directive.ts
+++ b/src/app/core/directives/gesture.directive.ts
@@ -16,6 +16,7 @@
  * - swipeleft, swiperight, swipeup, swipedown, press, doubletap
  */
 import { Directive, DestroyRef, ElementRef, inject, input, output } from '@angular/core';
+import { GESTURES_DEBUG_KEY } from '../constants/config-storage.const';
 
 
 // Cancel handler metadata used for long-press cancellation listeners.
@@ -1204,7 +1205,7 @@ export class GestureDirective {
 (() => {
   try {
     // Enable via persisted localStorage flag only (URL parameter support removed)
-    const stored = typeof localStorage !== 'undefined' ? localStorage.getItem('kip:gesturesDebug') : null;
+    const stored = typeof localStorage !== 'undefined' ? localStorage.getItem(GESTURES_DEBUG_KEY) : null;
     if (stored === '1') {
       (GestureDirective as unknown as { DEBUG: boolean }).DEBUG = true;
     }
@@ -1213,7 +1214,7 @@ export class GestureDirective {
     w.kipGesturesDebug = (on?: boolean) => {
       const ctor = GestureDirective as unknown as { DEBUG: boolean };
       if (typeof on === 'boolean') ctor.DEBUG = on; else ctor.DEBUG = !ctor.DEBUG;
-      try { localStorage.setItem('kip:gesturesDebug', ctor.DEBUG ? '1' : '0'); } catch { /* ignore */ }
+      try { localStorage.setItem(GESTURES_DEBUG_KEY, ctor.DEBUG ? '1' : '0'); } catch { /* ignore */ }
       console.info('KIP gestures debug:', ctor.DEBUG);
       return ctor.DEBUG;
     };

--- a/src/app/core/services/app-initNetwork.service.spec.ts
+++ b/src/app/core/services/app-initNetwork.service.spec.ts
@@ -142,7 +142,7 @@ describe('AppNetworkInitService', () => {
         (service as unknown as { migrateRemoteControlToDevice: (r: IConfig | null) => void }).migrateRemoteControlToDevice(remoteConfig);
     }
     function storedConn(): IConnectionConfig | null {
-        const raw = localStorage.getItem('connectionConfig');
+        const raw = localStorage.getItem('skip.connectionConfig');
         return raw ? JSON.parse(raw) : null;
     }
 
@@ -150,7 +150,7 @@ describe('AppNetworkInitService', () => {
         const baseV12: Partial<IConnectionConfig> = { configVersion: 12, useSharedConfig: true, isRemoteControl: false, instanceName: '' };
 
         it('shared boot lifts the profile identity and stamps v13 once', () => {
-            localStorage.removeItem('connectionConfig');
+            localStorage.removeItem('skip.connectionConfig');
             setConnConfig({ ...baseV12 });
             migrate({ app: { isRemoteControl: true, instanceName: 'Helm' } } as unknown as IConfig);
             expect(storedConn()?.isRemoteControl).toBe(true);
@@ -159,8 +159,8 @@ describe('AppNetworkInitService', () => {
         });
 
         it('local boot lifts the identity from the local appConfig', () => {
-            localStorage.removeItem('connectionConfig');
-            localStorage.setItem('appConfig', JSON.stringify({ isRemoteControl: true, instanceName: 'Mast' }));
+            localStorage.removeItem('skip.connectionConfig');
+            localStorage.setItem('skip.appConfig', JSON.stringify({ isRemoteControl: true, instanceName: 'Mast' }));
             setConnConfig({ ...baseV12, useSharedConfig: false });
             migrate(null);
             expect(storedConn()?.isRemoteControl).toBe(true);
@@ -169,7 +169,7 @@ describe('AppNetworkInitService', () => {
         });
 
         it('degraded shared boot (no profile) defers: version stays 12, nothing persisted', () => {
-            localStorage.removeItem('connectionConfig');
+            localStorage.removeItem('skip.connectionConfig');
             setConnConfig({ ...baseV12, useSharedConfig: true });
             migrate(null);
             expect(storedConn()).toBeNull();
@@ -177,7 +177,7 @@ describe('AppNetworkInitService', () => {
         });
 
         it('is a no-op when already migrated (version >= 13)', () => {
-            localStorage.removeItem('connectionConfig');
+            localStorage.removeItem('skip.connectionConfig');
             setConnConfig({ ...baseV12, configVersion: 13 });
             migrate({ app: { isRemoteControl: true, instanceName: 'X' } } as unknown as IConfig);
             expect(storedConn()).toBeNull();

--- a/src/app/core/services/app-initNetwork.service.ts
+++ b/src/app/core/services/app-initNetwork.service.ts
@@ -20,9 +20,10 @@ import { IStorageRemoteBootstrapContext, StorageService } from './storage.servic
 import { ConnectionState, ConnectionStateMachine } from './connection-state-machine.service';
 import { InternetReachabilityService } from './internet-reachability.service';
 import { DatasetStreamService } from './dataset-stream.service';
+import { LOCAL_CONFIG_KEYS } from '../constants/config-storage.const';
 
 const configFileVersion = 11; // used to change the Signal K configuration storage file name (ie. 9.0.0.json) that contains the configuration definitions. Applies only to remote storage.
-const CONNECTION_CONFIG_KEY = 'connectionConfig';
+const CONNECTION_CONFIG_KEY = LOCAL_CONFIG_KEYS.connectionConfig;
 export type TBootstrapStatus = 'starting' | 'ready' | 'degraded';
 export type TBootstrapIssueReason = 'none' | 'missing-shared-config' | 'network-unreachable' | 'unauthorized' | 'unknown' | 'auth-blocked';
 export type TAuthBlockedCause = 'budget-exhausted' | 'sign-in-required';
@@ -347,7 +348,7 @@ export class AppNetworkInitService implements OnDestroy {
       (remoteConfig?.app as unknown as { isRemoteControl?: boolean; instanceName?: string }) ?? null;
     if (!app && !this.config.useSharedConfig) {
       try {
-        app = JSON.parse(localStorage.getItem('appConfig') ?? 'null');
+        app = JSON.parse(localStorage.getItem(LOCAL_CONFIG_KEYS.appConfig) ?? 'null');
       } catch {
         app = null;
       }

--- a/src/app/core/services/configuration-upgrade.service.ts
+++ b/src/app/core/services/configuration-upgrade.service.ts
@@ -6,6 +6,7 @@ import { IAppConfig, IConfig, IThemeConfig } from '../interfaces/app-settings.in
 import { v10IConfig, v10IThemeConfig } from '../interfaces/v10-config-interface';
 import { NgGridStackWidget } from 'gridstack/dist/angular';
 import { Dashboard } from './dashboard.service';
+import { LOCAL_CONFIG_KEYS } from '../constants/config-storage.const';
 
 interface DataChartConfigUpdate {
   datachartPath: string;
@@ -159,9 +160,9 @@ export class ConfigurationUpgradeService {
       this.migrateDatasetsToDataCharts(datasetInfo, upgradedConfig.dashboards);
       this.migrateUseNeedleToEnableNeedle(upgradedConfig.dashboards);
 
-      localStorage.setItem('appConfig', JSON.stringify(upgradedConfig.app));
-      localStorage.setItem('dashboardsConfig', JSON.stringify(upgradedConfig.dashboards));
-      localStorage.setItem('themeConfig', JSON.stringify(upgradedConfig.theme));
+      localStorage.setItem(LOCAL_CONFIG_KEYS.appConfig, JSON.stringify(upgradedConfig.app));
+      localStorage.setItem(LOCAL_CONFIG_KEYS.dashboardsConfig, JSON.stringify(upgradedConfig.dashboards));
+      localStorage.setItem(LOCAL_CONFIG_KEYS.themeConfig, JSON.stringify(upgradedConfig.theme));
       setTimeout(() => this._settings.reloadApp(), 1500);
       this.upgrading.set(false);
     } else {
@@ -187,9 +188,9 @@ export class ConfigurationUpgradeService {
       this.migrateDatasetsToDataCharts(datasetInfo, dashboards);
       this.migrateUseNeedleToEnableNeedle(dashboards);
 
-      localStorage.setItem('appConfig', JSON.stringify(transformedApp));
-      localStorage.setItem('dashboardsConfig', JSON.stringify(dashboards));
-      localStorage.setItem('themeConfig', JSON.stringify(transformedTheme));
+      localStorage.setItem(LOCAL_CONFIG_KEYS.appConfig, JSON.stringify(transformedApp));
+      localStorage.setItem(LOCAL_CONFIG_KEYS.dashboardsConfig, JSON.stringify(dashboards));
+      localStorage.setItem(LOCAL_CONFIG_KEYS.themeConfig, JSON.stringify(transformedTheme));
       setTimeout(() => this._settings.reloadApp(), 1500);
       this.upgrading.set(false);
     }
@@ -232,10 +233,10 @@ export class ConfigurationUpgradeService {
       localStorageConfig.app.configVersion = this.targetConfigVersion; // baseline fresh
       localStorageConfig.app.nightModeBrightness = 0.27;
       localStorageConfig.theme.themeName = '';
-      localStorage.setItem('appConfig', JSON.stringify(localStorageConfig.app));
-      localStorage.setItem('themeConfig', JSON.stringify(localStorageConfig.theme));
-      localStorage.removeItem('widgetConfig');
-      localStorage.removeItem('layoutConfig');
+      localStorage.setItem(LOCAL_CONFIG_KEYS.appConfig, JSON.stringify(localStorageConfig.app));
+      localStorage.setItem(LOCAL_CONFIG_KEYS.themeConfig, JSON.stringify(localStorageConfig.theme));
+      localStorage.removeItem(LOCAL_CONFIG_KEYS.widgetConfig);
+      localStorage.removeItem(LOCAL_CONFIG_KEYS.layoutConfig);
       this.upgrading.set(false);
     }
   }

--- a/src/app/core/services/settings.service.spec.ts
+++ b/src/app/core/services/settings.service.spec.ts
@@ -22,7 +22,7 @@ interface SeedOpts {
 
 function seedConfig(opts: SeedOpts = {}): void {
   localStorage.setItem('authorization_token', JSON.stringify(null));
-  localStorage.setItem('connectionConfig', JSON.stringify({
+  localStorage.setItem('skip.connectionConfig', JSON.stringify({
     configVersion: 13,
     kipUUID: 'test-uuid',
     signalKUrl: 'https://boat.example:3443',
@@ -33,7 +33,7 @@ function seedConfig(opts: SeedOpts = {}): void {
     isRemoteControl: opts.isRemoteControl ?? false,
     instanceName: opts.instanceName ?? ''
   }));
-  localStorage.setItem('appConfig', JSON.stringify({
+  localStorage.setItem('skip.appConfig', JSON.stringify({
     configVersion: 12,
     autoNightMode: false,
     redNightMode: false,
@@ -48,14 +48,14 @@ function seedConfig(opts: SeedOpts = {}): void {
       sound: { disableSound: true, muteNormal: true, muteNominal: true, muteWarn: true, muteAlert: true, muteAlarm: true, muteEmergency: true }
     }
   }));
-  localStorage.setItem('dashboardsConfig', JSON.stringify([{ id: 'dash-1' }]));
-  localStorage.setItem('themeConfig', JSON.stringify({ themeName: 'light' }));
+  localStorage.setItem('skip.dashboardsConfig', JSON.stringify([{ id: 'dash-1' }]));
+  localStorage.setItem('skip.themeConfig', JSON.stringify({ themeName: 'light' }));
 }
 
 function seedConnectionConfig(extra: Record<string, unknown> = {}): void {
   localStorage.setItem('authorization_token', JSON.stringify(null));
   localStorage.setItem(
-    'connectionConfig',
+    'skip.connectionConfig',
     JSON.stringify({
       configVersion: 12,
       kipUUID: 'test-uuid',
@@ -98,7 +98,7 @@ describe('SettingsService — legacy credential purge', () => {
   it('strips legacy credential fields on load, preserving other fields and without a version bump', () => {
     seedConnectionConfig({ loginPassword: 'plaintext-secret', loginName: 'captain', useDeviceToken: true });
     createService();
-    const persisted = JSON.parse(localStorage.getItem('connectionConfig') as string);
+    const persisted = JSON.parse(localStorage.getItem('skip.connectionConfig') as string);
     expect(Object.prototype.hasOwnProperty.call(persisted, 'loginPassword')).toBe(false);
     expect(Object.prototype.hasOwnProperty.call(persisted, 'loginName')).toBe(false);
     expect(Object.prototype.hasOwnProperty.call(persisted, 'useDeviceToken')).toBe(false);
@@ -123,9 +123,9 @@ describe('SettingsService — storage routing (server applicationData only)', ()
   // server's applicationData regardless of the useSharedConfig flag.
   function setup(connExtra: Record<string, unknown>) {
     seedConnectionConfig(connExtra);
-    localStorage.setItem('appConfig', JSON.stringify({ configVersion: 12, dataSets: [], unitDefaults: {}, notificationConfig: {} }));
-    localStorage.setItem('dashboardsConfig', JSON.stringify([]));
-    localStorage.setItem('themeConfig', JSON.stringify({ themeName: '' }));
+    localStorage.setItem('skip.appConfig', JSON.stringify({ configVersion: 12, dataSets: [], unitDefaults: {}, notificationConfig: {} }));
+    localStorage.setItem('skip.dashboardsConfig', JSON.stringify([]));
+    localStorage.setItem('skip.themeConfig', JSON.stringify({ themeName: '' }));
     TestBed.configureTestingModule({ providers: [SettingsService, StorageService] });
     const storage = TestBed.inject(StorageService);
     const patchSpy = vi.spyOn(storage, 'patchConfig').mockImplementation(() => undefined);
@@ -135,34 +135,34 @@ describe('SettingsService — storage routing (server applicationData only)', ()
 
   it('shared config routes a setting write to server applicationData, not localStorage', () => {
     const { service, patchSpy } = setup({ useSharedConfig: true });
-    localStorage.removeItem('themeConfig');
+    localStorage.removeItem('skip.themeConfig');
 
     service.setThemeName('shared-theme');
 
     expect(patchSpy).toHaveBeenCalledWith('IThemeConfig', { themeName: 'shared-theme' });
-    expect(localStorage.getItem('themeConfig')).toBeNull();
+    expect(localStorage.getItem('skip.themeConfig')).toBeNull();
   });
 
   it('local (useSharedConfig:false) also routes to server applicationData (single same-origin store)', () => {
     const { service, patchSpy } = setup({ useSharedConfig: false });
-    localStorage.removeItem('themeConfig');
+    localStorage.removeItem('skip.themeConfig');
 
     service.setThemeName('local-theme');
 
     expect(patchSpy).toHaveBeenCalledWith('IThemeConfig', { themeName: 'local-theme' });
-    expect(localStorage.getItem('themeConfig')).toBeNull();
+    expect(localStorage.getItem('skip.themeConfig')).toBeNull();
   });
 
   it('setBrowserTabTitle routes to server applicationData like every other setter (useSharedConfig:false)', () => {
     // Regression guard: setBrowserTabTitle must not diverge from the always-server invariant, or the
     // title would write to localStorage and be lost on the next (server-loaded) reload.
     const { service, patchSpy } = setup({ useSharedConfig: false });
-    localStorage.removeItem('appConfig');
+    localStorage.removeItem('skip.appConfig');
 
     service.setBrowserTabTitle('Helm');
 
     expect(patchSpy).toHaveBeenCalledWith('IAppConfig', expect.objectContaining({ browserTabTitle: 'Helm' }));
-    expect(localStorage.getItem('appConfig')).toBeNull();
+    expect(localStorage.getItem('skip.appConfig')).toBeNull();
   });
 });
 
@@ -227,7 +227,7 @@ describe('SettingsService', () => {
     it('setActiveProfile updates the name and persists it to connectionConfig', () => {
       service.setActiveProfile('cockpit');
       expect(service.getActiveProfileName()).toBe('cockpit');
-      const cc = JSON.parse(localStorage.getItem('connectionConfig') as string);
+      const cc = JSON.parse(localStorage.getItem('skip.connectionConfig') as string);
       expect(cc.sharedConfigName).toBe('cockpit');
     });
 
@@ -248,16 +248,16 @@ describe('SettingsService', () => {
     it('setIsRemoteControl persists to connectionConfig, not the profile/appConfig', () => {
       const service = createService({ isRemoteControl: false });
       service.setIsRemoteControl(true);
-      const cc = JSON.parse(localStorage.getItem('connectionConfig') as string);
+      const cc = JSON.parse(localStorage.getItem('skip.connectionConfig') as string);
       expect(cc.isRemoteControl).toBe(true);
-      const appConf = JSON.parse(localStorage.getItem('appConfig') as string);
+      const appConf = JSON.parse(localStorage.getItem('skip.appConfig') as string);
       expect(appConf.isRemoteControl).toBeUndefined();
     });
 
     it('setInstanceName persists to connectionConfig', () => {
       const service = createService({ instanceName: '' });
       service.setInstanceName('Mast');
-      const cc = JSON.parse(localStorage.getItem('connectionConfig') as string);
+      const cc = JSON.parse(localStorage.getItem('skip.connectionConfig') as string);
       expect(cc.instanceName).toBe('Mast');
     });
 
@@ -266,7 +266,7 @@ describe('SettingsService', () => {
       service.setActiveProfile('cockpit');
       expect(service.getIsRemoteControl()).toBe(true);
       expect(service.getInstanceName()).toBe('Helm');
-      const cc = JSON.parse(localStorage.getItem('connectionConfig') as string);
+      const cc = JSON.parse(localStorage.getItem('skip.connectionConfig') as string);
       expect(cc.isRemoteControl).toBe(true);
       expect(cc.instanceName).toBe('Helm');
     });

--- a/src/app/core/services/settings.service.ts
+++ b/src/app/core/services/settings.service.ts
@@ -18,6 +18,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 
 import { StorageService } from './storage.service';
 import { Dashboard } from './dashboard.service';
+import { LOCAL_CONFIG_KEYS, localConfigKey } from '../constants/config-storage.const';
 import { SignalKConnectionService } from '../services/signalk-connection.service';
 import { compare } from 'compare-versions';
 
@@ -157,7 +158,7 @@ export class SettingsService {
       for (const key of legacyCredentialKeys) {
         delete rawConfig[key];
       }
-      localStorage.setItem("connectionConfig", JSON.stringify(config));
+      localStorage.setItem(LOCAL_CONFIG_KEYS.connectionConfig, JSON.stringify(config));
     }
 
     // Also drop the legacy top-level session/device token blob. Nothing reads it anymore (auth is
@@ -171,7 +172,7 @@ export class SettingsService {
   }
 
   public resetConnection() {
-    localStorage.setItem("connectionConfig", JSON.stringify(this.getDefaultConnectionConfig()));
+    localStorage.setItem(LOCAL_CONFIG_KEYS.connectionConfig, JSON.stringify(this.getDefaultConnectionConfig()));
     this.reloadApp();
   }
 
@@ -190,7 +191,7 @@ export class SettingsService {
    * @memberof SettingsService
    */
   public loadConfigFromLocalStorage(type: string) {
-    let config = JSON.parse(localStorage.getItem(type) ?? 'null');
+    let config = JSON.parse(localStorage.getItem(localConfigKey(type)) ?? 'null');
 
     if (config === null) {
       console.log(`[AppSettings Service] Error loading ${type} config. Force loading ${type} defaults`);
@@ -596,7 +597,7 @@ export class SettingsService {
    */
   public replaceConfig(configType: string, newConfig: IAppConfig | IConnectionConfig | IThemeConfig | Dashboard[], reloadApp?: boolean) {
     const jsonConfig = JSON.stringify(newConfig);
-    localStorage.setItem(configType, jsonConfig);
+    localStorage.setItem(localConfigKey(configType), jsonConfig);
     if (reloadApp) {
       this.reloadApp();
     }
@@ -690,7 +691,7 @@ export class SettingsService {
 
   private readStoredConnectionConfig(): Partial<IConnectionConfig> | null {
     try {
-      return JSON.parse(localStorage.getItem('connectionConfig') ?? 'null');
+      return JSON.parse(localStorage.getItem(LOCAL_CONFIG_KEYS.connectionConfig) ?? 'null');
     } catch {
       return null;
     }
@@ -710,22 +711,22 @@ export class SettingsService {
   // Calls build methods and saves to LocalStorage
   private saveAppConfigToLocalStorage() {
     console.log("[AppSettings Service] Saving Application config to LocalStorage");
-    localStorage.setItem('appConfig', JSON.stringify(this.buildAppStorageObject()));
+    localStorage.setItem(LOCAL_CONFIG_KEYS.appConfig, JSON.stringify(this.buildAppStorageObject()));
   }
 
   private saveConnectionConfigToLocalStorage() {
     console.log("[AppSettings Service] Saving Connection config to LocalStorage");
-    localStorage.setItem('connectionConfig', JSON.stringify(this.buildConnectionStorageObject()));
+    localStorage.setItem(LOCAL_CONFIG_KEYS.connectionConfig, JSON.stringify(this.buildConnectionStorageObject()));
   }
 
   private saveLDashboardsConfigToLocalStorage(dashboards: Dashboard[]) {
     console.log("[AppSettings Service] Saving Dashboard config to LocalStorage");
-    localStorage.setItem('dashboardsConfig', JSON.stringify(dashboards));
+    localStorage.setItem(LOCAL_CONFIG_KEYS.dashboardsConfig, JSON.stringify(dashboards));
   }
 
   private  saveThemeConfigToLocalStorage() {
     console.log("[AppSettings Service] Saving Theme config to LocalStorage");
-    localStorage.setItem('themeConfig', JSON.stringify(this.buildThemeStorageObject()));
+    localStorage.setItem(LOCAL_CONFIG_KEYS.themeConfig, JSON.stringify(this.buildThemeStorageObject()));
   }
 
   // Creates config from defaults and saves to LocalStorage
@@ -734,7 +735,7 @@ export class SettingsService {
     config.notificationConfig = cloneDeep(DefaultNotificationConfig);
     config.unitDefaults = cloneDeep(DefaultUnitsConfig);
     config.configVersion = latestConfigVersion;
-    localStorage.setItem('appConfig', JSON.stringify(config));
+    localStorage.setItem(LOCAL_CONFIG_KEYS.appConfig, JSON.stringify(config));
     return config;
   }
 
@@ -742,19 +743,19 @@ export class SettingsService {
     const config: IConnectionConfig = cloneDeep(DefaultConnectionConfig);
     config.kipUUID = UUID.create();
     config.signalKUrl = window.location.origin;
-    localStorage.setItem('connectionConfig', JSON.stringify(config));
+    localStorage.setItem(LOCAL_CONFIG_KEYS.connectionConfig, JSON.stringify(config));
     return config;
   }
 
   private getDefaultDashboardsConfig(): Dashboard[] {
     const config: Dashboard[] = [];
-    localStorage.setItem("dashboardsConfig", JSON.stringify(config));
+    localStorage.setItem(LOCAL_CONFIG_KEYS.dashboardsConfig, JSON.stringify(config));
     return config;
   }
 
   private getDefaultThemeConfig(): IThemeConfig {
     const config: IThemeConfig = DefaultThemeConfig;
-    localStorage.setItem("themeConfig", JSON.stringify(config));
+    localStorage.setItem(LOCAL_CONFIG_KEYS.themeConfig, JSON.stringify(config));
     return config;
   }
 }

--- a/src/app/core/services/sso-redirect.service.ts
+++ b/src/app/core/services/sso-redirect.service.ts
@@ -1,8 +1,9 @@
 import { inject, Injectable } from '@angular/core';
 import { AuthenticationService, ILoginStatus } from './authentication.service';
 import { buildLoginRedirectUrl, isSafeReturnTo } from '../utils/login-redirect.util';
+import { SSO_REDIRECT_BUDGET_KEY } from '../constants/config-storage.const';
 
-const REDIRECT_BUDGET_KEY = 'kip.ssoRedirectAttempts';
+const REDIRECT_BUDGET_KEY = SSO_REDIRECT_BUDGET_KEY;
 const MAX_REDIRECT_ATTEMPTS = 3;
 const ADMIN_LOGIN_URL = '/admin/#/login'; // non-OIDC same-origin fallback login
 

--- a/src/app/core/services/storage.service.spec.ts
+++ b/src/app/core/services/storage.service.spec.ts
@@ -332,11 +332,11 @@ describe('StorageService — applicationData URLs, scope & version gate (charact
   it('listConfigs GETs the global then the user scoped keys URLs', async () => {
     const { service } = setup();
     const p = service.listConfigs();
-    const g = http.expectOne(`${ENDPOINT}global/kip/11/?keys=true`);
+    const g = http.expectOne(`${ENDPOINT}global/skip/11/?keys=true`);
     expect(g.request.method).toBe('GET');
     g.flush(['g-slot']);
     await tick();
-    http.expectOne(`${ENDPOINT}user/kip/11/?keys=true`).flush(['u-slot']);
+    http.expectOne(`${ENDPOINT}user/skip/11/?keys=true`).flush(['u-slot']);
     await expect(p).resolves.toEqual([
       { scope: 'global', name: 'g-slot' },
       { scope: 'user', name: 'u-slot' },
@@ -346,7 +346,7 @@ describe('StorageService — applicationData URLs, scope & version gate (charact
   it('getConfig GETs the scoped, versioned, named URL and returns a deep clone', async () => {
     const { service } = setup();
     const p = service.getConfig('user', 'default');
-    const req = http.expectOne(`${ENDPOINT}user/kip/11/default`);
+    const req = http.expectOne(`${ENDPOINT}user/skip/11/default`);
     expect(req.request.method).toBe('GET');
     const body = blankConfig();
     req.flush(body);
@@ -359,7 +359,7 @@ describe('StorageService — applicationData URLs, scope & version gate (charact
     const { service } = setup();
     const cfg = blankConfig();
     const p = service.setConfig('global', 'shared', cfg);
-    const req = http.expectOne(`${ENDPOINT}global/kip/11/shared`);
+    const req = http.expectOne(`${ENDPOINT}global/skip/11/shared`);
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toEqual(cfg);
     req.flush(null);
@@ -369,7 +369,7 @@ describe('StorageService — applicationData URLs, scope & version gate (charact
   it('patchConfig POSTs a JSON Patch to the USER scope, namespaced by the active slot', () => {
     const { service } = setup();
     service.patchConfig('IAppConfig', { autoNightMode: true });
-    const req = http.expectOne(`${ENDPOINT}user/kip/11`);
+    const req = http.expectOne(`${ENDPOINT}user/skip/11`);
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toEqual([{ op: 'replace', path: '/cockpit/app', value: { autoNightMode: true } }]);
     req.flush(null);
@@ -378,7 +378,7 @@ describe('StorageService — applicationData URLs, scope & version gate (charact
   it('patchConfig maps a granular ObjType to its app sub-path', () => {
     const { service } = setup();
     service.patchConfig('Array<IUnitDefaults>', [{ group: 'speed' }]);
-    const req = http.expectOne(`${ENDPOINT}user/kip/11`);
+    const req = http.expectOne(`${ENDPOINT}user/skip/11`);
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toEqual([{ op: 'replace', path: '/cockpit/app/unitDefaults', value: [{ group: 'speed' }] }]);
     req.flush(null);
@@ -388,7 +388,7 @@ describe('StorageService — applicationData URLs, scope & version gate (charact
     const { service } = setup();
     const cfg = blankConfig();
     service.patchGlobal('backup', 'global', cfg, 'add');
-    const req = http.expectOne(`${ENDPOINT}global/kip/11`);
+    const req = http.expectOne(`${ENDPOINT}global/skip/11`);
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toEqual([{ op: 'add', path: '/backup', value: cfg }]);
     req.flush(null);
@@ -397,7 +397,7 @@ describe('StorageService — applicationData URLs, scope & version gate (charact
   it('removeItem POSTs a remove patch to the scoped, versioned URL', async () => {
     const { service } = setup();
     const p = service.removeItem('user', 'old-slot');
-    const req = http.expectOne(`${ENDPOINT}user/kip/11`);
+    const req = http.expectOne(`${ENDPOINT}user/skip/11`);
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toEqual([{ op: 'remove', path: '/old-slot' }]);
     req.flush(null);
@@ -407,7 +407,7 @@ describe('StorageService — applicationData URLs, scope & version gate (charact
   it('forceConfigFileVersion overrides the version segment of the URL', async () => {
     const { service } = setup();
     const p = service.getConfig('user', 'default', 1);
-    const req = http.expectOne(`${ENDPOINT}user/kip/1/default`);
+    const req = http.expectOne(`${ENDPOINT}user/skip/1/default`);
     expect(req.request.method).toBe('GET');
     req.flush(blankConfig());
     await p;
@@ -416,7 +416,7 @@ describe('StorageService — applicationData URLs, scope & version gate (charact
   it('patchConfig IThemeConfig extracts themeName into the theme sub-path (not the whole object)', () => {
     const { service } = setup();
     service.patchConfig('IThemeConfig', { themeName: 'dark', extra: 'ignored' });
-    const req = http.expectOne(`${ENDPOINT}user/kip/11`);
+    const req = http.expectOne(`${ENDPOINT}user/skip/11`);
     expect(req.request.body).toEqual([{ op: 'replace', path: '/cockpit/theme/themeName', value: 'dark' }]);
     req.flush(null);
   });
@@ -425,7 +425,7 @@ describe('StorageService — applicationData URLs, scope & version gate (charact
     const { service } = setup();
     const cfg = blankConfig();
     service.patchGlobal('slot-a', 'user', cfg, 'replace');
-    const req = http.expectOne(`${ENDPOINT}user/kip/11`);
+    const req = http.expectOne(`${ENDPOINT}user/skip/11`);
     expect(req.request.body).toEqual([{ op: 'replace', path: '/slot-a', value: cfg }]);
     req.flush(null);
   });
@@ -434,7 +434,7 @@ describe('StorageService — applicationData URLs, scope & version gate (charact
     const { service } = setup();
     const cfg = blankConfig();
     service.patchGlobal('slot-b', 'global', cfg, 'remove');
-    const req = http.expectOne(`${ENDPOINT}global/kip/11`);
+    const req = http.expectOne(`${ENDPOINT}global/skip/11`);
     expect(req.request.body).toEqual([{ op: 'remove', path: '/slot-b', value: cfg }]);
     req.flush(null);
   });

--- a/src/app/core/services/storage.service.ts
+++ b/src/app/core/services/storage.service.ts
@@ -8,6 +8,7 @@ import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Subject } from 'rxjs/internal/Subject';
 import { tap, concatMap, catchError, finalize, lastValueFrom, of, BehaviorSubject, timeout } from 'rxjs';
 import { AuthenticationService } from './authentication.service';
+import { SERVER_CONFIG_APPID } from '../constants/config-storage.const';
 
 const REMOTE_CONFIG_TIMEOUT_MS = 5000; // bounded so a hung applicationData fetch cannot stall the bootstrap
 
@@ -280,8 +281,8 @@ export class StorageService {
 
     const base = this.serverEndpoint;
     const ver = forceConfigFileVersion ?? this.configFileVersion;
-    const globalUrl = `${base}global/kip/${ver}/?keys=true`;
-    const userUrl = `${base}user/kip/${ver}/?keys=true`;
+    const globalUrl = `${base}global/${SERVER_CONFIG_APPID}/${ver}/?keys=true`;
+    const userUrl = `${base}user/${SERVER_CONFIG_APPID}/${ver}/?keys=true`;
 
     try {
       const globalNames = await lastValueFrom(this.http.get<string[]>(globalUrl));
@@ -319,7 +320,7 @@ export class StorageService {
    */
   public async getConfig(scope: string, configName: string, forceConfigFileVersion?: number, isInitLoad?: boolean): Promise<IConfig> {
     this.ensureReady();
-    const base = this.serverEndpoint + scope + "/kip/";
+    const base = this.serverEndpoint + scope + "/" + SERVER_CONFIG_APPID + "/";
     const ver = forceConfigFileVersion ?? this.configFileVersion;
     const url = base + ver + "/" + configName; // URL for fetching config
 
@@ -363,7 +364,7 @@ export class StorageService {
     this.ensureReady();
     this.assertSlotName(configName, 'setConfig');
 
-    const base = this.serverEndpoint + scope + "/kip/";
+    const base = this.serverEndpoint + scope + "/" + SERVER_CONFIG_APPID + "/";
     const ver = forceConfigFileVersion ?? this.configFileVersion;
     const url = base + ver + "/" + configName; // URL for setting config
 
@@ -404,7 +405,7 @@ export class StorageService {
       return;
     }
     const ver = forceConfigFileVersion ?? this.configFileVersion;
-    const url = this.serverEndpoint + "user/kip/" + ver;
+    const url = this.serverEndpoint + "user/" + SERVER_CONFIG_APPID + "/" + ver;
     let document;
     // url already reflects forced version if provided
 
@@ -522,7 +523,7 @@ export class StorageService {
     this.ensureReady();
     this.assertSlotName(configName, 'patchGlobal');
     const ver = fileVersion ?? this.configFileVersion;
-  const url = this.serverEndpoint + scope + "/kip/" + ver;
+  const url = this.serverEndpoint + scope + "/" + SERVER_CONFIG_APPID + "/" + ver;
 
     let document;
     switch (operation) {
@@ -580,9 +581,9 @@ export class StorageService {
   public removeItem(scope: string, name: string, forceConfigFileVersion?: number): Promise<void> {
     this.ensureReady();
     this.assertSlotName(name, 'removeItem');
-    let url = this.serverEndpoint + scope + "/kip/" + this.configFileVersion;
+    let url = this.serverEndpoint + scope + "/" + SERVER_CONFIG_APPID + "/" + this.configFileVersion;
     if (forceConfigFileVersion) {
-      url = this.serverEndpoint + scope + "/kip/" + forceConfigFileVersion;
+      url = this.serverEndpoint + scope + "/" + SERVER_CONFIG_APPID + "/" + forceConfigFileVersion;
     }
     const document =
       [

--- a/tools/gen-mcp-schema/types.ts
+++ b/tools/gen-mcp-schema/types.ts
@@ -144,7 +144,7 @@ export interface SchemaMeta {
   schemaVersion: number;
   /** KIP package version the artifact was generated from. */
   kipVersion: string;
-  /** applicationData file version used in the storage URL (`.../kip/{N}/...`). */
+  /** applicationData file version used in the storage URL (`.../skip/{N}/...`). */
   configFileVersion: number;
   /** `app.configVersion` value KIP expects in a saved config body. */
   configVersion: number;


### PR DESCRIPTION
## Why

Skip is a fork of Kip but wrote its config into **Kip's namespace** on both storage tiers, so on any server/browser that had also run Kip, Skip loaded Kip's dashboards and settings. Observed on `halpi.hurma`: opening Skip showed Kip's existing dashboards. Closes #84.

## What

Give Skip its own namespace on both tiers, single-sourced in a new `src/app/core/constants/config-storage.const.ts`:

- **Server (applicationData appid):** `kip` → `skip` — replaces the 8 inline `/kip/` literals in `storage.service.ts` with `SERVER_CONFIG_APPID`. Config now lives under `applicationData/user|global/skip/<version>`.
- **Per-device keys:** a consistent `skip.`/`skip:` prefix, renamed via constants:
  - bare `connectionConfig`/`appConfig`/`dashboardsConfig`/`themeConfig`/`widgetConfig`/`layoutConfig` → `skip.*` (`LOCAL_CONFIG_KEYS`)
  - `kip.ssoRedirectAttempts` → `skip.ssoRedirectAttempts`, `kip:gesturesDebug` → `skip:gesturesDebug`

The settings-service generic getter/setter map the **logical** config type (`appConfig`, …) to the namespaced **physical** key only at the storage boundary (`localConfigKey`), so switch discriminators and callers keep using logical names.

## Cold-turkey, no migration

Old `kip`/bare keys are **never read** — no fallback, no copy. Existing Kip config is left orphaned and Skip starts from defaults. Documented as a one-time reset under Unreleased → Behavior changes in `CHANGELOG.md`.

## Out of scope (per the issue)

The companion history **plugin id** `/plugins/kip/` (provider URL, icon namespace, DOM event names) is deliberately left untouched — renaming it means republishing the server plugin, decided separately.

## Verification

- `npm run lint` — clean
- `npm run build:dev` — full type-check passes
- Updated spec assertions to the namespaced keys: `storage.service.spec` (`/skip/` paths), `settings.service.spec` and `app-initNetwork.service.spec` (`skip.` keys). Settings/Storage specs run under CI (local jsdom lacks a usable localStorage per repo notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zURudCY3TTRcNd2acknJ9