### PR TITLE
fix(charts): raise chart point-density target (#86)

### DIFF
--- a/src/app/core/services/dataset-stream.service.spec.ts
+++ b/src/app/core/services/dataset-stream.service.spec.ts
@@ -2,6 +2,7 @@ import { TestBed, inject } from '@angular/core/testing';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { signal } from '@angular/core';
 import { DatasetStreamService, TimeScaleFormat } from './dataset-stream.service';
+import { deriveDataSourceInfo, resolveWindowMs, MIN_SAMPLE_TIME_MS } from '../utils/chart-window.util';
 import { SettingsService } from './settings.service';
 import { IAppConfig } from '../interfaces/app-settings.interfaces';
 import { DataService } from './data.service';
@@ -46,7 +47,7 @@ describe('DatasetStreamService', () => {
         expect(service).toBeTruthy();
     }));
 
-    it('derives ~120 points per window for larger windows', inject([DatasetStreamService], (service: DatasetStreamService) => {
+    it('derives the sampling config from the shared window util for each preset', inject([DatasetStreamService], (service: DatasetStreamService) => {
         const mk = (timeScaleFormat: TimeScaleFormat, period: number) => ({
             uuid: 'ds-1',
             path: 'navigation.speedThroughWater',
@@ -57,23 +58,17 @@ describe('DatasetStreamService', () => {
             label: 'test'
         });
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const lastMinute = (service as any).createDataSourceConfiguration(mk('Last Minute', 1));
-        expect(lastMinute.maxDataPoints).toBe(120);
-        expect(lastMinute.sampleTime).toBe(500);
-        expect(lastMinute.smoothingPeriod).toBe(30);
-
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const lastFive = (service as any).createDataSourceConfiguration(mk('Last 5 Minutes', 1));
-        expect(lastFive.maxDataPoints).toBe(120);
-        expect(lastFive.sampleTime).toBe(2500);
-        expect(lastFive.smoothingPeriod).toBe(30);
-
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const sixtyHours = (service as any).createDataSourceConfiguration(mk('hour', 60));
-        expect(sixtyHours.maxDataPoints).toBe(120);
-        expect(sixtyHours.sampleTime).toBe(1800000);
-        expect(sixtyHours.smoothingPeriod).toBe(30);
+        // The recorder must delegate to deriveDataSourceInfo(resolveWindowMs(...)); assert the wiring
+        // against the util rather than baking in point counts that drift when the target is retuned.
+        const cases: [TimeScaleFormat, number][] = [['Last Minute', 1], ['Last 5 Minutes', 1], ['hour', 60]];
+        for (const [timeScaleFormat, period] of cases) {
+            const expected = deriveDataSourceInfo(resolveWindowMs(timeScaleFormat, period));
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const cfg = (service as any).createDataSourceConfiguration(mk(timeScaleFormat, period));
+            expect(cfg.maxDataPoints).toBe(expected.maxDataPoints);
+            expect(cfg.sampleTime).toBe(expected.sampleTime);
+            expect(cfg.smoothingPeriod).toBe(expected.smoothingPeriod);
+        }
     }));
 
     it('enforces a minimum sampling interval for very small windows', inject([DatasetStreamService], (service: DatasetStreamService) => {
@@ -87,11 +82,12 @@ describe('DatasetStreamService', () => {
             label: 'test'
         };
 
+        const expected = deriveDataSourceInfo(resolveWindowMs('second', 1));
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const cfg = (service as any).createDataSourceConfiguration(ds);
-        expect(cfg.sampleTime).toBe(100);
-        expect(cfg.maxDataPoints).toBe(10);
-        expect(cfg.smoothingPeriod).toBe(2);
+        expect(cfg.sampleTime).toBe(MIN_SAMPLE_TIME_MS); // a 1s window floors the cadence
+        expect(cfg.maxDataPoints).toBe(expected.maxDataPoints);
+        expect(cfg.smoothingPeriod).toBe(expected.smoothingPeriod);
     }));
 
     it('skips history seeding when sampleTime is below one second', inject([DatasetStreamService], async (service: DatasetStreamService) => {
@@ -132,13 +128,13 @@ describe('DatasetStreamService', () => {
         });
 
         const config = {
-            uuid: 'ds-last-5',
+            uuid: 'ds-last-30',
             path: 'navigation.speedThroughWater',
             pathSource: 'test',
             baseUnit: 'number',
-            timeScaleFormat: 'Last 5 Minutes' as const,
+            timeScaleFormat: 'Last 30 Minutes' as const,
             period: 1,
-            label: 'test-last-5'
+            label: 'test-last-30'
         };
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -150,8 +146,9 @@ describe('DatasetStreamService', () => {
         const request = vi.mocked(historyServiceMock.getValues).mock.lastCall[0] as {
             resolution: number;
         };
-        // Last 5 Minutes resolves to sampleTime=2500ms, therefore history resolution=3s
-        expect(request.resolution).toBe(3);
+        // History resolution (seconds) is the derived sampleTime rounded to whole seconds.
+        const expected = deriveDataSourceInfo(resolveWindowMs('Last 30 Minutes', 1));
+        expect(request.resolution).toBe(Math.max(1, Math.round(expected.sampleTime / 1000)));
         service.ngOnDestroy();
     }));
 
@@ -178,7 +175,7 @@ describe('DatasetStreamService', () => {
             path: 'navigation.speedThroughWater',
             pathSource: 'test',
             baseUnit: 'number',
-            timeScaleFormat: 'Last 5 Minutes' as const,
+            timeScaleFormat: 'Last 30 Minutes' as const,
             period: 1,
             label: 'test-hydrate-history'
         };
@@ -228,7 +225,7 @@ describe('DatasetStreamService', () => {
             path: 'navigation.speedThroughWater',
             pathSource: 'test',
             baseUnit: 'number',
-            timeScaleFormat: 'Last 5 Minutes' as const,
+            timeScaleFormat: 'Last 30 Minutes' as const,
             period: 1,
             label: 'test-seeded-sma'
         };
@@ -269,7 +266,7 @@ describe('DatasetStreamService', () => {
             path: 'navigation.speedOverGround',
             pathSource: 'test',
             baseUnit: 'number',
-            timeScaleFormat: 'Last 5 Minutes' as const,
+            timeScaleFormat: 'Last 30 Minutes' as const,
             period: 1,
             label: 'test-live-fallback'
         };

--- a/src/app/core/utils/chart-window.util.spec.ts
+++ b/src/app/core/utils/chart-window.util.spec.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { resolveWindowMs, deriveDataSourceInfo } from './chart-window.util';
+import {
+  resolveWindowMs,
+  deriveDataSourceInfo,
+  TARGET_POINTS_PER_WINDOW,
+  MIN_SAMPLE_TIME_MS,
+  SMOOTHING_PERIOD_FACTOR
+} from './chart-window.util';
 
 describe('chart-window.util', () => {
   describe('resolveWindowMs', () => {
@@ -22,13 +28,40 @@ describe('chart-window.util', () => {
   });
 
   describe('deriveDataSourceInfo', () => {
-    it('targets ~120 points across a 60s window', () => {
-      expect(deriveDataSourceInfo(60_000)).toEqual({ sampleTime: 500, maxDataPoints: 120, smoothingPeriod: 30 });
+    const expectedSmoothing = (maxDataPoints: number) =>
+      Math.max(1, Math.floor(maxDataPoints * SMOOTHING_PERIOD_FACTOR));
+
+    it('samples a wide window at window/target cadence, hitting the target point count', () => {
+      // A window that is an exact multiple of the target divides cleanly (cadence = window / target,
+      // buffer = target), so the assertion tracks the target constant instead of a baked-in literal.
+      const cadenceMs = 600; // comfortably above the floor
+      const windowMs = TARGET_POINTS_PER_WINDOW * cadenceMs;
+      const info = deriveDataSourceInfo(windowMs);
+      expect(info.sampleTime).toBe(cadenceMs);
+      expect(info.maxDataPoints).toBe(TARGET_POINTS_PER_WINDOW);
+      expect(info.smoothingPeriod).toBe(expectedSmoothing(TARGET_POINTS_PER_WINDOW));
     });
 
-    it('enforces the 100ms minimum sample interval for tiny windows', () => {
-      // 6s / 120 = 50ms → floored to 100ms.
-      expect(deriveDataSourceInfo(6_000).sampleTime).toBe(100);
+    it('floors the sample interval for a window finer than the floor', () => {
+      // window / target below the floor → cadence pins to MIN_SAMPLE_TIME_MS, buffer = window / floor.
+      const windowMs = Math.floor((MIN_SAMPLE_TIME_MS * TARGET_POINTS_PER_WINDOW) / 2);
+      const info = deriveDataSourceInfo(windowMs);
+      expect(info.sampleTime).toBe(MIN_SAMPLE_TIME_MS);
+      expect(info.maxDataPoints).toBe(Math.ceil(windowMs / MIN_SAMPLE_TIME_MS));
+      expect(info.smoothingPeriod).toBe(expectedSmoothing(info.maxDataPoints));
+    });
+
+    it('holds the sample floor and a consistent smoothingPeriod across a wide sweep of windows', () => {
+      const windows = [
+        1_000, 6_000, 60_000, 5 * 60_000, 30 * 60_000,
+        60 * 60_000, 6 * 60 * 60_000, 24 * 60 * 60_000, 7 * 24 * 60 * 60_000
+      ];
+      for (const windowMs of windows) {
+        const info = deriveDataSourceInfo(windowMs);
+        expect(info.sampleTime).toBeGreaterThanOrEqual(MIN_SAMPLE_TIME_MS);
+        expect(info.maxDataPoints).toBeGreaterThanOrEqual(1);
+        expect(info.smoothingPeriod).toBe(expectedSmoothing(info.maxDataPoints));
+      }
     });
 
     it('never returns zero-sized buffers or cadence for an empty window', () => {

--- a/src/app/core/utils/chart-window.util.ts
+++ b/src/app/core/utils/chart-window.util.ts
@@ -1,8 +1,11 @@
 import type { TimeScaleFormat } from '../services/dataset-stream.service';
 
-const TARGET_POINTS_PER_WINDOW = 120;
-const MIN_SAMPLE_TIME_MS = 100;
-const SMOOTHING_PERIOD_FACTOR = 0.25;
+/** Points a window aims for at its derived cadence, once above the sample-time floor. */
+export const TARGET_POINTS_PER_WINDOW = 500;
+/** Floor sampling interval; very small windows sample no faster than this. */
+export const MIN_SAMPLE_TIME_MS = 100;
+/** SMA window as a fraction of the buffer size. */
+export const SMOOTHING_PERIOD_FACTOR = 0.25;
 
 /** Sampling cadence + buffer size derived from a display window. */
 export interface IChartDataSourceInfo {
@@ -41,8 +44,9 @@ export function resolveWindowMs(timeScaleFormat: TimeScaleFormat, period: number
 }
 
 /**
- * Derive the sampling cadence and buffer size for a window, targeting a consistent ~120 points per
- * window with a floor sampling interval for very small windows.
+ * Derive the sampling cadence and buffer size for a window, targeting a consistent ~500 points per
+ * window with a floor sampling interval for very small windows. The point count tracks the target
+ * (never far above it), so no separate buffer cap is needed.
  */
 export function deriveDataSourceInfo(windowMs: number): IChartDataSourceInfo {
   const sampleTime = windowMs > 0


### PR DESCRIPTION
## What

Fixes #86: chart sampling density was pinned to `TARGET_POINTS_PER_WINDOW = 120` in `chart-window.util.ts`, visibly coarse on wide/high-DPI charts (chunky stair-stepping) and on long-duration windows (a 24h window collapsed to one point per 12 min, hiding gusts/tacks/transients).

## Change

- Raise `TARGET_POINTS_PER_WINDOW` **120 → 500**.
- The shared util drives **both** the client-side recorder and the History-API chart engine, so both get the finer density.

No buffer cap: the derived point count tracks the target (never far above it, and smaller for sub-50 s windows that hit the sample floor), so a cap would be dead code at a fixed target.

The fully-dynamic "canvas-pixels × devicePixelRatio" target the issue floats was deliberately **not** taken: the recorder has no canvas access, and a resize-driven target would force stream re-init churn on every chart resize. The issue accepts raising the constant.

## Side effect worth calling out

The finer cadence lowers `sampleTime`, which pushes short windows (Last Minute → 120 ms, Last 5 Minutes → 600 ms) **below** the recorder's 1 s `shouldSeedHistory` threshold. Those windows no longer prefill from the History API — which is correct: the History API's 1 s-minimum aggregation is coarser than a sub-second chart cadence, so seeding it would look blocky at the live seam. They fill from live instead; windows ≥ ~8 min still seed. Consumer specs (`dataset-stream.service.spec.ts`) updated to seed via `Last 30 Minutes`, and all test expectations now **derive from the exported constants** rather than baked-in point counts.

## Testing

`npm run lint` ✓ · **full `ng test` suite: 812 tests across 134 files pass** locally · `npm run build:prod` ✓.

Closes #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zURudCY3TTRcNd2acknJ9
