### PR TITLE
Throttle + value-dedupe own-ship updates (replicates part of mxtommy/Kip#1101)

### DIFF
--- a/src/app/core/services/ais-processing.service.spec.ts
+++ b/src/app/core/services/ais-processing.service.spec.ts
@@ -183,3 +183,64 @@ describe('AisProcessingService applyAisUpdate dispatch', () => {
     expect(track!.ais.status).toBe('confirmed');
   });
 });
+
+/**
+ * Eviction bounds unbounded target growth (the "unresponsive after a while"
+ * freeze): many Signal K setups never send an explicit `status: 'remove'`, so
+ * every distinct MMSI ever heard used to accumulate for the app lifetime,
+ * making every flush + radar render O(targets) and heavier over uptime.
+ */
+describe('AisProcessingService target eviction (bounds unbounded growth)', () => {
+  let stream$: Subject<IPathUpdateWithPath>;
+  let service: AisProcessingService;
+  const EVENT_TS = new Date('2026-06-24T00:00:00Z').getTime();
+
+  function makeEvent(fullPath: string, value: unknown): IPathUpdateWithPath {
+    return { path: fullPath, update: { data: { value, timestamp: new Date(EVENT_TS) }, state: 'normal' } } as IPathUpdateWithPath;
+  }
+  function push(fullPath: string, value: unknown): void {
+    stream$.next(makeEvent(fullPath, value));
+    vi.advanceTimersByTime(300);
+  }
+  const internals = () => service as unknown as {
+    tracks: Map<string, unknown>;
+    contextIndex: Map<string, string>;
+    mmsiIndex: Map<string, Set<string>>;
+    maxTargets: number;
+    evictStaleTracks: (nowMs: number) => void;
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    stream$ = new Subject<IPathUpdateWithPath>();
+    TestBed.configureTestingModule({
+      providers: [AisProcessingService, { provide: DataService, useValue: { subscribePathTree: () => stream$.asObservable() } as Partial<DataService> }]
+    });
+    service = TestBed.inject(AisProcessingService);
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it('caps the retained track set at maxTargets, evicting the oldest, and prunes the indexes', () => {
+    internals().maxTargets = 5;
+    for (let i = 0; i < 12; i++) {
+      push(`vessels.urn:mrn:imo:mmsi:${100000000 + i}.navigation.position.latitude`, 10 + i * 0.001);
+    }
+    expect(internals().tracks.size).toBe(5);
+    // indexes must not leak entries for evicted tracks
+    expect(internals().contextIndex.size).toBe(5);
+  });
+
+  it('evicts tracks not updated within the TTL when the sweep runs', () => {
+    push(`vessels.urn:mrn:imo:mmsi:123456789.navigation.position.latitude`, 10);
+    expect(internals().tracks.size).toBe(1);
+    // 11 minutes after the last update (default TTL is 10 min) -> evicted
+    internals().evictStaleTracks(EVENT_TS + 11 * 60 * 1000);
+    expect(internals().tracks.size).toBe(0);
+  });
+
+  it('keeps tracks that were updated within the TTL', () => {
+    push(`vessels.urn:mrn:imo:mmsi:123456789.navigation.position.latitude`, 10);
+    internals().evictStaleTracks(EVENT_TS + 60 * 1000); // 1 min later, within TTL
+    expect(internals().tracks.size).toBe(1);
+  });
+});

--- a/src/app/core/services/ais-processing.service.spec.ts
+++ b/src/app/core/services/ais-processing.service.spec.ts
@@ -283,3 +283,43 @@ describe('AisProcessingService target eviction (bounds unbounded growth)', () =>
     expect(internals().contextIndex.has(contexts[4])).toBe(true);
   });
 });
