### PR TITLE
fix(ais-radar): refresh own-ship before settled early return

### DIFF
--- a/src/app/widgets/widget-ais-radar/widget-ais-radar.component.spec.ts
+++ b/src/app/widgets/widget-ais-radar/widget-ais-radar.component.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi, type Mock } from 'vitest';
 import { WidgetAisRadarComponent } from './widget-ais-radar.component';
 
 /**
@@ -67,5 +67,183 @@ describe('eventToRadarPoint course-up click mapping', () => {
     expect(point).not.toBeNull();
     expect(point!.x).toBeCloseTo(50, 4);
     expect(point!.y).toBeCloseTo(-100 * Math.cos(Math.PI / 6), 4);
+  });
+});
+
+/**
+ * Regression tests for own-ship staleness on settled frames (#124).
+ *
+ * Own-ship heading/COG/SOG are deliberately excluded from the render
+ * signature (that is the point of the settled-frame optimization), so the
+ * early return must not skip the O(1) own-ship refresh: re-orienting the
+ * own-ship icon and re-rendering its motion vector. The O(targets) rebuild
+ * (rings, target icons, target vectors) must still be skipped.
+ *
+ * render() is exercised on a hand-built context whose prototype is the real
+ * component prototype: geometry/signature helpers run for real, while the
+ * d3 layers and O(targets) render methods are replaced with spies.
+ */
+type RadarViewMode = 'north-up' | 'course-up';
+
+interface OwnShipState {
+  position?: { latitude: number; longitude: number };
+  headingTrue?: number;
+  courseOverGroundTrue?: number;
+  speedOverGround?: number;
+}
+
+interface RenderHarness {
+  render(): void;
+  setViewMode(mode: RadarViewMode): void;
+  setOwnShip(ownShip: OwnShipState): void;
+  clearSpies(): void;
+  ownShipIconAttr: Mock;
+  renderOwnShipVector: Mock;
+  renderRings: Mock;
+  buildTargets: Mock;
+  renderTargets: Mock;
+  scheduleRender: Mock;
+}
+
+const renderFn = WidgetAisRadarComponent.prototype['render'] as unknown as (this: object) => void;
+
+const makeRenderHarness = (viewMode: RadarViewMode, ownShip: OwnShipState): RenderHarness => {
+  let currentViewMode = viewMode;
+  const ownShipIconAttr = vi.fn();
+  const renderOwnShipVector = vi.fn();
+  const renderRings = vi.fn();
+  const buildTargets = vi.fn(() => []);
+  const renderTargets = vi.fn();
+  const scheduleRender = vi.fn();
+
+  const renderState = {
+    size: { width: 400, height: 400 },
+    cfg: {
+      color: 'grey',
+      ais: {
+        rangeRings: [3, 6, 12, 24, 48],
+        rangeIndex: '0',
+        showSelf: true,
+        showCogVectors: true,
+        cogVectorsMinutes: 10,
+        showLostTargets: true,
+        showUnconfirmedTargets: true
+      }
+    },
+    theme: {},
+    targets: [],
+    ownShip
+  };
+
+  const ctx = Object.create(WidgetAisRadarComponent.prototype) as Record<string, unknown>;
+  Object.assign(ctx, {
+    renderState,
+    svg: { attr: vi.fn() },
+    root: { attr: vi.fn() },
+    rotationGroup: { attr: vi.fn() },
+    ownShipLayer: { select: () => ({ attr: ownShipIconAttr }) },
+    viewRotationSmoothed: null,
+    lastRotationAt: null,
+    lastViewRotation: 0,
+    hasRenderedOnce: false,
+    lastRenderSignature: null,
+    ringCache: null,
+    effectiveRangeIndex: () => 0,
+    localViewMode: () => currentViewMode,
+    selectedId: () => null,
+    filterState: () => ({
+      anchoredMoored: false,
+      noCollisionRisk: false,
+      allAton: false,
+      allButSar: false,
+      allVessels: false,
+      vesselTypes: new Set<string>()
+    }),
+    // Headings below are authored in degrees; identity conversion keeps them.
+    units: { convertToUnit: (unit: string, value: number) => value },
+    renderRings,
+    buildTargets,
+    renderTargetVectors: vi.fn(),
+    renderTargets,
+    renderSelected: vi.fn(),
+    renderOwnShipVector,
+    raiseOwnshipAndVector: vi.fn(),
+    scheduleRender
+  });
+
+  return {
+    render: () => renderFn.call(ctx),
+    setViewMode: mode => { currentViewMode = mode; },
+    setOwnShip: next => { ctx['renderState'] = { ...renderState, ownShip: next }; },
+    clearSpies: () => {
+      ownShipIconAttr.mockClear();
+      renderOwnShipVector.mockClear();
+      renderRings.mockClear();
+      buildTargets.mockClear();
+      renderTargets.mockClear();
+      scheduleRender.mockClear();
+    },
+    ownShipIconAttr,
+    renderOwnShipVector,
+    renderRings,
+    buildTargets,
+    renderTargets,
+    scheduleRender
+  };
+};
+
+const position = { latitude: 60.1, longitude: 24.9 };
+
+describe('render() own-ship refresh on settled frames (#124)', () => {
+  it('re-orients own-ship in north-up after a course-up stint left a near-zero smoothed rotation', () => {
+    // Course-up stint near north settles the smoothed rotation at 0.3 deg.
+    const harness = makeRenderHarness('course-up', { position, headingTrue: 0.3, courseOverGroundTrue: 0.3, speedOverGround: 5 });
+    harness.render();
+
+    // Switching to north-up is a data change: a full render, but north-up
+    // pins the target rotation to 0 and never updates the smoothed value.
+    harness.setViewMode('north-up');
+    harness.render();
+
+    // Heading/COG-only change with bit-identical position and targets:
+    // the smoothed rotation still reads settled (0.3 deg within 0.5 of 0).
+    harness.clearSpies();
+    harness.setOwnShip({ position, headingTrue: 90, courseOverGroundTrue: 90, speedOverGround: 5 });
+    harness.render();
+
+    expect(harness.ownShipIconAttr).toHaveBeenCalledWith('transform', 'rotate(90)');
+    expect(harness.renderOwnShipVector).toHaveBeenCalledTimes(1);
+    // Pins that this stays a settled frame: adding heading/COG to the render
+    // signature would silently defeat the O(targets) skip for a streaming
+    // compass.
+    expect(harness.buildTargets).not.toHaveBeenCalled();
+  });
+
+  it('re-renders the own-ship vector on a SOG-only change in settled course-up', () => {
+    const harness = makeRenderHarness('course-up', { position, headingTrue: 45, courseOverGroundTrue: 45, speedOverGround: 5 });
+    harness.render();
+
+    harness.clearSpies();
+    harness.setOwnShip({ position, headingTrue: 45, courseOverGroundTrue: 45, speedOverGround: 7.5 });
+    harness.render();
+
+    expect(harness.renderOwnShipVector).toHaveBeenCalledTimes(1);
+    const [vectorOwnShip, , , viewRotation] = harness.renderOwnShipVector.mock.calls[0];
+    expect(vectorOwnShip).toMatchObject({ speedOverGround: 7.5 });
+    expect(viewRotation).toBeCloseTo(45, 6);
+  });
+
+  it('keeps skipping the O(targets) rebuild and does not reschedule on settled frames', () => {
+    const harness = makeRenderHarness('course-up', { position, headingTrue: 45, courseOverGroundTrue: 45, speedOverGround: 5 });
+    harness.render();
+
+    harness.clearSpies();
+    harness.setOwnShip({ position, headingTrue: 45, courseOverGroundTrue: 45, speedOverGround: 7.5 });
+    harness.render();
+
+    expect(harness.renderRings).not.toHaveBeenCalled();
+    expect(harness.buildTargets).not.toHaveBeenCalled();
+    expect(harness.renderTargets).not.toHaveBeenCalled();
+    expect(harness.scheduleRender).not.toHaveBeenCalled();
   });
 });

