### PR TITLE
fix(charts): back History backfill Value series with :last (closes #87, #132)

### DIFF
--- a/kip-plugin/src/index.ts
+++ b/kip-plugin/src/index.ts
@@ -679,7 +679,7 @@ const start = (server: ServerAPI): Plugin => {
     if (raw === 'average') {
       return 'avg';
     }
-    if (raw === 'min' || raw === 'max' || raw === 'sma' || raw === 'ema' || raw === 'avg') {
+    if (raw === 'min' || raw === 'max' || raw === 'sma' || raw === 'ema' || raw === 'avg' || raw === 'last') {
       return raw;
     }
     return 'avg';

--- a/kip-plugin/src/kip-series-contract.ts
+++ b/kip-plugin/src/kip-series-contract.ts
@@ -1,4 +1,4 @@
-export type THistoryMethod = 'min' | 'max' | 'avg' | 'sma' | 'ema';
+export type THistoryMethod = 'min' | 'max' | 'avg' | 'sma' | 'ema' | 'last';
 
 export type TElectricalFamilyKey = 'batteries' | 'solar' | 'chargers' | 'inverters' | 'alternators' | 'ac';
 export type TElectricalExpansionMode = 'bms-battery-tree' | 'solar-tree' | 'charger-tree' | 'inverter-tree' | 'alternator-tree' | 'ac-tree';

--- a/kip-plugin/src/openApi.json
+++ b/kip-plugin/src/openApi.json
@@ -187,7 +187,8 @@
                 "max",
                 "avg",
                 "sma",
-                "ema"
+                "ema",
+                "last"
               ]
             }
           },

