### PR TITLE
Throttle + value-dedupe own-ship updates (replicates part of mxtommy/Kip#1101)

### DIFF
--- a/src/app/core/services/ais-processing.service.spec.ts
+++ b/src/app/core/services/ais-processing.service.spec.ts
@@ -283,3 +283,43 @@ describe('AisProcessingService target eviction (bounds unbounded growth)', () =>
     expect(internals().contextIndex.has(contexts[4])).toBe(true);
   });
 });
+
+/**
+ * Own-ship updates used to set the `ownShip` signal (a brand-new object) on every
+ * self.navigation.* delta with no throttle/equality guard. The radar render effect
+ * depends on ownShip(), so a moving/anchored vessel with a streaming compass drove
+ * a full O(targets) re-render per fix. These tests pin the throttle + value guard.
+ */
+describe('AisProcessingService own-ship throttling', () => {
+  let stream$: Subject<IPathUpdateWithPath>;
+  let service: AisProcessingService;
+
+  function push(fullPath: string, value: unknown): void {
+    stream$.next({ path: fullPath, update: { data: { value, timestamp: new Date('2026-06-24T00:00:00Z') }, state: 'normal' } } as IPathUpdateWithPath);
+    vi.advanceTimersByTime(300); // > 250ms throttle, so the throttled flush fires
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    stream$ = new Subject<IPathUpdateWithPath>();
+    TestBed.configureTestingModule({
+      providers: [AisProcessingService, { provide: DataService, useValue: { subscribePathTree: () => stream$.asObservable() } as Partial<DataService> }]
+    });
+    service = TestBed.inject(AisProcessingService);
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it('does not emit a new ownShip object when the value is unchanged', () => {
+    push('self.navigation.headingTrue', 1.5);
+    const ref = service.ownShip();
+    expect(ref.headingTrue).toBe(1.5);
+    push('self.navigation.headingTrue', 1.5); // identical fix
+    expect(service.ownShip()).toBe(ref);      // no redundant emission => stable reference
+  });
+
+  it('emits an updated ownShip when the value changes', () => {
+    push('self.navigation.headingTrue', 1.5);
+    push('self.navigation.headingTrue', 2.0);
+    expect(service.ownShip().headingTrue).toBe(2.0);
+  });
+});

--- a/src/app/core/services/ais-processing.service.ts
+++ b/src/app/core/services/ais-processing.service.ts
@@ -146,6 +146,8 @@ export class AisProcessingService {
   private maxTargets = MAX_TARGETS;
   private targetTtlMs = TARGET_TTL_MS;
   private readonly targetsDirty$ = new Subject<void>();
+  private readonly ownShipDirty$ = new Subject<void>();
+  private pendingOwnShip: OwnShipState = {};
 
   private readonly _targets = signal<AisTrack[]>([]);
   private readonly _ownShip = signal<OwnShipState>({});
@@ -192,6 +194,12 @@ export class AisProcessingService {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(() => this.evictStaleTracks(Date.now()));
 
+    // Coalesce own-ship updates to the target cadence and only push the signal
+    // when a value actually changed, so the radar doesn't do a full re-render on
+    // every raw GPS/compass fix.
+    this.ownShipDirty$
+      .pipe(throttleTime(THROTTLE_MS, undefined, { leading: true, trailing: true }), takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => this.flushOwnShip());
   }
 
   private handleAisTreeUpdate(event: IPathUpdateWithPath): void {
@@ -241,7 +249,7 @@ export class AisProcessingService {
   }
 
   private applyOwnShipUpdate(path: string, value: unknown): void {
-    const next = { ...this._ownShip() } as OwnShipState;
+    const next = { ...this.pendingOwnShip } as OwnShipState;
     const position = this.readPositionValue(value);
 
     switch (path) {
@@ -277,7 +285,21 @@ export class AisProcessingService {
         return;
     }
 
-    this._ownShip.set(next);
+    this.pendingOwnShip = next;
+    this.ownShipDirty$.next();
+  }
+
+  private flushOwnShip(): void {
+    if (!this.ownShipChanged(this._ownShip(), this.pendingOwnShip)) return;
+    this._ownShip.set(this.pendingOwnShip);
+  }
+
+  private ownShipChanged(a: OwnShipState, b: OwnShipState): boolean {
+    return a.headingTrue !== b.headingTrue
+      || a.courseOverGroundTrue !== b.courseOverGroundTrue
+      || a.speedOverGround !== b.speedOverGround
+      || a.position?.latitude !== b.position?.latitude
+      || a.position?.longitude !== b.position?.longitude;
   }
 
   private applyAisUpdate(update: AisUpdate): void {


### PR DESCRIPTION
## Motivation

Part of adopting the AIS radar freeze-fix series from mxtommy/Kip#1101 (still **open** upstream; reconcile if it changes before merge). Upstream measured a −63% reduction in handler wait time on the AIS radar from cutting per-fix churn.

`applyOwnShipUpdate` set the `_ownShip` signal with a fresh object on every `self.navigation.*` delta, unthrottled. The radar's render effect guards re-renders by `ownShipRef` reference equality, which a fresh object per delta always defeats — so a streaming compass/GPS drove a full O(targets) re-render on every fix even when nothing changed.

## Approach

Cherry-picked from mxtommy/Kip#1101 with `git cherry-pick -x`, preserving upstream authorship and commit order:

- `b75a2315` — Add failing test for own-ship update throttling (RED)
- `b63859d4` — Throttle + dedupe own-ship updates (GREEN)

Own-ship updates now accumulate into a `pendingOwnShip` buffer and fire `ownShipDirty$`, throttled (250 ms, leading+trailing, `takeUntilDestroyed`) into `flushOwnShip()`, which sets the `_ownShip` signal only when `ownShipChanged()` detects a field-level difference (headingTrue, courseOverGroundTrue, speedOverGround, position lat/lon). Unchanged fixes keep the same object reference, so the radar's reference-equality guard short-circuits.

## Adaptations

None. Both commits auto-merged cleanly onto the eviction branch (this matches upstream's own commit order); the spec's new describe block landed at end of file after the fork-added eviction tests, and the service hunks applied at their intended locations. No fork-authored commits were needed.

## Supersedes #125

This PR was originally #125, stacked on the target-eviction PR #120. When #120 merged and its branch was deleted, GitHub closed #125 instead of retargeting it. Same branch, same commits, now based on `main` (which contains the eviction changes via #120). The review synthesis (correctness + testing lenses, no blockers) is on #125: https://github.com/halos-org/skip/pull/125#issuecomment-4870785166

## Verification

- `npx ng test --include='src/app/core/services/ais-processing.service.spec.ts'` — 1 file, **17/17 tests passed** (10 dispatch + 5 eviction + 2 new throttle tests)
- `npm run lint` — all files pass
- `npm run build:prod` — succeeds (pre-existing `piexifjs` CommonJS warning only)

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)