--- a/src/app/widgets/widget-ais-radar/widget-ais-radar.component.ts
+++ b/src/app/widgets/widget-ais-radar/widget-ais-radar.component.ts
@@ -376,10 +376,6 @@ export class WidgetAisRadarComponent implements AfterViewInit, OnDestroy {
     };
     const dataChanged = !this.lastRenderSignature || !this.signaturesEqual(this.lastRenderSignature, signature);
 
-    // Nothing to do: target data unchanged and the view rotation has settled.
-    if (!dataChanged && rotationSettled && this.hasRenderedOnce) return;
-    this.lastRenderSignature = signature;
-
     const viewRotation = viewMode === 'course-up'
       ? (hasOrientation ? this.smoothRotation(targetRotation) : 0)
       : 0;
@@ -389,36 +385,50 @@ export class WidgetAisRadarComponent implements AfterViewInit, OnDestroy {
     this.lastViewRotation = viewRotation;
 
     // Cheap per-frame updates: rotate the target group + keep own-ship oriented.
-    this.svg.attr('viewBox', `${-width / 2} ${-height / 2} ${width} ${height}`);
-    this.root.attr('transform', `scale(${scale})`);
+    // Own-ship heading/COG/SOG are deliberately excluded from the render
+    // signature, so these O(1) updates run before the settled-frame early
+    // return — otherwise a heading or SOG change with an otherwise unchanged
+    // signature would leave the own-ship icon and motion vector stale.
     this.rotationGroup.attr('transform', `rotate(${this.wrapDegrees(-viewRotation)})`);
     const ownShipRotation = this.wrapDegrees((ownCog ?? ownHeading ?? 0) - viewRotation);
-    // Rings/labels/own-ship icon only change with data (size/range/theme/showSelf),
-    // never with rotation — so rebuild them only on a data change and just
-    // re-orient the own-ship icon (O(1)) on pure-rotation frames.
-    if (dataChanged) {
-      const ringColor = getColors(cfg.color, theme).dim;
-      this.renderRings(ringCount, rangeNm, radius, maxRingRadius, viewRotation, scale, radarCfg.showSelf ?? true, ownShipRotation, ringColor);
-    }
+    // renderRings() applies the same rotation when it (re)creates the group,
+    // so this pre-rebuild selection being empty on the first frame is fine.
     this.ownShipLayer?.select<SVGGElement>('g.radar-ownship').attr('transform', `rotate(${ownShipRotation})`);
-
     if (ownShip.position && this.hasValidPosition(ownShip.position)) {
       // Own-ship motion vector is O(1) and lives in the non-rotated own-ship
       // layer, so it is recomputed every frame with the current rotation.
       this.renderOwnShipVector(ownShip, rangeNm, radius, viewRotation, radarCfg);
+    }
 
-      if (dataChanged) {
-        const maxRangeNm = (maxRingRadius / radius) * rangeNm;
-        // Targets are built NORTH-UP (viewRotation = 0); the rotation group
-        // applies the course-up rotation as a single transform.
-        const renderTargets = this.buildTargets(targets, ownShip.position, rangeNm, maxRangeNm, radius, 0, radarCfg);
-        this.lastRenderTargets = renderTargets;
-        this.lastRenderScale = scale;
-        this.lastRenderSize = size;
-        this.renderTargetVectors(renderTargets, rangeNm, radius, 0, radarCfg);
-        this.renderTargets(renderTargets, scale);
-        this.renderSelected(renderTargets, scale);
-      }
+    // Target data unchanged and the view rotation has settled: the own-ship
+    // refresh above is all this frame needs — skip the O(targets) rebuild.
+    if (!dataChanged && rotationSettled && this.hasRenderedOnce) return;
+    this.lastRenderSignature = signature;
+
+    // viewBox and root scale derive solely from the size, which is in the
+    // render signature — a settled frame can never change them, so they stay
+    // behind the early return.
+    this.svg.attr('viewBox', `${-width / 2} ${-height / 2} ${width} ${height}`);
+    this.root.attr('transform', `scale(${scale})`);
+
+    // Rings/labels only change with data (size/range/theme/showSelf), never
+    // with rotation — rebuild them only on a data change.
+    if (dataChanged) {
+      const ringColor = getColors(cfg.color, theme).dim;
+      this.renderRings(ringCount, rangeNm, radius, maxRingRadius, viewRotation, scale, radarCfg.showSelf ?? true, ownShipRotation, ringColor);
+    }
+
+    if (dataChanged && ownShip.position && this.hasValidPosition(ownShip.position)) {
+      const maxRangeNm = (maxRingRadius / radius) * rangeNm;
+      // Targets are built NORTH-UP (viewRotation = 0); the rotation group
+      // applies the course-up rotation as a single transform.
+      const renderTargets = this.buildTargets(targets, ownShip.position, rangeNm, maxRangeNm, radius, 0, radarCfg);
+      this.lastRenderTargets = renderTargets;
+      this.lastRenderScale = scale;
+      this.lastRenderSize = size;
+      this.renderTargetVectors(renderTargets, rangeNm, radius, 0, radarCfg);
+      this.renderTargets(renderTargets, scale);
+      this.renderSelected(renderTargets, scale);
     }
 
     this.raiseOwnshipAndVector();


### PR DESCRIPTION
## Motivation

`render()` early-returns when `!dataChanged && rotationSettled && hasRenderedOnce`. Own-ship heading/COG/SOG are deliberately excluded from `RenderSignature` (that is the point of the settled-frame optimization), but the early return also skipped the O(1) own-ship re-orient and `renderOwnShipVector` call. Two staleness windows (#124):

1. **North-up after a north-settled course-up stint**: north-up pins `targetRotation` to 0 and never calls `smoothRotation`, so a `viewRotationSmoothed` lingering within 0.5° of 0 keeps `rotationSettled` true. A heading/COG change with bit-identical GPS position and unchanged targets ref then froze the own-ship icon and COG-vector angle.
2. **SOG-only change in settled course-up**: SOG is not in the signature, so the own-ship vector length stayed stale.

Both self-healed on the next signature-field change, but on live data that is a visible ~1 s freeze of the own-ship glyph.

## Approach

Move the cheap per-frame block — viewBox/scale/rotation-group transforms, own-ship icon re-orient, and `renderOwnShipVector` — above the early return. All of it is O(1) and already ran on every non-settled frame; nothing O(targets) moves (rings, target build/vectors/icons/selection stay behind the return, still gated on `dataChanged`).

Design notes:

- `smoothRotation` now also runs on settled frames, so the smoothed rotation converges on sub-threshold heading drift instead of freezing, and `lastViewRotation` stays in step with the drawn rotation-group transform (hit-testing consistency).
- Init-order safe: the top-of-function guard still covers `renderState`/`svg`/`root`/`rotationGroup`; `ownShipLayer` access is optional-chained and `renderOwnShipVector` guards it too. On the first data frame the pre-rebuild `g.radar-ownship` selection is empty (no-op) and `renderRings()` applies the same rotation when it creates the group.
- On an early-returned frame the skipped `remainingRotation > 0.5` reschedule cannot trigger anyway: settled means the pre-smooth delta is ≤ 0.5°, and the post-smooth remainder only shrinks.

**Deliberate divergence from upstream Kip PR #1101** (mxtommy/Kip, still open): this file was inherited byte-identical from upstream commit dd5b59f2, and this fix diverges from it by design — Skip declares rebaseability a non-goal. Future upstream cherry-picks in this area must reconcile against this change, and upstream should eventually receive the same fix (report via the normal replication flow).

## Verification

TDD, RED first: `test(ais-radar)` commit adds three tests to the TestBed-free spec (prototype-backed context, spied d3 layers and O(targets) methods, real geometry/signature/smoothing helpers). On pre-fix code the two staleness tests fail with

```
AssertionError: expected "vi.fn()" to be called with arguments: [ 'transform', 'rotate(90)' ] — Number of calls: 0
AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
```

while the third test pins the preserved perf contract (no `buildTargets`/`renderRings`/`renderTargets`/`scheduleRender` on settled frames) and passes both before and after.

Post-fix:

- `npx ng test --include='src/app/widgets/widget-ais-radar/widget-ais-radar.component.spec.ts'` — 8/8 pass
- `npx ng test --include='src/app/core/services/ais-processing.service.spec.ts'` — 17/17 pass
- `npm run lint` — clean
- `npm run build:prod` — succeeds (pre-existing piexifjs CommonJS warning only)

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)
