### PR TITLE
Adopt the Kip#1101 freeze-measurement harness, ported to Skip

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,30 @@ Skip — an Angular 21 (zoneless, signals, new control flow) Signal K marine mul
 
 Node: the app builds on Node 20+; the kip-plugin's built-in history provider needs Node ≥22.5 (`node:sqlite`). CI runs the matrix 20/22/24.
 
+## Performance and freeze measurement (perf-harness/)
+
+Self-contained freeze/jank harness (own `package.json`, never touches app deps): builds the **real production bundle**, drives it in headless Chromium at **10× CPU throttle** (Pi-class HaLOS target) against a **mock Signal K server** on one origin. Use it for perf-sensitive changes to widgets, rendering, or the data pipeline, and for before/after numbers when replicating upstream perf work. Full operator docs: `perf-harness/README.md`.
+
+The three commands (from `perf-harness/`, after `npm install` there):
+
+```bash
+node run.mjs --public ../public --label dev --scenarios resize-storm --repeats 2  # quick, prebuilt ../public
+node run.mjs --branch main --label main       # full 7-scenario suite against any git ref
+node report.mjs --a pre-freeze-fixes --b main-freeze-fixes   # compare two labels
+```
+
+Traps that cost real time:
+
+- **Results accumulate per label**: scenarios merge into any existing `results/<label>.json`. Reusing a label for a different ref keeps the old ref's scenario entries under the new `branch` field — delete the file first.
+- **Blocking time and delta counts are raw sums over the probe window**, and the window self-extends while the throttled main thread is busy. Check the report's window-ms context row before claiming a regression from a small delta.
+- **Heap metrics are noise-dominated** (no forced GC; same-ref spreads of 5–21 MB observed). No leak claims from them without a sustained slope across repeats.
+- **AIS scenarios have large run-to-run variance** (same-build blocking spread 7.8–9.7 s observed) — never conclude from a single rep; compare against a same-build re-run (`results/diag-*.json` are committed examples).
+- **A boot-assertion failure** (`boot check failed: N widget-host2 rendered, expected M`) means the seeded config is wrong for that build (version or widget-schema drift) — not a flake. A mis-seeded config boots a plausible empty dashboard; the assert exists to catch exactly that.
+- `--branch` builds register **nested git worktrees** under `perf-harness/worktrees/`; `git worktree prune` alone does not deregister them — `git worktree remove` each one, or delete `perf-harness/worktrees/` and then prune.
+- Chrome path defaults to the macOS app bundle; set `CHROME_BIN` on other platforms.
+
+The mock serves Skip's full session/config surface (`loginStatus`, `applicationData`, `/plugins`) because Skip is session-SSO-only with server-side config — a localStorage-only bootstrap boots a degraded app; see the README. Committed baselines: `pre-freeze-fixes` (11f3fbd0, before the #119/#120/#121/#122/#135 freeze fixes) and `main-freeze-fixes` (2e358f17).
+
 ## Testing reality (read before touching specs)
 
 - The runner is **vitest** (`vitest.config.ts`, `environment: jsdom`) driven by `@angular/build:unit-test`. `src/test.ts` is the setup file and **monkey-patches `TestBed.configureTestingModule`** to inject a large set of global stubs/providers (SettingsService, AuthenticationService, SignalKConnectionService, ConnectionStateMachine, MatDialog refs, the widget host directives, etc.). Specs override these by listing their own local providers (local wins; globals are prepended).

--- a/perf-harness/.gitignore
+++ b/perf-harness/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+worktrees/
+results/*.raw.json

--- a/perf-harness/.gitignore
+++ b/perf-harness/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 worktrees/
 results/*.raw.json
+results/shots/

--- a/perf-harness/.gitignore
+++ b/perf-harness/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 worktrees/
 results/*.raw.json
+results-*.log
 results/shots/

--- a/perf-harness/README.md
+++ b/perf-harness/README.md
@@ -1,0 +1,57 @@
+# KIP freeze-audit measurement harness
+
+Reproducible, honest before/after measurement of the main-thread **freezes** users
+report ("randomly unresponsive; can't exit fullscreen"). Self-contained — its deps
+live in `perf-harness/package.json` and never touch the app's `package.json`.
+
+## What it measures (the symptom, not proxies)
+
+The same probe (`probe.js`) is injected into every build under test via Playwright
+`addInitScript`, so measurement code is identical across branches:
+
+| Metric | Meaning |
+|---|---|
+| `longTaskMaxMs` / `blockingTimeMs` | Longest single main-thread task, and total blocking time (Σ max(0, dur−50)). The browser's own "the main thread was stuck" signal. |
+| `taskLatencyMaxMs` / `p95` | A 16 ms self-rescheduling timer's lateness = **how long a queued handler (e.g. the exit-fullscreen keydown) waits**. The honest "frozen" proxy. |
+| `frameMaxGapMs` / `framesDropped` | rAF inter-frame gaps → dropped frames. |
+| `heapGrowthMB` / `heapSlopeKBps` | `usedJSHeapSize` slope over time (unbounded-growth findings). |
+
+## How it works
+
+`run.mjs` builds a branch's **production** bundle in an isolated git worktree
+(`lib/build-serve.mjs`), serves it plus a **mock Signal K server** on one origin
+(`lib/server.mjs` — no CORS), injects the probe + a localStorage config that puts
+KIP in anonymous local mode (`lib/kip-config.mjs`), throttles CPU via CDP to emulate
+low-power marine hardware, runs each scenario K times, and writes
+`results/<label>.json` (raw + median/p95).
+
+## Scenarios → audit findings (`scenarios.mjs`)
+
+| Scenario | Reproduces |
+|---|---|
+| `resize-storm` | Rank 1 — shared ResizeObserver reallocates every canvas in one task (the fullscreen enter/exit storm). |
+| `delta-storm-30x10` / `reconnect-backlog` | Rank 2 — delta ingestion / reconnect snapshot fan-out. |
+| `ais-radar-150` | Ranks 4/5 — AIS radar full re-render loops. |
+| `gauges-16` | Rank 7 — ng-canvas-gauge animation duty cycle. |
+| `ais-growth-churn` | Ranks 8/9 — unbounded AIS/track growth (heap slope). |
+
+## Run
+
+```bash
+cd perf-harness && npm install
+# baseline a branch (throttle defaults to 10x CPU):
+node run.mjs --branch master --label master
+node run.mjs --branch integration/perf-preview --label perf-preview
+# fast iteration against an already-built ./public:
+node run.mjs --public ../public --label dev --scenarios ais-radar-150 --repeats 2
+```
+
+## Honesty safeguards
+
+- Identical probe + scenarios + fixed CPU throttle across all branches; Chrome
+  version recorded in each result.
+- K repeats reported as **median and p95**, with every raw run kept in the JSON.
+- Baselines captured on `master` (pre-perf) **and** `integration/perf-preview`
+  (master + the 5 `perf/*` PRs) so perf gains and freeze-fix gains are never conflated.
+- Negative results are reported too (e.g. the delta fan-out is *not* a measurable
+  freeze at realistic rates — the rendering loops are).

--- a/perf-harness/README.md
+++ b/perf-harness/README.md
@@ -1,8 +1,11 @@
-# KIP freeze-audit measurement harness
+# Skip freeze-audit measurement harness
 
-Reproducible, honest before/after measurement of the main-thread **freezes** users
-report ("randomly unresponsive; can't exit fullscreen"). Self-contained — its deps
-live in `perf-harness/package.json` and never touch the app's `package.json`.
+Reproducible, honest before/after measurement of main-thread **freezes**
+("randomly unresponsive; can't exit fullscreen"). Self-contained — its deps live
+in `perf-harness/package.json` and never touch the app's `package.json`.
+
+Adopted from upstream [mxtommy/Kip#1101](https://github.com/mxtommy/Kip/pull/1101)
+and ported to Skip; see *Divergences from upstream* below.
 
 ## What it measures (the symptom, not proxies)
 
@@ -18,12 +21,26 @@ The same probe (`probe.js`) is injected into every build under test via Playwrig
 
 ## How it works
 
-`run.mjs` builds a branch's **production** bundle in an isolated git worktree
+`run.mjs` builds a ref's **production** bundle in an isolated git worktree
 (`lib/build-serve.mjs`), serves it plus a **mock Signal K server** on one origin
-(`lib/server.mjs` — no CORS), injects the probe + a localStorage config that puts
-KIP in anonymous local mode (`lib/kip-config.mjs`), throttles CPU via CDP to emulate
-low-power marine hardware, runs each scenario K times, and writes
+(`lib/server.mjs` — no CORS), throttles CPU via CDP to emulate low-power marine
+hardware (Skip's Pi-class HaLOS target), runs each scenario K times, and writes
 `results/<label>.json` (raw + median/p95).
+
+Skip's boot config is split across two tiers (`lib/kip-config.mjs`):
+
+- **localStorage** gets only `skip.connectionConfig` — the sole key Skip reads at
+  boot — pointing `signalKUrl` at the mock's origin.
+- **Everything else** (app/theme/dashboards) is an `IConfig` document the mock
+  serves from `applicationData/user/skip/<ver>/default`. Skip always persists
+  config server-side; there is no anonymous localStorage mode to bootstrap into.
+
+**Mock auth:** Skip is session-cookie SSO-only. The mock answers
+`GET /skServer/loginStatus` with a logged-in admin session, absorbs the boot
+Dashboards JSON-Patch/autosave POSTs with 200 (a failure would park an error
+snackbar inside the measurement), reports the KIP history-series plugin as
+disabled (suppressing the series-reconcile POST ~750 ms after boot), and
+advertises server version 2.24.0 (Skip gates widget history on ≥ 2.22.1).
 
 ## Scenarios → audit findings (`scenarios.mjs`)
 
@@ -39,19 +56,59 @@ low-power marine hardware, runs each scenario K times, and writes
 
 ```bash
 cd perf-harness && npm install
-# baseline a branch (throttle defaults to 10x CPU):
-node run.mjs --branch master --label master
-node run.mjs --branch integration/perf-preview --label perf-preview
-# fast iteration against an already-built ./public:
+node smoke.mjs                       # probe sanity check (no app build needed)
+# baseline a ref (throttle defaults to 10x CPU):
+node run.mjs --branch main --label main
+node run.mjs --branch 11f3fbd0 --label pre-fix   # pre-#119/#120/#121/#122/#135 baseline
+# fast iteration against an already-built ../public (the app's build output):
 node run.mjs --public ../public --label dev --scenarios ais-radar-150 --repeats 2
+# compare two result files (by label):
+node report.mjs --a pre-fix --b main
 ```
+
+`--branch` builds live in `perf-harness/worktrees/` (gitignored) and persist
+for reuse; they stay registered in the parent clone's `git worktree list`.
+`git worktree prune` alone does not deregister them while the directories
+exist — `git worktree remove` each one, or delete `perf-harness/worktrees/`
+and then run `git worktree prune`.
+
+`screenshot.mjs` renders the AIS radar with a fixed deterministic scene for
+visual before/after; `verify-click.mjs` checks radar hit-testing (overlapping
+targets under view rotation) end-to-end.
 
 ## Honesty safeguards
 
-- Identical probe + scenarios + fixed CPU throttle across all branches; Chrome
+- Identical probe + scenarios + fixed CPU throttle across all refs; Chrome
   version recorded in each result.
 - K repeats reported as **median and p95**, with every raw run kept in the JSON.
-- Baselines captured on `master` (pre-perf) **and** `integration/perf-preview`
-  (master + the 5 `perf/*` PRs) so perf gains and freeze-fix gains are never conflated.
-- Negative results are reported too (e.g. the delta fan-out is *not* a measurable
-  freeze at realistic rates — the rendering loops are).
+- Boot is asserted, not assumed: each repeat must render exactly the scenario's
+  widget count or the run fails — a mis-seeded config would otherwise boot a
+  plausible-looking empty dashboard and silently measure the wrong thing.
+- The one external request Skip makes (the `gstatic.com/generate_204`
+  reachability probe, re-fired on connection changes and every 60 s) is answered
+  locally via a Playwright route, so no real network noise lands in the window.
+- Negative results are reported too (upstream found the delta fan-out is *not* a
+  measurable freeze at realistic rates — the rendering loops are).
+
+## Divergences from upstream Kip#1101
+
+- Serving base is `/@halos-org/skip/` (Skip's `baseHref`), not `/@mxtommy/kip/`.
+- Mock adds Skip's session/config/plugin surface: `loginStatus`,
+  `applicationData` GET/POST (config file version path segment matched
+  per-request), `/plugins` + `/plugins/kip` (+ reconcile absorb), and a modern
+  `server.version` in the discovery document.
+- `lib/kip-config.mjs` (name kept for upstream-reconcile friendliness): only
+  `skip.connectionConfig` is seeded into localStorage (upstream's bare
+  `connectionConfig`/`appConfig`/`dashboardsConfig`/`themeConfig` keys are dead
+  in Skip); a new `serverConfigDocument()` feeds the mock; the radial-gauge
+  factory sets `displayScale` (upstream's top-level `minValue`/`maxValue` are
+  dead in Skip and silently rendered a default 0–100 scale); dashboards drop
+  Kip's `collapseSplitShell`.
+- The mock restarts live per-connection stream timers when a scenario changes
+  `rateHz`: Skip opens its WS once at `APP_INITIALIZER` and keeps it, so
+  upstream's connect-time rate snapshot would stream every scenario at the
+  boot-time default rate.
+- Determinism hardening (fork-authored): gstatic probe answered locally, and
+  `waitForBoot` asserts the rendered widget count (see Honesty safeguards).
+- Upstream's `results/` baselines are not carried over — they measure Kip
+  builds. Skip baselines are captured separately.

--- a/perf-harness/README.md
+++ b/perf-harness/README.md
@@ -107,6 +107,9 @@ targets under view rotation) end-to-end.
   factory sets `displayScale` (upstream's top-level `minValue`/`maxValue` are
   dead in Skip and silently rendered a default 0–100 scale); dashboards drop
   Kip's `collapseSplitShell`.
+- `report.mjs` prints each label's median probe-window length per scenario: the
+  window self-extends while the throttled main thread is busy, so raw window
+  sums (blocking time) drift with it and small deltas need the window context.
 - The mock restarts live per-connection stream timers when a scenario changes
   `rateHz`: Skip opens its WS once at `APP_INITIALIZER` and keeps it, so
   upstream's connect-time rate snapshot would stream every scenario at the

--- a/perf-harness/README.md
+++ b/perf-harness/README.md
@@ -75,9 +75,66 @@ for reuse; they stay registered in the parent clone's `git worktree list`.
 exist — `git worktree remove` each one, or delete `perf-harness/worktrees/`
 and then run `git worktree prune`.
 
+Label reuse hazard: because scenario results merge into any existing
+`results/<label>.json`, re-pointing a label at a different ref keeps the old
+build's scenario entries under the new `branch` field. Delete the file before
+reusing a label for a different build.
+
 `screenshot.mjs` renders the AIS radar with a fixed deterministic scene for
 visual before/after; `verify-click.mjs` checks radar hit-testing (overlapping
 targets under view rotation) end-to-end.
+
+## Interpreting the numbers
+
+| Question | Metric | Caveat |
+|---|---|---|
+| Would a queued handler (e.g. the exit-fullscreen keydown) have hung? | `taskLatencyMaxMs` / `taskLatencyP95Ms` | Max is one worst sample; p95 is the more stable signal. |
+| Is there a single monster task? | `longTaskMaxMs` | — |
+| How much total jank over the scenario? | `blockingTimeMs` | Raw sum over the probe window, which self-extends under load — compare the labels' median window lengths (report context row) before trusting small deltas. |
+| Are animations dropping frames? | `frameMaxGapMs` / `framesDropped` | — |
+| Is memory growing without bound? | `heapGrowthMB` / `heapSlopeKBps` | Weakest metrics: no forced GC, `usedJSHeapSize` includes uncollected garbage; same-ref spreads of 5–21 MB observed. |
+
+Claims the data cannot support:
+
+- Small blocking-time deltas between labels whose median windows differ —
+  normalize to a common window or dismiss.
+- Leak conclusions from heap deltas inside the same-ref spread.
+- Anything from a single AIS-scenario rep: `results/diag-pre-variance.json`
+  (the same build measured twice) spans blocking 7.8–9.7 s on `ais-radar-150`.
+- Comparisons across machines, Chrome versions, or throttle factors. Both are
+  recorded in every results JSON — compare like for like only.
+
+## Adding a scenario
+
+1. Append an entry to `scenarios` in `scenarios.mjs`: `label`, `note`,
+   `subscribeAll`, `durationMs`, `warmupMs`, `dashboards()` returning
+   `buildDashboards([...])` from widget factories, and `control`
+   (`rateHz`, `selfPaths`, `ais: { count, churnPerSec }`). Add an
+   `action(page, server, durationMs)` only when the scenario needs interaction
+   (viewport resizes, `blastBig`); otherwise the runner just waits `durationMs`.
+2. Widget factories live in `lib/kip-config.mjs` (`numericWidget`,
+   `radialGaugeWidget`, `aisRadarWidget`). For a new widget type, add a factory
+   whose `config` shape is taken verbatim from the widget's current schema — a
+   mis-shaped config silently renders defaults instead of erroring.
+3. The boot assertion expects exactly `dashboards[0].configuration.length`
+   rendered `widget-host2` elements: one factory, one widget host. A widget that
+   fails to render fails the run.
+4. Verify solo against a prebuilt bundle:
+
+   ```bash
+   node run.mjs --public ../public --label dev --scenarios <label> --repeats 2
+   ```
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `boot check failed: 0 widget-host2 rendered, expected N` | The build rejected or ignored the seeded config — config-version drift (three distinct version spaces; see the `lib/kip-config.mjs` header) or widget-schema drift — and booted the default empty dashboard | Diff `lib/kip-config.mjs` version constants and widget config shapes against the ref's `src/`; rerun with `--headed` to watch the boot |
+| App boots degraded or lands on the sign-in flow | The build probes a session/config endpoint the mock doesn't answer (`loginStatus`, `applicationData`, `/plugins`, discovery) | Cover the endpoint in `lib/server.mjs`; find the missing call with `--headed` and devtools |
+| Console shows `Unexpected token '<'` / an API response is HTML | An extensionless request fell through to the SPA `index.html` fallback — an unmocked API route | Same as above: add the route to `lib/server.mjs` |
+| `ENOENT … results/<label>.json` from `report.mjs` | Label typo, or the run never completed a scenario | `ls results/`; report labels must match `run.mjs --label` exactly |
+| `EADDRINUSE` at startup | A previous run's server still listening (default port 4399) | Kill the stray `node` process or pass `--port` |
+| Chromium launch fails: executable not found | Non-macOS host; the default Chrome path is the macOS app bundle | Set `CHROME_BIN` to the local Chrome/Chromium binary |
 
 ## Honesty safeguards
 

--- a/perf-harness/README.md
+++ b/perf-harness/README.md
@@ -62,6 +62,9 @@ node run.mjs --branch main --label main
 node run.mjs --branch 11f3fbd0 --label pre-fix   # pre-#119/#120/#121/#122/#135 baseline
 # fast iteration against an already-built ../public (the app's build output):
 node run.mjs --public ../public --label dev --scenarios ais-radar-150 --repeats 2
+# long suites can be chunked: per-scenario runs under one label accumulate
+# into the same results/<label>.json (--no-rebuild reuses the built worktree):
+node run.mjs --branch main --label main --no-rebuild --scenarios gauges-16
 # compare two result files (by label):
 node report.mjs --a pre-fix --b main
 ```

--- a/perf-harness/lib/build-serve.mjs
+++ b/perf-harness/lib/build-serve.mjs
@@ -1,0 +1,71 @@
+/*
+ * Cross-branch build+serve helpers. To measure a branch honestly we build the
+ * REAL production bundle for that exact ref in an isolated git worktree, then
+ * serve it. The harness itself (which lives only on the harness branch) is never
+ * part of the measured bundle — identical measurement code, different builds.
+ */
+import { spawn } from 'node:child_process';
+import { rm, mkdir, access } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const HARNESS_DIR = dirname(dirname(fileURLToPath(import.meta.url)));
+const REPO_DIR = dirname(HARNESS_DIR);
+const WORKTREES = join(HARNESS_DIR, 'worktrees');
+
+export function sh(cmd, args, opts = {}) {
+  return new Promise((resolve, reject) => {
+    const p = spawn(cmd, args, { stdio: 'inherit', ...opts });
+    p.on('exit', (code) => (code === 0 ? resolve() : reject(new Error(`${cmd} ${args.join(' ')} -> ${code}`))));
+    p.on('error', reject);
+  });
+}
+
+async function exists(p) { try { await access(p); return true; } catch { return false; } }
+
+/** Create/refresh a worktree for `ref`, install deps, build prod. Returns the public/ dir. */
+export async function buildBranch(ref, label, { rebuild = true } = {}) {
+  await mkdir(WORKTREES, { recursive: true });
+  const wt = join(WORKTREES, label);
+  const publicDir = join(wt, 'public');
+
+  if (rebuild && await exists(wt)) {
+    await sh('git', ['worktree', 'remove', '--force', wt], { cwd: REPO_DIR }).catch(() => {});
+    await rm(wt, { recursive: true, force: true });
+  }
+  if (!(await exists(wt))) {
+    console.log(`[build] worktree ${label} <- ${ref}`);
+    await sh('git', ['worktree', 'add', '--force', wt, ref], { cwd: REPO_DIR });
+  }
+  console.log(`[build] npm ci (${label}) …`);
+  await sh('npm', ['ci', '--no-audit', '--no-fund'], { cwd: wt });
+  console.log(`[build] production build (${label}) …`);
+  await sh('npm', ['run', 'build:prod'], { cwd: wt });
+  if (!(await exists(join(publicDir, 'index.html')))) {
+    throw new Error(`build for ${label} produced no public/index.html`);
+  }
+  return publicDir;
+}
+
+/** Start the static SPA server for a built public dir. Returns {url, base, stop()}. */
+export async function serve(publicDir, port, base = '/@mxtommy/kip/') {
+  const child = spawn('node', [join(HARNESS_DIR, 'serve.mjs'), '--root', publicDir, '--port', String(port), '--base', base], {
+    stdio: 'inherit',
+  });
+  // Wait for it to accept connections.
+  const deadline = Date.now() + 10000;
+  while (Date.now() < deadline) {
+    try {
+      const r = await fetch(`http://localhost:${port}${base}index.html`);
+      if (r.ok) break;
+    } catch { /* not up yet */ }
+    await new Promise((r) => setTimeout(r, 150));
+  }
+  return {
+    url: `http://localhost:${port}${base}`,
+    base,
+    stop() { child.kill('SIGTERM'); },
+  };
+}
+
+export { REPO_DIR, HARNESS_DIR, WORKTREES };

--- a/perf-harness/lib/build-serve.mjs
+++ b/perf-harness/lib/build-serve.mjs
@@ -37,8 +37,10 @@ export async function buildBranch(ref, label, { rebuild = true } = {}) {
     console.log(`[build] worktree ${label} <- ${ref}`);
     await sh('git', ['worktree', 'add', '--force', wt, ref], { cwd: REPO_DIR });
   }