--- a/kip-plugin/src/sqlite-history-storage.service.ts
+++ b/kip-plugin/src/sqlite-history-storage.service.ts
@@ -1049,7 +1049,7 @@ export class SqliteHistoryStorageService {
   private parseMethod(value?: string): THistoryMethod | undefined {
     if (!value) return undefined;
     const normalized = value.toLowerCase();
-    if (normalized === 'min' || normalized === 'max' || normalized === 'avg' || normalized === 'sma' || normalized === 'ema') {
+    if (normalized === 'min' || normalized === 'max' || normalized === 'avg' || normalized === 'sma' || normalized === 'ema' || normalized === 'last') {
       return normalized;
     }
     return undefined;
@@ -1159,7 +1159,7 @@ export class SqliteHistoryStorageService {
     if (rows.length === 0) return [];
 
     const method = request.method ?? 'avg';
-    if (method === 'min' || method === 'max' || method === 'avg') {
+    if (method === 'min' || method === 'max' || method === 'avg' || method === 'last') {
       return rows.map(entry => ({ timestamp: Number(entry.ts_ms), value: Number(entry.value) }));
     }
 
@@ -1233,6 +1233,12 @@ export class SqliteHistoryStorageService {
       return Math.max(...values);
     }
 
+    if (method === 'last') {
+      // Relies on bucket lists being timestamp-ascending, which holds because selectRowsForPaths
+      // fetches `ORDER BY path ASC, ts_ms ASC` and downsampleIfNeeded preserves that order.
+      return values[values.length - 1];
+    }
+
     const sum = values.reduce((acc, value) => acc + value, 0);
     return sum / values.length;
   }
@@ -1256,7 +1262,7 @@ export class SqliteHistoryStorageService {
     try {
       const parsed = JSON.parse(value);
       if (!Array.isArray(parsed)) return undefined;
-      const methods = parsed.filter(entry => entry === 'min' || entry === 'max' || entry === 'avg' || entry === 'sma' || entry === 'ema');
+      const methods = parsed.filter(entry => entry === 'min' || entry === 'max' || entry === 'avg' || entry === 'sma' || entry === 'ema' || entry === 'last');
       return methods.length > 0 ? methods as THistoryMethod[] : undefined;
     } catch {
       return undefined;

--- a/kip-plugin/tests/index.test.cjs
+++ b/kip-plugin/tests/index.test.cjs
@@ -2084,6 +2084,90 @@ test('history values does not create synthetic buckets for sparse data gaps', ()
   assert.equal(response.data[2][0], '2026-02-18T15:00:40.000Z');
 });
 
+test('history values :last returns the last raw sample per bucket, not the mean', () => {
+  const baseTs = Date.parse('2026-02-18T16:00:00.000Z');
+  const rows = [
+    { ts_ms: baseTs + 0, value: 10 },
+    { ts_ms: baseTs + 3000, value: 20 },
+    { ts_ms: baseTs + 6000, value: 355 },
+    { ts_ms: baseTs + 11000, value: 5 },
+    { ts_ms: baseTs + 18000, value: 359 }
+  ];
+
+  const response = computeSqliteHistoryResponse(rows, 'navigation.headingTrue:last', {
+    from: new Date(baseTs).toISOString(),
+    to: new Date(baseTs + 20000).toISOString(),
+    resolution: 10
+  });
+
+  assert.equal(response.values[0].method, 'last');
+  assert.equal(response.data.length, 2);
+  assert.equal(response.data[0][1], 355);
+  assert.equal(response.data[1][1], 359);
+});
+
+test('history values returns :sma and :last as independent columns (the chart backfill shape)', () => {
+  const baseTs = Date.parse('2026-02-18T20:00:00.000Z');
+  const rows = [
+    { ts_ms: baseTs + 0, value: 10 },
+    { ts_ms: baseTs + 3000, value: 20 },
+    { ts_ms: baseTs + 6000, value: 30 },
+    { ts_ms: baseTs + 11000, value: 40 }
+  ];
+
+  const response = computeSqliteHistoryResponse(
+    rows,
+    'navigation.speedOverGround:sma:2,navigation.speedOverGround:last',
+    {
+      from: new Date(baseTs).toISOString(),
+      to: new Date(baseTs + 20000).toISOString(),
+      resolution: 10
+    }
+  );
+
+  assert.equal(response.values[0].method, 'sma');
+  assert.equal(response.values[1].method, 'last');
+  assert.equal(response.data.length, 2);
+  // The :last column (index 2) is the final raw sample of each 10s bucket, independent of :sma.
+  assert.equal(response.data[0][2], 30);
+  assert.equal(response.data[1][2], 40);
+});
+
+test('history values :last passes through every raw sample when no resolution is given', () => {
+  const baseTs = Date.parse('2026-02-18T21:00:00.000Z');
+  const rows = [
+    { ts_ms: baseTs + 0, value: 10 },
+    { ts_ms: baseTs + 1000, value: 359 },
+    { ts_ms: baseTs + 2000, value: 5 }
+  ];
+
+  const response = computeSqliteHistoryResponse(rows, 'navigation.headingTrue:last', {
+    from: new Date(baseTs).toISOString(),
+    to: new Date(baseTs + 3000).toISOString()
+  });
+
+  assert.equal(response.data.length, 3);
+  assert.deepEqual(response.data.map((row) => row[1]), [10, 359, 5]);
+});
+
+test('history values :last skips a trailing non-finite sample and returns the last finite value', () => {
+  const baseTs = Date.parse('2026-02-18T22:00:00.000Z');
+  const rows = [
+    { ts_ms: baseTs + 0, value: 100 },
+    { ts_ms: baseTs + 3000, value: 200 },
+    { ts_ms: baseTs + 6000, value: NaN }
+  ];
+
+  const response = computeSqliteHistoryResponse(rows, 'navigation.speedOverGround:last', {
+    from: new Date(baseTs).toISOString(),
+    to: new Date(baseTs + 10000).toISOString(),
+    resolution: 10
+  });
+
+  assert.equal(response.data.length, 1);
+  assert.equal(response.data[0][1], 200);
+});
+
 test('history series enforces 1000ms minimum sampleTime for chart widgets', () => {
   const service = new HistorySeriesService(() => Date.now());
   service.upsertSeries({

--- a/src/app/core/services/history-chart-stream.service.spec.ts
+++ b/src/app/core/services/history-chart-stream.service.spec.ts
@@ -58,10 +58,14 @@ describe('HistoryChartStreamService', () => {
     expect(Array.isArray(first)).toBe(true);
     expect((first as IDatasetServiceDatapoint[]).map(p => p.data.value)).toEqual([1, 3]);
     expect(history.getValues).toHaveBeenCalledTimes(1);
-    // Aggregation suffixes + a from-window are requested.
+    // The Value series is the raw per-bucket `:last` sample (angle-safe, seam-free with the live
+    // tail), plus the `:sma` overlay. The dead `:min`/`:max` columns are no longer requested.
     const query = history.getValues.mock.calls[0][0];
-    expect(query.paths).toContain(':avg');
+    expect(query.paths).toContain(':last');
     expect(query.paths).toContain(':sma:');
+    expect(query.paths).not.toContain(':avg');
+    expect(query.paths).not.toContain(':min');
+    expect(query.paths).not.toContain(':max');
     expect(query.from).toBeTruthy();
   });
 

--- a/src/app/core/services/history-chart-stream.service.ts
+++ b/src/app/core/services/history-chart-stream.service.ts
@@ -198,9 +198,7 @@ export class HistoryChartStreamService {
     const normalizedPath = params.path.replace(/^(vessels\.)?self\./, '');
     const paths = [
       `${normalizedPath}:sma:${params.smoothingPeriod}`,
-      `${normalizedPath}:avg`,
-      `${normalizedPath}:min`,
-      `${normalizedPath}:max`
+      `${normalizedPath}:last`
     ].join(',');
     const resolutionSeconds = Math.max(1, Math.round(params.sampleTime / 1000));
 

--- a/src/app/core/services/history-to-chart-mapper.service.spec.ts
+++ b/src/app/core/services/history-to-chart-mapper.service.spec.ts
@@ -97,4 +97,54 @@ describe('HistoryToChartMapperService', () => {
     expect(final.lastMinimum).toBeCloseTo(3.0, 5);
     expect(final.lastMaximum).toBeCloseTo(-3.0, 5);
   });
+
+  it('prefers the :last column over :avg for the datapoint value', () => {
+    const response: IHistoryValuesResponse = {
+      context: 'vessels.self',
+      range: {
+        from: '2026-02-16T00:00:00.000Z',
+        to: '2026-02-16T00:02:00.000Z'
+      },
+      values: [
+        { path: 'navigation.headingTrue', method: 'avg' },
+        { path: 'navigation.headingTrue', method: 'last' }
+      ],
+      data: [
+        ['2026-02-16T00:00:00.000Z', 3.14, 6.2],
+        ['2026-02-16T00:01:00.000Z', 3.1, 0.05]
+      ]
+    };
+
+    const datapoints = service.mapValuesToChartDatapoints(response, {
+      domain: 'scalar'
+    });
+
+    expect(datapoints[0].data.value).toBe(6.2);
+    expect(datapoints[1].data.value).toBe(0.05);
+  });
+
+  it('does not plot a lone :sma column as the Value series', () => {
+    const response: IHistoryValuesResponse = {
+      context: 'vessels.self',
+      range: {
+        from: '2026-02-16T00:00:00.000Z',
+        to: '2026-02-16T00:02:00.000Z'
+      },
+      values: [
+        { path: 'navigation.headingTrue', method: 'sma' }
+      ],
+      data: [
+        ['2026-02-16T00:00:00.000Z', 1.5],
+        ['2026-02-16T00:01:00.000Z', 1.6]
+      ]
+    };
+
+    const datapoints = service.mapValuesToChartDatapoints(response, {
+      domain: 'scalar'
+    });
+
+    expect(datapoints[0].data.value).toBeNull();
+    expect(datapoints[1].data.value).toBeNull();
+    expect(datapoints[0].data.sma).toBe(1.5);
+  });
 });

--- a/src/app/core/services/history-to-chart-mapper.service.ts
+++ b/src/app/core/services/history-to-chart-mapper.service.ts
@@ -35,7 +35,7 @@ export class HistoryToChartMapperService {
   /**
    * Maps a History API response payload into normalized chart datapoints.
    *
-   * - Detects aggregate columns (`avg`/`average`, `sma`) from `response.values`.
+   * - Detects the Value column (`last` preferred, else `avg`/`average`) and `sma` from `response.values`.
    * - Emits one datapoint per response row.
    * - Computes dataset-wide summary stats from mapped datapoint values and
    *   stores them on the final datapoint (`lastAverage`, `lastMinimum`, `lastMaximum`).
@@ -58,6 +58,7 @@ export class HistoryToChartMapperService {
     }
 
     let smaIndex = -1;
+    let lastIndex = -1;
     let avgIndex = -1;
     if (response.values && Array.isArray(response.values)) {
       for (let i = 0; i < response.values.length; i++) {
@@ -66,15 +67,25 @@ export class HistoryToChartMapperService {
         if (!method) continue;
         const index = i + 1; // +1 because index 0 is timestamp
         if (method === 'sma') smaIndex = index;
+        else if (method === 'last') lastIndex = index;
         else if (method === 'avg' || method === 'average') avgIndex = index;
       }
 
-      if (avgIndex < 0 && response.values.length === 1) {
+      // Single-column fallback: treat the lone column as the value only when it is not a
+      // recognized non-value method. Guarding on smaIndex stops a provider that returns just an
+      // `sma` column (e.g. one that silently drops an unsupported `:last`) from being plotted as
+      // the raw Value series.
+      if (lastIndex < 0 && avgIndex < 0 && smaIndex < 0 && response.values.length === 1) {
         avgIndex = 1;
       }
     } else if (rows[0]?.length > 1) {
       avgIndex = 1;
     }
+
+    // The Value series prefers the raw per-bucket `last` sample: it is angle-safe at the 0/360° wrap
+    // and seam-free against the client-stamped live tail. `avg`/`average` stays the fallback for
+    // callers (e.g. the history-chart dialog) that still request bucket means.
+    const valueIndex = lastIndex >= 0 ? lastIndex : avgIndex;
 
     const shouldNormalizeAngle = options.domain !== 'scalar';
     const normalizeAngle = shouldNormalizeAngle
@@ -96,18 +107,18 @@ export class HistoryToChartMapperService {
       const timestamp = Date.parse(row[0] as string);
 
       let smaValue = smaIndex >= 0 ? (row[smaIndex] as number | null) : null;
-      let avgValue = avgIndex >= 0 ? (row[avgIndex] as number | null) : null;
+      let columnValue = valueIndex >= 0 ? (row[valueIndex] as number | null) : null;
 
       if (shouldNormalizeAngle) {
         smaValue = Number.isFinite(smaValue) ? normalizeAngle!(smaValue as number) : null;
-        avgValue = Number.isFinite(avgValue) ? normalizeAngle!(avgValue as number) : null;
+        columnValue = Number.isFinite(columnValue) ? normalizeAngle!(columnValue as number) : null;
       } else {
         smaValue = Number.isFinite(smaValue) ? (smaValue as number) : null;
-        avgValue = Number.isFinite(avgValue) ? (avgValue as number) : null;
+        columnValue = Number.isFinite(columnValue) ? (columnValue as number) : null;
       }
 
-      if (Number.isFinite(avgValue)) {
-        const value = avgValue as number;
+      if (Number.isFinite(columnValue)) {
+        const value = columnValue as number;
         if (shouldNormalizeAngle) {
           angleValues.push(value);
         } else {
@@ -121,7 +132,7 @@ export class HistoryToChartMapperService {
       datapoints.push({
         timestamp,
         data: {
-          value: avgValue,
+          value: columnValue,
           sma: smaValue,
           ema: null,
           doubleEma: null,


### PR DESCRIPTION
## Why

The History chart engine backfilled its **Value** series with `:avg` — the arithmetic mean of each resolution bucket. For circular/direction paths that mean is wrong at the 0/360° wrap (#87), and because the live tail plots raw instantaneous samples, the backfill→live handoff showed a visible seam (#132).

This is the first step of #64 (promote the History engine): the promoted engine must be seam-free and angle-safe before it becomes the default.

## What

Back the Value series with the raw per-bucket **`:last`** sample instead of `:avg`:

- **Client** — `history-chart-stream` backfill now requests `:sma` + `:last` (dropping the dead `:min`/`:max` columns the mapper never read; it derives min/max/avg from the value column). `history-to-chart-mapper` prefers a `:last` column and keeps `:avg`/`:average` as the fallback, so the other callers (history-chart dialog, the still-present recorder seed) are untouched.
- **kip-plugin** — a client-only change would have been inert: the bundled provider coerced any unknown method to `:avg` (`THistoryMethod` had no `last`). So `:last` is implemented end-to-end in the provider — method type, request normalization/parsing, the `applyMethod` passthrough, `aggregateBucket` (returns the bucket's final raw sample), and the OpenAPI enum.

`:last` cannot invert at the 0/360° wrap and matches the client-stamped live tail, so both #87 and #132 are resolved by the same change.

### Behavior note for reviewers

The reference lines (`lastAverage`/`lastMinimum`/`lastMaximum`) are computed from the Value column, so sourcing it from `:last` (raw samples) rather than `:avg` (bucket means) shifts their backfill values. That's intentional — it makes backfill consistent with the live tail, which already computes stats over raw samples.

## Verification

- `npm run test:plugin` — green, incl. a new test that `:last` returns the last raw sample per bucket (not the mean).
- Mapper spec — `:last` preferred over `:avg`; the `:avg`/`:average` fallback tests still pass.
- Stream spec — backfill requests `:last` + `:sma:`, never `:avg`/`:min`/`:max`.
- `npm run lint` — clean.

Closes #87
Closes #132

Part of #64.
