### PR TITLE
Drop dead storage-routing code from settings.service (#17 PR-1)

### DIFF
--- a/src/app/core/services/configuration-upgrade.service.ts
+++ b/src/app/core/services/configuration-upgrade.service.ts
@@ -210,7 +210,7 @@ export class ConfigurationUpgradeService {
             try {
               // Await the retire write for BOTH scopes so it completes before the
               // finally() block runs resetSettings() and reloads the page. The old
-              // 'global' branch scheduled a deferred, un-awaited patchGlobal (via
+              // 'global' branch scheduled a deferred, un-awaited write (via
               // setTimeout) that the reload aborted, leaving the legacy global config
               // un-retired. Mirror the awaited setConfig pattern used by runUpgrade().
               await this._storage.setConfig(rootConfig.scope, rootConfig.name, oldConfiguration, this.legacyFileVersion);

--- a/src/app/core/services/settings.service.ts
+++ b/src/app/core/services/settings.service.ts
@@ -5,7 +5,6 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { cloneDeep } from 'lodash-es';
 
 import { IDatasetServiceDatasetConfig } from '../interfaces/dataset.interfaces';
-import { IWidget } from '../interfaces/widgets-interface';
 import { IUnitDefaults } from './units.service';
 import { UUID } from '../utils/uuid.util';
 
@@ -53,7 +52,6 @@ export class SettingsService {
 
   private kipUUID = '';
   public signalkUrl: ISignalKUrl | undefined;
-  private widgets: IWidget[] = [];
   private _dashboards: Dashboard[] = [];
   private dataSets: IDatasetServiceDatasetConfig[] = [];
   public configUpgrade = signal<boolean>(false);
@@ -92,37 +90,18 @@ export class SettingsService {
     }
   }
 
-  /**
-   * Whether config persistence should target the server's applicationData rather than localStorage.
-   * SKip runs same-origin with the SK server (SSO session cookie), so persistence always targets the
-   * server's applicationData; localStorage holds only the per-device connection config.
-   */
-  private readonly useServerStorage = true;
-
   private async startup(): Promise<void> {
-    if (this.useServerStorage) {
-      // A missing server config comes back as {} (not a 404), so guard on the presence of app config —
-      // an empty/appless object must not fall through to pushSettings() and dereference activeConfig.app.
-      if (!this.storage.isRemoteContextBootstrapped() || !this.storage.initConfig?.app) {
-        console.warn('[AppSettings Service] Shared configuration enabled but remote bootstrap handoff is missing or empty. Waiting for explicit recovery action.');
-        return;
-      }
-
-      this.configVersion = this.storage.initConfig?.app?.configVersion;
-      this.checkConfigUpgradeRequired(false, this.storage.initConfig?.app?.configVersion);
-      this.activeConfig = this.storage.initConfig;
-      this.pushSettings();
-    } else {
-      console.log("[AppSettings Service] LocalStorage enabled");
-      const localStorageConfig: IConfig = { app: null, theme: null, dashboards: [] };
-      localStorageConfig.app = this.loadConfigFromLocalStorage("appConfig");
-      this.configVersion = localStorageConfig.app?.configVersion;
-      this.checkConfigUpgradeRequired(true, localStorageConfig.app?.configVersion);
-      localStorageConfig.dashboards = this.loadConfigFromLocalStorage("dashboardsConfig");
-      localStorageConfig.theme = this.loadConfigFromLocalStorage("themeConfig");
-      this.activeConfig = localStorageConfig;
-      this.pushSettings();
+    // A missing server config comes back as {} (not a 404), so guard on the presence of app config —
+    // an empty/appless object must not fall through to pushSettings() and dereference activeConfig.app.
+    if (!this.storage.isRemoteContextBootstrapped() || !this.storage.initConfig?.app) {
+      console.warn('[AppSettings Service] Shared configuration enabled but remote bootstrap handoff is missing or empty. Waiting for explicit recovery action.');
+      return;
     }
+
+    this.configVersion = this.storage.initConfig?.app?.configVersion;
+    this.checkConfigUpgradeRequired(false, this.storage.initConfig?.app?.configVersion);
+    this.activeConfig = this.storage.initConfig;
+    this.pushSettings();
   }
 
   private loadConnectionConfig(): void {
@@ -277,12 +256,7 @@ export class SettingsService {
   }
   public setDefaultUnits(newDefaults: IUnitDefaults) {
     this.unitDefaults.next(newDefaults);
-    if (this.useServerStorage) {
-      this.storage.patchConfig('Array<IUnitDefaults>', newDefaults);
-
-    } else {
-      this.saveAppConfigToLocalStorage();
-    }
+    this.storage.patchConfig('Array<IUnitDefaults>', newDefaults);
   }
 
   // Configuration version
@@ -346,14 +320,10 @@ export class SettingsService {
 
   public setThemeName(newTheme: string) {
     this.themeName.next(newTheme);
-    if (this.useServerStorage) {
-      const theme: IThemeConfig = {
-        themeName: newTheme
-      }
-      this.storage.patchConfig('IThemeConfig', theme)
-    } else {
-      this.saveThemeConfigToLocalStorage();
+    const theme: IThemeConfig = {
+      themeName: newTheme
     }
+    this.storage.patchConfig('IThemeConfig', theme)
   }
 
   public getThemeName(): string {
@@ -368,12 +338,7 @@ export class SettingsService {
   public setAutoNightMode(enabled: boolean) {
     this.autoNightMode.next(enabled);
     const appConf = this.buildAppStorageObject();
-
-    if (this.useServerStorage) {
-      this.storage.patchConfig('IAppConfig', appConf);
-    } else {
-      this.saveAppConfigToLocalStorage();
-    }
+    this.storage.patchConfig('IAppConfig', appConf);
   }
 
   public getAutoNightMode(): boolean {
@@ -392,12 +357,7 @@ export class SettingsService {
   public setRedNightMode(enabled: boolean) {
     this.redNightMode.next(enabled);
     const appConf = this.buildAppStorageObject();
-
-    if (this.useServerStorage) {
-      this.storage.patchConfig('IAppConfig', appConf);
-    } else {
-      this.saveAppConfigToLocalStorage();
-    }
+    this.storage.patchConfig('IAppConfig', appConf);
   }
 
   // isRemoteControl mode
@@ -446,12 +406,7 @@ export class SettingsService {
     // trims for display; this keeps the saved config clean and blank values normalized to '').
     this.browserTabTitle.next((title ?? '').trim());
     const appConf = this.buildAppStorageObject();
-
-    if (this.useServerStorage) {
-      this.storage.patchConfig('IAppConfig', appConf);
-    } else {
-      this.saveAppConfigToLocalStorage();
-    }
+    this.storage.patchConfig('IAppConfig', appConf);
   }
 
   public getDisablePathValidation(): boolean {
@@ -469,26 +424,12 @@ export class SettingsService {
   public setNightModeBrightness(brightness: number): void {
     this.nightModeBrightness.next(brightness);
     const appConf = this.buildAppStorageObject();
-
-    if (this.useServerStorage) {
-      this.storage.patchConfig('IAppConfig', appConf);
-    } else {
-      this.saveAppConfigToLocalStorage();
-    }
-  }
-
-  // Widgets
-  public getWidgets() {
-    return this.widgets;
+    this.storage.patchConfig('IAppConfig', appConf);
   }
 
   public saveDashboards(dashboards: Dashboard[]) {
-    if (this.useServerStorage) {
-      if (this.storage.storageServiceReady$.getValue()) {
-        this.storage.patchConfig('Dashboards', dashboards);
-      }
-    } else {
-      this.saveLDashboardsConfigToLocalStorage(dashboards);
+    if (this.storage.storageServiceReady$.getValue()) {
+      this.storage.patchConfig('Dashboards', dashboards);
     }
     this._dashboards = dashboards;
   }
@@ -496,11 +437,7 @@ export class SettingsService {
   // DataSets
   public saveDataSets(dataSets: IDatasetServiceDatasetConfig[]) {
     this.dataSets = dataSets;
-    if (this.useServerStorage) {
-      this.storage.patchConfig('Array<IDatasetDef>', dataSets);
-    } else {
-      this.saveAppConfigToLocalStorage();
-    }
+    this.storage.patchConfig('Array<IDatasetDef>', dataSets);
   }
   public getDataSets() {
     return this.dataSets;
@@ -515,11 +452,7 @@ export class SettingsService {
   }
   public setNotificationConfig(notificationConfig: INotificationConfig) {
     this.kipKNotificationConfig.next(notificationConfig);
-    if (this.useServerStorage) {
-      this.storage.patchConfig('INotificationConfig', notificationConfig);
-    } else {
-      this.saveAppConfigToLocalStorage();
-    }
+    this.storage.patchConfig('INotificationConfig', notificationConfig);
   }
 
   //Config manipulation: RAW and SignalK server - used by Settings Config Component
@@ -530,69 +463,14 @@ export class SettingsService {
     newDefaultConfig.theme = this.getDefaultThemeConfig();
     newDefaultConfig.dashboards = this.getDefaultDashboardsConfig();
 
-      if (this.useServerStorage) {
-        if (this.storage.storageServiceReady$.getValue()) {
-          this.storage.setConfig('user', this.sharedConfigName, newDefaultConfig)
-            .then(() => {
-              console.log("[AppSettings Service] Replaced server config name: " + this.sharedConfigName + ", with default configuration values");
-              this.reloadApp();
-            })
-            .catch(error => {
-              console.error("[AppSettings Service] Error replacing server config name: " + this.sharedConfigName + ", with default configuration values", error);
-              this.snackBar.open(
-                'Problem saving configuration to the server. Resolve this issue before KIP can be used reliably.',
-                'Close',
-                {
-                  duration: 0,
-                  verticalPosition: 'top'
-                }
-              );
-            });
-        }
-      } else {
-
-        this.reloadApp();
-      }
-  }
-
-  /**
-   * Updates keys of localStorage config and reloads apps if required to apply new config.
-   *
-   * IMPORTANT NOTE: Kip does not apply config unless app is reloaded
-   *
-   * @param configType String of either connectionConfig, appConfig, widgetConfig, dashboardConfig or themeConfig.
-   * @param newConfig Object containing config. Of type IAppConfig, IWidgetConfig, Dashboard[] or IThemeConfig
-   * @param reloadApp Optional Boolean. If True, the app will reload, else does nothing. Defaults to False.
-   */
-  public replaceConfig(configType: string, newConfig: IAppConfig | IConnectionConfig | IThemeConfig | Dashboard[], reloadApp?: boolean) {
-    const jsonConfig = JSON.stringify(newConfig);
-    localStorage.setItem(localConfigKey(configType), jsonConfig);
-    if (reloadApp) {
-      this.reloadApp();
-    }
-  }
-
-  public loadDemoConfig() {
-    if (this.useServerStorage) {
-      if (!this.storage.storageServiceReady$.getValue()) {
-        console.warn("[AppSettings Service] Storage not ready; cannot load demo configuration.");
-        return;
-      }
-      const demoConfig: IConfig = {
-        app: DemoAppConfig,
-        dashboards: DemoDashboardsConfig,
-        theme: DemoThemeConfig
-      };
-      console.log("[AppSettings Service] Loading Demo configuration settings as remote config: " + this.useServerStorage + " and reloading app.");
-      // Wait for the server write to land before reloading; reloading mid-request
-      // aborts the POST and leaves the previous configuration in place. Storage
-      // readiness is already guaranteed by the guard above.
-      this.storage.setConfig('user', this.sharedConfigName, demoConfig)
+    if (this.storage.storageServiceReady$.getValue()) {
+      this.storage.setConfig('user', this.sharedConfigName, newDefaultConfig)
         .then(() => {
+          console.log("[AppSettings Service] Replaced server config name: " + this.sharedConfigName + ", with default configuration values");
           this.reloadApp();
         })
         .catch(error => {
-          console.error("[AppSettings Service] Error saving demo configuration to the server", error);
+          console.error("[AppSettings Service] Error replacing server config name: " + this.sharedConfigName + ", with default configuration values", error);
           this.snackBar.open(
             'Problem saving configuration to the server. Resolve this issue before KIP can be used reliably.',
             'Close',
@@ -602,12 +480,38 @@ export class SettingsService {
             }
           );
         });
-    } else {
-      console.log("[AppSettings Service] Loading Demo configuration settings to LocalStorage");
-      this.replaceConfig("appConfig", DemoAppConfig);
-      this.replaceConfig("dashboardsConfig", DemoDashboardsConfig);
-      this.replaceConfig("themeConfig", DemoThemeConfig, true);
     }
+  }
+
+  public loadDemoConfig() {
+    if (!this.storage.storageServiceReady$.getValue()) {
+      console.warn("[AppSettings Service] Storage not ready; cannot load demo configuration.");
+      return;
+    }
+    const demoConfig: IConfig = {
+      app: DemoAppConfig,
+      dashboards: DemoDashboardsConfig,
+      theme: DemoThemeConfig
+    };
+    console.log("[AppSettings Service] Loading Demo configuration settings to the server and reloading app.");
+    // Wait for the server write to land before reloading; reloading mid-request
+    // aborts the POST and leaves the previous configuration in place. Storage
+    // readiness is already guaranteed by the guard above.
+    this.storage.setConfig('user', this.sharedConfigName, demoConfig)
+      .then(() => {
+        this.reloadApp();
+      })
+      .catch(error => {
+        console.error("[AppSettings Service] Error saving demo configuration to the server", error);
+        this.snackBar.open(
+          'Problem saving configuration to the server. Resolve this issue before KIP can be used reliably.',
+          'Close',
+          {
+            duration: 0,
+            verticalPosition: 'top'
+          }
+        );
+      });
   }
 
   public reloadApp() {
@@ -676,25 +580,9 @@ export class SettingsService {
     return storageObject;
   }
 
-  // Calls build methods and saves to LocalStorage
-  private saveAppConfigToLocalStorage() {
-    console.log("[AppSettings Service] Saving Application config to LocalStorage");
-    localStorage.setItem(LOCAL_CONFIG_KEYS.appConfig, JSON.stringify(this.buildAppStorageObject()));
-  }
-
   private saveConnectionConfigToLocalStorage() {
     console.log("[AppSettings Service] Saving Connection config to LocalStorage");
     localStorage.setItem(LOCAL_CONFIG_KEYS.connectionConfig, JSON.stringify(this.buildConnectionStorageObject()));
-  }
-
-  private saveLDashboardsConfigToLocalStorage(dashboards: Dashboard[]) {
-    console.log("[AppSettings Service] Saving Dashboard config to LocalStorage");
-    localStorage.setItem(LOCAL_CONFIG_KEYS.dashboardsConfig, JSON.stringify(dashboards));
-  }
-
-  private  saveThemeConfigToLocalStorage() {
-    console.log("[AppSettings Service] Saving Theme config to LocalStorage");
-    localStorage.setItem(LOCAL_CONFIG_KEYS.themeConfig, JSON.stringify(this.buildThemeStorageObject()));
   }
 
   // Creates config from defaults and saves to LocalStorage

--- a/src/app/core/services/storage.service.spec.ts
+++ b/src/app/core/services/storage.service.spec.ts
@@ -384,16 +384,6 @@ describe('StorageService — applicationData URLs, scope & version gate (charact
     req.flush(null);
   });
 
-  it('patchGlobal POSTs the operation to the given scope, keyed by config name', () => {
-    const { service } = setup();
-    const cfg = blankConfig();
-    service.patchGlobal('backup', 'global', cfg, 'add');
-    const req = http.expectOne(`${ENDPOINT}global/skip/11`);
-    expect(req.request.method).toBe('POST');
-    expect(req.request.body).toEqual([{ op: 'add', path: '/backup', value: cfg }]);
-    req.flush(null);
-  });
-
   it('removeItem POSTs a remove patch to the scoped, versioned URL', async () => {
     const { service } = setup();
     const p = service.removeItem('user', 'old-slot');
@@ -418,24 +408,6 @@ describe('StorageService — applicationData URLs, scope & version gate (charact
     service.patchConfig('IThemeConfig', { themeName: 'dark', extra: 'ignored' });
     const req = http.expectOne(`${ENDPOINT}user/skip/11`);
     expect(req.request.body).toEqual([{ op: 'replace', path: '/cockpit/theme/themeName', value: 'dark' }]);
-    req.flush(null);
-  });
-
-  it('patchGlobal replace targets the config-name path', () => {
-    const { service } = setup();
-    const cfg = blankConfig();
-    service.patchGlobal('slot-a', 'user', cfg, 'replace');
-    const req = http.expectOne(`${ENDPOINT}user/skip/11`);
-    expect(req.request.body).toEqual([{ op: 'replace', path: '/slot-a', value: cfg }]);
-    req.flush(null);
-  });
-
-  it('patchGlobal remove keeps a value field (unlike removeItem)', () => {
-    const { service } = setup();
-    const cfg = blankConfig();
-    service.patchGlobal('slot-b', 'global', cfg, 'remove');
-    const req = http.expectOne(`${ENDPOINT}global/skip/11`);
-    expect(req.request.body).toEqual([{ op: 'remove', path: '/slot-b', value: cfg }]);
     req.flush(null);
   });
 

--- a/src/app/core/services/storage.service.ts
+++ b/src/app/core/services/storage.service.ts
@@ -124,7 +124,7 @@ export class StorageService {
         }
       });
 
-    // Serial queue for ALL applicationData writes — JSON patches (patchConfig/patchGlobal/removeItem)
+    // Serial queue for ALL applicationData writes — JSON patches (patchConfig/removeItem)
     // and full-file replacements (setConfig) alike — so they never run over each other. SK does not
     // handle concurrent applicationData writes.
     this.patchQueue$
@@ -513,63 +513,6 @@ export class StorageService {
         appConfigVersionInValue: appVer,
         touchesConfigVersion
       });
-    }
-    this.enqueuePatch(patch);
-  }
-
-  /**
-   * Applies full KIP configuration entry file operations the server's Global Scope application storage.
-   *
-   * @param {string} configName name of the configuration.
-   * @param {string} scope the storage scope to use. Can either be: 'user' or 'global'.
-   * @param {string} operation string describing the type action to perform. values can be: 'add', 'replace' or 'remove'.
-   * @param {IConfig} config unstringified config object. The resulting outgoing POST request will automatically stringify.
-   * @param {number} fileVersion Configuration file version. Supported are 9 for current and 1 for old configs.
-   * @memberof StorageService
-   */
-  public patchGlobal(configName: string, scope: string, config: IConfig, operation: string, fileVersion?: number) {
-    this.ensureReady();
-    this.assertSlotName(configName, 'patchGlobal');
-    const ver = fileVersion ?? this.configFileVersion;
-  const url = this.serverEndpoint + scope + "/" + SERVER_CONFIG_APPID + "/" + ver;
-
-    let document;
-    switch (operation) {
-      case "add":
-        document =
-          [{
-            "op": "add",
-            "path": `/${configName}`,
-            "value": config
-          }]
-        break;
-
-      case "replace":
-        document =
-          [{
-            "op": "replace",
-            "path": `/${configName}`,
-            "value": config
-          }]
-        break;
-
-      case "remove":
-        document =
-          [{
-            "op": "remove",
-            "path": `/${configName}`,
-            "value": config
-          }]
-        break;
-
-      default: console.warn("[Storage Service] JSON Patch operation request type unknown");
-        break;
-    }
-
-    const patch: IPatchAction = { url, document };
-    if (this._logIO) {
-      const appVer: unknown = config?.app?.configVersion;
-      console.debug('[StorageService.patchGlobal]', { scope, configName, operation, ver, url, appConfigVersionInValue: appVer });
     }
     this.enqueuePatch(patch);
   }

--- a/src/app/widgets/widget-anchor-alarm/widget-anchor-alarm.component.ts
+++ b/src/app/widgets/widget-anchor-alarm/widget-anchor-alarm.component.ts
@@ -1,7 +1,6 @@
 import { AfterViewInit, ChangeDetectionStrategy, Component, effect, ElementRef, inject, OnDestroy, signal, viewChild, input, untracked } from '@angular/core';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { DashboardService } from '../../core/services/dashboard.service';
-import { SettingsService } from '../../core/services/settings.service';
 import { generateSwipeScript } from '../../core/utils/iframe-inputs-inject.utils';
 import { IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
 import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
@@ -23,7 +22,6 @@ export class WidgetAnchorAlarmComponent implements AfterViewInit, OnDestroy {
   protected readonly runtime = inject(WidgetRuntimeDirective);
   protected readonly _dashboard = inject(DashboardService);
   private readonly _sanitizer = inject(DomSanitizer);
-  private readonly settings = inject(SettingsService);
 
   // Static default config (legacy parity)
   public static readonly DEFAULT_CONFIG: IWidgetSvcConfig = {

--- a/src/app/widgets/widget-solar-charger/widget-solar-charger.component.spec.ts
+++ b/src/app/widgets/widget-solar-charger/widget-solar-charger.component.spec.ts
@@ -522,8 +522,7 @@ describe('WidgetSolarChargerComponent', () => {
 
   // End-to-end persistence round-trip for #1061, mirroring the exact KIP operations:
   //   dashboard.component.saveDashboard(): cloneDeep(grid.save(false,false))
-  //   settings.saveLDashboardsConfigToLocalStorage(): localStorage.setItem(JSON.stringify(dashboards))   [local config]
-  //   storage.patchConfig('Dashboards', dashboards): [{ op:'replace', path:'/<name>/dashboards', value }] [shared config]
+  //   storage.patchConfig('Dashboards', dashboards): [{ op:'replace', path:'/<name>/dashboards', value }]
   //   settings.loadConfigFromLocalStorage(): JSON.parse(...)
   //   widget-runtime.directive.options(): merge(cloneDeep(DEFAULT_CONFIG), cloneDeep(saved))
   // NOTE: the live-grid capture itself - gridstack grid.save(false,false) - cannot be exercised here

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,6 @@ import { StorageService } from './app/core/services/storage.service';
 import { provideMarkdown } from 'ngx-markdown';
 import { TimersService } from './app/core/services/timers.service';
 import { NotificationsService } from './app/core/services/notifications.service';
-import { SettingsService } from './app/core/services/settings.service';
 import { UnitsService } from './app/core/services/units.service';
 import { DashboardService } from './app/core/services/dashboard.service';
 import { DatasetStreamService } from './app/core/services/dataset-stream.service';
@@ -79,7 +78,6 @@ bootstrapApplication(AppComponent, {
     DashboardService,
     UnitsService,
     AppNetworkInitService,
-    SettingsService,
     NotificationsService,
     TimersService,
     StorageService,


### PR DESCRIPTION
PR-1 of the #17 settings.service rewrite (plan v2.1 in the issue body): the behavior-preserving dead-code sweep. Pure deletion — 259 lines removed, 58 added (all from unwrapping live branches).

## What's removed

- The `useServerStorage = true` constant and all 12 `if`/`else` shells around it: live server paths kept verbatim (including the `storageServiceReady$` guards), dead localStorage else-branches deleted.
- The three unreachable save helpers (`saveAppConfigToLocalStorage`, `saveThemeConfigToLocalStorage`, `saveLDashboardsConfigToLocalStorage`). `saveConnectionConfigToLocalStorage` stays — device-scope persistence is localStorage by design (4 live call sites).
- `replaceConfig` — its sole caller was `loadDemoConfig`'s dead else branch (found during the sweep, folded in).
- Vestigial `widgets` array + `getWidgets()` (always returned `[]`, zero callers).
- `StorageService.patchGlobal` (zero production callers) with its 3 spec assertions — the only spec edits in this PR; they tested the removed method.
- widget-anchor-alarm's injected-but-never-used `SettingsService`; main.ts's redundant `SettingsService` provider entry (`providedIn: 'root'`). `UnitsService`/`AppNetworkInitService` deliberately untouched — bare `@Injectable()`, main.ts is their sole registration.

Note: the plan's `getWidgetHistoryDisabledAsO` item was already satisfied by #157, which removed the whole field between plan-writing and this PR.

## Verification

- `npm run lint` clean; full suite 135 files / 956 tests green — exactly 3 fewer than main's 959, matching the removed patchGlobal tests; every other spec unmodified.
- `npm run build:dev` completes (catches DI/template breakage the specs might miss, e.g. the main.ts provider removal).

Refs #17 (PR-1 of 4 + fast-follow; sequencing and full plan in the issue body).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