-  console.log(`[build] npm ci (${label}) …`);
-  await sh('npm', ['ci', '--no-audit', '--no-fund'], { cwd: wt });
+  // npm install (not ci): lockfiles on some refs trip npm ci's strict
+  // platform-optional-dep check; install reconciles it. Worktree is disposable.
+  console.log(`[build] npm install (${label}) …`);
+  await sh('npm', ['install', '--no-audit', '--no-fund'], { cwd: wt });
   console.log(`[build] production build (${label}) …`);
   await sh('npm', ['run', 'build:prod'], { cwd: wt });
   if (!(await exists(join(publicDir, 'index.html')))) {

--- a/perf-harness/lib/build-serve.mjs
+++ b/perf-harness/lib/build-serve.mjs
@@ -50,7 +50,7 @@ export async function buildBranch(ref, label, { rebuild = true } = {}) {
 }
 
 /** Start the static SPA server for a built public dir. Returns {url, base, stop()}. */
-export async function serve(publicDir, port, base = '/@mxtommy/kip/') {
+export async function serve(publicDir, port, base = '/@halos-org/skip/') {
   const child = spawn('node', [join(HARNESS_DIR, 'serve.mjs'), '--root', publicDir, '--port', String(port), '--base', base], {
     stdio: 'inherit',
   });

--- a/perf-harness/lib/kip-config.mjs
+++ b/perf-harness/lib/kip-config.mjs
@@ -1,0 +1,117 @@
+/*
+ * Builders for the KIP localStorage bundle that puts the app in anonymous,
+ * local-config mode pointed at our mock Signal K server. Shapes are taken
+ * verbatim from src/default-config/* and the widget registry (configVersion 12).
+ */
+export const SELF_URN = 'vessels.urn:mrn:signalk:uuid:11111111-1111-4111-8111-111111111111';
+
+const DEFAULT_UNITS = {
+  Unitless: 'unitless', Speed: 'knots', Flow: 'l/h', Temperature: 'celsius', Length: 'm',
+  Volume: 'liter', Current: 'A', Potential: 'V', Charge: 'C', Power: 'W', Energy: 'J',
+  Pressure: 'mmHg', 'Fuel Distance': 'nm/l', 'Energy Distance': 'nm/kWh', Density: 'kg/m3',
+  Time: 'Hours', 'Angular Velocity': 'deg/min', Angle: 'deg', Frequency: 'Hz', Ratio: 'ratio',
+  Resistance: 'ohm',
+};
+
+const DEFAULT_NOTIF = {
+  disableNotifications: false, menuGrouping: true,
+  security: { disableSecurity: true },
+  devices: { disableDevices: false, showNormalState: false, showNominalState: false },
+  sound: { disableSound: false, muteNormal: true, muteNominal: true, muteWarn: true,
+    muteAlert: false, muteAlarm: false, muteEmergency: false },
+};
+
+export function appConfig(extra = {}) {
+  return {
+    configVersion: 12, autoNightMode: false, redNightMode: false, nightModeBrightness: 0.27,
+    isRemoteControl: false, instanceName: '', dataSets: [], unitDefaults: DEFAULT_UNITS,
+    notificationConfig: DEFAULT_NOTIF, splitShellEnabled: false, splitShellSide: 'left',
+    splitShellSwipeDisabled: false, splitShellWidth: 0.5, ...extra,
+  };
+}
+
+export function connectionConfig(subscribeAll = false) {
+  return {
+    configVersion: 12, kipUUID: '00000000-0000-4000-8000-000000000001',
+    signalKUrl: '__ORIGIN__', // replaced with the served origin at inject time
+    proxyEnabled: false, signalKSubscribeAll: subscribeAll, useDeviceToken: false,
+    loginName: null, loginPassword: null, useSharedConfig: false, sharedConfigName: 'default',
+  };
+}
+
+export const themeConfig = { themeName: '' };
+
+// --- widget factories (gridstack node wrapping widget-host2 + widgetProperties) ---
+let seq = 0;
+const uid = (p) => `${p}-0000-0000-0000-${String(++seq).padStart(12, '0')}`;
+
+function node(w, h, x, y, widgetProperties) {
+  const id = widgetProperties.uuid;
+  return { x, y, w, h, id, selector: 'widget-host2', input: { widgetProperties } };
+}
+
+export function numericWidget({ path = 'self.navigation.speedOverGround', unit = 'knots', sampleTime = 500, miniChart = false } = {}) {
+  const uuid = uid('num');
+  return (x, y) => node(4, 6, x, y, {
+    type: 'widget-numeric', uuid,
+    config: {
+      displayName: 'N', filterSelfPaths: true,
+      paths: { numericPath: { description: 'Numeric Data', path, source: 'default', pathType: 'number', isPathConfigurable: true, convertUnitTo: unit, sampleTime } },
+      numDecimal: 1, showMiniChart: miniChart, color: 'blue', enableTimeout: false, dataTimeout: 5, ignoreZones: false,
+    },
+  });
+}
+
+export function radialGaugeWidget({ path = 'self.navigation.speedOverGround', unit = 'knots', sampleTime = 500 } = {}) {
+  const uuid = uid('rad');
+  return (x, y) => node(4, 6, x, y, {
+    type: 'widget-gauge-ng-radial', uuid,
+    config: {
+      displayName: 'G', filterSelfPaths: true,
+      paths: { gaugePath: { description: 'Gauge', path, source: 'default', pathType: 'number', isPathConfigurable: true, convertUnitTo: unit, sampleTime } },
+      gauge: { type: 'ngRadial', subType: 'measuring' }, minValue: 0, maxValue: 30, numInt: 2, numDecimal: 1,
+      color: 'blue', enableTimeout: false, dataTimeout: 5,
+    },
+  });
+}
+
+export function aisRadarWidget() {
+  const uuid = uid('ais');
+  return (x, y) => node(12, 12, x, y, {
+    type: 'widget-ais-radar', uuid,
+    config: {
+      filterSelfPaths: false, enableTimeout: false, dataTimeout: 5, color: 'grey',
+      ais: {
+        filters: { anchoredMoored: false, noCollisionRisk: false, allAton: false, allButSar: false, allVessels: false, vesselTypes: [] },
+        viewMode: 'course-up', rangeRings: [1, 3, 6, 12, 24, 48], rangeIndex: '3',
+        showCogVectors: true, cogVectorsMinutes: 10, showLostTargets: true, showUnconfirmedTargets: true, showSelf: true,
+      },
+    },
+  });
+}
+
+/** Lay out widget factories in a grid and wrap them in one dashboard. */
+export function buildDashboards(factories, cols = 12) {
+  let x = 0, y = 0, rowH = 0;
+  const configuration = factories.map((make) => {
+    const probe = make(0, 0);
+    const w = probe.w, h = probe.h;
+    if (x + w > cols) { x = 0; y += rowH; rowH = 0; }
+    const n = make(x, y);
+    x += w; rowH = Math.max(rowH, h);
+    return n;
+  });
+  return [{ id: uid('dash'), name: 'Perf', icon: 'dashboard-dashboard', collapseSplitShell: false, configuration }];
+}
+
+/** The full localStorage bundle as {key: jsonString}. signalKUrl is patched to `origin` at inject time. */
+export function localStorageBundle({ origin, subscribeAll, dashboards, app = appConfig() }) {
+  const cc = connectionConfig(subscribeAll);
+  cc.signalKUrl = origin;
+  return {
+    connectionConfig: JSON.stringify(cc),
+    appConfig: JSON.stringify(app),
+    dashboardsConfig: JSON.stringify(dashboards),
+    themeConfig: JSON.stringify(themeConfig),
+  };
+}

--- a/perf-harness/lib/kip-config.mjs
+++ b/perf-harness/lib/kip-config.mjs
@@ -1,7 +1,15 @@
 /*
- * Builders for the KIP localStorage bundle that puts the app in anonymous,
- * local-config mode pointed at our mock Signal K server. Shapes are taken
- * verbatim from src/default-config/* and the widget registry (configVersion 12).
+ * Builders for the Skip boot config. Skip (unlike upstream Kip) always persists
+ * app/theme/dashboards config on the server's applicationData — localStorage holds
+ * only the per-device connection config ('skip.connectionConfig'). So the harness
+ * seeds one localStorage key and hands the mock server a full IConfig document to
+ * answer the applicationData GET with. Shapes are taken verbatim from
+ * src/default-config/* and the widget registry.
+ *
+ * Three distinct version spaces (all from src/app/core/services):
+ *  - applicationData URL path segment 11 (configFileVersion, app-initNetwork.service.ts)
+ *  - app.configVersion 12 (latestConfigVersion, settings.service.ts)
+ *  - connectionConfig.configVersion 13 (CONNECTION_CONFIG_VERSION, app-settings.interfaces.ts)
  */
 export const SELF_URN = 'vessels.urn:mrn:signalk:uuid:11111111-1111-4111-8111-111111111111';
 
@@ -24,22 +32,20 @@ const DEFAULT_NOTIF = {
 export function appConfig(extra = {}) {
   return {
     configVersion: 12, autoNightMode: false, redNightMode: false, nightModeBrightness: 0.27,
-    isRemoteControl: false, instanceName: '', dataSets: [], unitDefaults: DEFAULT_UNITS,
-    notificationConfig: DEFAULT_NOTIF, splitShellEnabled: false, splitShellSide: 'left',
-    splitShellSwipeDisabled: false, splitShellWidth: 0.5, ...extra,
+    widgetHistoryDisabled: false, dataSets: [], unitDefaults: DEFAULT_UNITS,
+    notificationConfig: DEFAULT_NOTIF, browserTabTitle: 'SKip', ...extra,
   };
 }
 
 export function connectionConfig(subscribeAll = false) {
   return {
-    configVersion: 12, kipUUID: '00000000-0000-4000-8000-000000000001',
+    configVersion: 13, kipUUID: '00000000-0000-4000-8000-000000000001',
     signalKUrl: '__ORIGIN__', // replaced with the served origin at inject time
-    proxyEnabled: false, signalKSubscribeAll: subscribeAll, useDeviceToken: false,
-    loginName: null, loginPassword: null, useSharedConfig: false, sharedConfigName: 'default',
+    proxyEnabled: false, signalKSubscribeAll: subscribeAll,
+    useSharedConfig: true, sharedConfigName: 'default',
+    isRemoteControl: false, instanceName: '',
   };
 }
-
-export const themeConfig = { themeName: '' };
 
 // --- widget factories (gridstack node wrapping widget-host2 + widgetProperties) ---
 let seq = 0;
@@ -69,7 +75,8 @@ export function radialGaugeWidget({ path = 'self.navigation.speedOverGround', un
     config: {
       displayName: 'G', filterSelfPaths: true,
       paths: { gaugePath: { description: 'Gauge', path, source: 'default', pathType: 'number', isPathConfigurable: true, convertUnitTo: unit, sampleTime } },
-      gauge: { type: 'ngRadial', subType: 'measuring' }, minValue: 0, maxValue: 30, numInt: 2, numDecimal: 1,
+      gauge: { type: 'ngRadial', subType: 'measuring' },
+      displayScale: { lower: 0, upper: 30, type: 'linear' }, numInt: 2, numDecimal: 1,
       color: 'blue', enableTimeout: false, dataTimeout: 5,
     },
   });
@@ -101,17 +108,20 @@ export function buildDashboards(factories, cols = 12) {
     x += w; rowH = Math.max(rowH, h);
     return n;
   });
-  return [{ id: uid('dash'), name: 'Perf', icon: 'dashboard-dashboard', collapseSplitShell: false, configuration }];
+  return [{ id: uid('dash'), name: 'Perf', icon: 'dashboard-dashboard', configuration }];
 }
 
-/** The full localStorage bundle as {key: jsonString}. signalKUrl is patched to `origin` at inject time. */
-export function localStorageBundle({ origin, subscribeAll, dashboards, app = appConfig() }) {
+/**
+ * The only localStorage key Skip reads at boot. All other config (app/theme/
+ * dashboards) lives server-side — see serverConfigDocument().
+ */
+export function localStorageBundle({ origin, subscribeAll }) {
   const cc = connectionConfig(subscribeAll);
   cc.signalKUrl = origin;
-  return {
-    connectionConfig: JSON.stringify(cc),
-    appConfig: JSON.stringify(app),
-    dashboardsConfig: JSON.stringify(dashboards),
-    themeConfig: JSON.stringify(themeConfig),
-  };
+  return { 'skip.connectionConfig': JSON.stringify(cc) };
+}
+
+/** Full IConfig document the mock serves from applicationData/user/skip/<ver>/default. */
+export function serverConfigDocument({ dashboards, app = appConfig() }) {
+  return { app, theme: { themeName: '' }, dashboards };
 }

--- a/perf-harness/lib/server.mjs
+++ b/perf-harness/lib/server.mjs
@@ -49,6 +49,26 @@ function aisDelta(mmsi, i, t) {
   });
 }
 
+// Deterministic scene deltas (for reproducible before/after radar screenshots).
+function selfSceneDelta(o, t) {
+  return JSON.stringify({ context: SELF_URN, updates: [{ $source: 'mock.0', timestamp: iso(t), values: [
+    { path: 'navigation.position', value: { latitude: o.lat, longitude: o.lon } },
+    { path: 'navigation.headingTrue', value: (o.heading ?? 0) * Math.PI / 180 },
+    { path: 'navigation.courseOverGroundTrue', value: (o.cog ?? o.heading ?? 0) * Math.PI / 180 },
+    { path: 'navigation.speedOverGround', value: o.sog ?? 5 },
+  ] }] });
+}
+function targetSceneDelta(tg, t) {
+  return JSON.stringify({ context: `vessels.urn:mrn:imo:mmsi:${tg.mmsi}`, updates: [{ $source: 'mock.ais', timestamp: iso(t), values: [
+    { path: 'navigation.position', value: { latitude: tg.lat, longitude: tg.lon } },
+    { path: 'navigation.headingTrue', value: (tg.heading ?? 0) * Math.PI / 180 },
+    { path: 'navigation.courseOverGroundTrue', value: (tg.cog ?? tg.heading ?? 0) * Math.PI / 180 },
+    { path: 'navigation.speedOverGround', value: tg.sog ?? 4 },
+    { path: 'name', value: tg.name ?? `T${tg.mmsi}` },
+    { path: 'mmsi', value: String(tg.mmsi) },
+  ] }] });
+}
+
 function helloMsg() {
   return JSON.stringify({ name: 'kip-mock', version: '2.3.0', self: SELF_URN, roles: ['master', 'main'], timestamp: iso(Date.now()) });
 }
@@ -117,6 +137,12 @@ export async function startServer({ publicDir, base, port }) {
     const timer = setInterval(() => {
       if (!control.streaming || ws.readyState !== ws.OPEN) return;
       const t = Date.now();
+      // Deterministic scene: fixed own-ship + fixed targets (reproducible screenshots).
+      if (control.staticScene) {
+        ws.send(selfSceneDelta(control.staticScene.ownShip, t)); sent++;
+        for (const tg of control.staticScene.targets) { ws.send(targetSceneDelta(tg, t)); sent++; }
+        return;
+      }
       ws.send(selfDelta(control.selfPaths, t)); sent++;
       const n = control.ais.count | 0;
       for (let i = 0; i < n; i++) { ws.send(aisDelta(mmsiBase + i, i, t)); sent++; }

--- a/perf-harness/lib/server.mjs
+++ b/perf-harness/lib/server.mjs
@@ -1,0 +1,155 @@
+/*
+ * Combined server for the harness: serves the built KIP app under `base`
+ * AND acts as the mock Signal K server (/signalk/ discovery, WS delta stream,
+ * v2 history) on the SAME origin — so signalKUrl is same-origin (no CORS) and
+ * the app talks to a fully controllable data source.
+ */
+import http from 'node:http';
+import { readFile, stat } from 'node:fs/promises';
+import { join, extname, normalize } from 'node:path';
+import { WebSocketServer } from 'ws';
+import { SELF_URN } from './kip-config.mjs';
+
+const TYPES = {
+  '.html': 'text/html; charset=utf-8', '.js': 'text/javascript', '.mjs': 'text/javascript',
+  '.css': 'text/css', '.json': 'application/json', '.svg': 'image/svg+xml', '.png': 'image/png',
+  '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg', '.webp': 'image/webp', '.ico': 'image/x-icon',
+  '.woff': 'font/woff', '.woff2': 'font/woff2', '.ttf': 'font/ttf', '.wasm': 'application/wasm', '.map': 'application/json',
+};
+
+const iso = (t) => new Date(t).toISOString();
+
+function genSelfValue(path, t) {
+  switch (path) {
+    case 'navigation.speedOverGround': return 5 + 2 * Math.sin(t / 1000);
+    case 'navigation.headingTrue':
+    case 'navigation.courseOverGroundTrue': return ((t / 40) % 360) * Math.PI / 180;
+    case 'navigation.position': return { latitude: 47.6 + 0.001 * Math.sin(t / 4000), longitude: -122.33 + 0.001 * Math.cos(t / 4000) };
+    case 'environment.depth.belowTransducer': return 12 + 3 * Math.sin(t / 2000);
+    case 'environment.wind.angleApparent': return Math.sin(t / 1000);
+    case 'environment.wind.speedApparent': return 8 + 3 * Math.sin(t / 1500);
+    default: return Math.sin(t / 1000) * 100;
+  }
+}
+
+function selfDelta(paths, t) {
+  return JSON.stringify({ context: SELF_URN, updates: [{ $source: 'mock.0', timestamp: iso(t), values: paths.map((p) => ({ path: p, value: genSelfValue(p, t) })) }] });
+}
+
+function aisDelta(mmsi, i, t) {
+  return JSON.stringify({
+    context: `vessels.urn:mrn:imo:mmsi:${mmsi}`,
+    updates: [{ $source: 'mock.ais', timestamp: iso(t), values: [
+      { path: 'navigation.position', value: { latitude: 47.6 + 0.02 * Math.sin(t / 3000 + i), longitude: -122.33 + 0.02 * Math.cos(t / 3000 + i) } },
+      { path: 'navigation.headingTrue', value: ((i * 11 + t / 50) % 360) * Math.PI / 180 },
+      { path: 'navigation.courseOverGroundTrue', value: ((i * 11) % 360) * Math.PI / 180 },
+      { path: 'navigation.speedOverGround', value: 3 + (i % 6) },
+      { path: 'mmsi', value: String(mmsi) },
+    ] }],
+  });
+}
+
+function helloMsg() {
+  return JSON.stringify({ name: 'kip-mock', version: '2.3.0', self: SELF_URN, roles: ['master', 'main'], timestamp: iso(Date.now()) });
+}
+
+function historyResponse(paths, rows, stepSec) {
+  const base = Date.parse('2026-06-30T00:00:00.000Z');
+  const values = paths.flatMap((p) => [{ path: p, method: 'sma' }, { path: p, method: 'avg' }, { path: p, method: 'min' }, { path: p, method: 'max' }]);
+  const data = [];
+  for (let i = 0; i < rows; i++) {
+    const row = [iso(base + i * stepSec * 1000)];
+    for (let k = 0; k < values.length; k++) row.push(5 + Math.sin((i + k) / 10));
+    data.push(row);
+  }
+  return { context: 'vessels.self', range: { from: iso(base), to: iso(base + rows * stepSec * 1000) }, values, data };
+}
+
+/**
+ * @param {object} o { publicDir, base, port }
+ * Returns { origin, appUrl, setControl(c), blast(n), streamCount(), stop() }.
+ * control: { streaming:bool, rateHz, selfPaths:[], ais:{count, churnPerSec} }
+ */
+export async function startServer({ publicDir, base, port }) {
+  const control = { streaming: false, rateHz: 10, selfPaths: ['navigation.speedOverGround'], ais: { count: 0, churnPerSec: 0 } };
+  let history = { rows: 0, stepSec: 1, paths: ['navigation.speedOverGround'] };
+  let sent = 0;
+  let mmsiBase = 100000000;
+
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url, 'http://x');
+    const p = decodeURIComponent(url.pathname);
+    // --- Signal K endpoints (origin root) ---
+    if (p === '/signalk' || p === '/signalk/') {
+      res.writeHead(200, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' });
+      return res.end(JSON.stringify({
+        endpoints: { v1: { version: '2.3.0', 'signalk-http': `http://localhost:${port}/signalk/v1/api/`, 'signalk-ws': `ws://localhost:${port}/signalk/v1/stream` } },
+        server: { id: 'kip-mock', version: '2.3.0' },
+      }));
+    }
+    if (p.startsWith('/signalk/v2/api/history/values')) {
+      res.writeHead(200, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' });
+      return res.end(JSON.stringify(historyResponse(history.paths, history.rows, history.stepSec)));
+    }
+    if (p.startsWith('/signalk/v1/api')) { // snapshot / misc — empty model
+      res.writeHead(200, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' });
+      return res.end('{}');
+    }
+    // --- static app ---
+    let rel = p.startsWith(base) ? p.slice(base.length) : p.replace(/^\//, '');
+    if (p === '/') { res.writeHead(302, { Location: base }); return res.end(); }
+    rel = normalize(rel).replace(/^(\.\.[/\\])+/, '');
+    let file = join(publicDir, rel);
+    try { if (!(await stat(file)).isFile()) throw 0; } catch {
+      if (!extname(rel)) file = join(publicDir, 'index.html'); else { res.writeHead(404); return res.end('nf'); }
+    }
+    try {
+      const body = await readFile(file);
+      res.writeHead(200, { 'Content-Type': TYPES[extname(file)] || 'application/octet-stream', 'Cache-Control': 'no-store' });
+      res.end(body);
+    } catch { res.writeHead(404); res.end('nf'); }
+  });
+
+  const wss = new WebSocketServer({ server, path: '/signalk/v1/stream' });
+  wss.on('connection', (ws) => {
+    ws.send(helloMsg());
+    let tick = 0;
+    const timer = setInterval(() => {
+      if (!control.streaming || ws.readyState !== ws.OPEN) return;
+      const t = Date.now();
+      ws.send(selfDelta(control.selfPaths, t)); sent++;
+      const n = control.ais.count | 0;
+      for (let i = 0; i < n; i++) { ws.send(aisDelta(mmsiBase + i, i, t)); sent++; }
+      // churn: introduce brand-new MMSIs over time (unbounded-growth scenario)
+      const churn = control.ais.churnPerSec | 0;
+      if (churn) {
+        const per = Math.max(1, Math.round(churn / control.rateHz));
+        for (let c = 0; c < per; c++) { mmsiBase++; ws.send(aisDelta(mmsiBase + n, n + c, t)); sent++; }
+      }
+      tick++;
+    }, Math.max(1, Math.round(1000 / control.rateHz)));
+    ws.on('close', () => clearInterval(timer));
+    // Many separate frames (sustained flood) — each is its own onmessage task.
+    ws._blast = (count) => { const t = Date.now(); for (let i = 0; i < count; i++) { ws.send(selfDelta(control.selfPaths, t + i)); sent++; } };
+    // ONE frame carrying many values (reconnect snapshot) — a single synchronous
+    // parse + fan-out, i.e. the worst-case long task that coalescing must bound.
+    ws._blastBig = (nValues) => {
+      const t = Date.now();
+      const values = [];
+      for (let i = 0; i < nValues; i++) values.push({ path: `sensors.mock.n${i}.value`, value: Math.sin((t + i) / 1000) });
+      ws.send(JSON.stringify({ context: SELF_URN, updates: [{ $source: 'mock.0', timestamp: iso(t), values }] }));
+      sent++;
+    };
+  });
+
+  await new Promise((r) => server.listen(port, r));
+  const origin = `http://localhost:${port}`;
+  return {
+    origin, appUrl: `${origin}${base}`,
+    setControl(c) { Object.assign(control, c); if (c.history) history = { ...history, ...c.history }; },
+    blast(count) { for (const ws of wss.clients) if (ws._blast) ws._blast(count); },
+    blastBig(nValues) { for (const ws of wss.clients) if (ws._blastBig) ws._blastBig(nValues); },
+    streamCount() { return sent; },
+    stop() { return new Promise((r) => { for (const ws of wss.clients) ws.terminate(); server.close(() => r()); }); },
+  };
+}

--- a/perf-harness/lib/server.mjs
+++ b/perf-harness/lib/server.mjs
@@ -1,8 +1,12 @@
 /*
- * Combined server for the harness: serves the built KIP app under `base`
- * AND acts as the mock Signal K server (/signalk/ discovery, WS delta stream,
+ * Combined server for the harness: serves the built Skip app under `base`
+ * AND acts as the mock Signal K server (/skServer/loginStatus session,
+ * applicationData config, /plugins, /signalk/ discovery, WS delta stream,
  * v2 history) on the SAME origin — so signalKUrl is same-origin (no CORS) and
- * the app talks to a fully controllable data source.
+ * the app talks to a fully controllable data source. Skip is SSO/session-only
+ * and always persists config server-side, so the mock must answer the auth
+ * probe and serve/absorb the applicationData document — a localStorage-only
+ * bootstrap (upstream Kip's approach) boots Skip into a degraded empty app.
  */
 import http from 'node:http';
 import { readFile, stat } from 'node:fs/promises';
@@ -69,9 +73,24 @@ function targetSceneDelta(tg, t) {
   ] }] });
 }
 
+// Skip gates widget history on server.version >= 2.22.1 (settings.service.ts).
+const SERVER_VERSION = '2.24.0';
+
 function helloMsg() {
-  return JSON.stringify({ name: 'kip-mock', version: '2.3.0', self: SELF_URN, roles: ['master', 'main'], timestamp: iso(Date.now()) });
+  return JSON.stringify({ name: 'skip-mock', version: SERVER_VERSION, self: SELF_URN, roles: ['master', 'main'], timestamp: iso(Date.now()) });
 }
