### PR TITLE
refactor(charts): unify angle-domain + circular stats across both chart engines (#133)

### DIFF
--- a/src/app/core/components/widget-history-chart-dialog/widget-history-chart-dialog.component.ts
+++ b/src/app/core/components/widget-history-chart-dialog/widget-history-chart-dialog.component.ts
@@ -207,7 +207,6 @@ export class WidgetHistoryChartDialogComponent implements OnInit, AfterViewInit,
       }
 
       const datapoints = this.historyMapper.mapValuesToChartDatapoints(response, {
-        unit: 'number',
         domain: 'scalar'
       });
 

--- a/src/app/core/services/dataset-stream.service.spec.ts
+++ b/src/app/core/services/dataset-stream.service.spec.ts
@@ -312,7 +312,7 @@ describe('DatasetStreamService', () => {
         };
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const datapoints = (service as any).convertHistoryToDatapoints(response, 'number', 'scalar');
+        const datapoints = (service as any).convertHistoryToDatapoints(response, 'scalar');
 
         expect(datapoints.length).toBe(3);
         expect(datapoints[0].data.lastAverage).toBeNull();
@@ -345,7 +345,7 @@ describe('DatasetStreamService', () => {
         };
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const datapoints = (service as any).convertHistoryToDatapoints(response, 'number', 'scalar');
+        const datapoints = (service as any).convertHistoryToDatapoints(response, 'scalar');
 
         expect(datapoints.length).toBe(2);
         expect(datapoints[0].data.value).toBe(0.5);
@@ -370,7 +370,7 @@ describe('DatasetStreamService', () => {
         };
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const datapoints = (service as any).convertHistoryToDatapoints(response, 'rad', 'direction');
+        const datapoints = (service as any).convertHistoryToDatapoints(response, 'direction');
 
         expect(datapoints.length).toBe(3);
         expect(datapoints[0].data.lastAverage).toBeNull();
@@ -382,21 +382,16 @@ describe('DatasetStreamService', () => {
         expect(final.lastMaximum).toBeCloseTo(0.0872664626, 6); // 5°
     }));
 
-    it('honors an explicit angle-domain override for non-allowlisted rad paths (#1070)', inject([DatasetStreamService], (service: DatasetStreamService) => {
+    it('updateDataset delegates to circular stats for angle domains (wrap-safe)', inject([DatasetStreamService], (service: DatasetStreamService) => {
+        // Guards the wiring: a dropped domain arg would silently compute linear stats on the
+        // recorder's live tail (the #6 bug, recorder side). Buffer straddles the 0/360° wrap.
+        const ds = { historicalData: [(350 * Math.PI) / 180, (10 * Math.PI) / 180], smoothingPeriod: 2 };
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const resolve = (path: string, unit: string, override?: 'signed' | 'direction') => (service as any).resolveAngleDomain(path, unit, override);
-
-        // A custom angular path (e.g. advancedwind wind shift, published in -PI..PI) is not in the
-        // signed allowlist, so by default it wraps into the 0..2PI direction domain.
-        expect(resolve('environment.wind.shift', 'rad')).toBe('direction');
-        // With an explicit 'signed' override the value keeps its native -PI..PI range.
-        expect(resolve('environment.wind.shift', 'rad', 'signed')).toBe('signed');
-        // A 'direction' override forces compass range for an otherwise-signed path.
-        expect(resolve('environment.wind.angleApparent', 'rad', 'direction')).toBe('direction');
-        // Non-rad units stay scalar regardless of override.
-        expect(resolve('navigation.speedOverGround', 'number', 'signed')).toBe('scalar');
-        // Back-compat: no override keeps the allowlist behavior.
-        expect(resolve('environment.wind.angleApparent', 'rad')).toBe('signed');
+        const point = (service as any).updateDataset(ds, 'direction');
+        const avg = point.data.lastAverage as number;
+        // Circular mean of 350° and 10° is ~0° in the direction domain, not the ~180° a linear mean gives.
+        expect(Math.min(avg, 2 * Math.PI - avg)).toBeLessThan(0.02);
+        expect(point.data.value).toBeCloseTo((10 * Math.PI) / 180, 5); // wrapped last value
     }));
 });
 

--- a/src/app/core/services/dataset-stream.service.ts
+++ b/src/app/core/services/dataset-stream.service.ts
@@ -6,6 +6,8 @@ import { HistoryApiClientService, IHistoryValuesResponse, IHistoryValuesQueryPar
 import { HistoryToChartMapperService } from './history-to-chart-mapper.service';
 import { UUID } from '../utils/uuid.util'
 import { resolveWindowMs, deriveDataSourceInfo } from '../utils/chart-window.util';
+import { resolveAngleDomain } from '../utils/angle-domain.util';
+import { computeWindowStats, ChartStatsDomain } from '../utils/chart-stats.util';
 import { cloneDeep } from 'lodash-es';
 import { NgGridStackWidget } from 'gridstack/dist/angular';
 
@@ -17,7 +19,6 @@ export interface IDatasetServiceDatapoint {
     sma?: number; // Simple Moving Average
     ema?: number; // Exponential Moving Average - A better Moving Average calculation than Simple Moving Average
     doubleEma?: number; // Double Exponential Moving Average - Moving Average that is even more reactive to data variation then EMA. Suitable for wind and angle average calculations
-    lastAngleAverage?: number;
     lastAverage?: number; // Computed from the latest historicalData.
     lastMinimum?: number;
     lastMaximum?: number;
@@ -54,9 +55,6 @@ interface IDatasetServiceObserverRegistration {
   rxjsSubject: ReplaySubject<IDatasetServiceDatapoint>;
 }
 
-// How to interpret angular (radian) data
-type AngleDomain = 'scalar' | 'direction' | 'signed';
-
 @Injectable({
   providedIn: 'root'
 })
@@ -71,18 +69,6 @@ export class DatasetStreamService implements OnDestroy {
   private _svcDataSource: IDatasetServiceDataSource[] = [];
   private _svcSubjectObserverRegistry: IDatasetServiceObserverRegistration[] = [];
   private _startAllPromise: Promise<void>;
-
-  // List of Signal K paths that should be interpreted as signed angles (-π, π].
-  // Add your specific paths here. All other radian paths will default to direction domain [0, 2π).
-  private readonly signedAnglePaths = new Set<string>([
-    "self.navigation.attitude.roll",
-    "self.navigation.attitude.pitch",
-    "self.navigation.attitude.yaw",
-    "self.environment.wind.angleApparent",
-    "self.environment.wind.angleTrueGround",
-    "self.environment.wind.angleTrueWater",
-    "self.steering.rudderAngle"
-  ]);
 
   constructor() {
     this._svcDatasetConfigs = this.appSettings.getDataSets();
@@ -247,7 +233,7 @@ export class DatasetStreamService implements OnDestroy {
     );
 
     // Decide how to interpret the dataset values (scalar vs radian domains)
-    const angleDomain = this.resolveAngleDomain(configuration.path, configuration.baseUnit, configuration.angleDomainOverride);
+    const angleDomain = resolveAngleDomain(configuration.path, configuration.baseUnit, configuration.angleDomainOverride);
 
     // Attempt to seed dataset with history if eligible
     const historyResolutionSeconds = Math.max(1, Math.round(newDataSourceConfig.sampleTime / 1000));
@@ -277,7 +263,7 @@ export class DatasetStreamService implements OnDestroy {
       }
       dataSource.historicalData.push(newValue.data.value);
 
-      const datapoint: IDatasetServiceDatapoint = this.updateDataset(dataSource, configuration.baseUnit, angleDomain);
+      const datapoint: IDatasetServiceDatapoint = this.updateDataset(dataSource, angleDomain);
 
       this._svcSubjectObserverRegistry
         .find(registration => registration.datasetUuid === dataSource.uuid)
@@ -292,14 +278,14 @@ export class DatasetStreamService implements OnDestroy {
    * @param {IDatasetServiceDataSource} dataSource The data source to seed.
    * @param {IDatasetServiceDatasetConfig} configuration The dataset config.
    * @param {number} historyResolutionSeconds The resolution in seconds (minimum 1).
-   * @param {AngleDomain} angleDomain The angle domain interpretation.
+   * @param {ChartStatsDomain} angleDomain The angle domain interpretation.
    * @return {Promise<void>}
    */
   private async seedHistoryData(
     dataSource: IDatasetServiceDataSource,
     configuration: IDatasetServiceDatasetConfig,
     historyResolutionSeconds: number,
-    angleDomain: AngleDomain
+    angleDomain: ChartStatsDomain
   ): Promise<void> {
     try {
       // Build history request path with aggregations
@@ -338,7 +324,7 @@ export class DatasetStreamService implements OnDestroy {
       }
 
       // Convert history response to datapoints
-      const historyDatapoints = this.convertHistoryToDatapoints(response, configuration.baseUnit, angleDomain);
+      const historyDatapoints = this.convertHistoryToDatapoints(response, angleDomain);
 
       // Seed the ReplaySubject with history datapoints
       const subject = this._svcSubjectObserverRegistry.find(r => r.datasetUuid === dataSource.uuid)?.rxjsSubject;
@@ -357,7 +343,7 @@ export class DatasetStreamService implements OnDestroy {
           }
           dataSource.historicalData.push(value);
 
-          const computedPoint = this.updateDataset(dataSource, configuration.baseUnit, angleDomain);
+          const computedPoint = this.updateDataset(dataSource, angleDomain);
           computedPoint.timestamp = historyPoint.timestamp;
           seededPoints.push(computedPoint);
         });
@@ -562,133 +548,20 @@ export class DatasetStreamService implements OnDestroy {
    * @return {*}  {IDatasetServiceDatapoint} A new historicalData object. Note: push() the object to the historicalData to
    * @memberof DatasetStreamService
    */
-  private updateDataset(ds: IDatasetServiceDataSource, unit: string, domain: AngleDomain = 'scalar'): IDatasetServiceDatapoint {
-    let avgCalc: number = null;
-    let smaCalc: number = null;
-    let minCalc: number = null;
-    let maxCalc: number = null;
-
-    if (unit === "rad") {
-      // Circular statistics for angles
-      avgCalc = this.circularMeanRad(ds.historicalData);
-      const window = ds.historicalData.slice(-ds.smoothingPeriod);
-      smaCalc = this.circularMeanRad(window);
-      const { min, max } = this.circularMinMaxRad(ds.historicalData);
-
-      // Normalize outputs to requested domain
-      if (domain === 'direction') {
-        avgCalc = this.normalizeToDirection(avgCalc);
-        smaCalc = this.normalizeToDirection(smaCalc);
-        minCalc = this.normalizeToDirection(min);
-        maxCalc = this.normalizeToDirection(max);
-      } else if (domain === 'signed') {
-        avgCalc = this.normalizeToSigned(avgCalc);
-        smaCalc = this.normalizeToSigned(smaCalc);
-        minCalc = this.normalizeToSigned(min);
-        maxCalc = this.normalizeToSigned(max);
-      } else {
-        // Fallback: treat as scalar (shouldn't happen for unit==='rad')
-        minCalc = min;
-        maxCalc = max;
-      }
-    } else {
-      // Arithmetic statistics for scalars
-      avgCalc = calculateAverage(ds.historicalData);
-      smaCalc = calculateSMA(ds.historicalData, ds.smoothingPeriod);
-      minCalc = Math.min(...ds.historicalData);
-      maxCalc = Math.max(...ds.historicalData);
-    }
-
-    const newDatapoint: IDatasetServiceDatapoint = {
+  private updateDataset(ds: IDatasetServiceDataSource, domain: ChartStatsDomain = 'scalar'): IDatasetServiceDatapoint {
+    const stats = computeWindowStats(ds.historicalData, ds.smoothingPeriod, domain);
+    return {
       timestamp: Date.now(),
       data: {
-        value: unit === 'rad'
-          ? (domain === 'signed'
-            ? this.normalizeToSigned(ds.historicalData[ds.historicalData.length - 1])
-            : this.normalizeToDirection(ds.historicalData[ds.historicalData.length - 1]))
-          : ds.historicalData[ds.historicalData.length - 1],
-        sma: smaCalc,
+        value: stats.value,
+        sma: stats.sma,
         ema: null,
         doubleEma: null,
-        lastAverage: avgCalc,
-        lastMinimum: minCalc,
-        lastMaximum: maxCalc
+        lastAverage: stats.lastAverage,
+        lastMinimum: stats.lastMinimum,
+        lastMaximum: stats.lastMaximum
       }
     };
-
-    return newDatapoint;
-
-    function calculateAverage(arr: number[]): number | null {
-      if (arr.length === 0) return null;
-      const sum = arr.reduce((acc, val) => acc + val, 0);
-      return sum / arr.length;
-    }
-
-    function calculateSMA(values: number[], windowSize: number): number {
-      if (values.length < windowSize) windowSize = values.length;
-      let sum = 0;
-      for (let i = values.length - windowSize; i < values.length; i++) {
-        sum += values[i];
-      }
-      return sum / windowSize;
-    }
-  }
-
-  // Windowed circular mean (for SMA)
-  private circularMeanRad(anglesRad: number[]): number {
-    if (anglesRad.length === 0) return 0;
-    const sumSin = anglesRad.reduce((sum, a) => sum + Math.sin(a), 0);
-    const sumCos = anglesRad.reduce((sum, a) => sum + Math.cos(a), 0);
-    return Math.atan2(sumSin / anglesRad.length, sumCos / anglesRad.length);
-  }
-
-  // Circular min/max: returns the smallest arc containing all points
-  private circularMinMaxRad(anglesRad: number[]): { min: number, max: number } {
-    if (anglesRad.length === 0) return { min: 0, max: 0 };
-    const degAngles = anglesRad.map(a => ((a * 180 / Math.PI) + 360) % 360).sort((a, b) => a - b);
-    let maxGap = 0;
-    let minIdx = 0;
-    for (let i = 0; i < degAngles.length; i++) {
-      const next = (i + 1) % degAngles.length;
-      const gap = (degAngles[next] - degAngles[i] + 360) % 360;
-      if (gap > maxGap) {
-        maxGap = gap;
-        minIdx = next;
-      }
-    }
-    // Convert back to radians
-    const min = degAngles[minIdx] * Math.PI / 180;
-    const max = degAngles[(minIdx - 1 + degAngles.length) % degAngles.length] * Math.PI / 180;
-    return { min, max };
-  }
-
-  // Domain resolution helpers
-  private resolveAngleDomain(path: string, unit: string, override?: 'signed' | 'direction'): AngleDomain {
-    if (unit !== 'rad') return 'scalar';
-    // A per-chart override wins over the path allowlist so any angular path (e.g. a plugin's
-    // wind-shift) can be shown in its native signed range instead of wrapping to 0..360 (#1070).
-    if (override === 'signed' || override === 'direction') return override;
-    const incoming = this.normalizePathKey(path);
-    for (const candidate of this.signedAnglePaths) {
-      if (incoming === this.normalizePathKey(candidate)) {
-        return 'signed';
-      }
-    }
-    return 'direction';
-  }
-
-  // Angle normalization helpers
-  private normalizePathKey(path: string): string {
-    return path.replace(/^vessels\.self\./, '').replace(/^self\./, '');
-  }
-  private mod(a: number, n: number): number { return ((a % n) + n) % n; }
-  private normalizeToDirection(rad: number): number {
-    const twoPi = 2 * Math.PI;
-    return this.mod(rad, twoPi); // [0, 2π)
-  }
-  private normalizeToSigned(rad: number): number {
-    const twoPi = 2 * Math.PI;
-    return this.mod(rad + Math.PI, twoPi) - Math.PI; // (-π, π]
   }
 
   /**
@@ -740,17 +613,14 @@ export class DatasetStreamService implements OnDestroy {
    *
    * @private
    * @param {IHistoryValuesResponse} response The History API response.
-   * @param {string} unit The base unit type (for angle interpretation).
-   * @param {AngleDomain} domain The angle domain (scalar, direction, or signed).
+   * @param {ChartStatsDomain} domain The angle domain (scalar, direction, or signed).
    * @returns {IDatasetServiceDatapoint[]} Array of datapoints with preserved timestamps.
    */
   private convertHistoryToDatapoints(
     response: IHistoryValuesResponse,
-    unit: string,
-    domain: AngleDomain
+    domain: ChartStatsDomain
   ): IDatasetServiceDatapoint[] {
     return this.historyChartAdapter.mapValuesToChartDatapoints(response, {
-      unit,
       domain
     }) as IDatasetServiceDatapoint[];
   }

--- a/src/app/core/services/history-chart-stream.service.spec.ts
+++ b/src/app/core/services/history-chart-stream.service.spec.ts
@@ -11,8 +11,6 @@ import { IDatasetServiceDatapoint } from './dataset-stream.service';
 const PARAMS: IHistoryChartStreamParams = {
   path: 'navigation.speedOverGround',
   source: 'default',
-  unit: 'number',
-  domain: 'scalar',
   windowMs: 60_000,
   sampleTime: 500,
   maxDataPoints: 3,
@@ -23,7 +21,7 @@ describe('HistoryChartStreamService', () => {
   let path$: Subject<IPathUpdate>;
   const history = { getValues: vi.fn() };
   const mapper = { mapValuesToChartDatapoints: vi.fn() };
-  const data = { subscribePath: vi.fn() };
+  const data = { subscribePath: vi.fn(), getPathUnitType: vi.fn() };
   const settings = { getWidgetHistoryDisabled: vi.fn() };
 
   function make(): HistoryChartStreamService {
@@ -44,6 +42,7 @@ describe('HistoryChartStreamService', () => {
     history.getValues.mockReset();
     mapper.mapValuesToChartDatapoints.mockReset().mockReturnValue([]);
     data.subscribePath.mockReset().mockReturnValue(path$);
+    data.getPathUnitType.mockReset().mockReturnValue(null); // scalar unless a test overrides
     settings.getWidgetHistoryDisabled.mockReset().mockReturnValue(false);
   });
 
@@ -168,5 +167,28 @@ describe('HistoryChartStreamService', () => {
     await Promise.resolve();
     expect(emissions.length).toBe(0); // the disposed guard prevents the batch
     expect(data.subscribePath).not.toHaveBeenCalled();
+  });
+
+  it('resolves a radian path with no override to a circular domain — live stats wrap correctly (#6)', async () => {
+    // navigation.headingTrue is a rad path, not on the signed allowlist -> direction domain.
+    data.getPathUnitType.mockReturnValue('rad');
+    history.getValues.mockResolvedValue({ context: 'vessels.self', range: {}, values: [], data: [] });
+    mapper.mapValuesToChartDatapoints.mockReturnValue([
+      { timestamp: 1000, data: { value: (350 * Math.PI) / 180 } } // seeds the window with 350°
+    ]);
+
+    const emissions: (IDatasetServiceDatapoint | IDatasetServiceDatapoint[] | { unavailable: true })[] = [];
+    make().getBackfillThenLive({ ...PARAMS, path: 'navigation.headingTrue' }).subscribe(e => emissions.push(e));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Live value at 10°, over a window already holding 350°.
+    path$.next({ data: { value: (10 * Math.PI) / 180, timestamp: new Date(2000) }, state: 'normal' });
+
+    const last = emissions[emissions.length - 1] as IDatasetServiceDatapoint;
+    const avg = last.data.lastAverage as number;
+    // Circular mean of 350° and 10° is ~0° in the direction domain, NOT the ~180° a linear mean gives.
+    // Pre-#133 this path resolved to 'scalar' and lastAverage would be ~π.
+    expect(Math.min(avg, 2 * Math.PI - avg)).toBeLessThan(0.02);
   });
 });

--- a/src/app/core/services/history-chart-stream.service.ts
+++ b/src/app/core/services/history-chart-stream.service.ts
@@ -2,7 +2,8 @@ import { Injectable, inject } from '@angular/core';
 import { Observable, Subscription, filter, merge, take, timer, withLatestFrom } from 'rxjs';
 import { DataService } from './data.service';
 import { HistoryApiClientService } from './history-api-client.service';
-import { HistoryToChartMapperService, THistoryChartAngleDomain } from './history-to-chart-mapper.service';
+import { HistoryToChartMapperService } from './history-to-chart-mapper.service';
+import { resolveAngleDomain } from '../utils/angle-domain.util';
 import { SettingsService } from './settings.service';
 import { IDatasetServiceDatapoint } from './dataset-stream.service';
 import { computeWindowStats, ChartStatsDomain } from '../utils/chart-stats.util';
@@ -22,9 +23,8 @@ export function isHistoryUnavailable(v: unknown): v is IHistoryUnavailable {
 export interface IHistoryChartStreamParams {
   path: string;
   source: string;
-  /** Base unit — `'rad'` selects circular aggregation. */
-  unit: string;
-  domain: ChartStatsDomain;
+  /** Raw per-chart angle-range override; combined with the path's base unit to resolve the domain. */
+  angleDomainOverride?: 'signed' | 'direction';
   windowMs: number;
   sampleTime: number;
   maxDataPoints: number;
@@ -56,6 +56,7 @@ export class HistoryChartStreamService {
   public getBackfillThenLive(params: IHistoryChartStreamParams): Observable<StreamEmission> {
     return new Observable<StreamEmission>(subscriber => {
       const perf = createChartPerfProbe('history');
+      const domain = resolveAngleDomain(params.path, this.data.getPathUnitType(params.path), params.angleDomainOverride);
       let disposed = false;
       let liveSub: Subscription | null = null;
       const buffer: number[] = [];
@@ -69,7 +70,7 @@ export class HistoryChartStreamService {
         return () => { /* nothing to tear down */ };
       }
 
-      this.fetchBackfill(params, perf)
+      this.fetchBackfill(params, domain, perf)
         .then(batch => {
           if (disposed) return;
           if (batch === null) {
@@ -82,7 +83,7 @@ export class HistoryChartStreamService {
             if (Number.isFinite(p.data.value)) buffer.push(p.data.value);
           }
           this.trim(buffer, params.maxDataPoints);
-          liveSub = this.startLive(params, buffer, perf, subscriber);
+          liveSub = this.startLive(params, domain, buffer, perf, subscriber);
         })
         .catch(() => {
           if (!disposed) {
@@ -100,6 +101,7 @@ export class HistoryChartStreamService {
 
   private startLive(
     params: IHistoryChartStreamParams,
+    domain: ChartStatsDomain,
     buffer: number[],
     perf: IChartPerfProbe,
     subscriber: { next: (v: StreamEmission) => void }
@@ -117,14 +119,14 @@ export class HistoryChartStreamService {
       if (!Number.isFinite(value)) return;
       buffer.push(value);
       this.trim(buffer, params.maxDataPoints);
-      const stats = computeWindowStats(buffer, params.smoothingPeriod, params.domain);
+      const stats = computeWindowStats(buffer, params.smoothingPeriod, domain);
       const timestamp = u.data.timestamp instanceof Date ? u.data.timestamp.getTime() : Date.now();
       perf.recordLive(timestamp);
       subscriber.next({ timestamp, data: { ...stats } });
     });
   }
 
-  private async fetchBackfill(params: IHistoryChartStreamParams, perf: IChartPerfProbe): Promise<IDatasetServiceDatapoint[] | null> {
+  private async fetchBackfill(params: IHistoryChartStreamParams, domain: ChartStatsDomain, perf: IChartPerfProbe): Promise<IDatasetServiceDatapoint[] | null> {
     const normalizedPath = params.path.replace(/^(vessels\.)?self\./, '');
     const paths = [
       `${normalizedPath}:sma:${params.smoothingPeriod}`,
@@ -144,8 +146,7 @@ export class HistoryChartStreamService {
       return null;
     }
     const mapped = this.mapper.mapValuesToChartDatapoints(response, {
-      unit: params.unit,
-      domain: params.domain as THistoryChartAngleDomain
+      domain
     });
     if (perf.enabled) {
       perf.endBackfill(mapped.length, JSON.stringify(response).length);

--- a/src/app/core/services/history-to-chart-mapper.service.spec.ts
+++ b/src/app/core/services/history-to-chart-mapper.service.spec.ts
@@ -31,7 +31,6 @@ describe('HistoryToChartMapperService', () => {
     };
 
     const datapoints = service.mapValuesToChartDatapoints(response, {
-      unit: 'number',
       domain: 'scalar'
     });
 
@@ -58,7 +57,6 @@ describe('HistoryToChartMapperService', () => {
     };
 
     const datapoints = service.mapValuesToChartDatapoints(response, {
-      unit: 'rad',
       domain: 'direction'
     });
 
@@ -70,5 +68,33 @@ describe('HistoryToChartMapperService', () => {
     expect(final.lastAverage).toBeCloseTo(0.0174959160, 6);
     expect(final.lastMinimum).toBeCloseTo(6.1959188446, 6);
     expect(final.lastMaximum).toBeCloseTo(0.0872664626, 6);
+  });
+
+  it('computes circular summary stats in the signed domain, mapping the ±π boundary to +π', () => {
+    const response: IHistoryValuesResponse = {
+      context: 'vessels.self',
+      range: {
+        from: '2026-02-16T00:00:00.000Z',
+        to: '2026-02-16T00:02:00.000Z'
+      },
+      values: [
+        { path: 'steering.rudderAngle', method: 'avg' }
+      ],
+      data: [
+        ['2026-02-16T00:00:00.000Z', 3.0], // ~172°
+        ['2026-02-16T00:01:00.000Z', -3.0] // ~-172°
+      ]
+    };
+
+    const datapoints = service.mapValuesToChartDatapoints(response, {
+      domain: 'signed'
+    });
+
+    // Circular mean of +172° and -172° is 180°, which the shared atan2 normalizer maps to +π
+    // (the included end of (-π, π]), not the recorder's former mod-based -π.
+    const final = datapoints[1].data;
+    expect(final.lastAverage).toBeCloseTo(Math.PI, 5);
+    expect(final.lastMinimum).toBeCloseTo(3.0, 5);
+    expect(final.lastMaximum).toBeCloseTo(-3.0, 5);
   });
 });

--- a/src/app/core/services/history-to-chart-mapper.service.ts
+++ b/src/app/core/services/history-to-chart-mapper.service.ts
@@ -1,10 +1,12 @@
 import { Injectable } from '@angular/core';
 import { IHistoryValuesResponse } from './history-api-client.service';
-
-/**
- * Defines how angular/radian values are interpreted while mapping historical data.
- */
-export type THistoryChartAngleDomain = 'scalar' | 'direction' | 'signed';
+import {
+  ChartStatsDomain,
+  circularMeanRad,
+  circularMinMaxRad,
+  normalizeDirectionRad,
+  normalizeSignedRad
+} from '../utils/chart-stats.util';
 
 /**
  * Normalized historical datapoint shape used by chart-oriented consumers.
@@ -33,27 +35,22 @@ export class HistoryToChartMapperService {
   /**
    * Maps a History API response payload into normalized chart datapoints.
    *
-   * - Detects aggregate columns (`avg`/`average`, `sma`, `min`, `max`) from
-   *   `response.values`.
+   * - Detects aggregate columns (`avg`/`average`, `sma`) from `response.values`.
    * - Emits one datapoint per response row.
    * - Computes dataset-wide summary stats from mapped datapoint values and
    *   stores them on the final datapoint (`lastAverage`, `lastMinimum`, `lastMaximum`).
    *
-   * @param {IHistoryValuesResponse} response Raw History API response.
-   * @param {{ unit: string; domain: THistoryChartAngleDomain }} options Mapping options.
-   * @param {string} options.unit Base unit (e.g., `number`, `rad`) used to choose scalar vs circular math.
-   * @param {THistoryChartAngleDomain} options.domain Angular domain interpretation for `rad` values.
-   * @returns {IHistoryChartDatapoint[]} Normalized datapoints ready for chart/data prefill pipelines.
+   * Angular (`direction`/`signed`) domains use circular math from `chart-stats.util`, matching the
+   * live-tail statistics so backfill and live tail agree; `scalar` uses arithmetic aggregates.
    *
-   * @example
-   * const datapoints = adapter.mapValuesToChartDatapoints(response, {
-   *   unit: 'number',
-   *   domain: 'scalar'
-   * });
+   * @param {IHistoryValuesResponse} response Raw History API response.
+   * @param {{ domain: ChartStatsDomain }} options Mapping options.
+   * @param {ChartStatsDomain} options.domain Domain interpretation; `scalar` is plain numeric.
+   * @returns {IHistoryChartDatapoint[]} Normalized datapoints ready for chart/data prefill pipelines.
    */
   public mapValuesToChartDatapoints(
     response: IHistoryValuesResponse,
-    options: { unit: string; domain: THistoryChartAngleDomain }
+    options: { domain: ChartStatsDomain }
   ): IHistoryChartDatapoint[] {
     const rows = response?.data;
     if (!rows || rows.length === 0) {
@@ -79,11 +76,9 @@ export class HistoryToChartMapperService {
       avgIndex = 1;
     }
 
-    const shouldNormalizeAngle = options.unit === 'rad';
+    const shouldNormalizeAngle = options.domain !== 'scalar';
     const normalizeAngle = shouldNormalizeAngle
-      ? (options.domain === 'signed'
-        ? this.normalizeToSigned.bind(this)
-        : this.normalizeToDirection.bind(this))
+      ? (options.domain === 'signed' ? normalizeSignedRad : normalizeDirectionRad)
       : null;
 
     const datapoints: IHistoryChartDatapoint[] = [];
@@ -93,8 +88,6 @@ export class HistoryToChartMapperService {
     let scalarMax = Number.NEGATIVE_INFINITY;
     let scalarCount = 0;
 
-    let angleSumSin = 0;
-    let angleSumCos = 0;
     const angleValues: number[] = [];
 
     for (const row of rows) {
@@ -117,8 +110,6 @@ export class HistoryToChartMapperService {
         const value = avgValue as number;
         if (shouldNormalizeAngle) {
           angleValues.push(value);
-          angleSumSin += Math.sin(value);
-          angleSumCos += Math.cos(value);
         } else {
           scalarCount++;
           scalarSum += value;
@@ -147,18 +138,11 @@ export class HistoryToChartMapperService {
       let datasetMaximum: number | null = null;
 
       if (shouldNormalizeAngle && angleValues.length > 0) {
-        datasetAverage = Math.atan2(angleSumSin / angleValues.length, angleSumCos / angleValues.length);
-        const { min, max } = this.circularMinMaxRad(angleValues);
-
-        if (options.domain === 'signed') {
-          datasetAverage = this.normalizeToSigned(datasetAverage);
-          datasetMinimum = this.normalizeToSigned(min);
-          datasetMaximum = this.normalizeToSigned(max);
-        } else {
-          datasetAverage = this.normalizeToDirection(datasetAverage);
-          datasetMinimum = this.normalizeToDirection(min);
-          datasetMaximum = this.normalizeToDirection(max);
-        }
+        const wrap = options.domain === 'signed' ? normalizeSignedRad : normalizeDirectionRad;
+        const { min, max } = circularMinMaxRad(angleValues);
+        datasetAverage = wrap(circularMeanRad(angleValues));
+        datasetMinimum = wrap(min);
+        datasetMaximum = wrap(max);
       } else if (!shouldNormalizeAngle && scalarCount > 0) {
         datasetAverage = scalarSum / scalarCount;
         datasetMinimum = scalarMin;
@@ -174,45 +158,5 @@ export class HistoryToChartMapperService {
     }
 
     return datapoints;
-  }
-
-  private circularMinMaxRad(anglesRad: number[]): { min: number; max: number } {
-    if (anglesRad.length === 0) {
-      return { min: 0, max: 0 };
-    }
-
-    const degAngles = anglesRad
-      .map(angle => ((angle * 180 / Math.PI) + 360) % 360)
-      .sort((left, right) => left - right);
-
-    let maxGap = 0;
-    let minIdx = 0;
-    for (let i = 0; i < degAngles.length; i++) {
-      const next = (i + 1) % degAngles.length;
-      const gap = (degAngles[next] - degAngles[i] + 360) % 360;
-      if (gap > maxGap) {
-        maxGap = gap;
-        minIdx = next;
-      }
-    }
-
-    return {
-      min: degAngles[minIdx] * Math.PI / 180,
-      max: degAngles[(minIdx - 1 + degAngles.length) % degAngles.length] * Math.PI / 180
-    };
-  }
-
-  private mod(value: number, modulo: number): number {
-    return ((value % modulo) + modulo) % modulo;
-  }
-
-  private normalizeToDirection(rad: number): number {
-    const twoPi = 2 * Math.PI;
-    return this.mod(rad, twoPi);
-  }
-
-  private normalizeToSigned(rad: number): number {
-    const twoPi = 2 * Math.PI;
-    return this.mod(rad + Math.PI, twoPi) - Math.PI;
   }
 }

--- a/src/app/core/utils/angle-domain.util.spec.ts
+++ b/src/app/core/utils/angle-domain.util.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeAnglePathKey, resolveAngleDomain } from './angle-domain.util';
+
+describe('angle-domain.util', () => {
+  it('treats a positively non-radian unit as scalar, even with a lingering override', () => {
+    expect(resolveAngleDomain('navigation.speedOverGround', 'm/s')).toBe('scalar');
+    expect(resolveAngleDomain('self.steering.rudderAngle', 'K')).toBe('scalar');
+    expect(resolveAngleDomain('self.environment.wind.angleApparent', 'm/s', 'signed')).toBe('scalar');
+  });
+
+  it('honors an explicit override when the base unit is unknown (metadata not yet published)', () => {
+    // A history chart commonly views past data while the producing instrument is idle, so
+    // getPathUnitType returns null; an explicit signed/direction override must still drive circular
+    // stats instead of silently reverting the chart to linear math.
+    expect(resolveAngleDomain('environment.wind.angleApparent', null, 'signed')).toBe('signed');
+    expect(resolveAngleDomain('some.plugin.windShift', undefined, 'direction')).toBe('direction');
+  });
+
+  it('defaults an unknown-unit path with no override to scalar', () => {
+    expect(resolveAngleDomain('some.unknown.path', null)).toBe('scalar');
+  });
+
+  it('defaults a non-allowlisted radian path to the direction domain', () => {
+    expect(resolveAngleDomain('self.navigation.headingTrue', 'rad')).toBe('direction');
+    expect(resolveAngleDomain('navigation.courseOverGroundTrue', 'rad')).toBe('direction');
+  });
+
+  it('resolves an allowlisted radian path to the signed domain', () => {
+    expect(resolveAngleDomain('self.steering.rudderAngle', 'rad')).toBe('signed');
+    expect(resolveAngleDomain('self.environment.wind.angleApparent', 'rad')).toBe('signed');
+  });
+
+  it('lets a per-chart override win over the allowlist for any radian path', () => {
+    // Allowlisted (signed) path forced to direction.
+    expect(resolveAngleDomain('self.steering.rudderAngle', 'rad', 'direction')).toBe('direction');
+    // Non-allowlisted (direction) path forced to signed.
+    expect(resolveAngleDomain('self.navigation.headingTrue', 'rad', 'signed')).toBe('signed');
+  });
+
+  it('honors an explicit override for a non-allowlisted custom rad path (#1070)', () => {
+    // A custom angular path (e.g. advancedwind wind shift, published in -π..π) is not on the signed
+    // allowlist, so it defaults to direction; an explicit override keeps its native signed range.
+    expect(resolveAngleDomain('environment.wind.shift', 'rad')).toBe('direction');
+    expect(resolveAngleDomain('environment.wind.shift', 'rad', 'signed')).toBe('signed');
+  });
+
+  it('resolves vessels.self. / self. / bare paths identically', () => {
+    expect(resolveAngleDomain('vessels.self.steering.rudderAngle', 'rad')).toBe('signed');
+    expect(resolveAngleDomain('self.steering.rudderAngle', 'rad')).toBe('signed');
+    expect(resolveAngleDomain('steering.rudderAngle', 'rad')).toBe('signed');
+  });
+
+  it('normalizes path keys by stripping the vessels.self. / self. prefix', () => {
+    expect(normalizeAnglePathKey('vessels.self.steering.rudderAngle')).toBe('steering.rudderAngle');
+    expect(normalizeAnglePathKey('self.steering.rudderAngle')).toBe('steering.rudderAngle');
+    expect(normalizeAnglePathKey('steering.rudderAngle')).toBe('steering.rudderAngle');
+  });
+});

--- a/src/app/core/utils/angle-domain.util.ts
+++ b/src/app/core/utils/angle-domain.util.ts
@@ -1,0 +1,47 @@
+import { ChartStatsDomain } from './chart-stats.util';
+
+/**
+ * Signal K paths interpreted as signed angles (-π, π]. Every other radian path defaults to the
+ * direction domain [0, 2π). A per-chart override still wins over this allowlist.
+ */
+const SIGNED_ANGLE_PATHS: ReadonlySet<string> = new Set<string>([
+  'self.navigation.attitude.roll',
+  'self.navigation.attitude.pitch',
+  'self.navigation.attitude.yaw',
+  'self.environment.wind.angleApparent',
+  'self.environment.wind.angleTrueGround',
+  'self.environment.wind.angleTrueWater',
+  'self.steering.rudderAngle'
+]);
+
+/** Strip the `vessels.self.` / `self.` prefix so allowlist matching is context-independent. */
+export function normalizeAnglePathKey(path: string): string {
+  return path.replace(/^vessels\.self\./, '').replace(/^self\./, '');
+}
+
+/**
+ * Resolve how a path's radian values should be interpreted. Non-radian paths are `scalar`; a
+ * `signed`/`direction` override wins for any radian path; otherwise the allowlist selects `signed`
+ * and everything else is `direction`. Single source of truth for both chart engines.
+ */
+export function resolveAngleDomain(
+  path: string,
+  baseUnit: string | null | undefined,
+  override?: 'signed' | 'direction'
+): ChartStatsDomain {
+  // A positively non-radian unit is scalar even if a stale override lingers on the config.
+  if (baseUnit != null && baseUnit !== '' && baseUnit !== 'rad') return 'scalar';
+  // Radian, or an unknown unit (metadata not yet published — common when viewing history while the
+  // producing instrument is idle): an explicit override wins, so angular charts aren't silently
+  // reverted to linear stats when the base unit can't be read.
+  if (override === 'signed' || override === 'direction') return override;
+  // Unknown unit and no override: we can't tell it's angular, so stay scalar.
+  if (baseUnit !== 'rad') return 'scalar';
+  const incoming = normalizeAnglePathKey(path);
+  for (const candidate of SIGNED_ANGLE_PATHS) {
+    if (incoming === normalizeAnglePathKey(candidate)) {
+      return 'signed';
+    }
+  }
+  return 'direction';
+}

--- a/src/app/core/utils/chart-stats.util.spec.ts
+++ b/src/app/core/utils/chart-stats.util.spec.ts
@@ -31,6 +31,12 @@ describe('chart-stats.util', () => {
     expect(normalizeSignedRad((3 * Math.PI) / 2)).toBeCloseTo(-Math.PI / 2, 5);
   });
 
+  it('normalizes exactly π to +π in the signed domain (atan2 boundary, shared by both engines)', () => {
+    // The single shared signed normalizer is the atan2 form, so 180° maps to +π (the included end of
+    // (-π, π]), not the recorder's former mod-based -π. Both chart engines now agree here.
+    expect(normalizeSignedRad(Math.PI)).toBeCloseTo(Math.PI, 10);
+  });
+
   it('wraps a single value into the direction domain [0, 2π)', () => {
     const dir = computeWindowStats([(350 * Math.PI) / 180], 1, 'direction');
     expect(dir.value).toBeCloseTo((350 * Math.PI) / 180, 5);

--- a/src/app/widgets/widget-data-chart/widget-data-chart.component.ts
+++ b/src/app/widgets/widget-data-chart/widget-data-chart.component.ts
@@ -10,7 +10,6 @@ import { ITheme } from '../../core/services/app-service';
 import { WidgetDatasetOrchestratorService } from '../../core/services/widget-dataset-orchestrator.service';
 import { HistoryChartStreamService, IHistoryChartStreamParams, isHistoryUnavailable } from '../../core/services/history-chart-stream.service';
 import { resolveWindowMs, deriveDataSourceInfo } from '../../core/utils/chart-window.util';
-import { ChartStatsDomain } from '../../core/utils/chart-stats.util';
 import { CHART_ENGINE_OVERRIDE_KEY } from '../../core/constants/config-storage.const';
 
 import { Chart, ChartConfiguration, ChartData, ChartType, TimeUnit, TimeScale, LinearScale, LineController, PointElement, LineElement, Filler, Title, SubTitle } from 'chart.js';
@@ -776,14 +775,13 @@ export class WidgetDataChartComponent implements OnDestroy {
     this.dsServiceSub?.unsubscribe();
 
     if (this.chartEngine() === 'history') {
-      const domain: ChartStatsDomain =
-        cfg.datachartAngleRange === 'signed' || cfg.datachartAngleRange === 'direction' ? cfg.datachartAngleRange : 'scalar';
       const info = this.dataSourceInfo;
       const params: IHistoryChartStreamParams = {
         path: cfg.datachartPath,
         source: cfg.datachartSource ?? 'default',
-        unit: domain === 'scalar' ? 'number' : 'rad',
-        domain,
+        angleDomainOverride: cfg.datachartAngleRange === 'signed' || cfg.datachartAngleRange === 'direction'
+          ? cfg.datachartAngleRange
+          : undefined,
         windowMs: resolveWindowMs(cfg.timeScale as TimeScaleFormat, cfg.period),
         sampleTime: info.sampleTime,
         maxDataPoints: info.maxDataPoints,


### PR DESCRIPTION
## What

Consolidates the duplicated angle math + domain resolution flagged in the #127 review (issue #133). One shared circular-stats source (`chart-stats.util`) and one shared angle-domain resolver (new `angle-domain.util`); the recorder, the mapper, and the History engine all consume them. **Foundational** for the rest of the #64 blocker chain (#131/#87/#132/#130/#85/#134 build on these shared utilities).

## Why

Circular math (`circularMean` / `circularMinMax` / normalize) existed in **three** places — `chart-stats.util`, the recorder, and the mapper — with two subtly different signed-normalizer formulas. Angle-domain resolution existed **twice** and incompatibly: the recorder auto-detects from the path's base unit + a signed-angle allowlist, but the History engine derived the domain from the explicit angle-range override only and hardcoded `baseUnit: ''`. So an angular (`rad`) path charted **without** an explicit override was treated as **scalar**, and its client-side live avg/min/max were computed with linear math — wrong across the 0/360° wrap.

## Changes

- **Recorder** (`DatasetStreamService`): delete the private circular helpers + `resolveAngleDomain` + allowlist; `updateDataset` delegates to `computeWindowStats`. Behaviour preserved for scalar and circular domains.
- **Mapper** (`HistoryToChartMapperService`): drop its private circular copies and the redundant `unit` option — `domain` is now authoritative.
- **History engine**: resolve the domain from the path's real base unit (`DataService.getPathUnitType`) via the shared resolver. The widget now passes only the raw override, not a synthesized `unit`/`domain`.
- **Signed normalizer** standardized on the `atan2` form `(-π, π]`; exactly 180° now maps to `+π` on both engines (was `-π` on the recorder).

## Behaviour preservation

`updateDataset` → `computeWindowStats` is equivalent for the guaranteed inputs (buffer length ≥ 1, smoothing period ≥ 1). The full recorder spec passes locally, including the seeded-history recompute and circular-domain cases. The only intended change is the ±π boundary above, pinned with a test.

## Testing

`npm run lint` ✓ · `npm run build:prod` ✓ · 47 tests across the 6 affected specs pass locally (recorder behaviour-preservation suite, mapper, engine, the new `angle-domain.util` spec, a `#6`-style regression proving a rad path with no override now aggregates circularly, and the ±π boundary). CI runs the full matrix.

Closes #133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zURudCY3TTRcNd2acknJ9