+
+/**
+ * Own-ship updates used to set the `ownShip` signal (a brand-new object) on every
+ * self.navigation.* delta with no throttle/equality guard. The radar render effect
+ * depends on ownShip(), so a moving/anchored vessel with a streaming compass drove
+ * a full O(targets) re-render per fix. These tests pin the throttle + value guard.
+ */
+describe('AisProcessingService own-ship throttling', () => {
+  let stream$: Subject<IPathUpdateWithPath>;
+  let service: AisProcessingService;
+
+  function push(fullPath: string, value: unknown): void {
+    stream$.next({ path: fullPath, update: { data: { value, timestamp: new Date('2026-06-24T00:00:00Z') }, state: 'normal' } } as IPathUpdateWithPath);
+    vi.advanceTimersByTime(300); // > 250ms throttle, so the throttled flush fires
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    stream$ = new Subject<IPathUpdateWithPath>();
+    TestBed.configureTestingModule({
+      providers: [AisProcessingService, { provide: DataService, useValue: { subscribePathTree: () => stream$.asObservable() } as Partial<DataService> }]
+    });
+    service = TestBed.inject(AisProcessingService);
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it('does not emit a new ownShip object when the value is unchanged', () => {
+    push('self.navigation.headingTrue', 1.5);
+    const ref = service.ownShip();
+    expect(ref.headingTrue).toBe(1.5);
+    push('self.navigation.headingTrue', 1.5); // identical fix
+    expect(service.ownShip()).toBe(ref);      // no redundant emission => stable reference
+  });
+
+  it('emits an updated ownShip when the value changes', () => {
+    push('self.navigation.headingTrue', 1.5);
+    push('self.navigation.headingTrue', 2.0);
+    expect(service.ownShip().headingTrue).toBe(2.0);
+  });
+});

--- a/src/app/core/services/ais-processing.service.spec.ts
+++ b/src/app/core/services/ais-processing.service.spec.ts
@@ -202,6 +202,10 @@ describe('AisProcessingService target eviction (bounds unbounded growth)', () =>
     stream$.next(makeEvent(fullPath, value));
     vi.advanceTimersByTime(300);
   }
+  function pushAt(fullPath: string, value: unknown, tsMs: number): void {
+    stream$.next({ path: fullPath, update: { data: { value, timestamp: new Date(tsMs) }, state: 'normal' } } as IPathUpdateWithPath);
+    vi.advanceTimersByTime(300);
+  }
   const internals = () => service as unknown as {
     tracks: Map<string, unknown>;
     contextIndex: Map<string, string>;
@@ -242,5 +246,40 @@ describe('AisProcessingService target eviction (bounds unbounded growth)', () =>
     push(`vessels.urn:mrn:imo:mmsi:123456789.navigation.position.latitude`, 10);
     internals().evictStaleTracks(EVENT_TS + 60 * 1000); // 1 min later, within TTL
     expect(internals().tracks.size).toBe(1);
+  });
+
+  it('runs TTL eviction through the periodic interval sweep', () => {
+    // Anchor the fake clock to the event timestamp so the sweep's Date.now()
+    // is deterministic relative to lastUpdateAt.
+    vi.setSystemTime(EVENT_TS);
+    push(`vessels.urn:mrn:imo:mmsi:123456789.mmsi`, '123456789');
+    expect(internals().tracks.size).toBe(1);
+    expect(internals().mmsiIndex.size).toBe(1);
+
+    // Sweeps within the TTL must keep the track (also proves the clock anchor
+    // took: an unanchored real-time clock would evict on the first sweep).
+    vi.advanceTimersByTime(5 * 60 * 1000);
+    expect(internals().tracks.size).toBe(1);
+
+    // Past the 10 min TTL the interval-driven sweep evicts and prunes indexes.
+    vi.advanceTimersByTime(6 * 60 * 1000);
+    expect(internals().tracks.size).toBe(0);
+    expect(internals().contextIndex.size).toBe(0);
+    expect(internals().mmsiIndex.size).toBe(0);
+  });
+
+  it('evicts the least-recently-updated tracks first when over the cap', () => {
+    internals().maxTargets = 3;
+    const contexts = [0, 1, 2, 3, 4].map(i => `vessels.urn:mrn:imo:mmsi:${200000000 + i}`);
+    contexts.forEach((context, i) => {
+      pushAt(`${context}.navigation.position.latitude`, 10 + i, EVENT_TS + i * 1000);
+    });
+
+    expect(internals().tracks.size).toBe(3);
+    expect(internals().contextIndex.has(contexts[0])).toBe(false);
+    expect(internals().contextIndex.has(contexts[1])).toBe(false);
+    expect(internals().contextIndex.has(contexts[2])).toBe(true);
+    expect(internals().contextIndex.has(contexts[3])).toBe(true);
+    expect(internals().contextIndex.has(contexts[4])).toBe(true);
   });
 });

