### PR TITLE
fix(ais): keep indexes consistent on at-birth eviction

### DIFF
--- a/src/app/core/services/ais-processing.service.spec.ts
+++ b/src/app/core/services/ais-processing.service.spec.ts
@@ -282,6 +282,48 @@ describe('AisProcessingService target eviction (bounds unbounded growth)', () =>
     expect(internals().contextIndex.has(contexts[3])).toBe(true);
     expect(internals().contextIndex.has(contexts[4])).toBe(true);
   });
+
+  /**
+   * A track evicted at birth: the map is at the cap and the newcomer's first
+   * timestamp is older than every retained track's lastUpdateAt (e.g. a
+   * buffered/replayed delta), so enforceTargetCap removes the just-created
+   * track inside createTrack. No index may keep referencing it afterwards.
+   */
+  function fillToCap(cap: number): void {
+    internals().maxTargets = cap;
+    for (let i = 0; i < cap; i++) {
+      pushAt(`vessels.urn:mrn:imo:mmsi:${300000001 + i}.navigation.position.latitude`, 10 + i, EVENT_TS + (i + 1) * 1000);
+    }
+    expect(internals().tracks.size).toBe(cap);
+  }
+
+  it('leaves no dangling contextIndex entry for a track evicted at birth', () => {
+    fillToCap(3);
+
+    const stillborn = 'vessels.urn:mrn:imo:mmsi:300000099';
+    pushAt(`${stillborn}.navigation.position.latitude`, 20, EVENT_TS);
+
+    expect(internals().tracks.size).toBe(3);
+    expect(internals().contextIndex.has(stillborn)).toBe(false);
+    for (const [context, id] of internals().contextIndex.entries()) {
+      expect(internals().tracks.has(id), `contextIndex entry for ${context} points at a missing track`).toBe(true);
+    }
+  });
+
+  it('leaves no dangling mmsiIndex entry when the first update of a track evicted at birth is an mmsi', () => {
+    fillToCap(3);
+
+    const stillborn = 'vessels.urn:mrn:imo:mmsi:300000099';
+    pushAt(`${stillborn}.mmsi`, '300000099', EVENT_TS);
+
+    expect(internals().tracks.size).toBe(3);
+    expect(internals().mmsiIndex.has('300000099')).toBe(false);
+    for (const [mmsi, ids] of internals().mmsiIndex.entries()) {
+      for (const id of ids) {
+        expect(internals().tracks.has(id), `mmsiIndex entry for ${mmsi} points at a missing track`).toBe(true);
+      }
+    }
+  });
 });
 
 /**

--- a/src/app/core/services/ais-processing.service.ts
+++ b/src/app/core/services/ais-processing.service.ts
@@ -561,8 +561,10 @@ export class AisProcessingService {
     if (existing) return existing;
 
     const created = this.createTrack(update.context, update.type, timestampMs, undefined);
-    this.contextIndex.set(update.context, created.id);
-    return created;
+    // At the cap, a newcomer older than every retained track is evicted inside
+    // createTrack; report it unresolvable so nothing downstream (e.g. applyMmsi)
+    // can index or mutate a dead track.
+    return this.tracks.has(created.id) ? created : null;
   }
 
   private createTrack(context: string, type: AisTargetType, timestampMs: number, mmsi?: string): AisTrack {
@@ -585,7 +587,10 @@ export class AisProcessingService {
         break;
     }
 
+    // Every index registration must precede cap enforcement: if the cap evicts
+    // this newborn track, removeTrack's sweep then cleans all its entries.
     this.tracks.set(track.id, track);
+    this.contextIndex.set(context, track.id);
     if (mmsi) this.addMmsiIndex(mmsi, track.id);
     this.enforceTargetCap();
     this.updateTargetsSignal();


### PR DESCRIPTION
## Motivation

At the target cap (`maxTargets`, default 500), a new AIS context whose first update timestamp is strictly older than every retained track's `lastUpdateAt` (e.g. a buffered/replayed delta) gets evicted by `enforceTargetCap` inside `createTrack` — but `resolveTrack` registered the `contextIndex` entry only *afterwards*, leaving a dangling entry pointing at a track no longer in the `tracks` map. It leaks permanently for contexts that never speak again.

Auditing all creation paths surfaced a second dangle on the same scenario: `resolveTrack` returned the evicted (dead) track object, so when the stillborn context's first update was an `mmsi` path, `applyMmsi` registered the dead id in `mmsiIndex` too.

## Approach

Two coordinated changes in `ais-processing.service.ts`:

- `createTrack` now registers the `contextIndex` entry itself, **before** `enforceTargetCap` — so if the cap evicts the newborn, `removeTrack`'s sweep cleans the entry. All index registration (tracks, contextIndex, mmsiIndex) is now co-located ahead of cap enforcement.
- `resolveTrack` returns `null` when the created track did not survive the cap, so `applyAisUpdate` drops the update instead of mutating a dead object or letting `applyMmsi` index it.

The invariant now holds on every path: **every id stored in `contextIndex`/`mmsiIndex` refers to a live entry in `tracks`.** Behavior for surviving tracks is unchanged; a stillborn track's update was already effectively dropped pre-fix (the track was gone from the map), so returning `null` only removes the dangling side effects.

**Deliberate divergence from upstream Kip:** this eviction code was cherry-picked byte-identical from upstream (mxtommy/Kip#1101, commit ca1df062, still open upstream), which has the same defect. Skip declares rebaseability a non-goal, so we fix it here; upstream should eventually receive an equivalent fix, and future cherry-picks from #1101 must reconcile against this change knowingly.

## Verification

- **RED proof:** the two new specs (`leaves no dangling contextIndex entry for a track evicted at birth`, `leaves no dangling mmsiIndex entry when the first update of a track evicted at birth is an mmsi`) fail on pre-fix code at the dangling-index assertions (`expected true to be false` at the `contextIndex.has(stillborn)` / `mmsiIndex.has('300000099')` checks) — commit 8ddd8767, 2 failed | 17 passed.
- After the fix: `npx ng test --include='src/app/core/services/ais-processing.service.spec.ts'` — 19/19 passed.
- `npx ng test --include='src/app/widgets/widget-ais-radar/widget-ais-radar.component.spec.ts'` — 5/5 passed (radar consumes the `targets()` signal).
- `npm run lint` — clean.
- `npm run build:prod` — succeeds.

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)