+
+// Raw /plugins list entry (IRawPluginInformation). getPlugin() reads plugin
+// configuration from the LIST response, not the /plugins/kip detail, so
+// historySeriesServiceEnabled:false must live here to suppress the
+// series-reconcile POST that otherwise fires ~750ms after boot.
+const KIP_PLUGIN_LIST = [{
+  id: 'kip', name: 'KIP', packageName: 'kip', keywords: [], version: '0.0.0',
+  description: 'mock', schema: null,
+  data: { configuration: { historySeriesServiceEnabled: false, registerAsHistoryApiProvider: false }, enabled: true, enableLogging: false, enableDebug: false },
+}];
+// IRawPluginDetail for GET /plugins/kip.
+const KIP_PLUGIN_DETAIL = { id: 'kip', name: 'KIP', version: '0.0.0', enabled: true };
 
 function historyResponse(paths, rows, stepSec) {
   const base = Date.parse('2026-06-30T00:00:00.000Z');
@@ -93,19 +112,47 @@ function historyResponse(paths, rows, stepSec) {
 export async function startServer({ publicDir, base, port }) {
   const control = { streaming: false, rateHz: 10, selfPaths: ['navigation.speedOverGround'], ais: { count: 0, churnPerSec: 0 } };
   let history = { rows: 0, stepSec: 1, paths: ['navigation.speedOverGround'] };
+  let configDoc = null; // IConfig served from applicationData (set per scenario by the runner)
   let sent = 0;
   let mmsiBase = 100000000;
+
+  const json = (res, body) => {
+    res.writeHead(200, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' });
+    res.end(typeof body === 'string' ? body : JSON.stringify(body));
+  };
 
   const server = http.createServer(async (req, res) => {
     const url = new URL(req.url, 'http://x');
     const p = decodeURIComponent(url.pathname);
     // --- Signal K endpoints (origin root) ---
     if (p === '/signalk' || p === '/signalk/') {
-      res.writeHead(200, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' });
-      return res.end(JSON.stringify({
-        endpoints: { v1: { version: '2.3.0', 'signalk-http': `http://localhost:${port}/signalk/v1/api/`, 'signalk-ws': `ws://localhost:${port}/signalk/v1/stream` } },
-        server: { id: 'kip-mock', version: '2.3.0' },
-      }));
+      return json(res, {
+        endpoints: { v1: { version: SERVER_VERSION, 'signalk-http': `http://localhost:${port}/signalk/v1/api/`, 'signalk-ws': `ws://localhost:${port}/signalk/v1/stream` } },
+        server: { id: 'skip-mock', version: SERVER_VERSION },
+      });
+    }
+    // Session probe: Skip is session-cookie SSO-only; a loggedIn answer with a
+    // write-capable userLevel unlocks the server-side config bootstrap.
+    if (p === '/skServer/loginStatus') {
+      return json(res, { status: 'loggedIn', username: 'harness', userLevel: 'admin' });
+    }
+    // applicationData: config document + slot listing; POSTs (the boot Dashboards
+    // JSON-Patch and autosaves) are absorbed with 200 — any non-2xx would put a
+    // persistent error snackbar into the measurement.
+    if (p.startsWith('/signalk/v1/applicationData/')) {
+      if (req.method === 'POST') { req.resume(); return req.on('end', () => json(res, {})); }
+      const m = p.match(/^\/signalk\/v1\/applicationData\/(user|global)\/skip\/\d+\/(.*)$/);
+      if (m && url.searchParams.get('keys') === 'true') return json(res, m[1] === 'user' ? ['default'] : []);
+      if (m && m[2] === 'default' && m[1] === 'user') return json(res, configDoc ?? {});
+      return json(res, {}); // SK answers never-created slots with 200 {}
+    }
+    // Plugin surface: disable the KIP history-series service so the dashboard
+    // sync's reconcile POST (~750ms after boot) is skipped.
+    if (p === '/plugins' || p === '/plugins/') return json(res, KIP_PLUGIN_LIST);
+    if (p === '/plugins/kip') return json(res, KIP_PLUGIN_DETAIL);
+    if (p === '/plugins/kip/series/reconcile' && req.method === 'POST') {
+      req.resume();
+      return req.on('end', () => json(res, { created: 0, updated: 0, deleted: 0, total: 0 }));
     }
     if (p.startsWith('/signalk/v2/api/history/values')) {
       res.writeHead(200, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' });
@@ -131,10 +178,14 @@ export async function startServer({ publicDir, base, port }) {
   });
 
   const wss = new WebSocketServer({ server, path: '/signalk/v1/stream' });
+  // Skip opens its WS once during APP_INITIALIZER (before the scenario's
+  // setControl) and keeps it — so a connection-time snapshot of rateHz (as
+  // upstream Kip could afford) would stream every scenario at the boot-time
+  // default. Timers restart on rateHz changes instead.
+  const timerRestarts = new Set();
   wss.on('connection', (ws) => {
     ws.send(helloMsg());
-    let tick = 0;
-    const timer = setInterval(() => {
+    const sendTick = () => {
       if (!control.streaming || ws.readyState !== ws.OPEN) return;
       const t = Date.now();
       // Deterministic scene: fixed own-ship + fixed targets (reproducible screenshots).
@@ -152,9 +203,15 @@ export async function startServer({ publicDir, base, port }) {
         const per = Math.max(1, Math.round(churn / control.rateHz));
         for (let c = 0; c < per; c++) { mmsiBase++; ws.send(aisDelta(mmsiBase + n, n + c, t)); sent++; }
       }
-      tick++;
-    }, Math.max(1, Math.round(1000 / control.rateHz)));
-    ws.on('close', () => clearInterval(timer));
+    };
+    let timer = null;
+    const startTimer = () => {
+      if (timer) clearInterval(timer);
+      timer = setInterval(sendTick, Math.max(1, Math.round(1000 / control.rateHz)));
+    };
+    startTimer();
+    timerRestarts.add(startTimer);
+    ws.on('close', () => { clearInterval(timer); timerRestarts.delete(startTimer); });
     // Many separate frames (sustained flood) — each is its own onmessage task.
     ws._blast = (count) => { const t = Date.now(); for (let i = 0; i < count; i++) { ws.send(selfDelta(control.selfPaths, t + i)); sent++; } };
     // ONE frame carrying many values (reconnect snapshot) — a single synchronous
@@ -172,7 +229,13 @@ export async function startServer({ publicDir, base, port }) {
   const origin = `http://localhost:${port}`;
   return {
     origin, appUrl: `${origin}${base}`,
-    setControl(c) { Object.assign(control, c); if (c.history) history = { ...history, ...c.history }; },
+    setControl(c) {
+      const rateChanged = c.rateHz !== undefined && c.rateHz !== control.rateHz;
+      Object.assign(control, c);
+      if (c.history) history = { ...history, ...c.history };
+      if (rateChanged) for (const restart of timerRestarts) restart();
+    },
+    setConfigDocument(doc) { configDoc = doc; },
     blast(count) { for (const ws of wss.clients) if (ws._blast) ws._blast(count); },
     blastBig(nValues) { for (const ws of wss.clients) if (ws._blastBig) ws._blastBig(nValues); },
     streamCount() { return sent; },

--- a/perf-harness/package-lock.json
+++ b/perf-harness/package-lock.json
@@ -1,0 +1,49 @@
+{
+  "name": "kip-perf-harness",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "kip-perf-harness",
+      "version": "0.1.0",
+      "dependencies": {
+        "playwright-core": "^1.49.0",
+        "ws": "^8.18.0"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/perf-harness/package.json
+++ b/perf-harness/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "kip-perf-harness",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Reproducible main-thread / freeze measurement harness for KIP. Self-contained: its deps never touch the app package.json.",
+  "scripts": {
+    "measure": "node run.mjs",
+    "serve": "node serve.mjs"
+  },
+  "dependencies": {
+    "playwright-core": "^1.49.0",
+    "ws": "^8.18.0"
+  }
+}

--- a/perf-harness/probe.js
+++ b/perf-harness/probe.js
@@ -1,0 +1,148 @@
+/*
+ * KIP performance probe — injected into the page via Playwright addInitScript
+ * BEFORE any app code runs, so identical measurement code is used across every
+ * branch/build under test (master, integration/perf-preview, freeze fixes).
+ *
+ * It measures the *symptom* — main-thread blocking and responsiveness — not
+ * proxy microbenchmarks:
+ *
+ *  - longtasks:      PerformanceObserver('longtask') — every task >50ms (the
+ *                    browser's own definition of "the main thread was blocked").
+ *  - blockingTime:   Total Blocking Time proxy = sum(max(0, dur-50)) over tasks.
+ *  - taskLatency:    a MessageChannel canary posts to itself continuously; the
+ *                    delay before the reply runs = how long a queued handler
+ *                    (e.g. the exit-fullscreen keydown) would wait. This is the
+ *                    honest proxy for "the UI is frozen / can't exit fullscreen".
+ *  - frameGaps:      requestAnimationFrame inter-frame gaps — dropped frames.
+ *  - heap:           usedJSHeapSize samples over time (growth-slope findings).
+ *
+ * Everything is exposed on window.__perf. The harness calls __perf.reset()
+ * before a scenario window and __perf.snapshot() after.
+ */
+(() => {
+  if (window.__perf) return;
+
+  const state = {
+    startedAt: performance.now(),
+    longtasks: [],       // { start, duration }
+    taskLatency: [],     // ms of canary reply delay
+    frameGaps: [],       // ms between rAF callbacks
+    heap: [],            // { t, used }
+    marks: {},           // name -> [durations ms]
+    windowStart: performance.now(),
+  };
+
+  // --- Long tasks (main-thread blocking) ---
+  try {
+    const po = new PerformanceObserver((list) => {
+      for (const e of list.getEntries()) {
+        state.longtasks.push({ start: e.startTime, duration: e.duration });
+      }
+    });
+    po.observe({ entryTypes: ['longtask'] });
+  } catch { /* longtask unsupported */ }
+
+  // --- Event-loop lag canary (task-queue responsiveness) ---
+  // A self-rescheduling timer measures how much LATER than its interval it
+  // actually fires. That lateness == how long an already-queued handler (e.g.
+  // the exit-fullscreen keydown) would sit starved while the thread is busy.
+  const CANARY_PERIOD_MS = 16;
+  let scheduledAt = performance.now();
+  function tick() {
+    const lateness = performance.now() - scheduledAt - CANARY_PERIOD_MS;
+    if (lateness > 0) state.taskLatency.push(lateness);
+    scheduledAt = performance.now();
+    setTimeout(tick, CANARY_PERIOD_MS);
+  }
+  setTimeout(tick, CANARY_PERIOD_MS);
+
+  // --- Frame gaps (rendering smoothness) ---
+  let lastFrame = performance.now();
+  function frame(now) {
+    const gap = now - lastFrame;
+    lastFrame = now;
+    if (gap > 0) state.frameGaps.push(gap);
+    requestAnimationFrame(frame);
+  }
+  requestAnimationFrame(frame);
+
+  // --- Heap sampling ---
+  const perfMem = () => (performance.memory ? performance.memory.usedJSHeapSize : null);
+  setInterval(() => {
+    const used = perfMem();
+    if (used != null) state.heap.push({ t: performance.now(), used });
+  }, 500);
+
+  // --- Custom marks the harness / app can bracket operations with ---
+  function measure(name, fn) {
+    const t0 = performance.now();
+    const r = fn();
+    const record = () => {
+      const d = performance.now() - t0;
+      (state.marks[name] = state.marks[name] || []).push(d);
+    };
+    if (r && typeof r.then === 'function') { r.then(record, record); return r; }
+    record();
+    return r;
+  }
+
+  function pct(arr, p) {
+    if (!arr.length) return 0;
+    const s = [...arr].sort((a, b) => a - b);
+    return s[Math.min(s.length - 1, Math.floor((p / 100) * s.length))];
+  }
+
+  window.__perf = {
+    reset() {
+      state.windowStart = performance.now();
+      state.longtasks.length = 0;
+      state.taskLatency.length = 0;
+      state.frameGaps.length = 0;
+      // keep heap series (growth is measured across the whole run)
+      for (const k of Object.keys(state.marks)) delete state.marks[k];
+    },
+    mark: measure,
+    snapshot() {
+      const durMs = performance.now() - state.windowStart;
+      const lts = state.longtasks;
+      const blockingTime = lts.reduce((a, e) => a + Math.max(0, e.duration - 50), 0);
+      const heap = state.heap;
+      let heapSlope = 0;
+      if (heap.length > 1) {
+        const first = heap[0], last = heap[heap.length - 1];
+        heapSlope = (last.used - first.used) / ((last.t - first.t) / 1000); // bytes/sec
+      }
+      const marks = {};
+      for (const [k, v] of Object.entries(state.marks)) {
+        marks[k] = { count: v.length, max: Math.max(...v), p50: pct(v, 50), p95: pct(v, 95) };
+      }
+      return {
+        windowMs: Math.round(durMs),
+        longTasks: {
+          count: lts.length,
+          totalMs: Math.round(lts.reduce((a, e) => a + e.duration, 0)),
+          maxMs: Math.round(lts.reduce((a, e) => Math.max(a, e.duration), 0)),
+          blockingTimeMs: Math.round(blockingTime),
+        },
+        taskLatencyMs: {
+          samples: state.taskLatency.length,
+          maxMs: Math.round(state.taskLatency.reduce((a, b) => Math.max(a, b), 0)),
+          p95Ms: Math.round(pct(state.taskLatency, 95)),
+        },
+        frames: {
+          samples: state.frameGaps.length,
+          maxGapMs: Math.round(state.frameGaps.reduce((a, b) => Math.max(a, b), 0)),
+          p95GapMs: Math.round(pct(state.frameGaps, 95)),
+          droppedOver50ms: state.frameGaps.filter((g) => g > 50).length,
+        },
+        heap: {
+          samples: heap.length,
+          firstBytes: heap.length ? heap[0].used : null,
+          lastBytes: heap.length ? heap[heap.length - 1].used : null,
+          slopeBytesPerSec: Math.round(heapSlope),
+        },
+        marks,
+      };
+    },
+  };
+})();

--- a/perf-harness/report.mjs
+++ b/perf-harness/report.mjs
@@ -1,0 +1,63 @@
+/*
+ * Build an honest before/after markdown report from two result files.
+ *   node report.mjs --a master --b perf-preview [--out results/report.md]
+ * Reads results/<label>.json written by run.mjs.
+ */
+import { readFile, writeFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const arg = (n, d) => { const i = process.argv.indexOf(`--${n}`); return i >= 0 ? process.argv[i + 1] : d; };
+
+const A = arg('a', 'master');
+const B = arg('b', 'perf-preview');
+const OUT = arg('out', join(HERE, 'results', `report-${A}-vs-${B}.md`));
+
+const load = async (label) => JSON.parse(await readFile(join(HERE, 'results', `${label}.json`), 'utf8'));
+
+// metric key -> [display, lowerIsBetter]
+const METRICS = [
+  ['longTaskMaxMs', 'Longest task (ms)', true],
+  ['blockingTimeMs', 'Blocking time (ms)', true],
+  ['taskLatencyMaxMs', 'Max handler wait (ms)', true],
+  ['taskLatencyP95Ms', 'p95 handler wait (ms)', true],
+  ['framesDropped', 'Dropped frames', true],
+  ['heapGrowthMB', 'Heap growth (MB)', true],
+];
+
+function pctChange(a, b) {
+  if (a === 0 && b === 0) return '0%';
+  if (a === 0) return b > 0 ? `+${b} (was 0)` : '0%';
+  const d = Math.round(((b - a) / Math.abs(a)) * 100);
+  return `${d > 0 ? '+' : ''}${d}%`;
+}
+
+const a = await load(A), b = await load(B);
+const lines = [];
+lines.push(`# Freeze metrics: ${A} → ${B}`);
+lines.push('');
+lines.push(`- CPU throttle: ${a.throttle}× (${A}) / ${b.throttle}× (${B}); repeats: ${a.repeats}/${b.repeats}; Chrome ${a.chrome}`);
+lines.push('- Values are **medians** across repeats. Lower is better for every metric.');
+lines.push('');
+
+const scenarios = Object.keys(a.scenarios).filter((s) => b.scenarios[s]);
+for (const s of scenarios) {
+  const sa = a.scenarios[s].agg, sb = b.scenarios[s].agg;
+  lines.push(`## ${s}`);
+  lines.push(`_${a.scenarios[s].note}_`);
+  lines.push('');
+  lines.push(`| Metric | ${A} | ${B} | Δ |`);
+  lines.push('|---|--:|--:|--:|');
+  for (const [k, label] of METRICS) {
+    const va = sa[k]?.median ?? 0, vb = sb[k]?.median ?? 0;
+    lines.push(`| ${label} | ${va} | ${vb} | ${pctChange(va, vb)} |`);
+  }
+  lines.push(`| _(context: widgets / deltas)_ | ${sa.widgetCount?.median}/${sa.deltasSent?.median} | ${sb.widgetCount?.median}/${sb.deltasSent?.median} | |`);
+  lines.push('');
+}
+
+const md = lines.join('\n');
+await writeFile(OUT, md);
+console.log(md);
+console.log(`\n[report] wrote ${OUT}`);

--- a/perf-harness/report.mjs
+++ b/perf-harness/report.mjs
@@ -26,6 +26,8 @@ const METRICS = [
   ['heapGrowthMB', 'Heap growth (MB)', true],
 ];
 
+const medOf = (vals) => { if (!vals.length) return 0; const s = [...vals].sort((x, y) => x - y); return s[Math.floor(s.length / 2)]; };
+
 function pctChange(a, b) {
   if (a === 0 && b === 0) return '0%';
   if (a === 0) return b > 0 ? `+${b} (was 0)` : '0%';
@@ -39,6 +41,7 @@ lines.push(`# Freeze metrics: ${A} → ${B}`);
 lines.push('');
 lines.push(`- CPU throttle: ${a.throttle}× (${A}) / ${b.throttle}× (${B}); repeats: ${a.repeats}/${b.repeats}; Chrome ${a.chrome}`);
 lines.push('- Values are **medians** across repeats. Lower is better for every metric.');
+lines.push('- Blocking time is a raw sum over the probe window, and the window self-extends while the main thread is busy — compare the two labels\' median window lengths (context row) before trusting small blocking deltas.');
 lines.push('');
 
 const scenarios = Object.keys(a.scenarios).filter((s) => b.scenarios[s]);
@@ -53,7 +56,9 @@ for (const s of scenarios) {
     const va = sa[k]?.median ?? 0, vb = sb[k]?.median ?? 0;
     lines.push(`| ${label} | ${va} | ${vb} | ${pctChange(va, vb)} |`);
   }
-  lines.push(`| _(context: widgets / deltas)_ | ${sa.widgetCount?.median}/${sa.deltasSent?.median} | ${sb.widgetCount?.median}/${sb.deltasSent?.median} | |`);
+  const wa = Math.round(medOf((a.scenarios[s].raw ?? []).map((r) => r.windowMs)));
+  const wb = Math.round(medOf((b.scenarios[s].raw ?? []).map((r) => r.windowMs)));
+  lines.push(`| _(context: widgets / deltas / window ms)_ | ${sa.widgetCount?.median}/${sa.deltasSent?.median}/${wa} | ${sb.widgetCount?.median}/${sb.deltasSent?.median}/${wb} | |`);
   lines.push('');
 }
 

--- a/perf-harness/results/diag-pre-variance.json
+++ b/perf-harness/results/diag-pre-variance.json
@@ -1,0 +1,246 @@
+{
+  "label": "diag-pre-variance",
+  "branch": "11f3fbd0",
+  "throttle": 10,
+  "repeats": 4,
+  "chrome": "149.0.7827.201",
+  "scenarios": {
+    "ais-radar-150": {
+      "note": "150 AIS targets @ 4Hz + streaming own-ship (ranks 4/5, radar render loops)",
+      "agg": {
+        "longTaskCount": {
+          "median": 20,
+          "p95": 32,
+          "all": [
+            32,
+            20,
+            16,
+            18
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 1040,
+          "p95": 1071,
+          "all": [
+            610,
+            901,
+            1040,
+            1071
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 9319,
+          "p95": 9697,
+          "all": [
+            7758,
+            8790,
+            9319,
+            9697
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 2277,
+          "p95": 2903,
+          "all": [
+            1165,
+            2277,
+            2208,
+            2903
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 2277,
+          "p95": 2903,
+          "all": [
+            1008,
+            2277,
+            2208,
+            2903
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 1142,
+          "p95": 1173,
+          "all": [
+            717,
+            1093,
+            1142,
+            1173
+          ]
+        },
+        "framesDropped": {
+          "median": 21,
+          "p95": 32,
+          "all": [
+            32,
+            21,
+            18,
+            19
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 877,
+          "p95": 1106,
+          "all": [
+            306,
+            877,
+            1106,
+            840
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 14,
+          "p95": 18,
+          "all": [
+            5,
+            14,
+            18,
+            14
+          ]
+        },
+        "deltasSent": {
+          "median": 8305,
+          "p95": 8607,
+          "all": [
+            7399,
+            8154,
+            8305,
+            8607
+          ]
+        },
+        "widgetCount": {
+          "median": 1,
+          "p95": 1,
+          "all": [
+            1,
+            1,
+            1,
+            1
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 12365,
+          "longTasks": {
+            "count": 32,
+            "totalMs": 9358,
+            "maxMs": 610,
+            "blockingTimeMs": 7758
+          },
+          "taskLatencyMs": {
+            "samples": 23,
+            "maxMs": 1165,
+            "p95Ms": 1008
+          },
+          "frames": {
+            "samples": 32,
+            "maxGapMs": 717,
+            "p95GapMs": 692,
+            "droppedOver50ms": 32
+          },
+          "heap": {
+            "samples": 24,
+            "firstBytes": 8726494,
+            "lastBytes": 13987977,
+            "slopeBytesPerSec": 313693
+          },
+          "marks": {},
+          "deltasSent": 7399,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 1812
+        },
+        {
+          "windowMs": 13522,
+          "longTasks": {
+            "count": 20,
+            "totalMs": 9790,
+            "maxMs": 901,
+            "blockingTimeMs": 8790
+          },
+          "taskLatencyMs": {
+            "samples": 15,
+            "maxMs": 2277,
+            "p95Ms": 2277
+          },
+          "frames": {
+            "samples": 21,
+            "maxGapMs": 1093,
+            "p95GapMs": 999,
+            "droppedOver50ms": 21
+          },
+          "heap": {
+            "samples": 20,
+            "firstBytes": 8670286,
+            "lastBytes": 23162639,
+            "slopeBytesPerSec": 897977
+          },
+          "marks": {},
+          "deltasSent": 8154,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 1963
+        },
+        {
+          "windowMs": 13928,
+          "longTasks": {
+            "count": 16,
+            "totalMs": 10119,
+            "maxMs": 1040,
+            "blockingTimeMs": 9319
+          },
+          "taskLatencyMs": {
+            "samples": 11,
+            "maxMs": 2208,
+            "p95Ms": 2208
+          },
+          "frames": {
+            "samples": 18,
+            "maxGapMs": 1142,
+            "p95GapMs": 1142,
+            "droppedOver50ms": 18
+          },
+          "heap": {
+            "samples": 17,
+            "firstBytes": 8731998,
+            "lastBytes": 27433854,
+            "slopeBytesPerSec": 1132238
+          },
+          "marks": {},
+          "deltasSent": 8305,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 1963
+        },
+        {
+          "windowMs": 14367,
+          "longTasks": {
+            "count": 18,
+            "totalMs": 10597,
+            "maxMs": 1071,
+            "blockingTimeMs": 9697
+          },
+          "taskLatencyMs": {
+            "samples": 12,
+            "maxMs": 2903,
+            "p95Ms": 2903
+          },
+          "frames": {
+            "samples": 19,
+            "maxGapMs": 1173,
+            "p95GapMs": 1173,
+            "droppedOver50ms": 19
+          },
+          "heap": {
+            "samples": 17,
+            "firstBytes": 8756779,
+            "lastBytes": 23036098,
+            "slopeBytesPerSec": 859692
+          },
+          "marks": {},
+          "deltasSent": 8607,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 1812
+        }
+      ]
+    }
+  }
+}

--- a/perf-harness/results/diag-pre127.json
+++ b/perf-harness/results/diag-pre127.json
@@ -1,0 +1,483 @@
+{
+  "label": "diag-pre127",
+  "branch": "63cf071e",
+  "throttle": 10,
+  "repeats": 4,
+  "chrome": "149.0.7827.201",
+  "scenarios": {
+    "ais-radar-150": {
+      "note": "150 AIS targets @ 4Hz + streaming own-ship (ranks 4/5, radar render loops)",
+      "agg": {
+        "longTaskCount": {
+          "median": 16,
+          "p95": 33,
+          "all": [
+            16,
+            15,
+            33,
+            16
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 1134,
+          "p95": 1365,
+          "all": [
+            1134,
+            1365,
+            546,
+            962
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 7990,
+          "p95": 8040,
+          "all": [
+            7990,
+            7666,
+            6430,
+            8040
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 1305,
+          "p95": 1914,
+          "all": [
+            1305,
+            1914,
+            553,
+            1188
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 1217,
+          "p95": 1500,
+          "all": [
+            1217,
+            1500,
+            473,
+            1114
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 1226,
+          "p95": 1876,
+          "all": [
+            1226,
+            1876,
+            583,
+            1158
+          ]
+        },
+        "framesDropped": {
+          "median": 37,
+          "p95": 65,
+          "all": [
+            37,
+            34,
+            65,
+            35
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 990,
+          "p95": 1208,
+          "all": [
+            990,
+            942,
+            651,
+            1208
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 17,
+          "p95": 19,
+          "all": [
+            17,
+            14,
+            11,
+            19
+          ]
+        },
+        "deltasSent": {
+          "median": 7701,
+          "p95": 7701,
+          "all": [
+            7701,
+            7701,
+            7248,
+            7701
+          ]
+        },
+        "widgetCount": {
+          "median": 1,
+          "p95": 1,
+          "all": [
+            1,
+            1,
+            1,
+            1
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 12758,
+          "longTasks": {
+            "count": 16,
+            "totalMs": 8790,
+            "maxMs": 1134,
+            "blockingTimeMs": 7990
+          },
+          "taskLatencyMs": {
+            "samples": 31,
+            "maxMs": 1305,
+            "p95Ms": 1217
+          },
+          "frames": {
+            "samples": 47,
+            "maxGapMs": 1226,
+            "p95GapMs": 1058,
+            "droppedOver50ms": 37
+          },
+          "heap": {
+            "samples": 27,
+            "firstBytes": 8640842,
+            "lastBytes": 26280413,
+            "slopeBytesPerSec": 1013448
+          },
+          "marks": {},
+          "deltasSent": 7701,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 1661
+        },
+        {
+          "windowMs": 12892,
+          "longTasks": {
+            "count": 15,
+            "totalMs": 8416,
+            "maxMs": 1365,
+            "blockingTimeMs": 7666
+          },
+          "taskLatencyMs": {
+            "samples": 31,
+            "maxMs": 1914,
+            "p95Ms": 1500
+          },
+          "frames": {
+            "samples": 46,
+            "maxGapMs": 1876,
+            "p95GapMs": 867,
+            "droppedOver50ms": 34
+          },
+          "heap": {
+            "samples": 23,
+            "firstBytes": 8741984,
+            "lastBytes": 23723948,
+            "slopeBytesPerSec": 965084
+          },
+          "marks": {},
+          "deltasSent": 7701,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 1812
+        },
+        {
+          "windowMs": 12017,
+          "longTasks": {
+            "count": 33,
+            "totalMs": 8080,
+            "maxMs": 546,
+            "blockingTimeMs": 6430
+          },
+          "taskLatencyMs": {
+            "samples": 74,
+            "maxMs": 553,
+            "p95Ms": 473
+          },
+          "frames": {
+            "samples": 129,
+            "maxGapMs": 583,
+            "p95GapMs": 385,
+            "droppedOver50ms": 65
+          },
+          "heap": {
+            "samples": 34,
+            "firstBytes": 8681143,
+            "lastBytes": 19906490,
+            "slopeBytesPerSec": 666600
+          },
+          "marks": {},
+          "deltasSent": 7248,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 1963
+        },
+        {
+          "windowMs": 12728,
+          "longTasks": {
+            "count": 16,
+            "totalMs": 8840,
+            "maxMs": 962,
+            "blockingTimeMs": 8040
+          },
+          "taskLatencyMs": {
+            "samples": 31,
+            "maxMs": 1188,
+            "p95Ms": 1114
+          },
+          "frames": {
+            "samples": 47,
+            "maxGapMs": 1158,
+            "p95GapMs": 1026,
+            "droppedOver50ms": 35
+          },
+          "heap": {
+            "samples": 25,
+            "firstBytes": 8741836,
+            "lastBytes": 28681837,
+            "slopeBytesPerSec": 1236536
+          },
+          "marks": {},
+          "deltasSent": 7701,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 1812
+        }
+      ]
+    },
+    "ais-growth-churn": {
+      "note": "AIS radar with 40 targets + 40 new MMSIs/sec churn for 30s (ranks 8/9, heap growth)",
+      "agg": {
+        "longTaskCount": {
+          "median": 36,
+          "p95": 41,
+          "all": [
+            17,
+            36,
+            41,
+            25
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 3344,
+          "p95": 5360,
+          "all": [
+            5360,
+            2151,
+            2814,
+            3344
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 23365,
+          "p95": 24793,
+          "all": [
+            22670,
+            22019,
+            23365,
+            24793
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 3539,
+          "p95": 6516,
+          "all": [
+            6516,
+            3425,
+            2974,
+            3539
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 3399,
+          "p95": 5487,
+          "all": [
+            5487,
+            1760,
+            1621,
+            3399
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 3448,
+          "p95": 6316,
+          "all": [
+            6316,
+            3357,
+            2917,
+            3448
+          ]
+        },
+        "framesDropped": {
+          "median": 58,
+          "p95": 61,
+          "all": [
+            29,
+            58,
+            61,
+            47
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 459,
+          "p95": 584,
+          "all": [
+            150,
+            584,
+            459,
+            190
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 15,
+          "p95": 21,
+          "all": [
+            5,
+            21,
+            15,
+            6
+          ]
+        },
+        "deltasSent": {
+          "median": 7791,
+          "p95": 7840,
+          "all": [
+            7840,
+            7644,
+            7791,
+            7350
+          ]
+        },
+        "widgetCount": {
+          "median": 1,
+          "p95": 1,
+          "all": [
+            1,
+            1,
+            1,
+            1
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 32059,
+          "longTasks": {
+            "count": 17,
+            "totalMs": 23520,
+            "maxMs": 5360,
+            "blockingTimeMs": 22670
+          },
+          "taskLatencyMs": {
+            "samples": 29,
+            "maxMs": 6516,
+            "p95Ms": 5487
+          },
+          "frames": {
+            "samples": 47,
+            "maxGapMs": 6316,
+            "p95GapMs": 4490,
+            "droppedOver50ms": 29
+          },
+          "heap": {
+            "samples": 24,
+            "firstBytes": 8751532,
+            "lastBytes": 14411805,
+            "slopeBytesPerSec": 153896
+          },
+          "marks": {},
+          "deltasSent": 7840,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 686
+        },
+        {
+          "windowMs": 31497,
+          "longTasks": {
+            "count": 36,
+            "totalMs": 23819,
+            "maxMs": 2151,
+            "blockingTimeMs": 22019
+          },
+          "taskLatencyMs": {
+            "samples": 64,
+            "maxMs": 3425,
+            "p95Ms": 1760
+          },
+          "frames": {
+            "samples": 103,
+            "maxGapMs": 3357,
+            "p95GapMs": 1568,
+            "droppedOver50ms": 58
+          },
+          "heap": {
+            "samples": 41,
+            "firstBytes": 8701931,
+            "lastBytes": 30408015,
+            "slopeBytesPerSec": 598480
+          },
+          "marks": {},
+          "deltasSent": 7644,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 735
+        },
+        {
+          "windowMs": 31955,
+          "longTasks": {
+            "count": 41,
+            "totalMs": 25415,
+            "maxMs": 2814,
+            "blockingTimeMs": 23365
+          },
+          "taskLatencyMs": {
+            "samples": 66,
+            "maxMs": 2974,
+            "p95Ms": 1621
+          },
+          "frames": {
+            "samples": 106,
+            "maxGapMs": 2917,
+            "p95GapMs": 1501,
+            "droppedOver50ms": 61
+          },
+          "heap": {
+            "samples": 41,
+            "firstBytes": 8714599,
+            "lastBytes": 24911476,
+            "slopeBytesPerSec": 469596
+          },
+          "marks": {},
+          "deltasSent": 7791,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 735
+        },
+        {
+          "windowMs": 30207,
+          "longTasks": {
+            "count": 25,
+            "totalMs": 26043,
+            "maxMs": 3344,
+            "blockingTimeMs": 24793
+          },
+          "taskLatencyMs": {
+            "samples": 40,
+            "maxMs": 3539,
+            "p95Ms": 3399
+          },
+          "frames": {
+            "samples": 64,
+            "maxGapMs": 3448,
+            "p95GapMs": 2457,
+            "droppedOver50ms": 47
+          },
+          "heap": {
+            "samples": 33,
+            "firstBytes": 8720615,
+            "lastBytes": 15439380,
+            "slopeBytesPerSec": 194324
+          },
+          "marks": {},
+          "deltasSent": 7350,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 784
+        }
+      ]
+    }
+  }
+}

--- a/perf-harness/results/main-freeze-fixes.json
+++ b/perf-harness/results/main-freeze-fixes.json
@@ -1,0 +1,1668 @@
+{
+  "label": "main-freeze-fixes",
+  "branch": "2e358f17",
+  "throttle": 10,
+  "repeats": 4,
+  "chrome": "149.0.7827.201",
+  "scenarios": {
+    "idle-numeric-24": {
+      "note": "baseline render/CD load: 24 numeric widgets, low data rate (WS4 baseline)",
+      "agg": {
+        "longTaskCount": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0,
+            0
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0,
+            0
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0,
+            0
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 7,
+          "p95": 9,
+          "all": [
+            9,
+            4,
+            6,
+            7
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 3,
+          "p95": 3,
+          "all": [
+            3,
+            2,
+            3,
+            3
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 10,
+          "p95": 16,
+          "all": [
+            10,
+            10,
+            10,
+            16
+          ]
+        },
+        "framesDropped": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0,
+            0
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 339,
+          "p95": 340,
+          "all": [
+            336,
+            339,
+            339,
+            340
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 4,
+          "p95": 4,
+          "all": [
+            4,
+            4,
+            4,
+            4
+          ]
+        },
+        "deltasSent": {
+          "median": 16,
+          "p95": 16,
+          "all": [
+            16,
+            16,
+            16,
+            16
+          ]
+        },
+        "widgetCount": {
+          "median": 24,
+          "p95": 24,
+          "all": [
+            24,
+            24,
+            24,
+            24
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 8006,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 450,
+            "maxMs": 9,
+            "p95Ms": 3
+          },
+          "frames": {
+            "samples": 961,
+            "maxGapMs": 10,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 24,
+            "firstBytes": 8747577,
+            "lastBytes": 12809033,
+            "slopeBytesPerSec": 343815
+          },
+          "marks": {},
+          "deltasSent": 16,
+          "widgetCount": 24,
+          "streamedDuringWarmup": 3
+        },
+        {
+          "windowMs": 8005,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 458,
+            "maxMs": 4,
+            "p95Ms": 2
+          },
+          "frames": {
+            "samples": 961,
+            "maxGapMs": 10,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 24,
+            "firstBytes": 8728517,
+            "lastBytes": 12830432,
+            "slopeBytesPerSec": 346982
+          },
+          "marks": {},
+          "deltasSent": 16,
+          "widgetCount": 24,
+          "streamedDuringWarmup": 4
+        },
+        {
+          "windowMs": 8004,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 461,
+            "maxMs": 6,
+            "p95Ms": 3
+          },
+          "frames": {
+            "samples": 961,
+            "maxGapMs": 10,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 24,
+            "firstBytes": 8724950,
+            "lastBytes": 12821737,
+            "slopeBytesPerSec": 346789
+          },
+          "marks": {},
+          "deltasSent": 16,
+          "widgetCount": 24,
+          "streamedDuringWarmup": 4
+        },
+        {
+          "windowMs": 8007,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 457,
+            "maxMs": 7,
+            "p95Ms": 3
+          },
+          "frames": {
+            "samples": 960,
+            "maxGapMs": 16,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 24,
+            "firstBytes": 8727017,
+            "lastBytes": 12835498,
+            "slopeBytesPerSec": 347808
+          },
+          "marks": {},
+          "deltasSent": 16,
+          "widgetCount": 24,
+          "streamedDuringWarmup": 4
+        }
+      ]
+    },
+    "delta-storm-30x10": {
+      "note": "sustained ingestion: 30 paths @ 10Hz over a numeric+gauge dashboard (rank 2, delta coalescing)",
+      "agg": {
+        "longTaskCount": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0,
+            0
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0,
+            0
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0,
+            0
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 4,
+          "p95": 8,
+          "all": [
+            4,
+            8,
+            4,
+            4
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 3,
+          "p95": 3,
+          "all": [
+            3,
+            3,
+            3,
+            3
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 10,
+          "p95": 10,
+          "all": [
+            10,
+            10,
+            10,
+            10
+          ]
+        },
+        "framesDropped": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0,
+            0
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 247,
+          "p95": 432,
+          "all": [
+            432,
+            247,
+            243,
+            245
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 4,
+          "p95": 7,
+          "all": [
+            7,
+            4,
+            4,
+            4
+          ]
+        },
+        "deltasSent": {
+          "median": 119,
+          "p95": 119,
+          "all": [
+            119,
+            119,
+            119,
+            119
+          ]
+        },
+        "widgetCount": {
+          "median": 20,
+          "p95": 20,
+          "all": [
+            20,
+            20,
+            20,
+            20
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 12009,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 688,
+            "maxMs": 4,
+            "p95Ms": 3
+          },
+          "frames": {
+            "samples": 1442,
+            "maxGapMs": 10,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 32,
+            "firstBytes": 8751886,
+            "lastBytes": 15718059,
+            "slopeBytesPerSec": 442581
+          },
+          "marks": {},
+          "deltasSent": 119,
+          "widgetCount": 20,
+          "streamedDuringWarmup": 20
+        },
+        {
+          "windowMs": 12006,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 689,
+            "maxMs": 8,
+            "p95Ms": 3
+          },
+          "frames": {
+            "samples": 1440,
+            "maxGapMs": 10,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 32,
+            "firstBytes": 8657989,
+            "lastBytes": 12662810,
+            "slopeBytesPerSec": 252643
+          },
+          "marks": {},
+          "deltasSent": 119,
+          "widgetCount": 20,
+          "streamedDuringWarmup": 20
+        },
+        {
+          "windowMs": 12006,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 689,
+            "maxMs": 4,
+            "p95Ms": 3
+          },
+          "frames": {
+            "samples": 1441,
+            "maxGapMs": 10,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 32,
+            "firstBytes": 8678746,
+            "lastBytes": 12611940,
+            "slopeBytesPerSec": 249006
+          },
+          "marks": {},
+          "deltasSent": 119,
+          "widgetCount": 20,
+          "streamedDuringWarmup": 20
+        },
+        {
+          "windowMs": 12004,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 686,
+            "maxMs": 4,
+            "p95Ms": 3
+          },
+          "frames": {
+            "samples": 1440,
+            "maxGapMs": 10,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 32,
+            "firstBytes": 8648252,
+            "lastBytes": 12626483,
+            "slopeBytesPerSec": 251219
+          },
+          "marks": {},
+          "deltasSent": 119,
+          "widgetCount": 20,
+          "streamedDuringWarmup": 20
+        }
+      ]
+    },
+    "reconnect-backlog": {
+      "note": "reconnect snapshot: one frame carrying 6000 values (rank 2, single synchronous parse+fan-out long task)",
+      "agg": {
+        "longTaskCount": {
+          "median": 1,
+          "p95": 1,
+          "all": [
+            0,
+            0,
+            1,
+            1
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 54,
+          "p95": 56,
+          "all": [
+            0,
+            0,
+            54,
+            56
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 4,
+          "p95": 6,
+          "all": [
+            0,
+            0,
+            4,
+            6
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 61,
+          "p95": 67,
+          "all": [
+            54,
+            61,
+            59,
+            67
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 3,
+          "p95": 3,
+          "all": [
+            3,
+            3,
+            3,
+            3
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 67,
+          "p95": 67,
+          "all": [
+            67,
+            58,
+            67,
+            66
+          ]
+        },
+        "framesDropped": {
+          "median": 1,
+          "p95": 1,
+          "all": [
+            1,
+            1,
+            1,
+            1
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 512,
+          "p95": 515,
+          "all": [
+            501,
+            512,
+            515,
+            512
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 5,
+          "p95": 5,
+          "all": [
+            5,
+            5,
+            5,
+            5
+          ]
+        },
+        "deltasSent": {
+          "median": 29,
+          "p95": 29,
+          "all": [
+            29,
+            29,
+            29,
+            29
+          ]
+        },
+        "widgetCount": {
+          "median": 20,
+          "p95": 20,
+          "all": [
+            20,
+            20,
+            20,
+            20
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 7007,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 397,
+            "maxMs": 54,
+            "p95Ms": 3
+          },
+          "frames": {
+            "samples": 833,
+            "maxGapMs": 67,
+            "p95GapMs": 10,
+            "droppedOver50ms": 1
+          },
+          "heap": {
+            "samples": 22,
+            "firstBytes": 8749586,
+            "lastBytes": 14272873,
+            "slopeBytesPerSec": 512859
+          },
+          "marks": {},
+          "deltasSent": 29,
+          "widgetCount": 20,
+          "streamedDuringWarmup": 7
+        },
+        {
+          "windowMs": 7042,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 388,
+            "maxMs": 61,
+            "p95Ms": 3
+          },
+          "frames": {
+            "samples": 835,
+            "maxGapMs": 58,
+            "p95GapMs": 10,
+            "droppedOver50ms": 1
+          },
+          "heap": {
+            "samples": 22,
+            "firstBytes": 8678748,
+            "lastBytes": 14383746,
+            "slopeBytesPerSec": 524197
+          },
+          "marks": {},
+          "deltasSent": 29,
+          "widgetCount": 20,
+          "streamedDuringWarmup": 8
+        },
+        {
+          "windowMs": 7009,
+          "longTasks": {
+            "count": 1,
+            "totalMs": 54,
+            "maxMs": 54,
+            "blockingTimeMs": 4
+          },
+          "taskLatencyMs": {
+            "samples": 391,
+            "maxMs": 59,
+            "p95Ms": 3
+          },
+          "frames": {
+            "samples": 831,
+            "maxGapMs": 67,
+            "p95GapMs": 10,
+            "droppedOver50ms": 1
+          },
+          "heap": {
+            "samples": 21,
+            "firstBytes": 8652864,
+            "lastBytes": 14318313,
+            "slopeBytesPerSec": 527009
+          },
+          "marks": {},
+          "deltasSent": 29,
+          "widgetCount": 20,
+          "streamedDuringWarmup": 8
+        },
+        {
+          "windowMs": 7012,
+          "longTasks": {
+            "count": 1,
+            "totalMs": 56,
+            "maxMs": 56,
+            "blockingTimeMs": 6
+          },
+          "taskLatencyMs": {
+            "samples": 395,
+            "maxMs": 67,
+            "p95Ms": 3
+          },
+          "frames": {
+            "samples": 832,
+            "maxGapMs": 66,
+            "p95GapMs": 10,
+            "droppedOver50ms": 1
+          },
+          "heap": {
+            "samples": 21,
+            "firstBytes": 8680353,
+            "lastBytes": 14299443,
+            "slopeBytesPerSec": 524639
+          },
+          "marks": {},
+          "deltasSent": 29,
+          "widgetCount": 20,
+          "streamedDuringWarmup": 8
+        }
+      ]
+    },
+    "resize-storm": {
+      "note": "28 canvas widgets + repeated viewport resizes: shared ResizeObserver reallocates every canvas in one task (rank 1, the fullscreen enter/exit storm)",
+      "agg": {
+        "longTaskCount": {
+          "median": 10,
+          "p95": 11,
+          "all": [
+            11,
+            8,
+            10,
+            7
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 73,
+          "p95": 75,
+          "all": [
+            72,
+            69,
+            73,
+            75
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 112,
+          "p95": 117,
+          "all": [
+            117,
+            63,
+            112,
+            90
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 134,
+          "p95": 138,
+          "all": [
+            138,
+            133,
+            134,
+            116
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 79,
+          "p95": 79,
+          "all": [
+            79,
+            67,
+            76,
+            79
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 91,
+          "p95": 93,
+          "all": [
+            85,
+            93,
+            91,
+            83
+          ]
+        },
+        "framesDropped": {
+          "median": 21,
+          "p95": 25,
+          "all": [
+            25,
+            17,
+            18,
+            21
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 364,
+          "p95": 373,
+          "all": [
+            326,
+            373,
+            347,
+            364
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 4,
+          "p95": 4,
+          "all": [
+            4,
+            4,
+            4,
+            4
+          ]
+        },
+        "deltasSent": {
+          "median": 15,
+          "p95": 15,
+          "all": [
+            14,
+            15,
+            15,
+            15
+          ]
+        },
+        "widgetCount": {
+          "median": 28,
+          "p95": 28,
+          "all": [
+            28,
+            28,
+            28,
+            28
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 7277,
+          "longTasks": {
+            "count": 11,
+            "totalMs": 667,
+            "maxMs": 72,
+            "blockingTimeMs": 117
+          },
+          "taskLatencyMs": {
+            "samples": 227,
+            "maxMs": 138,
+            "p95Ms": 79
+          },
+          "frames": {
+            "samples": 472,
+            "maxGapMs": 85,
+            "p95GapMs": 50,
+            "droppedOver50ms": 25
+          },
+          "heap": {
+            "samples": 23,
+            "firstBytes": 8709245,
+            "lastBytes": 12614795,
+            "slopeBytesPerSec": 333528
+          },
+          "marks": {},
+          "deltasSent": 14,
+          "widgetCount": 28,
+          "streamedDuringWarmup": 5
+        },
+        {
+          "windowMs": 7239,
+          "longTasks": {
+            "count": 8,
+            "totalMs": 463,
+            "maxMs": 69,
+            "blockingTimeMs": 63
+          },
+          "taskLatencyMs": {
+            "samples": 236,
+            "maxMs": 133,
+            "p95Ms": 67
+          },
+          "frames": {
+            "samples": 479,
+            "maxGapMs": 93,
+            "p95GapMs": 48,
+            "droppedOver50ms": 17
+          },
+          "heap": {
+            "samples": 22,
+            "firstBytes": 8681733,
+            "lastBytes": 12997733,
+            "slopeBytesPerSec": 382160
+          },
+          "marks": {},
+          "deltasSent": 15,
+          "widgetCount": 28,
+          "streamedDuringWarmup": 5
+        },
+        {
+          "windowMs": 7250,
+          "longTasks": {
+            "count": 10,
+            "totalMs": 612,
+            "maxMs": 73,
+            "blockingTimeMs": 112
+          },
+          "taskLatencyMs": {
+            "samples": 225,
+            "maxMs": 134,
+            "p95Ms": 76
+          },
+          "frames": {
+            "samples": 468,
+            "maxGapMs": 91,
+            "p95GapMs": 49,
+            "droppedOver50ms": 18
+          },
+          "heap": {
+            "samples": 22,
+            "firstBytes": 8760582,
+            "lastBytes": 12780013,
+            "slopeBytesPerSec": 355736
+          },
+          "marks": {},
+          "deltasSent": 15,
+          "widgetCount": 28,
+          "streamedDuringWarmup": 5
+        },
+        {
+          "windowMs": 7239,
+          "longTasks": {
+            "count": 7,
+            "totalMs": 440,
+            "maxMs": 75,
+            "blockingTimeMs": 90
+          },
+          "taskLatencyMs": {
+            "samples": 233,
+            "maxMs": 116,
+            "p95Ms": 79
+          },
+          "frames": {
+            "samples": 476,
+            "maxGapMs": 83,
+            "p95GapMs": 50,
+            "droppedOver50ms": 21
+          },
+          "heap": {
+            "samples": 22,
+            "firstBytes": 8682461,
+            "lastBytes": 12893937,
+            "slopeBytesPerSec": 373113
+          },
+          "marks": {},
+          "deltasSent": 15,
+          "widgetCount": 28,
+          "streamedDuringWarmup": 5
+        }
+      ]
+    },
+    "ais-radar-150": {
+      "note": "150 AIS targets @ 4Hz + streaming own-ship (ranks 4/5, radar render loops)",
+      "agg": {
+        "longTaskCount": {
+          "median": 14,
+          "p95": 26,
+          "all": [
+            26,
+            13,
+            12,
+            14
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 1169,
+          "p95": 1551,
+          "all": [
+            805,
+            1133,
+            1551,
+            1169
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 8398,
+          "p95": 9461,
+          "all": [
+            6229,
+            7147,
+            9461,
+            8398
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 1511,
+          "p95": 1778,
+          "all": [
+            1005,
+            1352,
+            1778,
+            1511
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 1316,
+          "p95": 1778,
+          "all": [
+            737,
+            1289,
+            1778,
+            1316
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 1476,
+          "p95": 1649,
+          "all": [
+            910,
+            1242,
+            1649,
+            1476
+          ]
+        },
+        "framesDropped": {
+          "median": 38,
+          "p95": 59,
+          "all": [
+            59,
+            38,
+            30,
+            32
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 754,
+          "p95": 1198,
+          "all": [
+            712,
+            731,
+            754,
+            1198
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 13,
+          "p95": 19,
+          "all": [
+            12,
+            12,
+            13,
+            19
+          ]
+        },
+        "deltasSent": {
+          "median": 7701,
+          "p95": 7852,
+          "all": [
+            7399,
+            7399,
+            7701,
+            7852
+          ]
+        },
+        "widgetCount": {
+          "median": 1,
+          "p95": 1,
+          "all": [
+            1,
+            1,
+            1,
+            1
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 12272,
+          "longTasks": {
+            "count": 26,
+            "totalMs": 7529,
+            "maxMs": 805,
+            "blockingTimeMs": 6229
+          },
+          "taskLatencyMs": {
+            "samples": 48,
+            "maxMs": 1005,
+            "p95Ms": 737
+          },
+          "frames": {
+            "samples": 82,
+            "maxGapMs": 910,
+            "p95GapMs": 474,
+            "droppedOver50ms": 59
+          },
+          "heap": {
+            "samples": 29,
+            "firstBytes": 8706467,
+            "lastBytes": 21049800,
+            "slopeBytesPerSec": 728732
+          },
+          "marks": {},
+          "deltasSent": 7399,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 1812
+        },
+        {
+          "windowMs": 12372,
+          "longTasks": {
+            "count": 13,
+            "totalMs": 7797,
+            "maxMs": 1133,
+            "blockingTimeMs": 7147
+          },
+          "taskLatencyMs": {
+            "samples": 25,
+            "maxMs": 1352,
+            "p95Ms": 1289
+          },
+          "frames": {
+            "samples": 43,
+            "maxGapMs": 1242,
+            "p95GapMs": 1159,
+            "droppedOver50ms": 38
+          },
+          "heap": {
+            "samples": 23,
+            "firstBytes": 8657534,
+            "lastBytes": 21681853,
+            "slopeBytesPerSec": 748421
+          },
+          "marks": {},
+          "deltasSent": 7399,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 1812
+        },
+        {
+          "windowMs": 12764,
+          "longTasks": {
+            "count": 12,
+            "totalMs": 10061,
+            "maxMs": 1551,
+            "blockingTimeMs": 9461
+          },
+          "taskLatencyMs": {
+            "samples": 18,
+            "maxMs": 1778,
+            "p95Ms": 1778
+          },
+          "frames": {
+            "samples": 33,
+            "maxGapMs": 1649,
+            "p95GapMs": 1585,
+            "droppedOver50ms": 30
+          },
+          "heap": {
+            "samples": 21,
+            "firstBytes": 8650506,
+            "lastBytes": 22364018,
+            "slopeBytesPerSec": 771757
+          },
+          "marks": {},
+          "deltasSent": 7701,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 1812
+        },
+        {
+          "windowMs": 13251,
+          "longTasks": {
+            "count": 14,
+            "totalMs": 9098,
+            "maxMs": 1169,
+            "blockingTimeMs": 8398
+          },
+          "taskLatencyMs": {
+            "samples": 26,
+            "maxMs": 1511,
+            "p95Ms": 1316
+          },
+          "frames": {
+            "samples": 39,
+            "maxGapMs": 1476,
+            "p95GapMs": 1267,
+            "droppedOver50ms": 32
+          },
+          "heap": {
+            "samples": 22,
+            "firstBytes": 8704224,
+            "lastBytes": 28913341,
+            "slopeBytesPerSec": 1226825
+          },
+          "marks": {},
+          "deltasSent": 7852,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 1963
+        }
+      ]
+    },
+    "gauges-16": {
+      "note": "16 radial ng-canvas-gauges @ 4Hz (rank 7, animation duty cycle)",
+      "agg": {
+        "longTaskCount": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0,
+            0
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0,
+            0
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0,
+            0
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 39,
+          "p95": 52,
+          "all": [
+            29,
+            52,
+            31,
+            39
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 19,
+          "p95": 19,
+          "all": [
+            19,
+            18,
+            16,
+            19
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 41,
+          "p95": 41,
+          "all": [
+            18,
+            41,
+            32,
+            41
+          ]
+        },
+        "framesDropped": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0,
+            0
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 243,
+          "p95": 285,
+          "all": [
+            285,
+            210,
+            212,
+            243
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 3,
+          "p95": 4,
+          "all": [
+            4,
+            3,
+            3,
+            3
+          ]
+        },
+        "deltasSent": {
+          "median": 40,
+          "p95": 40,
+          "all": [
+            40,
+            40,
+            40,
+            40
+          ]
+        },
+        "widgetCount": {
+          "median": 16,
+          "p95": 16,
+          "all": [
+            16,
+            16,
+            16,
+            16
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 10007,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 497,
+            "maxMs": 29,
+            "p95Ms": 19
+          },
+          "frames": {
+            "samples": 1129,
+            "maxGapMs": 18,
+            "p95GapMs": 16,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 27,
+            "firstBytes": 8751506,
+            "lastBytes": 12762377,
+            "slopeBytesPerSec": 291791
+          },
+          "marks": {},
+          "deltasSent": 40,
+          "widgetCount": 16,
+          "streamedDuringWarmup": 7
+        },
+        {
+          "windowMs": 10005,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 499,
+            "maxMs": 52,
+            "p95Ms": 18
+          },
+          "frames": {
+            "samples": 1147,
+            "maxGapMs": 41,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 28,
+            "firstBytes": 8741618,
+            "lastBytes": 11696347,
+            "slopeBytesPerSec": 214818
+          },
+          "marks": {},
+          "deltasSent": 40,
+          "widgetCount": 16,
+          "streamedDuringWarmup": 8
+        },
+        {
+          "windowMs": 10008,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 500,
+            "maxMs": 31,
+            "p95Ms": 16
+          },
+          "frames": {
+            "samples": 1143,
+            "maxGapMs": 32,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 28,
+            "firstBytes": 8742334,
+            "lastBytes": 11727365,
+            "slopeBytesPerSec": 216776
+          },
+          "marks": {},
+          "deltasSent": 40,
+          "widgetCount": 16,
+          "streamedDuringWarmup": 8
+        },
+        {
+          "windowMs": 10005,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 494,
+            "maxMs": 39,
+            "p95Ms": 19
+          },
+          "frames": {
+            "samples": 1128,
+            "maxGapMs": 41,
+            "p95GapMs": 16,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 28,
+            "firstBytes": 8724482,
+            "lastBytes": 12151444,
+            "slopeBytesPerSec": 249139
+          },
+          "marks": {},
+          "deltasSent": 40,
+          "widgetCount": 16,
+          "streamedDuringWarmup": 8
+        }
+      ]
+    },
+    "ais-growth-churn": {
+      "note": "AIS radar with 40 targets + 40 new MMSIs/sec churn for 30s (ranks 8/9, heap growth)",
+      "agg": {
+        "longTaskCount": {
+          "median": 21,
+          "p95": 38,
+          "all": [
+            15,
+            20,
+            21,
+            38
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 6313,
+          "p95": 6375,
+          "all": [
+            4949,
+            6375,
+            6313,
+            2070
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 25163,
+          "p95": 26022,
+          "all": [
+            22501,
+            25163,
+            26022,
+            23377
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 6447,
+          "p95": 6519,
+          "all": [
+            5698,
+            6519,
+            6447,
+            2240
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 5091,
+          "p95": 5578,
+          "all": [
+            5091,
+            4390,
+            5578,
+            1911
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 6417,
+          "p95": 6474,
+          "all": [
+            5651,
+            6474,
+            6417,
+            2165
+          ]
+        },
+        "framesDropped": {
+          "median": 41,
+          "p95": 59,
+          "all": [
+            30,
+            41,
+            38,
+            59
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 549,
+          "p95": 622,
+          "all": [
+            622,
+            206,
+            182,
+            549
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 18,
+          "p95": 19,
+          "all": [
+            18,
+            7,
+            6,
+            19
+          ]
+        },
+        "deltasSent": {
+          "median": 7546,
+          "p95": 7791,
+          "all": [
+            7546,
+            7399,
+            7350,
+            7791
+          ]
+        },
+        "widgetCount": {
+          "median": 1,
+          "p95": 1,
+          "all": [
+            1,
+            1,
+            1,
+            1
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 31073,
+          "longTasks": {
+            "count": 15,
+            "totalMs": 23251,
+            "maxMs": 4949,
+            "blockingTimeMs": 22501
+          },
+          "taskLatencyMs": {
+            "samples": 25,
+            "maxMs": 5698,
+            "p95Ms": 5091
+          },
+          "frames": {
+            "samples": 40,
+            "maxGapMs": 5651,
+            "p95GapMs": 5051,
+            "droppedOver50ms": 30
+          },
+          "heap": {
+            "samples": 25,
+            "firstBytes": 8761044,
+            "lastBytes": 28031249,
+            "slopeBytesPerSec": 637124
+          },
+          "marks": {},
+          "deltasSent": 7546,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 735
+        },
+        {
+          "windowMs": 30399,
+          "longTasks": {
+            "count": 20,
+            "totalMs": 26163,
+            "maxMs": 6375,
+            "blockingTimeMs": 25163
+          },
+          "taskLatencyMs": {
+            "samples": 34,
+            "maxMs": 6519,
+            "p95Ms": 4390
+          },
+          "frames": {
+            "samples": 54,
+            "maxGapMs": 6474,
+            "p95GapMs": 3416,
+            "droppedOver50ms": 41
+          },
+          "heap": {
+            "samples": 30,
+            "firstBytes": 8742168,
+            "lastBytes": 15961547,
+            "slopeBytesPerSec": 211052
+          },
+          "marks": {},
+          "deltasSent": 7399,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 735
+        },
+        {
+          "windowMs": 30150,
+          "longTasks": {
+            "count": 21,
+            "totalMs": 27072,
+            "maxMs": 6313,
+            "blockingTimeMs": 26022
+          },
+          "taskLatencyMs": {
+            "samples": 35,
+            "maxMs": 6447,
+            "p95Ms": 5578
+          },
+          "frames": {
+            "samples": 55,
+            "maxGapMs": 6417,
+            "p95GapMs": 3774,
+            "droppedOver50ms": 38
+          },
+          "heap": {
+            "samples": 27,
+            "firstBytes": 8742320,
+            "lastBytes": 15237814,
+            "slopeBytesPerSec": 186396
+          },
+          "marks": {},
+          "deltasSent": 7350,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 735
+        },
+        {
+          "windowMs": 32049,
+          "longTasks": {
+            "count": 38,
+            "totalMs": 25277,
+            "maxMs": 2070,
+            "blockingTimeMs": 23377
+          },
+          "taskLatencyMs": {
+            "samples": 66,
+            "maxMs": 2240,
+            "p95Ms": 1911
+          },
+          "frames": {
+            "samples": 106,
+            "maxGapMs": 2165,
+            "p95GapMs": 1484,
+            "droppedOver50ms": 59
+          },
+          "heap": {
+            "samples": 42,
+            "firstBytes": 8747423,
+            "lastBytes": 28264733,
+            "slopeBytesPerSec": 561989
+          },
+          "marks": {},
+          "deltasSent": 7791,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 735
+        }
+      ]
+    }
+  }
+}

--- a/perf-harness/results/pre-freeze-fixes.json
+++ b/perf-harness/results/pre-freeze-fixes.json
@@ -1,0 +1,1668 @@
+{
+  "label": "pre-freeze-fixes",
+  "branch": "11f3fbd0",
+  "throttle": 10,
+  "repeats": 4,
+  "chrome": "149.0.7827.201",
+  "scenarios": {
+    "idle-numeric-24": {
+      "note": "baseline render/CD load: 24 numeric widgets, low data rate (WS4 baseline)",
+      "agg": {
+        "longTaskCount": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0,
+            0
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0,
+            0
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0,
+            0
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 4,
+          "p95": 4,
+          "all": [
+            4,
+            4,
+            4,
+            3
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 2,
+          "p95": 2,
+          "all": [
+            2,
+            2,
+            2,
+            2
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 9,
+          "p95": 9,
+          "all": [
+            9,
+            9,
+            9,
+            9
+          ]
+        },
+        "framesDropped": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0,
+            0
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 341,
+          "p95": 342,
+          "all": [
+            340,
+            342,
+            338,
+            341
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 4,
+          "p95": 4,
+          "all": [
+            4,
+            4,
+            4,
+            4
+          ]
+        },
+        "deltasSent": {
+          "median": 16,
+          "p95": 16,
+          "all": [
+            16,
+            16,
+            16,
+            16
+          ]
+        },
+        "widgetCount": {
+          "median": 24,
+          "p95": 24,
+          "all": [
+            24,
+            24,
+            24,
+            24
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 8010,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 459,
+            "maxMs": 4,
+            "p95Ms": 2
+          },
+          "frames": {
+            "samples": 961,
+            "maxGapMs": 9,
+            "p95GapMs": 9,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 24,
+            "firstBytes": 8669560,
+            "lastBytes": 12795753,
+            "slopeBytesPerSec": 348137
+          },
+          "marks": {},
+          "deltasSent": 16,
+          "widgetCount": 24,
+          "streamedDuringWarmup": 4
+        },
+        {
+          "windowMs": 8005,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 464,
+            "maxMs": 4,
+            "p95Ms": 2
+          },
+          "frames": {
+            "samples": 960,
+            "maxGapMs": 9,
+            "p95GapMs": 9,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 24,
+            "firstBytes": 8671024,
+            "lastBytes": 12823946,
+            "slopeBytesPerSec": 350118
+          },
+          "marks": {},
+          "deltasSent": 16,
+          "widgetCount": 24,
+          "streamedDuringWarmup": 4
+        },
+        {
+          "windowMs": 8007,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 453,
+            "maxMs": 4,
+            "p95Ms": 2
+          },
+          "frames": {
+            "samples": 960,
+            "maxGapMs": 9,
+            "p95GapMs": 9,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 24,
+            "firstBytes": 8754236,
+            "lastBytes": 12850223,
+            "slopeBytesPerSec": 346015
+          },
+          "marks": {},
+          "deltasSent": 16,
+          "widgetCount": 24,
+          "streamedDuringWarmup": 4
+        },
+        {
+          "windowMs": 8004,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 459,
+            "maxMs": 3,
+            "p95Ms": 2
+          },
+          "frames": {
+            "samples": 961,
+            "maxGapMs": 9,
+            "p95GapMs": 9,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 24,
+            "firstBytes": 8748565,
+            "lastBytes": 12863476,
+            "slopeBytesPerSec": 348689
+          },
+          "marks": {},
+          "deltasSent": 16,
+          "widgetCount": 24,
+          "streamedDuringWarmup": 4
+        }
+      ]
+    },
+    "delta-storm-30x10": {
+      "note": "sustained ingestion: 30 paths @ 10Hz over a numeric+gauge dashboard (rank 2, delta coalescing)",
+      "agg": {
+        "longTaskCount": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0,
+            0
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0,
+            0
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0,
+            0
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 9,
+          "p95": 9,
+          "all": [
+            9,
+            4,
+            7,
+            9
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 2,
+          "p95": 2,
+          "all": [
+            2,
+            2,
+            2,
+            2
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 9,
+          "p95": 9,
+          "all": [
+            9,
+            9,
+            9,
+            9
+          ]
+        },
+        "framesDropped": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0,
+            0
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 243,
+          "p95": 246,
+          "all": [
+            243,
+            240,
+            242,
+            246
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 4,
+          "p95": 4,
+          "all": [
+            4,
+            4,
+            4,
+            4
+          ]
+        },
+        "deltasSent": {
+          "median": 119,
+          "p95": 119,
+          "all": [
+            119,
+            119,
+            119,
+            119
+          ]
+        },
+        "widgetCount": {
+          "median": 20,
+          "p95": 20,
+          "all": [
+            20,
+            20,
+            20,
+            20
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 12004,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 688,
+            "maxMs": 9,
+            "p95Ms": 2
+          },
+          "frames": {
+            "samples": 1441,
+            "maxGapMs": 9,
+            "p95GapMs": 9,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 32,
+            "firstBytes": 8741489,
+            "lastBytes": 12663841,
+            "slopeBytesPerSec": 248473
+          },
+          "marks": {},
+          "deltasSent": 119,
+          "widgetCount": 20,
+          "streamedDuringWarmup": 20
+        },
+        {
+          "windowMs": 12005,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 694,
+            "maxMs": 4,
+            "p95Ms": 2
+          },
+          "frames": {
+            "samples": 1441,
+            "maxGapMs": 9,
+            "p95GapMs": 9,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 32,
+            "firstBytes": 8741517,
+            "lastBytes": 12631859,
+            "slopeBytesPerSec": 245902
+          },
+          "marks": {},
+          "deltasSent": 119,
+          "widgetCount": 20,
+          "streamedDuringWarmup": 20
+        },
+        {
+          "windowMs": 12003,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 692,
+            "maxMs": 7,
+            "p95Ms": 2
+          },
+          "frames": {
+            "samples": 1440,
+            "maxGapMs": 9,
+            "p95GapMs": 9,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 32,
+            "firstBytes": 8730992,
+            "lastBytes": 12655407,
+            "slopeBytesPerSec": 248158
+          },
+          "marks": {},
+          "deltasSent": 119,
+          "widgetCount": 20,
+          "streamedDuringWarmup": 20
+        },
+        {
+          "windowMs": 12005,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 691,
+            "maxMs": 9,
+            "p95Ms": 2
+          },
+          "frames": {
+            "samples": 1440,
+            "maxGapMs": 9,
+            "p95GapMs": 9,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 32,
+            "firstBytes": 8741657,
+            "lastBytes": 12734610,
+            "slopeBytesPerSec": 251975
+          },
+          "marks": {},
+          "deltasSent": 119,
+          "widgetCount": 20,
+          "streamedDuringWarmup": 20
+        }
+      ]
+    },
+    "reconnect-backlog": {
+      "note": "reconnect snapshot: one frame carrying 6000 values (rank 2, single synchronous parse+fan-out long task)",
+      "agg": {
+        "longTaskCount": {
+          "median": 1,
+          "p95": 1,
+          "all": [
+            1,
+            1,
+            0,
+            0
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 50,
+          "p95": 52,
+          "all": [
+            52,
+            50,
+            0,
+            0
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 0,
+          "p95": 2,
+          "all": [
+            2,
+            0,
+            0,
+            0
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 58,
+          "p95": 68,
+          "all": [
+            55,
+            68,
+            51,
+            58
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 2,
+          "p95": 2,
+          "all": [
+            2,
+            2,
+            2,
+            2
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 67,
+          "p95": 67,
+          "all": [
+            67,
+            58,
+            58,
+            67
+          ]
+        },
+        "framesDropped": {
+          "median": 1,
+          "p95": 1,
+          "all": [
+            1,
+            1,
+            1,
+            1
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 510,
+          "p95": 528,
+          "all": [
+            505,
+            508,
+            510,
+            528
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 5,
+          "p95": 5,
+          "all": [
+            5,
+            5,
+            5,
+            5
+          ]
+        },
+        "deltasSent": {
+          "median": 29,
+          "p95": 29,
+          "all": [
+            28,
+            29,
+            29,
+            29
+          ]
+        },
+        "widgetCount": {
+          "median": 20,
+          "p95": 20,
+          "all": [
+            20,
+            20,
+            20,
+            20
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 7007,
+          "longTasks": {
+            "count": 1,
+            "totalMs": 52,
+            "maxMs": 52,
+            "blockingTimeMs": 2
+          },
+          "taskLatencyMs": {
+            "samples": 402,
+            "maxMs": 55,
+            "p95Ms": 2
+          },
+          "frames": {
+            "samples": 834,
+            "maxGapMs": 67,
+            "p95GapMs": 9,
+            "droppedOver50ms": 1
+          },
+          "heap": {
+            "samples": 22,
+            "firstBytes": 8728896,
+            "lastBytes": 14333194,
+            "slopeBytesPerSec": 517073
+          },
+          "marks": {},
+          "deltasSent": 28,
+          "widgetCount": 20,
+          "streamedDuringWarmup": 8
+        },
+        {
+          "windowMs": 7009,
+          "longTasks": {
+            "count": 1,
+            "totalMs": 50,
+            "maxMs": 50,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 400,
+            "maxMs": 68,
+            "p95Ms": 2
+          },
+          "frames": {
+            "samples": 834,
+            "maxGapMs": 58,
+            "p95GapMs": 9,
+            "droppedOver50ms": 1
+          },
+          "heap": {
+            "samples": 22,
+            "firstBytes": 8722248,
+            "lastBytes": 14358942,
+            "slopeBytesPerSec": 520129
+          },
+          "marks": {},
+          "deltasSent": 29,
+          "widgetCount": 20,
+          "streamedDuringWarmup": 8
+        },
+        {
+          "windowMs": 7008,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 401,
+            "maxMs": 51,
+            "p95Ms": 2
+          },
+          "frames": {
+            "samples": 835,
+            "maxGapMs": 58,
+            "p95GapMs": 9,
+            "droppedOver50ms": 1
+          },
+          "heap": {
+            "samples": 22,
+            "firstBytes": 8721753,
+            "lastBytes": 14369407,
+            "slopeBytesPerSec": 522370
+          },
+          "marks": {},
+          "deltasSent": 29,
+          "widgetCount": 20,
+          "streamedDuringWarmup": 8
+        },
+        {
+          "windowMs": 7007,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 397,
+            "maxMs": 58,
+            "p95Ms": 2
+          },
+          "frames": {
+            "samples": 834,
+            "maxGapMs": 67,
+            "p95GapMs": 9,
+            "droppedOver50ms": 1
+          },
+          "heap": {
+            "samples": 21,
+            "firstBytes": 8713013,
+            "lastBytes": 14304587,
+            "slopeBytesPerSec": 540567
+          },
+          "marks": {},
+          "deltasSent": 29,
+          "widgetCount": 20,
+          "streamedDuringWarmup": 8
+        }
+      ]
+    },
+    "resize-storm": {
+      "note": "28 canvas widgets + repeated viewport resizes: shared ResizeObserver reallocates every canvas in one task (rank 1, the fullscreen enter/exit storm)",
+      "agg": {
+        "longTaskCount": {
+          "median": 36,
+          "p95": 37,
+          "all": [
+            35,
+            35,
+            37,
+            36
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 177,
+          "p95": 204,
+          "all": [
+            177,
+            204,
+            166,
+            171
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 1900,
+          "p95": 1933,
+          "all": [
+            1933,
+            1900,
+            1786,
+            1851
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 324,
+          "p95": 401,
+          "all": [
+            324,
+            401,
+            304,
+            296
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 170,
+          "p95": 172,
+          "all": [
+            172,
+            152,
+            170,
+            163
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 232,
+          "p95": 358,
+          "all": [
+            358,
+            232,
+            192,
+            199
+          ]
+        },
+        "framesDropped": {
+          "median": 37,
+          "p95": 37,
+          "all": [
+            37,
+            36,
+            37,
+            36
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 333,
+          "p95": 354,
+          "all": [
+            354,
+            299,
+            325,
+            333
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 4,
+          "p95": 4,
+          "all": [
+            4,
+            3,
+            4,
+            4
+          ]
+        },
+        "deltasSent": {
+          "median": 15,
+          "p95": 15,
+          "all": [
+            15,
+            15,
+            15,
+            15
+          ]
+        },
+        "widgetCount": {
+          "median": 28,
+          "p95": 28,
+          "all": [
+            28,
+            28,
+            28,
+            28
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 7862,
+          "longTasks": {
+            "count": 35,
+            "totalMs": 3683,
+            "maxMs": 177,
+            "blockingTimeMs": 1933
+          },
+          "taskLatencyMs": {
+            "samples": 216,
+            "maxMs": 324,
+            "p95Ms": 172
+          },
+          "frames": {
+            "samples": 419,
+            "maxGapMs": 358,
+            "p95GapMs": 109,
+            "droppedOver50ms": 37
+          },
+          "heap": {
+            "samples": 24,
+            "firstBytes": 8654875,
+            "lastBytes": 12952021,
+            "slopeBytesPerSec": 362638
+          },
+          "marks": {},
+          "deltasSent": 15,
+          "widgetCount": 28,
+          "streamedDuringWarmup": 5
+        },
+        {
+          "windowMs": 7540,
+          "longTasks": {
+            "count": 35,
+            "totalMs": 3650,
+            "maxMs": 204,
+            "blockingTimeMs": 1900
+          },
+          "taskLatencyMs": {
+            "samples": 194,
+            "maxMs": 401,
+            "p95Ms": 152
+          },
+          "frames": {
+            "samples": 405,
+            "maxGapMs": 232,
+            "p95GapMs": 101,
+            "droppedOver50ms": 36
+          },
+          "heap": {
+            "samples": 24,
+            "firstBytes": 8739097,
+            "lastBytes": 12357180,
+            "slopeBytesPerSec": 305729
+          },
+          "marks": {},
+          "deltasSent": 15,
+          "widgetCount": 28,
+          "streamedDuringWarmup": 5
+        },
+        {
+          "windowMs": 7401,
+          "longTasks": {
+            "count": 37,
+            "totalMs": 3636,
+            "maxMs": 166,
+            "blockingTimeMs": 1786
+          },
+          "taskLatencyMs": {
+            "samples": 192,
+            "maxMs": 304,
+            "p95Ms": 170
+          },
+          "frames": {
+            "samples": 399,
+            "maxGapMs": 192,
+            "p95GapMs": 100,
+            "droppedOver50ms": 37
+          },
+          "heap": {
+            "samples": 23,
+            "firstBytes": 8708192,
+            "lastBytes": 12492169,
+            "slopeBytesPerSec": 333082
+          },
+          "marks": {},
+          "deltasSent": 15,
+          "widgetCount": 28,
+          "streamedDuringWarmup": 5
+        },
+        {
+          "windowMs": 7417,
+          "longTasks": {
+            "count": 36,
+            "totalMs": 3651,
+            "maxMs": 171,
+            "blockingTimeMs": 1851
+          },
+          "taskLatencyMs": {
+            "samples": 194,
+            "maxMs": 296,
+            "p95Ms": 163
+          },
+          "frames": {
+            "samples": 405,
+            "maxGapMs": 199,
+            "p95GapMs": 100,
+            "droppedOver50ms": 36
+          },
+          "heap": {
+            "samples": 23,
+            "firstBytes": 8704561,
+            "lastBytes": 12574321,
+            "slopeBytesPerSec": 341005
+          },
+          "marks": {},
+          "deltasSent": 15,
+          "widgetCount": 28,
+          "streamedDuringWarmup": 5
+        }
+      ]
+    },
+    "ais-radar-150": {
+      "note": "150 AIS targets @ 4Hz + streaming own-ship (ranks 4/5, radar render loops)",
+      "agg": {
+        "longTaskCount": {
+          "median": 31,
+          "p95": 31,
+          "all": [
+            30,
+            27,
+            31,
+            31
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 795,
+          "p95": 830,
+          "all": [
+            591,
+            795,
+            830,
+            643
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 7826,
+          "p95": 8098,
+          "all": [
+            8098,
+            7826,
+            7503,
+            7623
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 1406,
+          "p95": 1557,
+          "all": [
+            1180,
+            1402,
+            1557,
+            1406
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 1180,
+          "p95": 1402,
+          "all": [
+            1180,
+            1402,
+            1052,
+            1157
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 900,
+          "p95": 925,
+          "all": [
+            690,
+            900,
+            925,
+            749
+          ]
+        },
+        "framesDropped": {
+          "median": 32,
+          "p95": 33,
+          "all": [
+            29,
+            28,
+            32,
+            33
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 651,
+          "p95": 685,
+          "all": [
+            577,
+            651,
+            434,
+            685
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 10,
+          "p95": 11,
+          "all": [
+            10,
+            10,
+            7,
+            11
+          ]
+        },
+        "deltasSent": {
+          "median": 7550,
+          "p95": 7550,
+          "all": [
+            7399,
+            7399,
+            7550,
+            7550
+          ]
+        },
+        "widgetCount": {
+          "median": 1,
+          "p95": 1,
+          "all": [
+            1,
+            1,
+            1,
+            1
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 12274,
+          "longTasks": {
+            "count": 30,
+            "totalMs": 9598,
+            "maxMs": 591,
+            "blockingTimeMs": 8098
+          },
+          "taskLatencyMs": {
+            "samples": 20,
+            "maxMs": 1180,
+            "p95Ms": 1180
+          },
+          "frames": {
+            "samples": 29,
+            "maxGapMs": 690,
+            "p95GapMs": 675,
+            "droppedOver50ms": 29
+          },
+          "heap": {
+            "samples": 24,
+            "firstBytes": 8740347,
+            "lastBytes": 18931831,
+            "slopeBytesPerSec": 591147
+          },
+          "marks": {},
+          "deltasSent": 7399,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 1812
+        },
+        {
+          "windowMs": 12351,
+          "longTasks": {
+            "count": 27,
+            "totalMs": 9176,
+            "maxMs": 795,
+            "blockingTimeMs": 7826
+          },
+          "taskLatencyMs": {
+            "samples": 19,
+            "maxMs": 1402,
+            "p95Ms": 1402
+          },
+          "frames": {
+            "samples": 28,
+            "maxGapMs": 900,
+            "p95GapMs": 783,
+            "droppedOver50ms": 28
+          },
+          "heap": {
+            "samples": 21,
+            "firstBytes": 8736478,
+            "lastBytes": 19704817,
+            "slopeBytesPerSec": 666712
+          },
+          "marks": {},
+          "deltasSent": 7399,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 1963
+        },
+        {
+          "windowMs": 12592,
+          "longTasks": {
+            "count": 31,
+            "totalMs": 9053,
+            "maxMs": 830,
+            "blockingTimeMs": 7503
+          },
+          "taskLatencyMs": {
+            "samples": 21,
+            "maxMs": 1557,
+            "p95Ms": 1052
+          },
+          "frames": {
+            "samples": 32,
+            "maxGapMs": 925,
+            "p95GapMs": 725,
+            "droppedOver50ms": 32
+          },
+          "heap": {
+            "samples": 24,
+            "firstBytes": 8764903,
+            "lastBytes": 16472360,
+            "slopeBytesPerSec": 444534
+          },
+          "marks": {},
+          "deltasSent": 7550,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 2114
+        },
+        {
+          "windowMs": 12619,
+          "longTasks": {
+            "count": 31,
+            "totalMs": 9173,
+            "maxMs": 643,
+            "blockingTimeMs": 7623
+          },
+          "taskLatencyMs": {
+            "samples": 21,
+            "maxMs": 1406,
+            "p95Ms": 1157
+          },
+          "frames": {
+            "samples": 33,
+            "maxGapMs": 749,
+            "p95GapMs": 724,
+            "droppedOver50ms": 33
+          },
+          "heap": {
+            "samples": 24,
+            "firstBytes": 8722214,
+            "lastBytes": 20557811,
+            "slopeBytesPerSec": 701547
+          },
+          "marks": {},
+          "deltasSent": 7550,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 1963
+        }
+      ]
+    },
+    "gauges-16": {
+      "note": "16 radial ng-canvas-gauges @ 4Hz (rank 7, animation duty cycle)",
+      "agg": {
+        "longTaskCount": {
+          "median": 1,
+          "p95": 1,
+          "all": [
+            1,
+            0,
+            0,
+            1
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 51,
+          "p95": 54,
+          "all": [
+            51,
+            0,
+            0,
+            54
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 1,
+          "p95": 4,
+          "all": [
+            1,
+            0,
+            0,
+            4
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 48,
+          "p95": 54,
+          "all": [
+            46,
+            44,
+            48,
+            54
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 25,
+          "p95": 25,
+          "all": [
+            20,
+            19,
+            25,
+            25
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 49,
+          "p95": 51,
+          "all": [
+            51,
+            42,
+            43,
+            49
+          ]
+        },
+        "framesDropped": {
+          "median": 0,
+          "p95": 1,
+          "all": [
+            1,
+            0,
+            0,
+            0
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 288,
+          "p95": 293,
+          "all": [
+            288,
+            212,
+            261,
+            293
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 4,
+          "p95": 4,
+          "all": [
+            4,
+            3,
+            4,
+            4
+          ]
+        },
+        "deltasSent": {
+          "median": 40,
+          "p95": 40,
+          "all": [
+            40,
+            40,
+            39,
+            40
+          ]
+        },
+        "widgetCount": {
+          "median": 16,
+          "p95": 16,
+          "all": [
+            16,
+            16,
+            16,
+            16
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 10007,
+          "longTasks": {
+            "count": 1,
+            "totalMs": 51,
+            "maxMs": 51,
+            "blockingTimeMs": 1
+          },
+          "taskLatencyMs": {
+            "samples": 379,
+            "maxMs": 46,
+            "p95Ms": 20
+          },
+          "frames": {
+            "samples": 1035,
+            "maxGapMs": 51,
+            "p95GapMs": 17,
+            "droppedOver50ms": 1
+          },
+          "heap": {
+            "samples": 27,
+            "firstBytes": 8764637,
+            "lastBytes": 12704374,
+            "slopeBytesPerSec": 294963
+          },
+          "marks": {},
+          "deltasSent": 40,
+          "widgetCount": 16,
+          "streamedDuringWarmup": 7
+        },
+        {
+          "windowMs": 10008,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 385,
+            "maxMs": 44,
+            "p95Ms": 19
+          },
+          "frames": {
+            "samples": 1068,
+            "maxGapMs": 42,
+            "p95GapMs": 17,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 27,
+            "firstBytes": 8761717,
+            "lastBytes": 11656667,
+            "slopeBytesPerSec": 216806
+          },
+          "marks": {},
+          "deltasSent": 40,
+          "widgetCount": 16,
+          "streamedDuringWarmup": 8
+        },
+        {
+          "windowMs": 10009,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 320,
+            "maxMs": 48,
+            "p95Ms": 25
+          },
+          "frames": {
+            "samples": 894,
+            "maxGapMs": 43,
+            "p95GapMs": 18,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 28,
+            "firstBytes": 8753241,
+            "lastBytes": 12455239,
+            "slopeBytesPerSec": 267685
+          },
+          "marks": {},
+          "deltasSent": 39,
+          "widgetCount": 16,
+          "streamedDuringWarmup": 8
+        },
+        {
+          "windowMs": 10020,
+          "longTasks": {
+            "count": 1,
+            "totalMs": 54,
+            "maxMs": 54,
+            "blockingTimeMs": 4
+          },
+          "taskLatencyMs": {
+            "samples": 333,
+            "maxMs": 54,
+            "p95Ms": 25
+          },
+          "frames": {
+            "samples": 922,
+            "maxGapMs": 49,
+            "p95GapMs": 18,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 27,
+            "firstBytes": 8662647,
+            "lastBytes": 12808823,
+            "slopeBytesPerSec": 299538
+          },
+          "marks": {},
+          "deltasSent": 40,
+          "widgetCount": 16,
+          "streamedDuringWarmup": 8
+        }
+      ]
+    },
+    "ais-growth-churn": {
+      "note": "AIS radar with 40 targets + 40 new MMSIs/sec churn for 30s (ranks 8/9, heap growth)",
+      "agg": {
+        "longTaskCount": {
+          "median": 31,
+          "p95": 33,
+          "all": [
+            31,
+            27,
+            33,
+            28
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 4347,
+          "p95": 4872,
+          "all": [
+            3107,
+            4872,
+            4347,
+            3784
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 27231,
+          "p95": 27762,
+          "all": [
+            24475,
+            27762,
+            27231,
+            26443
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 8696,
+          "p95": 8942,
+          "all": [
+            8942,
+            8696,
+            7284,
+            6658
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 6658,
+          "p95": 8696,
+          "all": [
+            5660,
+            8696,
+            3772,
+            6658
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 4974,
+          "p95": 5917,
+          "all": [
+            5917,
+            4974,
+            4450,
+            3883
+          ]
+        },
+        "framesDropped": {
+          "median": 33,
+          "p95": 34,
+          "all": [
+            34,
+            28,
+            33,
+            29
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 277,
+          "p95": 319,
+          "all": [
+            319,
+            224,
+            277,
+            265
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 9,
+          "p95": 10,
+          "all": [
+            10,
+            8,
+            9,
+            9
+          ]
+        },
+        "deltasSent": {
+          "median": 8183,
+          "p95": 8526,
+          "all": [
+            8526,
+            8183,
+            7791,
+            8183
+          ]
+        },
+        "widgetCount": {
+          "median": 1,
+          "p95": 1,
+          "all": [
+            1,
+            1,
+            1,
+            1
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 34956,
+          "longTasks": {
+            "count": 31,
+            "totalMs": 26025,
+            "maxMs": 3107,
+            "blockingTimeMs": 24475
+          },
+          "taskLatencyMs": {
+            "samples": 21,
+            "maxMs": 8942,
+            "p95Ms": 5660
+          },
+          "frames": {
+            "samples": 34,
+            "maxGapMs": 5917,
+            "p95GapMs": 3218,
+            "droppedOver50ms": 34
+          },
+          "heap": {
+            "samples": 24,
+            "firstBytes": 8720859,
+            "lastBytes": 19581045,
+            "slopeBytesPerSec": 326987
+          },
+          "marks": {},
+          "deltasSent": 8526,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 735
+        },
+        {
+          "windowMs": 33571,
+          "longTasks": {
+            "count": 27,
+            "totalMs": 29112,
+            "maxMs": 4872,
+            "blockingTimeMs": 27762
+          },
+          "taskLatencyMs": {
+            "samples": 17,
+            "maxMs": 8696,
+            "p95Ms": 8696
+          },
+          "frames": {
+            "samples": 28,
+            "maxGapMs": 4974,
+            "p95GapMs": 3783,
+            "droppedOver50ms": 28
+          },
+          "heap": {
+            "samples": 22,
+            "firstBytes": 8741491,
+            "lastBytes": 16655775,
+            "slopeBytesPerSec": 229477
+          },
+          "marks": {},
+          "deltasSent": 8183,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 735
+        },
+        {
+          "windowMs": 31907,
+          "longTasks": {
+            "count": 33,
+            "totalMs": 28881,
+            "maxMs": 4347,
+            "blockingTimeMs": 27231
+          },
+          "taskLatencyMs": {
+            "samples": 21,
+            "maxMs": 7284,
+            "p95Ms": 3772
+          },
+          "frames": {
+            "samples": 33,
+            "maxGapMs": 4450,
+            "p95GapMs": 3275,
+            "droppedOver50ms": 33
+          },
+          "heap": {
+            "samples": 24,
+            "firstBytes": 8671554,
+            "lastBytes": 17632805,
+            "slopeBytesPerSec": 283553
+          },
+          "marks": {},
+          "deltasSent": 7791,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 735
+        },
+        {
+          "windowMs": 33771,
+          "longTasks": {
+            "count": 28,
+            "totalMs": 27843,
+            "maxMs": 3784,
+            "blockingTimeMs": 26443
+          },
+          "taskLatencyMs": {
+            "samples": 18,
+            "maxMs": 6658,
+            "p95Ms": 6658
+          },
+          "frames": {
+            "samples": 30,
+            "maxGapMs": 3883,
+            "p95GapMs": 2783,
+            "droppedOver50ms": 29
+          },
+          "heap": {
+            "samples": 22,
+            "firstBytes": 8676077,
+            "lastBytes": 17628904,
+            "slopeBytesPerSec": 271099
+          },
+          "marks": {},
+          "deltasSent": 8183,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 784
+        }
+      ]
+    }
+  }
+}

--- a/perf-harness/results/report-pre-freeze-fixes-vs-main-freeze-fixes.md
+++ b/perf-harness/results/report-pre-freeze-fixes-vs-main-freeze-fixes.md
@@ -2,6 +2,7 @@
 
 - CPU throttle: 10× (pre-freeze-fixes) / 10× (main-freeze-fixes); repeats: 4/4; Chrome 149.0.7827.201
 - Values are **medians** across repeats. Lower is better for every metric.
+- Blocking time is a raw sum over the probe window, and the window self-extends while the main thread is busy — compare the two labels' median window lengths (context row) before trusting small blocking deltas.
 
 ## idle-numeric-24
 _baseline render/CD load: 24 numeric widgets, low data rate (WS4 baseline)_
@@ -14,7 +15,7 @@ _baseline render/CD load: 24 numeric widgets, low data rate (WS4 baseline)_
 | p95 handler wait (ms) | 2 | 3 | +50% |
 | Dropped frames | 0 | 0 | 0% |
 | Heap growth (MB) | 4 | 4 | 0% |
-| _(context: widgets / deltas)_ | 24/16 | 24/16 | |
+| _(context: widgets / deltas / window ms)_ | 24/16/8007 | 24/16/8006 | |
 
 ## delta-storm-30x10
 _sustained ingestion: 30 paths @ 10Hz over a numeric+gauge dashboard (rank 2, delta coalescing)_
@@ -27,7 +28,7 @@ _sustained ingestion: 30 paths @ 10Hz over a numeric+gauge dashboard (rank 2, de
 | p95 handler wait (ms) | 2 | 3 | +50% |
 | Dropped frames | 0 | 0 | 0% |
 | Heap growth (MB) | 4 | 4 | 0% |
-| _(context: widgets / deltas)_ | 20/119 | 20/119 | |
+| _(context: widgets / deltas / window ms)_ | 20/119/12005 | 20/119/12006 | |
 
 ## reconnect-backlog
 _reconnect snapshot: one frame carrying 6000 values (rank 2, single synchronous parse+fan-out long task)_
@@ -40,7 +41,7 @@ _reconnect snapshot: one frame carrying 6000 values (rank 2, single synchronous 
 | p95 handler wait (ms) | 2 | 3 | +50% |
 | Dropped frames | 1 | 1 | 0% |
 | Heap growth (MB) | 5 | 5 | 0% |
-| _(context: widgets / deltas)_ | 20/29 | 20/29 | |
+| _(context: widgets / deltas / window ms)_ | 20/29/7008 | 20/29/7012 | |
 
 ## resize-storm
 _28 canvas widgets + repeated viewport resizes: shared ResizeObserver reallocates every canvas in one task (rank 1, the fullscreen enter/exit storm)_
@@ -53,7 +54,7 @@ _28 canvas widgets + repeated viewport resizes: shared ResizeObserver reallocate
 | p95 handler wait (ms) | 170 | 79 | -54% |
 | Dropped frames | 37 | 21 | -43% |
 | Heap growth (MB) | 4 | 4 | 0% |
-| _(context: widgets / deltas)_ | 28/15 | 28/15 | |
+| _(context: widgets / deltas / window ms)_ | 28/15/7540 | 28/15/7250 | |
 
 ## ais-radar-150
 _150 AIS targets @ 4Hz + streaming own-ship (ranks 4/5, radar render loops)_
@@ -66,7 +67,7 @@ _150 AIS targets @ 4Hz + streaming own-ship (ranks 4/5, radar render loops)_
 | p95 handler wait (ms) | 1180 | 1316 | +12% |
 | Dropped frames | 32 | 38 | +19% |
 | Heap growth (MB) | 10 | 13 | +30% |
-| _(context: widgets / deltas)_ | 1/7550 | 1/7701 | |
+| _(context: widgets / deltas / window ms)_ | 1/7550/12592 | 1/7701/12764 | |
 
 ## gauges-16
 _16 radial ng-canvas-gauges @ 4Hz (rank 7, animation duty cycle)_
@@ -79,7 +80,7 @@ _16 radial ng-canvas-gauges @ 4Hz (rank 7, animation duty cycle)_
 | p95 handler wait (ms) | 25 | 19 | -24% |
 | Dropped frames | 0 | 0 | 0% |
 | Heap growth (MB) | 4 | 3 | -25% |
-| _(context: widgets / deltas)_ | 16/40 | 16/40 | |
+| _(context: widgets / deltas / window ms)_ | 16/40/10009 | 16/40/10007 | |
 
 ## ais-growth-churn
 _AIS radar with 40 targets + 40 new MMSIs/sec churn for 30s (ranks 8/9, heap growth)_
@@ -92,4 +93,4 @@ _AIS radar with 40 targets + 40 new MMSIs/sec churn for 30s (ranks 8/9, heap gro
 | p95 handler wait (ms) | 6658 | 5091 | -24% |
 | Dropped frames | 33 | 41 | +24% |
 | Heap growth (MB) | 9 | 18 | +100% |
-| _(context: widgets / deltas)_ | 1/8183 | 1/7546 | |
+| _(context: widgets / deltas / window ms)_ | 1/8183/33771 | 1/7546/31073 | |

--- a/perf-harness/results/report-pre-freeze-fixes-vs-main-freeze-fixes.md
+++ b/perf-harness/results/report-pre-freeze-fixes-vs-main-freeze-fixes.md
@@ -1,0 +1,95 @@
+# Freeze metrics: pre-freeze-fixes → main-freeze-fixes
+
+- CPU throttle: 10× (pre-freeze-fixes) / 10× (main-freeze-fixes); repeats: 4/4; Chrome 149.0.7827.201
+- Values are **medians** across repeats. Lower is better for every metric.
+
+## idle-numeric-24
+_baseline render/CD load: 24 numeric widgets, low data rate (WS4 baseline)_
+
+| Metric | pre-freeze-fixes | main-freeze-fixes | Δ |
+|---|--:|--:|--:|
+| Longest task (ms) | 0 | 0 | 0% |
+| Blocking time (ms) | 0 | 0 | 0% |
+| Max handler wait (ms) | 4 | 7 | +75% |
+| p95 handler wait (ms) | 2 | 3 | +50% |
+| Dropped frames | 0 | 0 | 0% |
+| Heap growth (MB) | 4 | 4 | 0% |
+| _(context: widgets / deltas)_ | 24/16 | 24/16 | |
+
+## delta-storm-30x10
+_sustained ingestion: 30 paths @ 10Hz over a numeric+gauge dashboard (rank 2, delta coalescing)_
+
+| Metric | pre-freeze-fixes | main-freeze-fixes | Δ |
+|---|--:|--:|--:|
+| Longest task (ms) | 0 | 0 | 0% |
+| Blocking time (ms) | 0 | 0 | 0% |
+| Max handler wait (ms) | 9 | 4 | -56% |
+| p95 handler wait (ms) | 2 | 3 | +50% |
+| Dropped frames | 0 | 0 | 0% |
+| Heap growth (MB) | 4 | 4 | 0% |
+| _(context: widgets / deltas)_ | 20/119 | 20/119 | |
+
+## reconnect-backlog
+_reconnect snapshot: one frame carrying 6000 values (rank 2, single synchronous parse+fan-out long task)_
+
+| Metric | pre-freeze-fixes | main-freeze-fixes | Δ |
+|---|--:|--:|--:|
+| Longest task (ms) | 50 | 54 | +8% |
+| Blocking time (ms) | 0 | 4 | +4 (was 0) |
+| Max handler wait (ms) | 58 | 61 | +5% |
+| p95 handler wait (ms) | 2 | 3 | +50% |
+| Dropped frames | 1 | 1 | 0% |
+| Heap growth (MB) | 5 | 5 | 0% |
+| _(context: widgets / deltas)_ | 20/29 | 20/29 | |
+
+## resize-storm
+_28 canvas widgets + repeated viewport resizes: shared ResizeObserver reallocates every canvas in one task (rank 1, the fullscreen enter/exit storm)_
+
+| Metric | pre-freeze-fixes | main-freeze-fixes | Δ |
+|---|--:|--:|--:|
+| Longest task (ms) | 177 | 73 | -59% |
+| Blocking time (ms) | 1900 | 112 | -94% |
+| Max handler wait (ms) | 324 | 134 | -59% |
+| p95 handler wait (ms) | 170 | 79 | -54% |
+| Dropped frames | 37 | 21 | -43% |
+| Heap growth (MB) | 4 | 4 | 0% |
+| _(context: widgets / deltas)_ | 28/15 | 28/15 | |
+
+## ais-radar-150
+_150 AIS targets @ 4Hz + streaming own-ship (ranks 4/5, radar render loops)_
+
+| Metric | pre-freeze-fixes | main-freeze-fixes | Δ |
+|---|--:|--:|--:|
+| Longest task (ms) | 795 | 1169 | +47% |
+| Blocking time (ms) | 7826 | 8398 | +7% |
+| Max handler wait (ms) | 1406 | 1511 | +7% |
+| p95 handler wait (ms) | 1180 | 1316 | +12% |
+| Dropped frames | 32 | 38 | +19% |
+| Heap growth (MB) | 10 | 13 | +30% |
+| _(context: widgets / deltas)_ | 1/7550 | 1/7701 | |
+
+## gauges-16
+_16 radial ng-canvas-gauges @ 4Hz (rank 7, animation duty cycle)_
+
+| Metric | pre-freeze-fixes | main-freeze-fixes | Δ |
+|---|--:|--:|--:|
+| Longest task (ms) | 51 | 0 | -100% |
+| Blocking time (ms) | 1 | 0 | -100% |
+| Max handler wait (ms) | 48 | 39 | -19% |
+| p95 handler wait (ms) | 25 | 19 | -24% |
+| Dropped frames | 0 | 0 | 0% |
+| Heap growth (MB) | 4 | 3 | -25% |
+| _(context: widgets / deltas)_ | 16/40 | 16/40 | |
+
+## ais-growth-churn
+_AIS radar with 40 targets + 40 new MMSIs/sec churn for 30s (ranks 8/9, heap growth)_
+
+| Metric | pre-freeze-fixes | main-freeze-fixes | Δ |
+|---|--:|--:|--:|
+| Longest task (ms) | 4347 | 6313 | +45% |
+| Blocking time (ms) | 27231 | 25163 | -8% |
+| Max handler wait (ms) | 8696 | 6447 | -26% |
+| p95 handler wait (ms) | 6658 | 5091 | -24% |
+| Dropped frames | 33 | 41 | +24% |
+| Heap growth (MB) | 9 | 18 | +100% |
+| _(context: widgets / deltas)_ | 1/8183 | 1/7546 | |

--- a/perf-harness/run.mjs
+++ b/perf-harness/run.mjs
@@ -1,0 +1,140 @@
+/*
+ * Freeze-audit measurement runner.
+ *
+ *   node run.mjs --branch <ref> --label <name> [--scenarios a,b] [--repeats 5]
+ *                [--throttle 4] [--port 4399] [--no-rebuild] [--headed]
+ *
+ * Builds the branch's production bundle in an isolated worktree, serves it +
+ * a mock Signal K server on one origin, injects the identical probe + a
+ * localStorage config into a throttled Chromium, runs each scenario K times,
+ * and writes results/<label>.json (raw + median/p95 aggregate).
+ */
+import { chromium } from 'playwright-core';
+import { readFile, writeFile, mkdir, access } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildBranch, WORKTREES } from './lib/build-serve.mjs';
+import { startServer } from './lib/server.mjs';
+import { localStorageBundle } from './lib/kip-config.mjs';
+import { scenarios as ALL } from './scenarios.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CHROME = process.env.CHROME_BIN || '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const BASE = '/@mxtommy/kip/';
+
+const arg = (n, d) => { const i = process.argv.indexOf(`--${n}`); return i >= 0 ? process.argv[i + 1] : d; };
+const flag = (n) => process.argv.includes(`--${n}`);
+
+const BRANCH = arg('branch', 'master');
+const LABEL = arg('label', BRANCH.replace(/[^\w.-]/g, '_'));
+const REPEATS = Number(arg('repeats', '4'));
+const THROTTLE = Number(arg('throttle', '10'));
+const PORT = Number(arg('port', '4399'));
+const ONLY = (arg('scenarios', '') || '').split(',').filter(Boolean);
+const scenarios = ONLY.length ? ALL.filter((s) => ONLY.includes(s.label)) : ALL;
+
+const exists = async (p) => { try { await access(p); return true; } catch { return false; } };
+const med = (a) => { if (!a.length) return 0; const s = [...a].sort((x, y) => x - y); return s[Math.floor(s.length / 2)]; };
+const p95 = (a) => { if (!a.length) return 0; const s = [...a].sort((x, y) => x - y); return s[Math.min(s.length - 1, Math.floor(0.95 * s.length))]; };
+
+function aggregate(reps) {
+  const pick = {
+    longTaskCount: (r) => r.longTasks.count,
+    longTaskMaxMs: (r) => r.longTasks.maxMs,
+    blockingTimeMs: (r) => r.longTasks.blockingTimeMs,
+    taskLatencyMaxMs: (r) => r.taskLatencyMs.maxMs,
+    taskLatencyP95Ms: (r) => r.taskLatencyMs.p95Ms,
+    frameMaxGapMs: (r) => r.frames.maxGapMs,
+    framesDropped: (r) => r.frames.droppedOver50ms,
+    heapSlopeKBps: (r) => Math.round(r.heap.slopeBytesPerSec / 1024),
+    heapGrowthMB: (r) => r.heap.firstBytes != null ? Math.round((r.heap.lastBytes - r.heap.firstBytes) / 1048576) : 0,
+    deltasSent: (r) => r.deltasSent || 0,
+    widgetCount: (r) => r.widgetCount || 0,
+  };
+  const out = {};
+  for (const [k, f] of Object.entries(pick)) {
+    const vals = reps.map(f);
+    out[k] = { median: med(vals), p95: p95(vals), all: vals };
+  }
+  return out;
+}
+
+async function prepareBuild() {
+  const forced = arg('public', '');
+  if (forced) { console.log(`[build] using provided public dir: ${forced}`); return forced; }
+  const wtPublic = join(WORKTREES, LABEL, 'public');
+  if (flag('no-rebuild') && await exists(join(wtPublic, 'index.html'))) {
+    console.log(`[build] reusing existing build for ${LABEL}`);
+    return wtPublic;
+  }
+  return buildBranch(BRANCH, LABEL, { rebuild: !flag('no-rebuild') });
+}
+
+async function waitForBoot(page, expectedWidgets) {
+  await page.waitForSelector('widget-host2', { timeout: 25000 }).catch(() => {});
+  // settle a couple of frames
+  await page.waitForTimeout(800);
+  return page.$$eval('widget-host2', (els) => els.length).catch(() => 0);
+}
+
+async function main() {
+  const probeJs = await readFile(join(HERE, 'probe.js'), 'utf8');
+  const publicDir = await prepareBuild();
+  const server = await startServer({ publicDir, base: BASE, port: PORT });
+  console.log(`[serve] ${server.appUrl}  (SignalK mock @ ${server.origin})`);
+
+  const browser = await chromium.launch({
+    executablePath: CHROME, headless: !flag('headed'),
+    args: ['--enable-precise-memory-info', '--js-flags=--expose-gc'],
+  });
+
+  const results = { label: LABEL, branch: BRANCH, throttle: THROTTLE, repeats: REPEATS, chrome: await browser.version(), scenarios: {} };
+
+  for (const s of scenarios) {
+    console.log(`\n=== scenario: ${s.label} — ${s.note} ===`);
+    const reps = [];
+    for (let r = 0; r < REPEATS; r++) {
+      const ctx = await browser.newContext();
+      await ctx.addInitScript({ content: probeJs });
+      const bundle = localStorageBundle({ origin: server.origin, subscribeAll: s.subscribeAll, dashboards: s.dashboards() });
+      const injector = `window.__KIP_TEST__ = true;` +
+        Object.entries(bundle).map(([k, v]) => `localStorage.setItem(${JSON.stringify(k)}, ${JSON.stringify(v)});`).join('');
+      await ctx.addInitScript({ content: injector });
+      const page = await ctx.newPage();
+      const cdp = await ctx.newCDPSession(page);
+      await cdp.send('Emulation.setCPUThrottlingRate', { rate: THROTTLE });
+
+      // fresh stream state
+      server.setControl({ streaming: false, ais: { count: 0, churnPerSec: 0 } });
+      await page.goto(server.appUrl + '#/dashboard/0', { waitUntil: 'load', timeout: 30000 });
+      const widgetCount = await waitForBoot(page);
+
+      // start the scenario data profile, warm up, then measure
+      server.setControl({ streaming: true, ...s.control });
+      const c0 = server.streamCount();
+      await page.waitForTimeout(s.warmupMs ?? 1500);
+      await page.evaluate(() => window.__perf.reset());
+      const sentAtReset = server.streamCount();
+      if (s.action) await s.action(page, server, s.durationMs);
+      else await page.waitForTimeout(s.durationMs);
+      const snap = await page.evaluate(() => window.__perf.snapshot());
+      snap.deltasSent = server.streamCount() - sentAtReset;
+      snap.widgetCount = widgetCount;
+      snap.streamedDuringWarmup = sentAtReset - c0;
+      reps.push(snap);
+      console.log(`  rep ${r + 1}/${REPEATS}: widgets=${widgetCount} deltas=${snap.deltasSent} longTaskMax=${snap.longTasks.maxMs}ms block=${snap.longTasks.blockingTimeMs}ms taskLatMax=${snap.taskLatencyMs.maxMs}ms heapΔ=${snap.heap.firstBytes != null ? Math.round((snap.heap.lastBytes - snap.heap.firstBytes) / 1048576) : '?'}MB`);
+      await ctx.close();
+    }
+    results.scenarios[s.label] = { note: s.note, agg: aggregate(reps), raw: reps.map((r) => ({ ...r, heap: { ...r.heap } })) };
+  }
+
+  await server.stop();
+  await browser.close();
+
+  await mkdir(join(HERE, 'results'), { recursive: true });
+  const outPath = join(HERE, 'results', `${LABEL}.json`);
+  await writeFile(outPath, JSON.stringify(results, null, 2));
+  console.log(`\n[done] wrote ${outPath}`);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/perf-harness/run.mjs
+++ b/perf-harness/run.mjs
@@ -70,11 +70,25 @@ async function prepareBuild() {
   return buildBranch(BRANCH, LABEL, { rebuild: !flag('no-rebuild') });
 }
 
+/*
+ * A mis-seeded config still boots Skip into a plausible-looking empty/default
+ * dashboard, which would silently measure the wrong thing — so a boot that does
+ * not render exactly the scenario's widgets fails the run.
+ */
 async function waitForBoot(page, expectedWidgets) {
-  await page.waitForSelector('widget-host2', { timeout: 25000 }).catch(() => {});
+  const deadline = Date.now() + 25000;
+  let count = 0;
+  while (Date.now() < deadline) {
+    count = await page.$$eval('widget-host2', (els) => els.length).catch(() => 0);
+    if (count === expectedWidgets) break;
+    await page.waitForTimeout(250);
+  }
+  if (count !== expectedWidgets) {
+    throw new Error(`boot check failed: ${count} widget-host2 rendered, expected ${expectedWidgets}`);
+  }
   // settle a couple of frames
   await page.waitForTimeout(800);
-  return page.$$eval('widget-host2', (els) => els.length).catch(() => 0);
+  return count;
 }
 
 async function main() {
@@ -95,6 +109,10 @@ async function main() {
     const reps = [];
     for (let r = 0; r < REPEATS; r++) {
       const ctx = await browser.newContext();
+      // InternetReachabilityService probes gstatic at boot, on connection-state
+      // changes, and every 60s — answer locally so no external request lands
+      // inside the measurement window.
+      await ctx.route('https://www.gstatic.com/generate_204', (route) => route.fulfill({ status: 204, body: '' }));
       await ctx.addInitScript({ content: probeJs });
       const dashboards = s.dashboards();
       server.setConfigDocument(serverConfigDocument({ dashboards }));
@@ -109,7 +127,7 @@ async function main() {
       // fresh stream state
       server.setControl({ streaming: false, ais: { count: 0, churnPerSec: 0 } });
       await page.goto(server.appUrl + '#/dashboard/0', { waitUntil: 'load', timeout: 30000 });
-      const widgetCount = await waitForBoot(page);
+      const widgetCount = await waitForBoot(page, dashboards[0].configuration.length);
 
       // start the scenario data profile, warm up, then measure
       server.setControl({ streaming: true, ...s.control });

--- a/perf-harness/run.mjs
+++ b/perf-harness/run.mjs
@@ -15,17 +15,17 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { buildBranch, WORKTREES } from './lib/build-serve.mjs';
 import { startServer } from './lib/server.mjs';
-import { localStorageBundle } from './lib/kip-config.mjs';
+import { localStorageBundle, serverConfigDocument } from './lib/kip-config.mjs';
 import { scenarios as ALL } from './scenarios.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const CHROME = process.env.CHROME_BIN || '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
-const BASE = '/@mxtommy/kip/';
+const BASE = '/@halos-org/skip/';
 
 const arg = (n, d) => { const i = process.argv.indexOf(`--${n}`); return i >= 0 ? process.argv[i + 1] : d; };
 const flag = (n) => process.argv.includes(`--${n}`);
 
-const BRANCH = arg('branch', 'master');
+const BRANCH = arg('branch', 'main');
 const LABEL = arg('label', BRANCH.replace(/[^\w.-]/g, '_'));
 const REPEATS = Number(arg('repeats', '4'));
 const THROTTLE = Number(arg('throttle', '10'));
@@ -96,7 +96,9 @@ async function main() {
     for (let r = 0; r < REPEATS; r++) {
       const ctx = await browser.newContext();
       await ctx.addInitScript({ content: probeJs });
-      const bundle = localStorageBundle({ origin: server.origin, subscribeAll: s.subscribeAll, dashboards: s.dashboards() });
+      const dashboards = s.dashboards();
+      server.setConfigDocument(serverConfigDocument({ dashboards }));
+      const bundle = localStorageBundle({ origin: server.origin, subscribeAll: s.subscribeAll });
       const injector = `window.__KIP_TEST__ = true;` +
         Object.entries(bundle).map(([k, v]) => `localStorage.setItem(${JSON.stringify(k)}, ${JSON.stringify(v)});`).join('');
       await ctx.addInitScript({ content: injector });

--- a/perf-harness/run.mjs
+++ b/perf-harness/run.mjs
@@ -8,6 +8,10 @@
  * a mock Signal K server on one origin, injects the identical probe + a
  * localStorage config into a throttled Chromium, runs each scenario K times,
  * and writes results/<label>.json (raw + median/p95 aggregate).
+ *
+ * Scenario results merge into any existing results/<label>.json and are written
+ * after every scenario, so a long suite can run as chunked --scenarios
+ * invocations under one label and a crash never loses completed scenarios.
  */
 import { chromium } from 'playwright-core';
 import { readFile, writeFile, mkdir, access } from 'node:fs/promises';
@@ -102,7 +106,10 @@ async function main() {
     args: ['--enable-precise-memory-info', '--js-flags=--expose-gc'],
   });
 
-  const results = { label: LABEL, branch: BRANCH, throttle: THROTTLE, repeats: REPEATS, chrome: await browser.version(), scenarios: {} };
+  await mkdir(join(HERE, 'results'), { recursive: true });
+  const outPath = join(HERE, 'results', `${LABEL}.json`);
+  const prior = JSON.parse(await readFile(outPath, 'utf8').catch(() => 'null'));
+  const results = { label: LABEL, branch: BRANCH, throttle: THROTTLE, repeats: REPEATS, chrome: await browser.version(), scenarios: prior?.scenarios ?? {} };
 
   for (const s of scenarios) {
     console.log(`\n=== scenario: ${s.label} — ${s.note} ===`);
@@ -146,14 +153,11 @@ async function main() {
       await ctx.close();
     }
     results.scenarios[s.label] = { note: s.note, agg: aggregate(reps), raw: reps.map((r) => ({ ...r, heap: { ...r.heap } })) };
+    await writeFile(outPath, JSON.stringify(results, null, 2));
   }
 
   await server.stop();
   await browser.close();
-
-  await mkdir(join(HERE, 'results'), { recursive: true });
-  const outPath = join(HERE, 'results', `${LABEL}.json`);
-  await writeFile(outPath, JSON.stringify(results, null, 2));
   console.log(`\n[done] wrote ${outPath}`);
 }
 

--- a/perf-harness/scenarios.mjs
+++ b/perf-harness/scenarios.mjs
@@ -1,0 +1,80 @@
+/*
+ * Measurement scenarios. Each exercises a specific verified audit finding so the
+ * before/after numbers map to a named root cause. Data profiles drive the mock
+ * server; dashboards are built fresh per repeat (unique widget uuids).
+ */
+import { numericWidget, radialGaugeWidget, aisRadarWidget, buildDashboards } from './lib/kip-config.mjs';
+
+const POOL = [
+  'navigation.speedOverGround', 'navigation.headingTrue', 'navigation.courseOverGroundTrue',
+  'environment.depth.belowTransducer', 'environment.wind.angleApparent', 'environment.wind.speedApparent',
+];
+
+// Many extra paths to stress the delta parse + fan-out (widgets need not subscribe;
+// data.service still upserts _skData and emits _pathUpdates$ for every path).
+const manyPaths = (n) => [...POOL, ...Array.from({ length: Math.max(0, n - POOL.length) }, (_, i) => `sensors.mock.n${i}.value`)];
+
+const numericGrid = (n) => buildDashboards(Array.from({ length: n }, (_, i) => numericWidget({ path: 'self.' + POOL[i % POOL.length], sampleTime: 500 })));
+const gaugeGrid = (n) => buildDashboards(Array.from({ length: n }, (_, i) => radialGaugeWidget({ path: 'self.' + POOL[i % POOL.length], sampleTime: 500 })));
+
+export const scenarios = [
+  {
+    label: 'idle-numeric-24',
+    note: 'baseline render/CD load: 24 numeric widgets, low data rate (WS4 baseline)',
+    subscribeAll: false, durationMs: 8000, warmupMs: 2000,
+    dashboards: () => numericGrid(24),
+    control: { rateHz: 2, selfPaths: POOL, ais: { count: 0, churnPerSec: 0 } },
+  },
+  {
+    label: 'delta-storm-30x10',
+    note: 'sustained ingestion: 30 paths @ 10Hz over a numeric+gauge dashboard (rank 2, delta coalescing)',
+    subscribeAll: false, durationMs: 12000, warmupMs: 2000,
+    dashboards: () => numericGrid(20),
+    control: { rateHz: 10, selfPaths: manyPaths(30), ais: { count: 0, churnPerSec: 0 } },
+  },
+  {
+    label: 'reconnect-backlog',
+    note: 'reconnect snapshot: one frame carrying 6000 values (rank 2, single synchronous parse+fan-out long task)',
+    subscribeAll: false, durationMs: 7000, warmupMs: 2000,
+    dashboards: () => numericGrid(20),
+    control: { rateHz: 4, selfPaths: manyPaths(20), ais: { count: 0, churnPerSec: 0 } },
+    async action(page, server, durationMs) {
+      await page.waitForTimeout(1000);
+      server.blastBig(6000); // reconnect snapshot: one big frame => one long task
+      await page.waitForTimeout(durationMs - 1000);
+    },
+  },
+  {
+    label: 'resize-storm',
+    note: '28 canvas widgets + repeated viewport resizes: shared ResizeObserver reallocates every canvas in one task (rank 1, the fullscreen enter/exit storm)',
+    subscribeAll: false, durationMs: 7000, warmupMs: 2500,
+    dashboards: () => numericGrid(28),
+    control: { rateHz: 2, selfPaths: POOL, ais: { count: 0, churnPerSec: 0 } },
+    async action(page, server, durationMs) {
+      const sizes = [[1600, 1000], [900, 1400], [1600, 1000], [1280, 800], [1920, 1080], [800, 1200], [1600, 1000], [1100, 900]];
+      for (const [w, h] of sizes) { await page.setViewportSize({ width: w, height: h }); await page.waitForTimeout(500); }
+      await page.waitForTimeout(Math.max(0, durationMs - sizes.length * 500));
+    },
+  },
+  {
+    label: 'ais-radar-150',
+    note: '150 AIS targets @ 4Hz + streaming own-ship (ranks 4/5, radar render loops)',
+    subscribeAll: true, durationMs: 12000, warmupMs: 3000,
+    dashboards: () => buildDashboards([aisRadarWidget()]),
+    control: { rateHz: 4, selfPaths: ['navigation.position', 'navigation.headingTrue', 'navigation.courseOverGroundTrue', 'navigation.speedOverGround'], ais: { count: 150, churnPerSec: 0 } },
+  },
+  {
+    label: 'gauges-16',
+    note: '16 radial ng-canvas-gauges @ 4Hz (rank 7, animation duty cycle)',
+    subscribeAll: false, durationMs: 10000, warmupMs: 2000,
+    dashboards: () => gaugeGrid(16),
+    control: { rateHz: 4, selfPaths: POOL, ais: { count: 0, churnPerSec: 0 } },
+  },
+  {
+    label: 'ais-growth-churn',
+    note: 'AIS radar with 40 targets + 40 new MMSIs/sec churn for 30s (ranks 8/9, heap growth)',
+    subscribeAll: true, durationMs: 30000, warmupMs: 3000,
+    dashboards: () => buildDashboards([aisRadarWidget()]),
+    control: { rateHz: 5, selfPaths: ['navigation.position', 'navigation.headingTrue'], ais: { count: 40, churnPerSec: 40 } },
+  },
+];

--- a/perf-harness/screenshot.mjs
+++ b/perf-harness/screenshot.mjs
@@ -1,0 +1,54 @@
+/*
+ * Deterministic AIS-radar screenshot for visual verification.
+ *   node screenshot.mjs --public ../public --label before --port 4420
+ * Loads the radar with a fixed scene (own-ship + targets at known bearings/ranges)
+ * so before/after images are directly comparable. Writes results/shots/<label>.png.
+ */
+import { chromium } from 'playwright-core';
+import { mkdir } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { startServer } from './lib/server.mjs';
+import { aisRadarWidget, buildDashboards, localStorageBundle } from './lib/kip-config.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CHROME = process.env.CHROME_BIN || '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const arg = (n, d) => { const i = process.argv.indexOf(`--${n}`); return i >= 0 ? process.argv[i + 1] : d; };
+
+const publicDir = arg('public', join(HERE, '..', 'public'));
+const label = arg('label', 'radar');
+const port = Number(arg('port', '4420'));
+
+// Deterministic scene: own-ship + targets at fixed bearings/ranges (nm).
+const own = { lat: 47.6, lon: -122.33, heading: 45, cog: 45, sog: 6 };
+const place = (bearingDeg, rangeNm, extra) => {
+  const b = bearingDeg * Math.PI / 180;
+  const dLat = (rangeNm / 60) * Math.cos(b);
+  const dLon = (rangeNm / 60) * Math.sin(b) / Math.cos(own.lat * Math.PI / 180);
+  return { lat: own.lat + dLat, lon: own.lon + dLon, heading: (bearingDeg + 90) % 360, cog: (bearingDeg + 90) % 360, sog: 5, ...extra };
+};
+let mmsi = 200000000;
+const targets = [];
+for (const r of [3, 7]) for (const b of [0, 45, 90, 135, 180, 225, 270, 315]) targets.push({ mmsi: mmsi++, ...place(b, r) });
+// two targets well beyond a 12nm ring (to visually check range culling later)
+for (const b of [30, 210]) targets.push({ mmsi: mmsi++, ...place(b, 20, { sog: 9 }) });
+
+const server = await startServer({ publicDir, base: '/@mxtommy/kip/', port });
+const browser = await chromium.launch({ executablePath: CHROME, headless: true });
+const ctx = await browser.newContext({ viewport: { width: 900, height: 900 }, deviceScaleFactor: 2 });
+const bundle = localStorageBundle({ origin: server.origin, subscribeAll: true, dashboards: buildDashboards([aisRadarWidget()]) });
+await ctx.addInitScript({ content: `window.__KIP_TEST__=true;` + Object.entries(bundle).map(([k, v]) => `localStorage.setItem(${JSON.stringify(k)}, ${JSON.stringify(v)});`).join('') });
+const page = await ctx.newPage();
+
+server.setControl({ streaming: true, staticScene: { ownShip: own, targets } });
+await page.goto(server.appUrl + '#/dashboard/0', { waitUntil: 'load', timeout: 30000 });
+await page.waitForSelector('widget-ais-radar', { timeout: 20000 });
+await page.waitForTimeout(3500); // let the scene stream in and the radar settle
+
+await mkdir(join(HERE, 'results', 'shots'), { recursive: true });
+const out = join(HERE, 'results', 'shots', `${label}.png`);
+await page.locator('widget-ais-radar').screenshot({ path: out });
+console.log(`[shot] ${out}  (deltas: ${server.streamCount()}, targets: ${targets.length})`);
+
+await browser.close();
+await server.stop();

--- a/perf-harness/screenshot.mjs
+++ b/perf-harness/screenshot.mjs
@@ -9,7 +9,7 @@ import { mkdir } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { startServer } from './lib/server.mjs';
-import { aisRadarWidget, buildDashboards, localStorageBundle } from './lib/kip-config.mjs';
+import { aisRadarWidget, buildDashboards, localStorageBundle, serverConfigDocument } from './lib/kip-config.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const CHROME = process.env.CHROME_BIN || '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
@@ -33,10 +33,11 @@ for (const r of [3, 7]) for (const b of [0, 45, 90, 135, 180, 225, 270, 315]) ta
 // two targets well beyond a 12nm ring (to visually check range culling later)
 for (const b of [30, 210]) targets.push({ mmsi: mmsi++, ...place(b, 20, { sog: 9 }) });
 
-const server = await startServer({ publicDir, base: '/@mxtommy/kip/', port });
+const server = await startServer({ publicDir, base: '/@halos-org/skip/', port });
+server.setConfigDocument(serverConfigDocument({ dashboards: buildDashboards([aisRadarWidget()]) }));
 const browser = await chromium.launch({ executablePath: CHROME, headless: true });
 const ctx = await browser.newContext({ viewport: { width: 900, height: 900 }, deviceScaleFactor: 2 });
-const bundle = localStorageBundle({ origin: server.origin, subscribeAll: true, dashboards: buildDashboards([aisRadarWidget()]) });
+const bundle = localStorageBundle({ origin: server.origin, subscribeAll: true });
 await ctx.addInitScript({ content: `window.__KIP_TEST__=true;` + Object.entries(bundle).map(([k, v]) => `localStorage.setItem(${JSON.stringify(k)}, ${JSON.stringify(v)});`).join('') });
 const page = await ctx.newPage();
 

--- a/perf-harness/screenshot.mjs
+++ b/perf-harness/screenshot.mjs
@@ -37,6 +37,7 @@ const server = await startServer({ publicDir, base: '/@halos-org/skip/', port })
 server.setConfigDocument(serverConfigDocument({ dashboards: buildDashboards([aisRadarWidget()]) }));
 const browser = await chromium.launch({ executablePath: CHROME, headless: true });
 const ctx = await browser.newContext({ viewport: { width: 900, height: 900 }, deviceScaleFactor: 2 });
+await ctx.route('https://www.gstatic.com/generate_204', (route) => route.fulfill({ status: 204, body: '' }));
 const bundle = localStorageBundle({ origin: server.origin, subscribeAll: true });
 await ctx.addInitScript({ content: `window.__KIP_TEST__=true;` + Object.entries(bundle).map(([k, v]) => `localStorage.setItem(${JSON.stringify(k)}, ${JSON.stringify(v)});`).join('') });
 const page = await ctx.newPage();

--- a/perf-harness/serve.mjs
+++ b/perf-harness/serve.mjs
@@ -1,0 +1,67 @@
+/*
+ * Minimal static SPA server for a built KIP bundle.
+ * KIP builds to <root>/public with <base href="/@mxtommy/kip/">, so we mount the
+ * files under that base and SPA-fallback unknown routes to index.html.
+ *
+ * Usage: node serve.mjs --root /path/to/worktree/public --port 4321 [--base /@mxtommy/kip/]
+ */
+import http from 'node:http';
+import { readFile, stat } from 'node:fs/promises';
+import { join, extname, normalize } from 'node:path';
+
+function arg(name, def) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 ? process.argv[i + 1] : def;
+}
+
+const ROOT = arg('root', 'public');
+const PORT = Number(arg('port', '4321'));
+let BASE = arg('base', '/@mxtommy/kip/');
+if (!BASE.endsWith('/')) BASE += '/';
+
+const TYPES = {
+  '.html': 'text/html; charset=utf-8', '.js': 'text/javascript', '.mjs': 'text/javascript',
+  '.css': 'text/css', '.json': 'application/json', '.svg': 'image/svg+xml',
+  '.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg', '.webp': 'image/webp',
+  '.ico': 'image/x-icon', '.woff': 'font/woff', '.woff2': 'font/woff2', '.ttf': 'font/ttf',
+  '.wasm': 'application/wasm', '.map': 'application/json',
+};
+
+async function tryFile(p) {
+  try { const s = await stat(p); if (s.isFile()) return p; } catch { /* nope */ }
+  return null;
+}
+
+const server = http.createServer(async (req, res) => {
+  try {
+    let urlPath = decodeURIComponent(new URL(req.url, 'http://x').pathname);
+    // Redirect bare root to the app base so relative asset URLs resolve.
+    if (urlPath === '/' ) { res.writeHead(302, { Location: BASE }); return res.end(); }
+    // Strip the base prefix.
+    let rel = urlPath.startsWith(BASE) ? urlPath.slice(BASE.length) : urlPath.replace(/^\//, '');
+    rel = normalize(rel).replace(/^(\.\.[/\\])+/, '');
+    let filePath = join(ROOT, rel);
+
+    let resolved = await tryFile(filePath);
+    // SPA fallback: unknown route with no file extension -> index.html
+    if (!resolved && !extname(rel)) resolved = await tryFile(join(ROOT, 'index.html'));
+    if (!resolved) { res.writeHead(404); return res.end('not found: ' + rel); }
+
+    const body = await readFile(resolved);
+    res.writeHead(200, {
+      'Content-Type': TYPES[extname(resolved)] || 'application/octet-stream',
+      'Cache-Control': 'no-store',
+    });
+    res.end(body);
+  } catch (e) {
+    res.writeHead(500); res.end(String(e));
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`[serve] ${ROOT} at http://localhost:${PORT}${BASE}`);
+});
+
+// Allow the parent (run.mjs) to shut us down cleanly.
+process.on('SIGTERM', () => server.close(() => process.exit(0)));
+process.on('message', (m) => { if (m === 'shutdown') server.close(() => process.exit(0)); });

--- a/perf-harness/serve.mjs
+++ b/perf-harness/serve.mjs
@@ -1,9 +1,9 @@
 /*
- * Minimal static SPA server for a built KIP bundle.
- * KIP builds to <root>/public with <base href="/@mxtommy/kip/">, so we mount the
- * files under that base and SPA-fallback unknown routes to index.html.
+ * Minimal static SPA server for a built Skip bundle.
+ * Skip builds to <root>/public with <base href="/@halos-org/skip/">, so we mount
+ * the files under that base and SPA-fallback unknown routes to index.html.
  *
- * Usage: node serve.mjs --root /path/to/worktree/public --port 4321 [--base /@mxtommy/kip/]
+ * Usage: node serve.mjs --root /path/to/worktree/public --port 4321 [--base /@halos-org/skip/]
  */
 import http from 'node:http';
 import { readFile, stat } from 'node:fs/promises';
@@ -16,7 +16,7 @@ function arg(name, def) {
 
 const ROOT = arg('root', 'public');
 const PORT = Number(arg('port', '4321'));
-let BASE = arg('base', '/@mxtommy/kip/');
+let BASE = arg('base', '/@halos-org/skip/');
 if (!BASE.endsWith('/')) BASE += '/';
 
 const TYPES = {

--- a/perf-harness/smoke.mjs
+++ b/perf-harness/smoke.mjs
@@ -1,0 +1,50 @@
+/* Smoke test: verify the browser launch + probe measure a synthetic main-thread block. */
+import { chromium } from 'playwright-core';
+import { readFile } from 'node:fs/promises';
+
+const CHROME = process.env.CHROME_BIN
+  || '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+
+const probe = await readFile(new URL('./probe.js', import.meta.url), 'utf8');
+
+const browser = await chromium.launch({
+  executablePath: CHROME,
+  headless: true,
+  args: ['--enable-precise-memory-info', '--js-flags=--expose-gc'],
+});
+const ctx = await browser.newContext();
+await ctx.addInitScript({ content: probe });
+const page = await ctx.newPage();
+
+// Throttle CPU 4x to emulate a low-power marine display.
+const cdp = await ctx.newCDPSession(page);
+await cdp.send('Emulation.setCPUThrottlingRate', { rate: 4 });
+
+await page.goto('data:text/html,<title>smoke</title><body>smoke</body>');
+await page.evaluate(() => window.__perf.reset());
+
+// Synthetic 400ms blocking task scheduled as a REAL page task (setTimeout),
+// so it is attributed as a long task exactly like the app's own work would be.
+await page.evaluate(() => new Promise((resolve) => {
+  setTimeout(() => {
+    const end = performance.now() + 400;
+    while (performance.now() < end) { /* block */ }
+    resolve();
+  }, 0);
+}));
+// Let the canary/observers catch up.
+await page.waitForTimeout(500);
+
+const snap = await page.evaluate(() => window.__perf.snapshot());
+console.log('CHROME:', (await browser.version()));
+console.log(JSON.stringify(snap, null, 2));
+
+await browser.close();
+
+// Assert the probe actually saw the block.
+if (snap.longTasks.maxMs < 200 && snap.taskLatencyMs.maxMs < 200) {
+  console.error('FAIL: probe did not detect the synthetic block');
+  process.exit(1);
+}
+console.log('SMOKE OK: probe detected the block (longtask maxMs=%d, taskLatency maxMs=%d)',
+  snap.longTasks.maxMs, snap.taskLatencyMs.maxMs);

--- a/perf-harness/verify-click.mjs
+++ b/perf-harness/verify-click.mjs
@@ -1,0 +1,56 @@
+/*
+ * Verifies AIS-radar hit-testing after the rotation refactor: with two targets
+ * overlapping at a non-zero view rotation (heading 45deg), clicking them must
+ * open the multi-target disambiguation MENU (findTargetsNearEvent found both) —
+ * not fall back to a single dialog. This is the one correctness path a static
+ * screenshot can't cover (the click-point un-rotate math).
+ */
+import { chromium } from 'playwright-core';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { startServer } from './lib/server.mjs';
+import { aisRadarWidget, buildDashboards, localStorageBundle } from './lib/kip-config.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CHROME = process.env.CHROME_BIN || '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const arg = (n, d) => { const i = process.argv.indexOf(`--${n}`); return i >= 0 ? process.argv[i + 1] : d; };
+const publicDir = arg('public', join(HERE, '..', 'public'));
+const port = Number(arg('port', '4425'));
+
+const own = { lat: 47.6, lon: -122.33, heading: 45, cog: 45, sog: 6 };
+// Two vessels at (nearly) the same spot, bearing 90deg / 4nm from own-ship.
+const b = 90 * Math.PI / 180, r = 4;
+const dLat = (r / 60) * Math.cos(b), dLon = (r / 60) * Math.sin(b) / Math.cos(own.lat * Math.PI / 180);
+const targets = [
+  { mmsi: 300000001, lat: own.lat + dLat, lon: own.lon + dLon, heading: 200, cog: 200, sog: 5, name: 'Overlap A' },
+  { mmsi: 300000002, lat: own.lat + dLat, lon: own.lon + dLon, heading: 20, cog: 20, sog: 5, name: 'Overlap B' },
+];
+
+const server = await startServer({ publicDir, base: '/@mxtommy/kip/', port });
+const browser = await chromium.launch({ executablePath: CHROME, headless: true });
+const ctx = await browser.newContext({ viewport: { width: 900, height: 900 }, deviceScaleFactor: 1 });
+const bundle = localStorageBundle({ origin: server.origin, subscribeAll: true, dashboards: buildDashboards([aisRadarWidget()]) });
+await ctx.addInitScript({ content: `window.__KIP_TEST__=true;` + Object.entries(bundle).map(([k, v]) => `localStorage.setItem(${JSON.stringify(k)}, ${JSON.stringify(v)});`).join('') });
+const page = await ctx.newPage();
+
+server.setControl({ streaming: true, staticScene: { ownShip: own, targets } });
+await page.goto(server.appUrl + '#/dashboard/0', { waitUntil: 'load', timeout: 30000 });
+await page.waitForSelector('widget-ais-radar .radar-targets g.target', { timeout: 20000 });
+await page.waitForTimeout(3000);
+
+const count = await page.locator('widget-ais-radar .radar-targets g.target').count();
+const box = await page.locator('widget-ais-radar .radar-targets g.target').first().boundingBox();
+if (!box) { console.error('FAIL: no target box'); process.exit(1); }
+await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+await page.waitForTimeout(600);
+
+const menuOpen = await page.locator('.mat-mdc-menu-panel, [role="menu"]').count();
+const dialogOpen = await page.locator('mat-dialog-container, .cdk-dialog-container, dialog-ais-target').count();
+console.log(`targets rendered: ${count}`);
+console.log(`after click at heading=45deg -> menu panels: ${menuOpen}, dialogs: ${dialogOpen}`);
+if (menuOpen > 0) console.log('PASS: overlapping-target menu opened -> hit-test un-rotate is correct');
+else if (dialogOpen > 0) console.log('WARN: single dialog opened -> findTargetsNearEvent did NOT find the overlap (un-rotate sign?)');
+else console.log('WARN: neither menu nor dialog detected');
+
+await browser.close();
+await server.stop();

--- a/perf-harness/verify-click.mjs
+++ b/perf-harness/verify-click.mjs
@@ -30,6 +30,7 @@ const server = await startServer({ publicDir, base: '/@halos-org/skip/', port })
 server.setConfigDocument(serverConfigDocument({ dashboards: buildDashboards([aisRadarWidget()]) }));
 const browser = await chromium.launch({ executablePath: CHROME, headless: true });
 const ctx = await browser.newContext({ viewport: { width: 900, height: 900 }, deviceScaleFactor: 1 });
+await ctx.route('https://www.gstatic.com/generate_204', (route) => route.fulfill({ status: 204, body: '' }));
 const bundle = localStorageBundle({ origin: server.origin, subscribeAll: true });
 await ctx.addInitScript({ content: `window.__KIP_TEST__=true;` + Object.entries(bundle).map(([k, v]) => `localStorage.setItem(${JSON.stringify(k)}, ${JSON.stringify(v)});`).join('') });
 const page = await ctx.newPage();

--- a/perf-harness/verify-click.mjs
+++ b/perf-harness/verify-click.mjs
@@ -9,7 +9,7 @@ import { chromium } from 'playwright-core';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { startServer } from './lib/server.mjs';
-import { aisRadarWidget, buildDashboards, localStorageBundle } from './lib/kip-config.mjs';
+import { aisRadarWidget, buildDashboards, localStorageBundle, serverConfigDocument } from './lib/kip-config.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const CHROME = process.env.CHROME_BIN || '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
@@ -26,10 +26,11 @@ const targets = [
   { mmsi: 300000002, lat: own.lat + dLat, lon: own.lon + dLon, heading: 20, cog: 20, sog: 5, name: 'Overlap B' },
 ];
 
-const server = await startServer({ publicDir, base: '/@mxtommy/kip/', port });
+const server = await startServer({ publicDir, base: '/@halos-org/skip/', port });
+server.setConfigDocument(serverConfigDocument({ dashboards: buildDashboards([aisRadarWidget()]) }));
 const browser = await chromium.launch({ executablePath: CHROME, headless: true });
 const ctx = await browser.newContext({ viewport: { width: 900, height: 900 }, deviceScaleFactor: 1 });
-const bundle = localStorageBundle({ origin: server.origin, subscribeAll: true, dashboards: buildDashboards([aisRadarWidget()]) });
+const bundle = localStorageBundle({ origin: server.origin, subscribeAll: true });
 await ctx.addInitScript({ content: `window.__KIP_TEST__=true;` + Object.entries(bundle).map(([k, v]) => `localStorage.setItem(${JSON.stringify(k)}, ${JSON.stringify(v)});`).join('') });
 const page = await ctx.newPage();
 


### PR DESCRIPTION
## Motivation

Skip adopted five freeze fixes from mxtommy/Kip#1101 (#119, #120, #121, #122, #135) entirely on upstream's measurements: we had no way to produce before/after numbers on our own build, and future perf-sensitive work (chart/history engine, widget rendering) had no regression net. Kip#1101's other half is a self-contained measurement harness; #129 tracks adopting it. Its 10x CPU-throttled headless-Chromium setup maps directly onto Skip's Pi-class HaLOS target. First real use: measuring the five fixes we already merged (baselines below).

## Approach

Three tiers, by how much of the upstream code survives contact with Skip:

**Cherry-picked verbatim** (`-x`, upstream authorship preserved):
- `caa13a41` — harness core: probe, mock Signal K server, scenario runner, cross-ref worktree builder.
- `e631654a` — deterministic AIS-radar screenshot tooling.

**Adopted with attribution** (fork commits citing the upstream SHA, because the source commits carry material we must not take):
- `report.mjs` + the `npm ci` → `npm install` build change from `fb391574`, *excluding* upstream's `results/` baselines — those measure Kip builds and are meaningless for Skip.
- `verify-click.mjs` from `dd5b59f2` — the rest of that commit is app code Skip already replicated in #122.

**Fork-ported** (upstream's approach is dead on Skip):
- Upstream bootstraps Kip into anonymous localStorage-config mode. Skip is session-cookie SSO-only and persists config server-side, so the mock now serves the whole session/config surface: `GET /skServer/loginStatus` (logged-in admin), `applicationData` GET/POST (the scenario's full `IConfig` document; boot JSON-Patch/autosave absorbed with 200 so no error snackbar lands in the measurement), the `/plugins` surface reporting the history-series plugin disabled (suppresses the reconcile POST ~750 ms after boot), and `server.version` 2.24.0 (Skip gates widget history on >= 2.22.1; upstream's 2.3.0 silently fails that semver check). Only `skip.connectionConfig` is seeded in localStorage — the sole key Skip reads at boot.
- Serving base `/@halos-org/skip/` (Skip's baseHref) in all five sites; widget factories fixed for Skip's schema (radial gauge `displayScale`; upstream's top-level `minValue`/`maxValue` are dead and silently render a 0–100 scale).
- Determinism hardening: the gstatic reachability probe is answered locally (fulfilled 204 — aborting it triggers retry cadence inside the window), boot *asserts* the exact rendered widget count (a mis-seeded config still boots a plausible empty dashboard), and scenario rate changes restart live WS timers (Skip opens its socket once at APP_INITIALIZER, so upstream's connect-time rate snapshot streamed everything at boot-default 10 Hz).
- Chunked runs accumulate into `results/<label>.json` per scenario, so long suites survive command time ceilings and mid-suite crashes.
- `report.mjs` additionally prints each label's median probe-window length per scenario: the window self-extends while the throttled main thread is busy, so raw window sums (blocking time) drift with it — see the ais-growth-churn honesty note below.

`perf-harness/` is self-contained: own `package.json`, no changes to the app's dependencies or any `src/` runtime code.

## Baselines: 11f3fbd0 (pre-fixes) vs main 2e358f17

Full suite, 4 repeats, 10x CPU throttle, Chrome 149. Medians; full tables in `perf-harness/results/report-pre-freeze-fixes-vs-main-freeze-fixes.md`, raw runs in the results JSONs. The after-ref also contains #127 (history-chart prototype), see diagnostics.

| Scenario | Blocking time (ms) | Max handler wait (ms) | Verdict |
|---|--:|--:|---|
| resize-storm | 1900 → 112 (**-94%**) | 324 → 134 (-59%) | The headline: #121's coalescing kills the fullscreen enter/exit freeze. Longest task 177 → 73 ms, dropped frames 37 → 21. Windows are tight (±2%), so this survives normalization. |
| gauges-16 | 1 → 0 | 48 → 39 (-19%) | Small, consistent improvement; Skip's pre-fix gauge cost was already near-zero at this throttle, so #119 has little left to show here. |
| ais-growth-churn | 27231 → 25163 | 8696 → 6447 | **Null-to-weak.** The raw -8% blocking is a window-length artifact and the -26% max-wait sits inside same-code variance; only p95 wait (-24%) has directional support. See diagnostics. Churn remains heavy — an open cost. |
| ais-radar-150 | 7826 → 8398 | 1406 → 1511 | **Null result.** See diagnostics — apparent deltas are same-build noise. |
| idle-numeric-24 | 0 → 0 | 4 → 7 | Null, as expected. |
| delta-storm-30x10 | 0 → 0 | 9 → 4 | Null — no delta-path fix was among the five replicas; matches upstream's finding that ingestion isn't the freeze. |
| reconnect-backlog | 0 → 4 | 58 → 61 | Null (single ~50 ms parse task on both refs). |

**Honesty notes / diagnostics** (committed as `results/diag-*.json`):
- ais-growth-churn first looked directionally better (-8% blocking, -26% max wait). Neither claim survives scrutiny. Blocking is a raw sum over the probe window, and the pre-fix churn windows ran long (median 33.8 s vs 31.1 s; the window self-extends while the main thread is busy) — normalized to a common 30 s window the medians are 24809 vs 24833 (+0.1%), i.e. no change. The -26% max-wait sits inside same-code run-to-run variance: `diag-pre127` (63cf071e, effectively identical code to main for this scenario) has churn max-wait median 3539 vs main's 6447, a same-code swing larger than the claimed improvement. Only p95 wait (6658 → 5091, -24%) reproduces directionally. `report.mjs` now prints median window length per scenario so this artifact class is visible in every future report.
- ais-radar-150 first looked like a regression (+47% longest task, +30% heap). Two diagnostics say otherwise: `diag-pre127` (63cf071e = the five fixes without #127) shows the same numbers as main, ruling out #127; `diag-pre-variance` (the *same pre-fix build* measured again) spans longest-task 610–1071 ms and blocking 7.8–9.7 s — the entire pre/post delta sits inside same-build run-to-run spread. The baseline pre-fix run was a low draw. Verdict: no measurable change on this scenario, high variance; #122/#135 target rotation-only and own-ship-driven frames, and this scenario re-renders 150 moving targets at 4 Hz regardless.
- Heap-growth medians on the AIS scenarios (9 → 18 MB churn) are noise-dominated: same-ref raw spreads run 5–21 MB (no forced GC; usedJSHeapSize includes uncollected garbage). No leak signal either way.

## Verification

- `node smoke.mjs` — probe detects a synthetic 400 ms block.
- Full 7-scenario suite ran twice (both refs) with zero boot-assertion failures; every rep rendered the exact expected widget count; delta counts match scenario rate semantics (16 deltas at 2 Hz / 8 s).
- Boot-path diagnostic: zero 404s, zero SPA-fallback hits on `/signalk|/plugins|/skServer`, zero console errors; radar screenshot and click-verification tools pass.
- `npm run lint` passes (flat config only matches `**/*.ts`/`**/*.html`; harness `.mjs` is out of scope by design); `node --check` on all harness modules.
- App build untouched: no `src/` or app `package.json` changes anywhere in the branch.

## Documentation

- `CLAUDE.md` gains a "Performance and freeze measurement (perf-harness/)" section (the auto-loaded surface): what the harness is, when to reach for it, the three commands, the traps (per-label result accumulation, probe-window drift, heap noise, AIS variance, boot-assertion semantics, nested worktrees, `CHROME_BIN`), and the committed baseline labels with their refs.
- `perf-harness/README.md` is the full operator guide: architecture and mock-auth surface, scenario table, metric interpretation (which metric answers which question, which claims the data cannot support), an add-a-scenario recipe, and a troubleshooting table (boot assertion, degraded boot, HTML fallthrough, report ENOENT, port in use, Chrome path).

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)