--- a/src/app/core/services/ais-processing.service.ts
+++ b/src/app/core/services/ais-processing.service.ts
@@ -146,6 +146,8 @@ export class AisProcessingService {
   private maxTargets = MAX_TARGETS;
   private targetTtlMs = TARGET_TTL_MS;
   private readonly targetsDirty$ = new Subject<void>();
+  private readonly ownShipDirty$ = new Subject<void>();
+  private pendingOwnShip: OwnShipState = {};
 
   private readonly _targets = signal<AisTrack[]>([]);
   private readonly _ownShip = signal<OwnShipState>({});
@@ -192,6 +194,12 @@ export class AisProcessingService {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(() => this.evictStaleTracks(Date.now()));
 
+    // Coalesce own-ship updates to the target cadence and only push the signal
+    // when a value actually changed, so the radar doesn't do a full re-render on
+    // every raw GPS/compass fix.
+    this.ownShipDirty$
+      .pipe(throttleTime(THROTTLE_MS, undefined, { leading: true, trailing: true }), takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => this.flushOwnShip());
   }
 
   private handleAisTreeUpdate(event: IPathUpdateWithPath): void {
@@ -241,7 +249,7 @@ export class AisProcessingService {
   }
 
   private applyOwnShipUpdate(path: string, value: unknown): void {
-    const next = { ...this._ownShip() } as OwnShipState;
+    const next = { ...this.pendingOwnShip } as OwnShipState;
     const position = this.readPositionValue(value);
 
     switch (path) {
@@ -277,7 +285,21 @@ export class AisProcessingService {
         return;
     }
 
-    this._ownShip.set(next);
+    this.pendingOwnShip = next;
+    this.ownShipDirty$.next();
+  }
+
+  private flushOwnShip(): void {
+    if (!this.ownShipChanged(this._ownShip(), this.pendingOwnShip)) return;
+    this._ownShip.set(this.pendingOwnShip);
+  }
+
+  private ownShipChanged(a: OwnShipState, b: OwnShipState): boolean {
+    return a.headingTrue !== b.headingTrue
+      || a.courseOverGroundTrue !== b.courseOverGroundTrue
+      || a.speedOverGround !== b.speedOverGround
+      || a.position?.latitude !== b.position?.latitude
+      || a.position?.longitude !== b.position?.longitude;
   }
 
   private applyAisUpdate(update: AisUpdate): void {

--- a/src/app/core/services/ais-processing.service.ts
+++ b/src/app/core/services/ais-processing.service.ts
@@ -1,10 +1,17 @@
 import { DestroyRef, Injectable, inject, signal } from '@angular/core';
-import { Subject, merge, throttleTime } from 'rxjs';
+import { Subject, interval, merge, throttleTime } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { DataService, IPathUpdateWithPath } from './data.service';
 
 const AIS_DEBUG = false;
 const THROTTLE_MS = 250;
+// Target eviction bounds unbounded growth. Many Signal K setups never send an
+// explicit `status: 'remove'`, so without this every distinct MMSI ever heard
+// would accumulate for the app lifetime, making every flush + radar render
+// O(targets) and heavier over uptime (the "unresponsive after a while" freeze).
+const TARGET_TTL_MS = 10 * 60 * 1000; // drop targets not heard from in 10 minutes
+const MAX_TARGETS = 500;              // hard cap on retained targets
+const EVICTION_SWEEP_MS = 15000;      // periodic stale-target sweep cadence
 
 type AisClass = 'A' | 'B' | undefined;
 type AisTargetType = 'vessel' | 'aton' | 'basestation' | 'sar';
@@ -136,6 +143,8 @@ export class AisProcessingService {
   private readonly tracks = new Map<string, AisTrack>();
   private readonly contextIndex = new Map<string, string>();
   private readonly mmsiIndex = new Map<string, Set<string>>();
+  private maxTargets = MAX_TARGETS;
+  private targetTtlMs = TARGET_TTL_MS;
   private readonly targetsDirty$ = new Subject<void>();
 
   private readonly _targets = signal<AisTrack[]>([]);
@@ -176,6 +185,12 @@ export class AisProcessingService {
     this.targetsDirty$
       .pipe(throttleTime(THROTTLE_MS, undefined, { leading: true, trailing: true }), takeUntilDestroyed(this.destroyRef))
       .subscribe(() => this.flushTargetsSignal());
+
+    // Periodically evict stale targets so the retained set (and thus flush +
+    // radar render cost) stays bounded over long uptime.
+    interval(EVICTION_SWEEP_MS)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => this.evictStaleTracks(Date.now()));
 
   }
 
@@ -550,6 +565,7 @@ export class AisProcessingService {
 
     this.tracks.set(track.id, track);
     if (mmsi) this.addMmsiIndex(mmsi, track.id);
+    this.enforceTargetCap();
     this.updateTargetsSignal();
     return track;
   }
@@ -600,6 +616,27 @@ export class AisProcessingService {
 
   private updateTargetsSignal(): void {
     this.targetsDirty$.next();
+  }
+
+  /** Keep the retained target set within the hard cap by removing the oldest. */
+  private enforceTargetCap(): void {
+    if (this.tracks.size <= this.maxTargets) return;
+    const overflow = this.tracks.size - this.maxTargets;
+    const oldest = Array.from(this.tracks.values())
+      .sort((a, b) => a.lastUpdateAt - b.lastUpdateAt)
+      .slice(0, overflow);
+    for (const track of oldest) this.removeTrack(track);
+  }
+
+  /** Remove targets not heard from within the TTL, then enforce the hard cap. */
+  private evictStaleTracks(nowMs: number): void {
+    const cutoff = nowMs - this.targetTtlMs;
+    const stale: AisTrack[] = [];
+    for (const track of this.tracks.values()) {
+      if (track.lastUpdateAt < cutoff) stale.push(track);
+    }
+    for (const track of stale) this.removeTrack(track);
+    this.enforceTargetCap();
   }
 
   private flushTargetsSignal(): void {

--- a/src/app/core/services/ais-processing.service.ts
+++ b/src/app/core/services/ais-processing.service.ts
@@ -618,14 +618,20 @@ export class AisProcessingService {
     this.targetsDirty$.next();
   }
 
-  /** Keep the retained target set within the hard cap by removing the oldest. */
+  /**
+   * Keep the retained target set within the hard cap by removing the oldest.
+   * Single O(n) pass per removed target (no full sort/allocation) so it stays
+   * cheap even under a high rate of new contexts.
+   */
   private enforceTargetCap(): void {
-    if (this.tracks.size <= this.maxTargets) return;
-    const overflow = this.tracks.size - this.maxTargets;
-    const oldest = Array.from(this.tracks.values())
-      .sort((a, b) => a.lastUpdateAt - b.lastUpdateAt)
-      .slice(0, overflow);
-    for (const track of oldest) this.removeTrack(track);
+    while (this.tracks.size > this.maxTargets) {
+      let oldest: AisTrack | null = null;
+      for (const track of this.tracks.values()) {
+        if (!oldest || track.lastUpdateAt < oldest.lastUpdateAt) oldest = track;
+      }
+      if (!oldest) break;
+      this.removeTrack(oldest);
+    }
   }
 
   /** Remove targets not heard from within the TTL, then enforce the hard cap. */


### PR DESCRIPTION
## Motivation

Part of adopting the AIS radar freeze-fix series from mxtommy/Kip#1101 (still **open** upstream; reconcile if it changes before merge). Upstream measured a −63% reduction in handler wait time on the AIS radar from cutting per-fix churn.

`applyOwnShipUpdate` set the `_ownShip` signal with a fresh object on every `self.navigation.*` delta, unthrottled. The radar's render effect guards re-renders by `ownShipRef` reference equality, which a fresh object per delta always defeats — so a streaming compass/GPS drove a full O(targets) re-render on every fix even when nothing changed.

## Approach

Cherry-picked from mxtommy/Kip#1101 with `git cherry-pick -x`, preserving upstream authorship and commit order:

- `b75a2315` — Add failing test for own-ship update throttling (RED)
- `b63859d4` — Throttle + dedupe own-ship updates (GREEN)

Own-ship updates now accumulate into a `pendingOwnShip` buffer and fire `ownShipDirty$`, throttled (250 ms, leading+trailing, `takeUntilDestroyed`) into `flushOwnShip()`, which sets the `_ownShip` signal only when `ownShipChanged()` detects a field-level difference (headingTrue, courseOverGroundTrue, speedOverGround, position lat/lon). Unchanged fixes keep the same object reference, so the radar's reference-equality guard short-circuits.

## Adaptations

None. Both commits auto-merged cleanly onto the eviction branch (this matches upstream's own commit order); the spec's new describe block landed at end of file after the fork-added eviction tests, and the service hunks applied at their intended locations. No fork-authored commits were needed.

## Stacking

Stacked on the target-eviction PR #120 (both change `ais-processing.service.ts`); base is `replicate/pr-1101-ais-target-eviction`. Retarget to `main` after #120 merges, and merge this PR only after it.

## Verification

- `npx ng test --include='src/app/core/services/ais-processing.service.spec.ts'` — 1 file, **17/17 tests passed** (10 dispatch + 5 eviction + 2 new throttle tests)
- `npm run lint` — all files pass
- `npm run build:prod` — succeeds (pre-existing `piexifjs` CommonJS warning only)

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)
