### PR TITLE
Cap gauge needle animation to a short fixed window (replicates part of mxtommy/Kip#1101)

### DIFF
--- a/src/app/core/utils/gauge-animation.util.spec.ts
+++ b/src/app/core/utils/gauge-animation.util.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { GAUGE_ANIMATION_MS, gaugeAnimationDurationMs } from './gauge-animation.util';
+
+describe('gaugeAnimationDurationMs', () => {
+  it('uses a short fixed window instead of ~the whole sample interval', () => {
+    // Old behavior would have been ~475ms (500 - 25); the gauge should now idle
+    // for most of the interval.
+    expect(gaugeAnimationDurationMs(500)).toBe(GAUGE_ANIMATION_MS);
+    expect(gaugeAnimationDurationMs(500)).toBeLessThan(500);
+  });
+
+  it('never exceeds the sample interval (avoids a full duty cycle at fast rates)', () => {
+    expect(gaugeAnimationDurationMs(100)).toBe(100);
+  });
+
+  it('falls back to the fixed window for invalid sample times', () => {
+    expect(gaugeAnimationDurationMs(0)).toBe(GAUGE_ANIMATION_MS);
+    expect(gaugeAnimationDurationMs(Number.NaN)).toBe(GAUGE_ANIMATION_MS);
+  });
+});

--- a/src/app/core/utils/gauge-animation.util.ts
+++ b/src/app/core/utils/gauge-animation.util.ts
@@ -1,0 +1,19 @@
+/**
+ * Animation duration (ms) for live ng-canvas gauges.
+ *
+ * The radial/compass gauges previously set `animationDuration = sampleTime - 25/50`,
+ * i.e. the needle animation nearly filled the whole sample interval (~95% duty
+ * cycle). A gauge fed changing data then repainted its needle layer almost
+ * continuously via its own rAF loop, so a gauge-heavy dashboard stayed near the
+ * frame budget on low-power marine hardware.
+ *
+ * A short fixed window leaves the gauge idle for most of each interval, clamped so
+ * it never exceeds the sample interval itself (which would re-introduce a full
+ * duty cycle at very fast sample rates).
+ */
+export const GAUGE_ANIMATION_MS = 120;
+
+export function gaugeAnimationDurationMs(sampleTimeMs: number): number {
+  if (!Number.isFinite(sampleTimeMs) || sampleTimeMs <= 0) return GAUGE_ANIMATION_MS;
+  return Math.min(GAUGE_ANIMATION_MS, sampleTimeMs);
+}

--- a/src/app/widgets/widget-gauge-ng-compass/widget-gauge-ng-compass.component.ts
+++ b/src/app/widgets/widget-gauge-ng-compass/widget-gauge-ng-compass.component.ts
@@ -6,6 +6,7 @@
  * instantiated gauge config.
  */
 import { Component, AfterViewInit, ElementRef, effect, viewChild, input, inject, untracked, computed, signal } from '@angular/core';
+import { gaugeAnimationDurationMs } from '../../core/utils/gauge-animation.util';
 import { ChangeDetectionStrategy } from '@angular/core';
 
 import { GaugesModule, RadialGaugeOptions, RadialGauge } from '@godind/ng-canvas-gauges';
@@ -230,7 +231,7 @@ export class WidgetGaugeNgCompassComponent implements AfterViewInit {
     else {
       g.animationTarget = this.ANIMATION_TARGET_NEEDLE; g.useMinPath = true;
     }
-    g.animateOnInit = false; g.animation = this.animationEnabled(); g.animatedValue = this.animationEnabled(); g.animationRule = 'linear'; g.animationDuration = (cfg.paths?.['gaugePath']?.sampleTime ?? 500) - 50;
+    g.animateOnInit = false; g.animation = this.animationEnabled(); g.animatedValue = this.animationEnabled(); g.animationRule = 'linear'; g.animationDuration = gaugeAnimationDurationMs(cfg.paths?.['gaugePath']?.sampleTime ?? 500);
     // Colors (RGBA unsupported -> convert)
     const palette = getColors(cfg.color, theme);
     const dim = rgbaToHex(palette.dim);

--- a/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.ts
+++ b/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.ts
@@ -10,6 +10,7 @@ import { ChangeDetectionStrategy } from '@angular/core';
 import { LinearGaugeOptions, LinearGauge, GaugesModule } from '@godind/ng-canvas-gauges';
 import { IWidgetSvcConfig, IDataHighlight } from '../../core/interfaces/widgets-interface';
 import { adjustLinearScaleAndMajorTicks, IScale } from '../../core/utils/dataScales.util';
+import { gaugeAnimationDurationMs } from '../../core/utils/gauge-animation.util';
 import { getHighlights } from '../../core/utils/zones-highlight.utils';
 import { getColors } from '../../core/utils/themeColors.utils';
 import { States } from '../../core/interfaces/signalk-interfaces';
@@ -294,7 +295,7 @@ export class WidgetGaugeNgLinearComponent implements AfterViewInit {
     opt.ticksWidth = ticks ? (enableNeedle ? (isVertical ? 15 : 10) : 10) : 0;
     opt.ticksPadding = ticks ? (isVertical ? (enableNeedle ? 0 : 5) : (enableNeedle ? 9 : 8)) : 0;
     opt.tickSide = 'left';
-    opt.animation = this.animationEnabled(); opt.animationRule = 'linear'; opt.animatedValue = this.animationEnabled(); opt.animateOnInit = false; opt.animationDuration = (cfg.paths?.['gaugePath']?.sampleTime ?? 500) - 25;
+    opt.animation = this.animationEnabled(); opt.animationRule = 'linear'; opt.animatedValue = this.animationEnabled(); opt.animateOnInit = false; opt.animationDuration = gaugeAnimationDurationMs(cfg.paths?.['gaugePath']?.sampleTime ?? 500);
     opt.highlights = []; opt.highlightsWidth = cfg.gauge?.highlightsWidth;
     // pre-populate highlights if already available
     const h = this.highlights();

--- a/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
+++ b/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
@@ -6,6 +6,7 @@
  * instantiated gauge config.
  */
 import { Component, AfterViewInit, ElementRef, effect, viewChild, inject, input, untracked, computed, signal } from '@angular/core';
+import { gaugeAnimationDurationMs } from '../../core/utils/gauge-animation.util';
 import { ChangeDetectionStrategy } from '@angular/core';
 import { GaugesModule, RadialGaugeOptions, RadialGauge } from '@godind/ng-canvas-gauges';
 import { IWidgetSvcConfig, IDataHighlight } from '../../core/interfaces/widgets-interface';
@@ -301,7 +302,7 @@ export class WidgetGaugeNgRadialComponent implements AfterViewInit {
     g.valueInt = cfg.numInt ?? 1; g.valueDec = cfg.numDecimal ?? 2; g.majorTicksInt = g.valueInt; g.majorTicksDec = g.valueDec;
     g.highlightsWidth = cfg.gauge?.highlightsWidth;
     g.animation = this.animationEnabled(); g.animateOnInit = false; g.animatedValue = this.animationEnabled(); g.animationRule = 'linear';
-    const st = cfg.paths?.['gaugePath']?.sampleTime ?? 500; g.animationDuration = st - 25;
+    const st = cfg.paths?.['gaugePath']?.sampleTime ?? 500; g.animationDuration = gaugeAnimationDurationMs(st);
     g.colorBorderShadow = false; g.colorBorderOuter = theme.cardColor; g.colorBorderOuterEnd = ''; g.colorBorderMiddle = theme.cardColor; g.colorBorderMiddleEnd = '';
     g.colorPlate = g.colorPlateEnd = theme.cardColor; g.colorBar = theme.background;
 


### PR DESCRIPTION
## Motivation

The ng-compass and ng-radial gauges derived `animationDuration` from the path sample time minus a small constant (`sampleTime - 50` / `sampleTime - 25`), so the needle animation nearly filled each sample interval (~95% duty cycle). A gauge fed changing data repainted its needle layer almost continuously through its own rAF loop, pinning gauge-heavy dashboards on low-power marine hardware. Upstream mxtommy/Kip#1101 caps the animation to a short fixed window so each gauge idles most of the interval.

## Approach

Cherry-picked from mxtommy/Kip#1101 with `git cherry-pick -x`, preserving upstream authorship. Note: the upstream PR is still **open**; if it changes before merge there, reconcile per the issue notes.

- `5c790b22` — adds `src/app/core/utils/gauge-animation.util.ts` (`GAUGE_ANIMATION_MS = 120`, clamped to never exceed the sample interval, 120 ms fallback for non-finite/<= 0 sample times) plus a spec, and swaps the call sites in `widget-gauge-ng-compass.component.ts` and `widget-gauge-ng-radial.component.ts`. Applied cleanly with no conflicts.

## Deliberate divergence from a faithful replica

- **ng-linear also capped** (separate fork-authored commit): `widget-gauge-ng-linear.component.ts` carries the identical `sampleTime - 25` pattern that upstream left unfixed, so the same `gaugeAnimationDurationMs()` cap is applied there as well.

## Verification

- `npx ng test --include='src/app/core/utils/gauge-animation.util.spec.ts'` — 1 test file, 3/3 tests passed
- `npm run lint` — all files pass linting
- `npm run build:prod` — bundle generation complete (only the pre-existing `piexifjs` non-ESM warning)

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)
