### PR TITLE
Coalesce + time-slice canvas ResizeObserver work (replicates part of mxtommy/Kip#1101)

### DIFF
--- a/src/app/core/services/canvas.service.spec.ts
+++ b/src/app/core/services/canvas.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CanvasService } from './canvas.service';
 
 describe('CanvasService', () => {
@@ -36,5 +36,62 @@ describe('CanvasService', () => {
     // A different geometry/text is a cache miss and runs the search again.
     service.calculateOptimalFontSize(ctx, '12.3', 120, 40, 'normal');
     expect(measureCalls).toBeGreaterThan(callsAfterFirst);
+  });
+});
+
+/**
+ * The shared ResizeObserver used to reallocate every canvas's backing store and
+ * redraw it synchronously in one callback — a single long task on a fullscreen/
+ * grid-relayout storm that blocks input (incl. the exit-fullscreen gesture).
+ * These pin the two mitigations: skip the realloc when the size is unchanged,
+ * and time-slice the batch across animation frames.
+ */
+describe('CanvasService resize handling (freeze-audit)', () => {
+  let service: CanvasService;
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(CanvasService);
+    service.scaleFactor = 1;
+  });
+
+  function fakeCanvas() {
+    const c: { style: Record<string, string>; getContext: () => null; _w: number; _h: number; writes: number; width: number; height: number } =
+      { style: {}, getContext: () => null, _w: 0, _h: 0, writes: 0 } as never;
+    Object.defineProperty(c, 'width', { get() { return c._w; }, set(v: number) { c._w = v; c.writes++; } });
+    Object.defineProperty(c, 'height', { get() { return c._h; }, set(v: number) { c._h = v; } });
+    return c;
+  }
+
+  it('setHighDPISize skips the backing-store realloc when the device-pixel size is unchanged', () => {
+    const c = fakeCanvas();
+    const rect = { width: 100, height: 80 } as DOMRectReadOnly;
+    service.setHighDPISize(c as unknown as HTMLCanvasElement, rect);
+    expect(c.writes).toBe(1);
+    service.setHighDPISize(c as unknown as HTMLCanvasElement, rect);
+    expect(c.writes).toBe(1); // unchanged size -> no second realloc
+    service.setHighDPISize(c as unknown as HTMLCanvasElement, { width: 120, height: 80 } as DOMRectReadOnly);
+    expect(c.writes).toBe(2); // genuine change still reallocates
+  });
+
+  it('flushResizes time-slices: it defers the remainder to the next frame when the budget is exceeded', () => {
+    const a = fakeCanvas(), b = fakeCanvas();
+    const internals = service as unknown as {
+      pendingResize: Map<HTMLCanvasElement, DOMRectReadOnly>;
+      flushResizes: () => void;
+    };
+    const rect = { width: 100, height: 80 } as DOMRectReadOnly;
+    internals.pendingResize.set(a as unknown as HTMLCanvasElement, rect);
+    internals.pendingResize.set(b as unknown as HTMLCanvasElement, rect);
+
+    const rafSpy = vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation(() => 1 as unknown as number);
+    let t = 0;
+    vi.spyOn(performance, 'now').mockImplementation(() => (t += 100)); // each call jumps 100ms past the 8ms budget
+
+    internals.flushResizes();
+
+    expect(internals.pendingResize.size).toBe(1); // one processed, remainder deferred
+    expect(rafSpy).toHaveBeenCalled();            // rescheduled to a later frame
+    rafSpy.mockRestore();
+    vi.restoreAllMocks();
   });
 });

