### PR TITLE
Fix shared-config mutation, loose typing, and WS frame validation (review batch)

### DIFF
--- a/src/app/core/services/app-initNetwork.service.spec.ts
+++ b/src/app/core/services/app-initNetwork.service.spec.ts
@@ -16,6 +16,7 @@ import { InternetReachabilityService } from './internet-reachability.service';
 import { DatasetStreamService } from './dataset-stream.service';
 import { Injector } from '@angular/core';
 import { ensureLocalStorage } from '../../../test-helpers/local-storage.test-helper';
+import { DefaultConnectionConfig } from '../../../default-config/config.blank.const';
 
 // jsdom has no FontFace; preloadFonts() constructs one during the end-to-end initNetworkServices runs.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -265,6 +266,21 @@ describe('AppNetworkInitService', () => {
 
     it('should be created', () => {
         expect(service).toBeTruthy();
+    });
+
+    describe('loadLocalStorageConfig default seeding (issue #100)', () => {
+        it('clones DefaultConnectionConfig instead of mutating the shared singleton', () => {
+            localStorage.removeItem('skip.connectionConfig');
+
+            (service as unknown as { loadLocalStorageConfig: () => void }).loadLocalStorageConfig();
+
+            const config = (service as unknown as { config: IConnectionConfig }).config;
+            expect(config).not.toBe(DefaultConnectionConfig);
+            expect(config.signalKUrl).toBe(window.location.origin);
+            // The blank singleton stays pristine: earlier end-to-end runs in this file also seed the
+            // default config, so assert the known blank value rather than a captured "before" value.
+            expect(DefaultConnectionConfig.signalKUrl).toBeNull();
+        });
     });
 
     it('should use connection retry window when no timeout is provided', async () => {

--- a/src/app/core/services/app-initNetwork.service.ts
+++ b/src/app/core/services/app-initNetwork.service.ts
@@ -13,6 +13,7 @@ import { SignalKConnectionService } from "./signalk-connection.service";
 import { AuthenticationService, ILoginStatus } from './authentication.service';
 import { SsoRedirectService } from './sso-redirect.service';
 import { DefaultConnectionConfig } from '../../../default-config/config.blank.const';
+import { cloneDeep } from 'lodash-es';
 import { BehaviorSubject, Observable, Subscription } from 'rxjs';
 import { DataService } from './data.service';
 import { SignalKDeltaService } from './signalk-delta.service';
@@ -367,7 +368,7 @@ export class AppNetworkInitService implements OnDestroy {
     this.config = JSON.parse(localStorage.getItem(CONNECTION_CONFIG_KEY));
 
     if (!this.config) {
-      this.config = DefaultConnectionConfig;
+      this.config = cloneDeep(DefaultConnectionConfig);
       this.config.signalKUrl = window.location.origin;
       console.log(`[AppInit Network Service] Connection Configuration not found. Creating configuration using Auto-Discovery URL: ${this.config.signalKUrl}`);
       this.setLocalStorageConfig();

--- a/src/app/core/services/data.service.spec.ts
+++ b/src/app/core/services/data.service.spec.ts
@@ -292,4 +292,73 @@ describe('DataService', () => {
     subA.unsubscribe();
     subB.unsubscribe();
   });
+
+  it('resets value, timestamp and state on timeout for a recognised pathType', () => {
+    let latest: IPathUpdate | undefined;
+    service
+      .subscribePath('self.environment.wind.speedApparent', 'default')
+      .subscribe(update => (latest = update));
+
+    dataPathUpdates$.next({
+      context: 'self',
+      path: 'environment.wind.speedApparent',
+      source: 'test-source',
+      timestamp: '2026-01-01T00:00:01.000Z',
+      value: 5.5,
+    });
+    expect(latest!.data.value).toBe(5.5);
+
+    service.timeoutPathObservable('self.environment.wind.speedApparent', 'number');
+
+    expect(latest!.data.value).toBeNull();
+    expect(latest!.data.timestamp).toBeNull();
+    expect(latest!.state).toBe(States.Normal);
+  });
+
+  it('does not emit on timeout for an unrecognised pathType', () => {
+    const updates: IPathUpdate[] = [];
+    service
+      .subscribePath('self.navigation.position', 'default')
+      .subscribe(update => updates.push(update));
+
+    const countBefore = updates.length;
+    service.timeoutPathObservable('self.navigation.position', 'object');
+
+    expect(updates.length).toBe(countBefore);
+    expect(updates.every(update => update !== undefined)).toBe(true);
+  });
+
+  it('derives path type from meta units when meta precedes the value', () => {
+    metadataUpdates$.next({
+      context: 'self',
+      path: 'electrical.batteries.10.current',
+      meta: { description: 'Battery current', units: 'A', properties: {} },
+    });
+    metadataUpdates$.next({
+      context: 'self',
+      path: 'navigation.datetime',
+      meta: { description: 'Time', units: 'RFC 3339 (UTC)', properties: {} },
+    });
+    metadataUpdates$.next({
+      context: 'self',
+      path: 'design.aisShipType',
+      meta: { description: 'Ship type', units: undefined, properties: {} },
+    });
+
+    expect(service.getPathObject('self.electrical.batteries.10.current')!.type).toBe('number');
+    expect(service.getPathObject('self.navigation.datetime')!.type).toBe('Date');
+    expect(service.getPathObject('self.design.aisShipType')!.type).toBeUndefined();
+  });
+
+  it('leaves path type undefined when the first received value is null', () => {
+    dataPathUpdates$.next({
+      context: 'self',
+      path: 'navigation.anchor.position',
+      source: 'test-source',
+      timestamp: '2026-01-01T00:00:01.000Z',
+      value: null,
+    });
+
+    expect(service.getPathObject('self.navigation.anchor.position')!.type).toBeUndefined();
+  });
 });

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -42,7 +42,7 @@ const isRfc3339StringDate = (date: Date | string): boolean => {
 };
 
 // Translate units from sk metadata to appropriate type category
-const typeFromUnits = (units: string): string => {
+const typeFromUnits = (units: string): string | undefined => {
   if (!units) {
     return undefined;
   }
@@ -390,7 +390,7 @@ export class DataService implements OnDestroy {
     // Find the path item in _skData or create a new one if it doesn't exist
     let pathItem = this._skData.get(updatePath);
     if (!pathItem) {
-      let pathType: string = dataPath.value === null ? undefined : typeof (dataPath.value);
+      let pathType: string | undefined = dataPath.value === null ? undefined : typeof (dataPath.value);
       if (pathType === "string" && isRfc3339StringDate(dataPath.value)) {
         pathType = "Date";
       }
@@ -717,20 +717,14 @@ export class DataService implements OnDestroy {
    */
   public timeoutPathObservable(path: string, pathType: string): void {
     const pathRegister = this._pathRegister.find(item => item.path == path);
-    if (pathRegister) {
-      let timeoutValue: IPathUpdate;
-
-      if (['string', 'Date', 'number', 'multiple'].includes(pathType)) {
-        timeoutValue = {
-          data: {
-            value: null,
-            timestamp: null
-          },
-          state: States.Normal
-        };
-      }
-
-      pathRegister.pathDataUpdate$.next(timeoutValue);
+    if (pathRegister && ['string', 'Date', 'number', 'multiple'].includes(pathType)) {
+      pathRegister.pathDataUpdate$.next({
+        data: {
+          value: null,
+          timestamp: null
+        },
+        state: States.Normal
+      });
     }
   }
 

--- a/src/app/core/services/signalk-delta.service.spec.ts
+++ b/src/app/core/services/signalk-delta.service.spec.ts
@@ -32,6 +32,7 @@ class CsmStub {
 interface DeltaInternals {
   buildWebSocketUrl(): string;
   processWebsocketMessage(message: ISignalKDeltaMessage): void;
+  handleStreamFrame(frame: unknown): void;
 }
 
 function setup() {
@@ -361,6 +362,130 @@ describe('SignalKDeltaService', () => {
         { context: CTX, path: 'navigation.speedOverGround', source: 'gps.1', timestamp: '2024-01-01T00:00:00Z', value: 1 },
         { context: CTX, path: 'environment.wind.speedApparent', source: 'wind.2', timestamp: '2024-01-02T00:00:00Z', value: 2 },
       ]);
+    });
+
+    describe('malformed frames', () => {
+      function handleFrame(service: SignalKDeltaService, frame: unknown): void {
+        (service as unknown as DeltaInternals).handleStreamFrame(frame);
+      }
+
+      function collectAll(service: SignalKDeltaService) {
+        const data = collectData(service);
+        const metas: IMeta[] = [];
+        const reqs: ISignalKDeltaMessage[] = [];
+        const notes: ISignalKDataValueUpdate[] = [];
+        const selves: string[] = [];
+        service.subscribeMetadataUpdates().subscribe(v => metas.push(v));
+        service.subscribeRequestUpdates().subscribe(v => reqs.push(v));
+        service.subscribeNotificationsUpdates().subscribe(v => notes.push(v));
+        service.subscribeSelfUpdates().subscribe(v => selves.push(v));
+        return { data, metas, reqs, notes, selves };
+      }
+
+      it('drops and logs a junk frame without discriminator fields at the boundary', () => {
+        const { service } = setup();
+        const streams = collectAll(service);
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        expect(() => handleFrame(service, { foo: 'bar', baz: 42 })).not.toThrow();
+        expect(warn).toHaveBeenCalled();
+        expect(streams).toEqual({ data: [], metas: [], reqs: [], notes: [], selves: [] });
+        warn.mockRestore();
+      });
+
+      it('drops non-object frames (string, number, null, array) without throwing', () => {
+        const { service } = setup();
+        const streams = collectAll(service);
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        for (const frame of ['junk', 42, null, undefined, [1, 2]]) {
+          expect(() => handleFrame(service, frame)).not.toThrow();
+        }
+        expect(streams).toEqual({ data: [], metas: [], reqs: [], notes: [], selves: [] });
+        warn.mockRestore();
+      });
+
+      it('passes a valid update frame through the boundary guard unchanged', () => {
+        const { service } = setup();
+        const out = collectData(service);
+        handleFrame(service, { context: CTX, updates: [update([{ path: 'navigation.speedOverGround', value: 3.2 }])] });
+        expect(out).toEqual([
+          { context: CTX, path: 'navigation.speedOverGround', source: 'src.1', timestamp: TS, value: 3.2 },
+        ]);
+      });
+
+      it('passes a valid hello/self frame through the boundary guard unchanged', () => {
+        const { service } = setup();
+        const selves: string[] = [];
+        service.subscribeSelfUpdates().subscribe(v => selves.push(v));
+        handleFrame(service, { self: 'vessels.urn:mrn:signalk:uuid:self', name: 'sk', version: '2.0.0' });
+        expect(selves).toEqual(['vessels.urn:mrn:signalk:uuid:self']);
+      });
+
+      it('passes a valid request-response frame through the boundary guard unchanged', () => {
+        const { service } = setup();
+        const reqs: ISignalKDeltaMessage[] = [];
+        service.subscribeRequestUpdates().subscribe(v => reqs.push(v));
+        const msg: ISignalKDeltaMessage = { requestId: 'req-1', state: 'COMPLETED', statusCode: 200 };
+        handleFrame(service, msg);
+        expect(reqs).toEqual([msg]);
+      });
+
+      it('accepts an errorMessage frame at the boundary instead of dropping it', () => {
+        const { service } = setup();
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        handleFrame(service, { errorMessage: 'stream error' });
+        expect(warn).toHaveBeenCalledWith('[Delta Service] Service received stream error message: stream error');
+        expect(warn).not.toHaveBeenCalledWith('[Delta Service] Dropping malformed stream frame:', expect.anything());
+        warn.mockRestore();
+      });
+
+      it('drops a value item with a null path and keeps processing the rest of the update', () => {
+        const { service } = setup();
+        const out = collectData(service);
+        const badItem = { path: null, value: 1 } as unknown as ISignalKDataValueUpdate;
+        expect(() => parse(service, { context: CTX, updates: [update([badItem, { path: 'navigation.speedOverGround', value: 2 }])] })).not.toThrow();
+        expect(out).toEqual([
+          { context: CTX, path: 'navigation.speedOverGround', source: 'src.1', timestamp: TS, value: 2 },
+        ]);
+      });
+
+      it('drops a value item with a missing path without throwing', () => {
+        const { service } = setup();
+        const out = collectData(service);
+        const badItem = { value: 1 } as unknown as ISignalKDataValueUpdate;
+        expect(() => parse(service, { context: CTX, updates: [update([badItem])] })).not.toThrow();
+        expect(out).toEqual([]);
+      });
+
+      it('ignores a null update entry and non-array values without throwing', () => {
+        const { service } = setup();
+        const out = collectData(service);
+        const badUpdates = [
+          null as unknown as ISignalKUpdateMessage,
+          { $source: 'src.1', timestamp: TS, values: 'junk' as unknown as ISignalKDataValueUpdate[] },
+        ];
+        expect(() => parse(service, { context: CTX, updates: badUpdates })).not.toThrow();
+        expect(out).toEqual([]);
+      });
+
+      it('drops a meta item whose value is missing without throwing', () => {
+        const { service } = setup();
+        const metas: IMeta[] = [];
+        service.subscribeMetadataUpdates().subscribe(v => metas.push(v));
+        const meta = [{ path: 'navigation.position' } as unknown as ISignalKMeta];
+        expect(() => parse(service, { context: CTX, updates: [update([], { meta })] })).not.toThrow();
+        expect(metas).toEqual([]);
+      });
+
+      it('falls back to a single meta emission when properties is null', () => {
+        const { service } = setup();
+        const metas: IMeta[] = [];
+        service.subscribeMetadataUpdates().subscribe(v => metas.push(v));
+        const value = { units: 'm/s', description: 'Speed over ground', properties: null };
+        parse(service, { context: CTX, updates: [update([], { meta: [skMeta('navigation.speedOverGround', value)] })] });
+        expect(metas).toEqual([
+          { context: CTX, path: 'navigation.speedOverGround', meta: value },
+        ]);
+      });
     });
   });
 });

--- a/src/app/core/services/signalk-delta.service.ts
+++ b/src/app/core/services/signalk-delta.service.ts
@@ -26,6 +26,22 @@ export interface IStreamStatus {
   message: string;
 }
 
+/**
+ * Narrows a raw WebSocket frame to ISignalKDeltaMessage by checking the
+ * discriminator fields of the frame types the stream can carry: data/meta
+ * updates, request/response, server hello and stream errors.
+ */
+function isDeltaFrame(frame: unknown): frame is ISignalKDeltaMessage {
+  if (typeof frame !== 'object' || frame === null) {
+    return false;
+  }
+  const msg = frame as Record<string, unknown>;
+  return Array.isArray(msg.updates)
+    || typeof msg.requestId === 'string'
+    || typeof msg.self === 'string'
+    || typeof msg.errorMessage === 'string';
+}
+
 @Injectable({
     providedIn: 'root'
   })
@@ -201,7 +217,7 @@ export class SignalKDeltaService implements OnDestroy {
 
     this.socketWS$.pipe(takeUntilDestroyed(this._destroyRef))
       .subscribe({
-        next: msgWS => this.processWebsocketMessage(msgWS),
+        next: msgWS => this.handleStreamFrame(msgWS),
         error: err => {
           console.error('[Delta Service] WebSocket error:', err);
           // Note: ConnectionStateMachine error reporting is handled in the close event handler
@@ -306,6 +322,14 @@ export class SignalKDeltaService implements OnDestroy {
     }
   }
 
+  private handleStreamFrame(frame: unknown): void {
+    if (!isDeltaFrame(frame)) {
+      console.warn("[Delta Service] Dropping malformed stream frame:", frame);
+      return;
+    }
+    this.processWebsocketMessage(frame);
+  }
+
   private processWebsocketMessage(message: ISignalKDeltaMessage) {
     if (message.updates) {
       this.parseUpdates(message.updates, message.context);
@@ -338,12 +362,16 @@ export class SignalKDeltaService implements OnDestroy {
     // }
 
     updates.forEach(update => {
-      if (update.meta !== undefined) {
+      if (Array.isArray(update?.meta)) {
         update.meta.forEach(meta => this.parseSkMeta(meta, context));
       }
 
-      if (update.values !== undefined) {
+      if (Array.isArray(update?.values)) {
         update.values.forEach(item => {
+          if (typeof item?.path !== 'string') {
+            console.warn("[Delta Service] Dropping value update without a string path:", item);
+            return;
+          }
           if (item.path.startsWith("notifications.")) {  // It's a notification message, pass to notification service
             this._skNotificationsMsg$.next(item);
           } else {
@@ -453,7 +481,11 @@ export class SignalKDeltaService implements OnDestroy {
   }
 
   private parseSkMeta(metadata: ISignalKMeta, context: string) {
-    if (metadata.value.properties !== undefined) {
+    if (metadata?.value == null) {
+      console.warn("[Delta Service] Dropping metadata update without a value:", metadata);
+      return;
+    }
+    if (metadata.value.properties != null) {
       Object.keys(metadata.value.properties).forEach(key => {
         this._skMetadata$.next({
           context: context,

--- a/src/app/core/services/signalk-requests.service.spec.ts
+++ b/src/app/core/services/signalk-requests.service.spec.ts
@@ -131,6 +131,19 @@ describe('SignalkRequestsService', () => {
     expect(received[0].statusCode).toBe(200);
   });
 
+  it('reports a described but unhandled status code (500) as unknown yet still dispatches it', () => {
+    const received: skRequest[] = [];
+    service.subscribeRequest().subscribe(r => received.push(r));
+
+    const requestId = service.putRequest('navigation.lights', true, 'widget-1')!;
+    requestUpdates$.next({ requestId, state: 'COMPLETED', statusCode: 500 });
+
+    expect(toastShow).toHaveBeenCalledWith(expect.stringContaining('Unknown Request Status Code'), 0, false, 'error');
+    expect(received).toHaveLength(1);
+    expect(received[0].statusCode).toBe(500);
+    expect(received[0].statusCodeDescription).toBeUndefined();
+  });
+
   it('warns via toast when a response carries an unknown requestId', () => {
     const received: skRequest[] = [];
     service.subscribeRequest().subscribe(r => received.push(r));

--- a/src/app/core/services/signalk-requests.service.ts
+++ b/src/app/core/services/signalk-requests.service.ts
@@ -7,7 +7,7 @@ import { SignalKDeltaService } from './signalk-delta.service';
 import { UUID } from '../utils/uuid.util'
 import { ToastService } from './toast.service';
 
-const deltaStatusCodes = {
+const deltaStatusCodes: Record<number, string> = {
   200: "The request was successfully.",
   202: "Request accepted and pending completion.",
   400: "Something is wrong with the client's request.",
@@ -18,6 +18,8 @@ const deltaStatusCodes = {
   502: "Something went wrong carrying out the request on the server.",
   504: "Timeout on the server side trying to carry out the request."
 }
+// Codes dispatched as recognized responses; anything else raises the unknown-status error toast.
+const handledStatusCodes = new Set([200, 202, 400, 401, 403, 405]);
 export interface skRequest {
   requestId: string;
   state: string;
@@ -109,7 +111,7 @@ export class SignalkRequestsService {
 
       const currentStatusCode = deltaStatusCodes[delta.statusCode];
 
-      if ((typeof currentStatusCode != 'undefined') && (this.requests[index].statusCode == 200 || this.requests[index].statusCode == 202 || this.requests[index].statusCode == 400 || this.requests[index].statusCode == 401 || this.requests[index].statusCode == 403 || this.requests[index].statusCode == 405)) {
+      if ((typeof currentStatusCode != 'undefined') && handledStatusCodes.has(this.requests[index].statusCode)) {
         this.requests[index].statusCodeDescription = currentStatusCode;
 
         if (this.requests[index].statusCode == 202) {

--- a/src/app/core/services/storage.service.ts
+++ b/src/app/core/services/storage.service.ts
@@ -17,9 +17,13 @@ export interface Config {
   scope: string
 }
 
+export type TConfigObjectType =
+  'IAppConfig' | 'IThemeConfig' | 'IWidgetConfig' | 'ILayoutConfig' | 'Dashboards' |
+  'Array<IUnitDefaults>' | 'Array<IDatasetDef>' | 'INotificationConfig';
+
 export interface IPatchFailure {
   // Config target that failed to persist — patchConfig's ObjType, when known.
-  key?: string;
+  key?: TConfigObjectType;
   error: unknown;
 }
 
@@ -34,7 +38,7 @@ interface IPatchAction {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   document: any,
   // Config target of the patch, carried into patchFailure$ so a failed save names what was lost.
-  key?: string,
+  key?: TConfigObjectType,
   // Optional deferred handlers so callers can await a queued patch's completion.
   resolve?: () => void,
   reject?: (error: unknown) => void
@@ -391,12 +395,12 @@ export class StorageService {
   /**
    * Updates JSON configuration entry section in the server application storage. This uses the JSON Patch standard.
    *
-   * @param {string} ObjType string describing the type of configuration object. Value can be: IAppConfig, IThemeConfig, IWidgetConfig, ILayoutConfig, Array\<IUnitDefaults\>, Array\<IDataSet\>, Array\<IZone\>, IZonesConfig, INotificationConfig
+   * @param {TConfigObjectType} ObjType type of configuration object to patch. See TConfigObjectType for supported values.
    * @param {*} value unstringified update object. The resulting outgoing POST request will automatically stringify.
    * @memberof StorageService
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public patchConfig(ObjType: string, value: any, forceConfigFileVersion?: number) {
+  public patchConfig(ObjType: TConfigObjectType, value: any, forceConfigFileVersion?: number) {
     this.ensureReady();
     if (!this.sharedConfigName) {
       const error = new Error('[StorageService] Refusing patchConfig: active config slot name is unset.');
@@ -490,8 +494,12 @@ export class StorageService {
           }]
         break;
 
-      default: console.warn("[Storage Service] JSON Patch request type unknown");
+      default: {
+        // Compile-time exhaustiveness: adding a TConfigObjectType member without a case errors here.
+        const unhandled: never = ObjType;
+        console.warn(`[Storage Service] JSON Patch request type unknown: ${unhandled}`);
         break;
+      }
     }
 
     const patch: IPatchAction = { url, document, key: ObjType };


### PR DESCRIPTION
Batches the four independent items from the #76 "Actionable now" block into one PR (per maintainer preference, to limit review churn). Each fix is its own atomic commit; none share files.

## What's in here

**`fix(services): clone default connection config on boot`** — closes #100
`loadLocalStorageConfig` assigned the shared `DefaultConnectionConfig` module singleton by reference and then mutated it in place (`signalKUrl`, version upgrades, v13 migration fields). Now `cloneDeep`s the constant first, mirroring `settings.service.getDefaultConnectionConfig()`. Regression test pins that the singleton's `signalKUrl` stays `null` (asserting the known blank value so the test fails under the bug regardless of spec execution order). Note: unlike settings.service, this path does not regenerate `kipUUID` after cloning — the constant already gets a fresh UUID at module evaluation each page load, so both paths yield a per-boot UUID; left as-is deliberately.

**`fix(core): guard timeout emit, fix loose types`** — closes #23 (pilot slice for the #6 ratchet)
- `timeoutPathObservable` no longer pushes `undefined` into the widget data stream for unrecognised path types (the downstream `widget-streams.directive` conversion map dereferences `x.data.value` and would crash). Recognised types emit exactly the same payload as before.
- `typeFromUnits` return type corrected to `string | undefined`; both callers verified safe (one guarded by a truthy-units check, the other feeds `ISkPathData.type` whose `undefined` state the code already branches on).
- `pathType` local typed `string | undefined` to match its ternary.
- 4 new behavioral tests; the unrecognised-path-type test was verified red before the fix.

**`fix(delta): validate SK frames at WS boundary`** — closes #24
- Hand-rolled `isDeltaFrame` type guard on the four discriminators (`updates`, `requestId`, `self`, `errorMessage`); frames failing it are logged and dropped — never thrown on.
- `parseUpdates` drops items whose `path` isn't a string (keeping siblings), and the `meta`/`values` checks are now `Array.isArray` so null entries can't throw.
- `parseSkMeta` drops null/undefined `value` and treats `properties: null` as the single-emission branch instead of throwing in `Object.keys`.
- 9 new malformed-frame specs, verified red first; all 19 pre-existing characterization tests unchanged. Adopting `@signalk/server-api` delta types in place of the all-optional `ISignalKDeltaMessage` remains a possible follow-up (deliberately out of scope here).

**`refactor(core): typed config and status dispatch`** — closes #26
- `patchConfig`'s `ObjType` is now the exported string-literal union `TConfigObjectType` (exactly the 8 literals the switch dispatches on; all call sites verified in-union). The default branch stays as runtime defense and gains a `never` exhaustiveness check. The stale docstring list (which disagreed with the switch) now points at the union.
- `deltaStatusCodes` annotated `Record<number, string>`; the six-way magic-number disjunction replaced with a single `handledStatusCodes` Set. Behavior unchanged — 500/502/504 still route to the unknown-code branch, now pinned by a new characterization test.
- `patchConfig`'s `value: any` is out of scope (existing eslint-disable retained).

## Verification

- `npm run lint` clean; full suite green locally on the assembled branch: 134 files / 841 tests (baseline on main: 821).
- Every behavioral fix had its test verified red before the fix (TDD).
- `tsc --noEmit` on the app and spec tsconfigs passes with the narrowed `patchConfig` signature (lint alone does not typecheck).

Pre-existing defects surfaced while implementing (multi-source timeout-reset gap, de-facto-optional interface fields, delta `$source`/`timestamp` validation gaps) are being filed as separate issues rather than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
