### PR TITLE
fix(charts): fall back to the live tail on a transient backfill failure (#130)

### DIFF
--- a/src/app/core/components/widget-history-chart-dialog/widget-history-chart-dialog.component.ts
+++ b/src/app/core/components/widget-history-chart-dialog/widget-history-chart-dialog.component.ts
@@ -195,12 +195,14 @@ export class WidgetHistoryChartDialogComponent implements OnInit, AfterViewInit,
     const convertUnitTo = this.resolveConvertUnitTo(rawPath);
 
     for (const candidate of requestCandidates) {
+      // A transient failure (network/5xx/timeout) now throws; treat it like an empty result so this
+      // candidate is skipped and the next one (or an empty chart) is tried.
       const response = await this.historyApiClient.getValues({
         paths: candidate.paths,
         context: candidate.context,
         duration,
         resolution: resolutionSeconds
-      });
+      }).catch(() => null);
 
       if (!response?.data?.length) {
         continue;

--- a/src/app/core/services/dataset-stream.service.ts
+++ b/src/app/core/services/dataset-stream.service.ts
@@ -315,8 +315,9 @@ export class DatasetStreamService implements OnDestroy {
         resolution: historyResolutionSeconds
       };
 
-      // Fetch history data
-      const response = await this.history.getValues(query);
+      // Fetch history data. A transient failure (network/5xx/timeout) now throws; treat it like
+      // "no data" so the seed is skipped and the live recorder carries on.
+      const response = await this.history.getValues(query).catch(() => null);
 
       if (!response || !response.data || response.data.length === 0) {
         console.log(`[DatasetStreamService] No history data available for ${configuration.path}`);

--- a/src/app/core/services/history-api-client.service.spec.ts
+++ b/src/app/core/services/history-api-client.service.spec.ts
@@ -3,7 +3,16 @@ import { beforeEach, describe, expect, it, afterEach } from 'vitest';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { BehaviorSubject } from 'rxjs';
 import { SignalKConnectionService, IEndpointStatus } from './signalk-connection.service';
-import { HistoryApiClientService } from './history-api-client.service';
+import { HistoryApiClientService, HistoryRequestError } from './history-api-client.service';
+
+const CONNECTED_ENDPOINT: IEndpointStatus = {
+  operation: 2,
+  message: 'Connected',
+  serverDescription: 'Signal K',
+  httpServiceUrl: 'http://localhost:3000/signalk/v1/api/',
+  WsServiceUrl: 'ws://localhost:3000/signalk/v1/stream'
+};
+const VALUES_URL = 'http://localhost:3000/signalk/v2/api/history/values';
 
 class SignalKConnectionServiceStub {
   public serverServiceEndpoint$ = new BehaviorSubject<IEndpointStatus>({
@@ -258,6 +267,42 @@ describe('HistoryApiClientService', () => {
 
     const response = await promise;
     expect(response).toBeNull();
+  });
+
+  it('getValues returns null when the endpoint returns 501 (no provider)', async () => {
+    connectionStub.serverServiceEndpoint$.next(CONNECTED_ENDPOINT);
+
+    const promise = service.getValues({ paths: 'navigation.speedThroughWater:avg', resolution: 1 });
+    await new Promise(resolve => setTimeout(resolve));
+
+    const req = httpMock.expectOne(request => request.url === VALUES_URL);
+    req.flush({ message: 'Not Implemented' }, { status: 501, statusText: 'Not Implemented' });
+
+    expect(await promise).toBeNull();
+  });
+
+  it('getValues throws HistoryRequestError on a 5xx (transient failure), not null', async () => {
+    connectionStub.serverServiceEndpoint$.next(CONNECTED_ENDPOINT);
+
+    const promise = service.getValues({ paths: 'navigation.speedThroughWater:avg', resolution: 1 });
+    await new Promise(resolve => setTimeout(resolve));
+
+    const req = httpMock.expectOne(request => request.url === VALUES_URL);
+    req.flush({ message: 'Server Error' }, { status: 503, statusText: 'Service Unavailable' });
+
+    await expect(promise).rejects.toBeInstanceOf(HistoryRequestError);
+  });
+
+  it('getValues throws HistoryRequestError (status 0) on a network error', async () => {
+    connectionStub.serverServiceEndpoint$.next(CONNECTED_ENDPOINT);
+
+    const promise = service.getValues({ paths: 'navigation.speedThroughWater:avg', resolution: 1 });
+    await new Promise(resolve => setTimeout(resolve));
+
+    const req = httpMock.expectOne(request => request.url === VALUES_URL);
+    req.error(new ProgressEvent('error'));
+
+    await expect(promise).rejects.toMatchObject({ name: 'HistoryRequestError', status: 0 });
   });
 
   it('should return null when history paths endpoint returns 500', async () => {

--- a/src/app/core/services/history-api-client.service.ts
+++ b/src/app/core/services/history-api-client.service.ts
@@ -1,9 +1,24 @@
 import { Injectable, inject, DestroyRef } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
-import { firstValueFrom } from 'rxjs';
+import { HttpClient, HttpErrorResponse, HttpParams } from '@angular/common/http';
+import { firstValueFrom, timeout } from 'rxjs';
+
+/** A backfill request that hangs past this is treated as a transient failure, not left to spin forever. */
+const HISTORY_VALUES_TIMEOUT_MS = 30_000;
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import type { AggregateMethod, TimeRangeQueryParams } from '@signalk/server-api/history';
 import { SignalKConnectionService } from './signalk-connection.service';
+
+/**
+ * A History `getValues` request failed for a *transient* reason (network error, timeout, or a 5xx
+ * server error) — as opposed to the server having no history provider (see {@link HistoryApiClientService.getValues}).
+ * Callers distinguish this from a `null` return so a passing blip does not read as a permanent absence.
+ */
+export class HistoryRequestError extends Error {
+  constructor(public readonly status: number, public readonly reason?: unknown) {
+    super(`History API request failed (status ${status})`);
+    this.name = 'HistoryRequestError';
+  }
+}
 
 /**
  * Represents a single series metadata from the History API response.
@@ -193,7 +208,10 @@ export class HistoryApiClientService {
    *   - resolution: optional downsampling window
    *   - context: optional Signal K context (defaults to 'vessels.self')
    *
-   * @returns {Promise<IHistoryValuesResponse | null>} The history response, or null if the request fails.
+   * @returns {Promise<IHistoryValuesResponse | null>} The history response, or `null` when the server
+   *   has no history provider (no service URL, or a 404/501 response).
+   * @throws {HistoryRequestError} on a transient failure (network error, timeout, or 5xx) — distinct
+   *   from the no-provider `null` so callers can retry or fall back to live data.
    *
    * @example
    *   const response = await historyService.getValues({
@@ -242,14 +260,26 @@ export class HistoryApiClientService {
       console.log(`[HistoryApiClientService] GET ${fullUrl}`);
 
       const response = await firstValueFrom(
-        this.http.get<IHistoryValuesResponse>(historyUrl, { params: httpParams })
+        this.http.get<IHistoryValuesResponse>(historyUrl, { params: httpParams }).pipe(
+          timeout(HISTORY_VALUES_TIMEOUT_MS)
+        )
       );
 
       console.log(`[HistoryApiClientService] History fetch successful, received ${response.data?.length ?? 0} data points`);
       return response;
     } catch (error) {
+      const status = error instanceof HttpErrorResponse ? error.status : 0;
+      // 404 / 501: the server has no history provider (plugin/API missing) — a stable "unavailable",
+      // reported as null so trend charts degrade to a clean empty state.
+      if (status === 404 || status === 501) {
+        console.warn(`[HistoryApiClientService] History API not available (status ${status}); no provider`);
+        return null;
+      }
+      // Any other failure — network error, timeout (status 0), 5xx, or an unexpected 4xx — is surfaced
+      // as a request error rather than null, so the caller can fall back to live data instead of
+      // claiming history is permanently absent. Only the 404/501 above mean "no provider".
       console.error('[HistoryApiClientService] History API request failed:', error);
-      return null;
+      throw new HistoryRequestError(status, error);
     }
   }
 

--- a/src/app/core/services/history-chart-stream.service.spec.ts
+++ b/src/app/core/services/history-chart-stream.service.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Subject, firstValueFrom } from 'rxjs';
 import { HistoryChartStreamService, IHistoryChartStreamParams, isHistoryUnavailable } from './history-chart-stream.service';
-import { HistoryApiClientService } from './history-api-client.service';
+import { HistoryApiClientService, HistoryRequestError } from './history-api-client.service';
 import { HistoryToChartMapperService } from './history-to-chart-mapper.service';
 import { DataService, IPathUpdate } from './data.service';
 import { SettingsService } from './settings.service';
@@ -250,8 +250,62 @@ describe('HistoryChartStreamService', () => {
     expect(Number.isNaN(last.data.value)).toBe(true);
   });
 
-  it('emits HISTORY_UNAVAILABLE and starts no live tail when the backfill request rejects', async () => {
-    history.getValues.mockRejectedValue(new Error('network down'));
+  it('on a transient HistoryRequestError, does not disable the chart — rides the live tail with no backfill seed (#130)', async () => {
+    history.getValues.mockRejectedValue(new HistoryRequestError(503));
+
+    const emissions: (IDatasetServiceDatapoint | IDatasetServiceDatapoint[] | { unavailable: true })[] = [];
+    make().getBackfillThenLive(PARAMS).subscribe(e => emissions.push(e));
+    await new Promise(resolve => setTimeout(resolve)); // let the rejected backfill settle → live fallback
+
+    // The transient failure must NOT surface HISTORY_UNAVAILABLE; the live tail is subscribed instead.
+    expect(emissions.some(e => !Array.isArray(e) && 'unavailable' in e)).toBe(false);
+    expect(data.subscribePath).toHaveBeenCalled();
+
+    // A live delta still renders, so the chart keeps working through the blip.
+    const before = Date.now();
+    path$.next({ data: { value: 7, timestamp: new Date() }, state: 'normal' });
+    const last = emissions[emissions.length - 1] as IDatasetServiceDatapoint;
+    expect(last.data.value).toBe(7);
+    expect(last.timestamp).toBeGreaterThanOrEqual(before);
+  });
+
+  it('transient fallback derives the clock offset from live samples so a skewed source is not false-gapped (#130)', async () => {
+    // The fallback has no backfill to anchor the server→client offset. With a naive offset of 0 the
+    // staleness check would read the server-behind-client skew as age and gap every healthy delta —
+    // exactly the just-restarted-marine-server case that triggers the fallback. The offset must be
+    // derived from the first live sample instead.
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+    try {
+      history.getValues.mockRejectedValue(new HistoryRequestError(503));
+
+      const emissions: (IDatasetServiceDatapoint | IDatasetServiceDatapoint[] | { unavailable: true })[] = [];
+      make().getBackfillThenLive(PARAMS).subscribe(e => emissions.push(e));
+      await vi.advanceTimersByTimeAsync(0); // settle the rejected backfill → live fallback subscribes
+
+      const SKEW_MS = 60_000; // server clock trails this client by 60s (no NTP)
+      const SRC_INTERVAL_MS = 1_000;
+      // First live value (drawn immediately via take(1)); source timestamp is 60s behind the client.
+      path$.next({ data: { value: 10, timestamp: new Date(Date.now() - SKEW_MS) }, state: 'normal' });
+      // A second value one source-interval later, then a resample tick to emit it.
+      vi.setSystemTime(1_000_000 + SRC_INTERVAL_MS);
+      path$.next({ data: { value: 11, timestamp: new Date(Date.now() - SKEW_MS) }, state: 'normal' });
+      await vi.advanceTimersByTimeAsync(PARAMS.sampleTime);
+
+      const points = emissions.filter(
+        (e): e is IDatasetServiceDatapoint => !Array.isArray(e) && !('unavailable' in e)
+      );
+      // No gap markers despite the 60s skew, and the real values render.
+      expect(points.some(p => Number.isNaN(p.data.value))).toBe(false);
+      expect(points.map(p => p.data.value)).toContain(10);
+      expect(points.map(p => p.data.value)).toContain(11);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('on an unexpected (non-transient) backfill error, emits HISTORY_UNAVAILABLE and starts no live tail', async () => {
+    history.getValues.mockRejectedValue(new Error('boom'));
     const first = await firstValueFrom(make().getBackfillThenLive(PARAMS));
     expect(isHistoryUnavailable(first)).toBe(true);
     expect(data.subscribePath).not.toHaveBeenCalled();

--- a/src/app/core/services/history-chart-stream.service.ts
+++ b/src/app/core/services/history-chart-stream.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable, Subscription, filter, merge, shareReplay, take, timer, withLatestFrom } from 'rxjs';
 import { DataService, IPathUpdate } from './data.service';
-import { HistoryApiClientService } from './history-api-client.service';
+import { HistoryApiClientService, HistoryRequestError } from './history-api-client.service';
 import { HistoryToChartMapperService } from './history-to-chart-mapper.service';
 import { resolveAngleDomain } from '../utils/angle-domain.util';
 import { SettingsService } from './settings.service';
@@ -61,7 +61,8 @@ export class HistoryChartStreamService {
   /**
    * Backfill (History API, one-shot) then a live delta tail. Emits the backfill as a single array,
    * then live datapoints one at a time. Emits {@link HISTORY_UNAVAILABLE} and stops when there is no
-   * history provider (or history is disabled) — no live-only fallback.
+   * history provider (or history is disabled). A *transient* backfill failure (network/5xx/timeout)
+   * does not disable the chart: it falls through to the live delta tail with no backfill seed.
    */
   public getBackfillThenLive(params: IHistoryChartStreamParams): Observable<StreamEmission> {
     return new Observable<StreamEmission>(subscriber => {
@@ -97,11 +98,21 @@ export class HistoryChartStreamService {
           const newestBackfillTs = points.length ? points[points.length - 1].timestamp : null;
           liveSub = this.startLive(params, domain, buffer, offsetMs, newestBackfillTs, perf, subscriber);
         })
-        .catch(() => {
-          if (!disposed) {
-            subscriber.next(HISTORY_UNAVAILABLE);
-            subscriber.complete();
+        .catch(err => {
+          if (disposed) return;
+          if (err instanceof HistoryRequestError) {
+            // Transient backfill failure (network blip, 5xx, timeout): don't disable the chart. Ride
+            // the live delta tail with no seed so live data still renders; a reconnect re-backfill
+            // (#85) fills the gap. Only a genuine no-provider (null result above) degrades to empty.
+            // offsetMs is null (no backfill anchor) → startLive derives it from the first live sample.
+            liveSub = this.startLive(params, domain, buffer, null, null, perf, subscriber);
+            return;
           }
+          // An unexpected error (e.g. a mapper/logic bug), not a known request failure: degrade to
+          // empty but log it so a real bug is not indistinguishable from a legitimate no-provider.
+          console.error('[HistoryChartStreamService] Unexpected backfill error; degrading to history-unavailable:', err);
+          subscriber.next(HISTORY_UNAVAILABLE);
+          subscriber.complete();
         });
 
       return () => {
@@ -115,7 +126,7 @@ export class HistoryChartStreamService {
     params: IHistoryChartStreamParams,
     domain: ChartStatsDomain,
     buffer: number[],
-    offsetMs: number,
+    offsetMs: number | null,
     newestBackfillTs: number | null,
     perf: IChartPerfProbe,
     subscriber: { next: (v: StreamEmission) => void }
@@ -127,10 +138,16 @@ export class HistoryChartStreamService {
       shareReplay({ bufferSize: 1, refCount: true })
     );
 
+    // Server→client clock offset. Backfill supplies it (from range.to); in the transient-failure
+    // fallback there is no backfill, so `offsetMs` is null and we anchor on the first live sample —
+    // otherwise the staleness check below would measure clock skew, not age, and gap a healthy source.
+    let resolvedOffsetMs = offsetMs;
     // A value's source timestamp shifted into the client clock; NaN when the delta carries no timestamp.
     const sourceTsOf = (u: IPathUpdate): number => {
       const t = u?.data?.timestamp instanceof Date ? u.data.timestamp.getTime() : NaN;
-      return Number.isFinite(t) ? t + offsetMs : NaN;
+      if (!Number.isFinite(t)) return NaN;
+      if (resolvedOffsetMs === null) resolvedOffsetMs = Date.now() - t;
+      return t + resolvedOffsetMs;
     };
 
     let prevSourceTs: number | null = null;


### PR DESCRIPTION
## What

Fixes #130: a transient failure during the History engine's one-shot backfill left the chart permanently stuck on "history unavailable" — no retry, no live fallback — until an unrelated rebuild.

## Why

`HistoryApiClientService.getValues` caught **every** error and returned `null`, indistinguishable from the genuine no-provider case. `getBackfillThenLive` then emitted `HISTORY_UNAVAILABLE` and `complete()`d without ever starting the live delta tail. So a passing server restart or network blip during that single backfill request killed the chart, while the recorder rode straight through the same blip.

## Changes

- **`getValues` now distinguishes the two conditions:** it returns `null` only for a genuine no-provider (no service URL, or a 404/501), and throws a typed **`HistoryRequestError`** for a transient failure (network error, timeout, or 5xx). A bounded 30 s `timeout` is added so a server that accepts the connection but never responds can't hang the backfill forever.
- **`getBackfillThenLive`** shows `HISTORY_UNAVAILABLE` only on the `null` (no-provider) result. On a `HistoryRequestError` it **rides the live delta tail** with no backfill seed, so live data keeps rendering through the blip; a reconnect re-backfill (#85) will fill the gap. An unexpected (non-request) error still degrades to empty, now with a log line.
- The two other `getValues` callers (recorder backfill, history-chart dialog) swallow the new throw to `null`, preserving their existing graceful no-data behaviour.

## Reviewer catch worth highlighting

An independent reliability review found that the transient live-fallback, started with `offsetMs = 0`, would **false-gap a healthy source under server-behind-client clock skew** — precisely the just-rebooted marine-Pi-without-NTP case that triggers the fallback. The live tail stamps the chart axis with the client clock (fine), but its staleness check compared `Date.now()` against the raw server timestamp, reading the skew as age. Fixed by **deriving the offset from the first live sample** when no backfill anchored it, with a reproducing test (60 s skew + two deltas) that the previous zero-skew test couldn't catch.

## Scope

History engine only, behind the default-OFF `chartEngine` / `skip.chartEngine` flag. **Blocks #64 promotion.**

## Testing

`npm run lint` ✓ · `npm run build:prod` ✓ · full `ng test` suite **820 pass** locally, incl. the new transient-fallback, clock-skew-offset, and `getValues` 501/5xx/network-error contract tests. CI runs the full matrix.

Closes #130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zURudCY3TTRcNd2acknJ9