--- a/src/app/core/services/canvas.service.ts
+++ b/src/app/core/services/canvas.service.ts
@@ -14,6 +14,9 @@ export class CanvasService {
   private observedCanvases = new Map<HTMLCanvasElement, { autoRelease?: boolean }>();
   private dprMediaQuery: MediaQueryList | null = null;
   private resizeCallbacks = new WeakMap<HTMLCanvasElement, (w: number, h: number) => void>();
+  /** Canvases whose size changed, awaiting a time-sliced resize flush. */
+  private pendingResize = new Map<HTMLCanvasElement, DOMRectReadOnly>();
+  private resizeRafId: number | null = null;
   /**
    * Memo of optimal font sizes keyed by (text, rounded maxWidth, rounded maxHeight, fontWeight).
    * The binary search below runs a handful of measureText() calls on every value redraw of the
@@ -81,49 +84,14 @@ export class CanvasService {
         console.log('[CanvasService] Creating shared ResizeObserver for all canvases');
       }
       this.sharedResizeObserver = new ResizeObserver(entries => {
-        if (this.debug) {
-          console.log('[CanvasService] Shared ResizeObserver callback fired', entries.map(entry => {
-            const target = entry.target as HTMLCanvasElement;
-            const parent = target.parentElement;
-            return {
-              tag: target.tagName,
-              id: target.id,
-              class: target.className,
-              parent: parent ? {
-                tag: parent.tagName,
-                class: parent.className,
-                id: parent.id
-              } : null,
-              contentRect: entry.contentRect,
-              style: { width: target.style.width, height: target.style.height },
-              backingStore: { width: target.width, height: target.height }
-            };
-          }));
-        }
+        // Coalesce entries and process them time-sliced across animation frames
+        // (see flushResizes) so a fullscreen / grid-relayout storm that resizes
+        // every canvas at once can't become a single long task that blocks input
+        // (including the exit-fullscreen gesture).
         for (const entry of entries) {
-          const target = entry.target as HTMLCanvasElement;
-          if (this.debug) {
-            const parent = target.parentElement;
-            console.log('[CanvasService] Shared ResizeObserver entry (detailed)', {
-              tag: target.tagName,
-              id: target.id,
-              class: target.className,
-              parent: parent ? {
-                tag: parent.tagName,
-                class: parent.className,
-                id: parent.id
-              } : null,
-              contentRect: entry.contentRect,
-              style: { width: target.style.width, height: target.style.height },
-              backingStore: { width: target.width, height: target.height }
-            });
-          }
-          this.setHighDPISize(target, entry.contentRect);
-          const cb = this.resizeCallbacks.get(target);
-          if (cb) {
-            cb(Math.round(entry.contentRect.width), Math.round(entry.contentRect.height));
-          }
+          this.pendingResize.set(entry.target as HTMLCanvasElement, entry.contentRect);
         }
+        this.scheduleResizeFlush();
       });
     }
     this.sharedResizeObserver.observe(canvas);
@@ -251,12 +219,48 @@ export class CanvasService {
   * drawing into the 2D context may require scaling (the service handles that
   * for offscreen canvases by calling `setTransform` or `scale`).
    */
+  private scheduleResizeFlush(): void {
+    if (this.resizeRafId !== null) return;
+    this.resizeRafId = requestAnimationFrame(() => this.flushResizes());
+  }
+
+  /**
+   * Apply pending canvas resizes within a per-frame time budget, deferring any
+   * remainder to the next animation frame. Bounds the worst-case task so a
+   * many-canvas resize storm never blocks the main thread in one shot.
+   */
+  private flushResizes(): void {
+    this.resizeRafId = null;
+    const budgetMs = 8;
+    const start = performance.now();
+    for (const [canvas, rect] of this.pendingResize) {
+      this.pendingResize.delete(canvas);
+      this.setHighDPISize(canvas, rect);
+      const cb = this.resizeCallbacks.get(canvas);
+      if (cb) cb(Math.round(rect.width), Math.round(rect.height));
+      if (this.pendingResize.size > 0 && performance.now() - start > budgetMs) {
+        this.scheduleResizeFlush();
+        return;
+      }
+    }
+  }
+
   public setHighDPISize(canvas: HTMLCanvasElement, parentContainer: DOMRectReadOnly): void {
     const cssWidth = Math.round(parentContainer.width);
     const cssHeight = Math.round(parentContainer.height);
+    const devWidth = Math.round(cssWidth * this.scaleFactor);
+    const devHeight = Math.round(cssHeight * this.scaleFactor);
 
-    canvas.width = Math.round(cssWidth * this.scaleFactor);
-    canvas.height = Math.round(cssHeight * this.scaleFactor);
+    // Reassigning canvas.width/height always reallocates and clears the backing
+    // store even when the value is identical. Skip it (and the transform reset)
+    // when the device-pixel size is unchanged — avoids most of the redundant
+    // work during resize/fullscreen storms and sub-pixel jitter.
+    if (canvas.width === devWidth && canvas.height === devHeight) {
+      return;
+    }
+
+    canvas.width = devWidth;
+    canvas.height = devHeight;
 
     canvas.style.width = `${cssWidth}px`;
     canvas.style.height = `${cssHeight}px`;


### PR DESCRIPTION
## Motivation

`CanvasService`'s shared `ResizeObserver` callback processed every entry synchronously (`setHighDPISize` + per-canvas resize callback per entry), so a fullscreen/grid-relayout that resizes many canvases at once formed one long blocking main-thread task — the primary "can't exit fullscreen" freeze. `setHighDPISize` also unconditionally reassigned `canvas.width`/`height`, reallocating and clearing the backing store even when the device-pixel size was unchanged. Upstream measured this fix eliminating a 1097 ms main-thread block (median @10x CPU throttle) during resize storms.

## Approach

Cherry-picked from the open upstream PR mxtommy/Kip#1101 with `git cherry-pick -x`, preserving upstream authorship (Dillan Laughlin):

- `7e3327d5` — failing tests pinning the two mitigations (RED)
- `5de5810e` — coalesce ResizeObserver entries into a pending map, flush under an 8 ms/frame rAF budget with the remainder deferred to the next frame, and skip `setHighDPISize`'s backing-store realloc when the device-pixel size is unchanged (GREEN)

Note: upstream #1101 is still open; if it changes before merge there, we reconcile per the tracking issue.

## Adaptations

Both commits applied cleanly with no conflicts — Skip's pre-patch observer callback and `setHighDPISize` matched upstream's shape. Two Skip-specific divergences were verified rather than adapted:

- Skip's `setHighDPISize` does `ctx.setTransform` + `clearRect` after sizing (unlike upstream Kip). The cherry-picked early return lands *before* the realloc, so the unchanged-size path now also skips the transform reset and clear — which is the upstream intent (the comment even says "Skip it (and the transform reset)"). Skip's block is preserved on the genuine-change path.
- Skip's observer callback carried debug-log blocks that the upstream patch deletes; deleting them with the patch is correct (they were part of the storm's synchronous work).

No fork-authored commits were needed.

## Verification

- `npx ng test --include='src/app/core/services/canvas.service.spec.ts'` — 1 file, 4 tests passed (2 pre-existing + 2 new)
- `npm run lint` — all files pass
- `npm run build:prod` — completes (only the pre-existing `piexifjs` CommonJS warning)

CI is the source of truth for the full suite.

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)
