### PR TITLE
refactor(charts): relocate shared dataset types to a neutral module

### DIFF
--- a/src/app/core/interfaces/app-settings.interfaces.ts
+++ b/src/app/core/interfaces/app-settings.interfaces.ts
@@ -1,4 +1,4 @@
-import { IDatasetServiceDatasetConfig } from '../services/dataset-stream.service';
+import { IDatasetServiceDatasetConfig } from './dataset.interfaces';
 import { IUnitDefaults } from '../services/units.service';
 import { Dashboard } from './../services/dashboard.service';
 

--- a/src/app/core/interfaces/dataset.interfaces.ts
+++ b/src/app/core/interfaces/dataset.interfaces.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared dataset/chart data contracts.
+ *
+ * These types describe the time-windowed datapoints, dataset configuration, and sampling metadata
+ * consumed by both chart engines (the History-API engine and the legacy recorder) plus the config
+ * and persistence layers. They live in a neutral module so they survive the recorder's removal.
+ */
+
+export interface IDatasetServiceDatapoint {
+  timestamp: number;
+  data: {
+    value: number;
+    sma?: number; // Simple Moving Average
+    ema?: number; // Exponential Moving Average - A better Moving Average calculation than Simple Moving Average
+    doubleEma?: number; // Double Exponential Moving Average - Moving Average that is even more reactive to data variation then EMA. Suitable for wind and angle average calculations
+    lastAverage?: number; // Computed from the latest historicalData.
+    lastMinimum?: number;
+    lastMaximum?: number;
+  }
+}
+
+export type TimeScaleFormat = "day" | "hour" | "minute" | "second" | "Last Minute" | "Last 5 Minutes" | "Last 30 Minutes";
+
+export interface IDatasetServiceDatasetConfig {
+  uuid: string;
+  path: string;
+  pathSource: string;
+  baseUnit: string;         // The path's Signal K base unit type
+  timeScaleFormat: TimeScaleFormat;  // Dataset time scale measure.
+  period: number;           // Window size expressed in units of timeScaleFormat (ignored for "Last *" presets).
+  label: string;           // label of the historicalData
+  editable?: boolean;       // Whether the dataset is editable, or created with Widgets and not editable by user
+  angleDomainOverride?: 'signed' | 'direction'; // Optional override for how radian angles are wrapped: signed (-PI..PI) or direction (0..2PI). Undefined uses the path allowlist.
+}
+
+export interface IDatasetServiceDataSourceInfo {
+  sampleTime: number;       // DataSource Observer's path value sampling rate in milliseconds. ie. How often we get data from Signal K.
+  maxDataPoints: number;    // How many data points do we keep for that timescale
+  smoothingPeriod: number;  // Number of previous plus current value to use as the moving average
+}

--- a/src/app/core/services/dataset-stream.service.spec.ts
+++ b/src/app/core/services/dataset-stream.service.spec.ts
@@ -1,7 +1,8 @@
 import { TestBed, inject } from '@angular/core/testing';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { signal } from '@angular/core';
-import { DatasetStreamService, TimeScaleFormat } from './dataset-stream.service';
+import { DatasetStreamService } from './dataset-stream.service';
+import { TimeScaleFormat } from '../interfaces/dataset.interfaces';
 import { deriveDataSourceInfo, resolveWindowMs, MIN_SAMPLE_TIME_MS } from '../utils/chart-window.util';
 import { SettingsService } from './settings.service';
 import { IAppConfig } from '../interfaces/app-settings.interfaces';

--- a/src/app/core/services/dataset-stream.service.ts
+++ b/src/app/core/services/dataset-stream.service.ts
@@ -10,40 +10,12 @@ import { resolveAngleDomain } from '../utils/angle-domain.util';
 import { computeWindowStats, ChartStatsDomain } from '../utils/chart-stats.util';
 import { cloneDeep } from 'lodash-es';
 import { NgGridStackWidget } from 'gridstack/dist/angular';
-
-
-export interface IDatasetServiceDatapoint {
-  timestamp: number;
-  data: {
-    value: number;
-    sma?: number; // Simple Moving Average
-    ema?: number; // Exponential Moving Average - A better Moving Average calculation than Simple Moving Average
-    doubleEma?: number; // Double Exponential Moving Average - Moving Average that is even more reactive to data variation then EMA. Suitable for wind and angle average calculations
-    lastAverage?: number; // Computed from the latest historicalData.
-    lastMinimum?: number;
-    lastMaximum?: number;
-  }
-}
-
-export type TimeScaleFormat = "day" | "hour" | "minute" | "second" | "Last Minute" | "Last 5 Minutes" | "Last 30 Minutes";
-
-export interface IDatasetServiceDatasetConfig {
-  uuid: string;
-  path: string;
-  pathSource: string;
-  baseUnit: string;         // The path's Signal K base unit type
-  timeScaleFormat: TimeScaleFormat;  // Dataset time scale measure.
-  period: number;           // Window size expressed in units of timeScaleFormat (ignored for "Last *" presets).
-  label: string;           // label of the historicalData
-  editable?: boolean;       // Whether the dataset is editable, or created with Widgets and not editable by user
-  angleDomainOverride?: 'signed' | 'direction'; // Optional override for how radian angles are wrapped: signed (-PI..PI) or direction (0..2PI). Undefined uses the path allowlist.
-};
-
-export interface IDatasetServiceDataSourceInfo {
-  sampleTime: number;       // DataSource Observer's path value sampling rate in milliseconds. ie. How often we get data from Signal K.
-  maxDataPoints: number;    // How many data points do we keep for that timescale
-  smoothingPeriod: number;  // Number of previous plus current value to use as the moving average
-};
+import {
+  IDatasetServiceDatapoint,
+  TimeScaleFormat,
+  IDatasetServiceDatasetConfig,
+  IDatasetServiceDataSourceInfo
+} from '../interfaces/dataset.interfaces';
 
 interface IDatasetServiceDataSource extends IDatasetServiceDataSourceInfo {
   uuid: string;

--- a/src/app/core/services/history-chart-stream.service.spec.ts
+++ b/src/app/core/services/history-chart-stream.service.spec.ts
@@ -5,7 +5,7 @@ import { HistoryChartStreamService, IHistoryChartStreamParams, isHistoryUnavaila
 import { HistoryApiClientService, HistoryRequestError } from './history-api-client.service';
 import { HistoryToChartMapperService } from './history-to-chart-mapper.service';
 import { DataService, IPathUpdate } from './data.service';
-import { IDatasetServiceDatapoint } from './dataset-stream.service';
+import { IDatasetServiceDatapoint } from '../interfaces/dataset.interfaces';
 
 const PARAMS: IHistoryChartStreamParams = {
   path: 'navigation.speedOverGround',

--- a/src/app/core/services/history-chart-stream.service.ts
+++ b/src/app/core/services/history-chart-stream.service.ts
@@ -4,7 +4,7 @@ import { DataService, IPathUpdate } from './data.service';
 import { HistoryApiClientService, HistoryRequestError } from './history-api-client.service';
 import { HistoryToChartMapperService } from './history-to-chart-mapper.service';
 import { resolveAngleDomain } from '../utils/angle-domain.util';
-import { IDatasetServiceDatapoint } from './dataset-stream.service';
+import { IDatasetServiceDatapoint } from '../interfaces/dataset.interfaces';
 import { computeWindowStats, ChartStatsDomain } from '../utils/chart-stats.util';
 
 /** Emitted (instead of datapoints) when trend history cannot be served — no history provider. */

--- a/src/app/core/services/settings.service.ts
+++ b/src/app/core/services/settings.service.ts
@@ -4,7 +4,7 @@ import { BehaviorSubject, Observable, filter } from 'rxjs';
 import { HttpErrorResponse } from '@angular/common/http';
 import { cloneDeep } from 'lodash-es';
 
-import { IDatasetServiceDatasetConfig } from './dataset-stream.service';
+import { IDatasetServiceDatasetConfig } from '../interfaces/dataset.interfaces';
 import { IWidget } from '../interfaces/widgets-interface';
 import { IUnitDefaults } from './units.service';
 import { UUID } from '../utils/uuid.util';

--- a/src/app/core/services/widget-dataset-orchestrator.service.spec.ts
+++ b/src/app/core/services/widget-dataset-orchestrator.service.spec.ts
@@ -1,7 +1,8 @@
 import { TestBed } from '@angular/core/testing';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { WidgetDatasetOrchestratorService } from './widget-dataset-orchestrator.service';
-import { DatasetStreamService, IDatasetServiceDatasetConfig } from './dataset-stream.service';
+import { DatasetStreamService } from './dataset-stream.service';
+import { IDatasetServiceDatasetConfig } from '../interfaces/dataset.interfaces';
 import { IWidgetSvcConfig } from '../interfaces/widgets-interface';
 
 describe('WidgetDatasetOrchestratorService', () => {

--- a/src/app/core/services/widget-dataset-orchestrator.service.ts
+++ b/src/app/core/services/widget-dataset-orchestrator.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, inject } from '@angular/core';
-import { DatasetStreamService, IDatasetServiceDatasetConfig, TimeScaleFormat } from './dataset-stream.service';
+import { DatasetStreamService } from './dataset-stream.service';
+import { IDatasetServiceDatasetConfig, TimeScaleFormat } from '../interfaces/dataset.interfaces';
 import { IWidgetSvcConfig } from '../interfaces/widgets-interface';
 
 @Injectable({

--- a/src/app/core/utils/chart-window.util.ts
+++ b/src/app/core/utils/chart-window.util.ts
@@ -1,4 +1,4 @@
-import type { TimeScaleFormat } from '../services/dataset-stream.service';
+import type { TimeScaleFormat } from '../interfaces/dataset.interfaces';
 
 /** Points a window aims for at its derived cadence, once above the sample-time floor. */
 export const TARGET_POINTS_PER_WINDOW = 500;

--- a/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.ts
+++ b/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.ts
@@ -15,7 +15,8 @@ import { DisplayChartOptionsComponent } from '../display-chart-options/display-c
 import { DatasetChartOptionsComponent } from '../dataset-chart-options/dataset-chart-options.component';
 import { IUnitGroup, UnitsService } from '../../core/services/units.service';
 import { AppService } from '../../core/services/app-service';
-import { DatasetStreamService, IDatasetServiceDatasetConfig } from '../../core/services/dataset-stream.service';
+import { DatasetStreamService } from '../../core/services/dataset-stream.service';
+import { IDatasetServiceDatasetConfig } from '../../core/interfaces/dataset.interfaces';
 import type { ElectricalTrackedDevice, IDynamicControl, IWidgetPath, IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
 import { PathsOptionsComponent } from '../paths-options/paths-options.component';
 import { IDeleteEventObj } from '../boolean-control-config/boolean-control-config.component';

--- a/src/app/widgets/minichart/minichart.component.ts
+++ b/src/app/widgets/minichart/minichart.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnDestroy, ElementRef, viewChild, inject, effect, NgZone, input, untracked, ChangeDetectionStrategy } from '@angular/core';
-import { DatasetStreamService, IDatasetServiceDatapoint, IDatasetServiceDataSourceInfo } from '../../core/services/dataset-stream.service';
-import { IDatasetServiceDatasetConfig } from '../../core/services/dataset-stream.service';
+import { DatasetStreamService } from '../../core/services/dataset-stream.service';
+import { IDatasetServiceDatapoint, IDatasetServiceDataSourceInfo, IDatasetServiceDatasetConfig } from '../../core/interfaces/dataset.interfaces';
 import { Subscription } from 'rxjs';
 import { CanvasService } from '../../core/services/canvas.service';
 import { ITheme } from '../../core/services/app-service';

--- a/src/app/widgets/widget-data-chart/widget-data-chart.component.ts
+++ b/src/app/widgets/widget-data-chart/widget-data-chart.component.ts
@@ -1,7 +1,8 @@
-import { IDatasetServiceDatasetConfig, TimeScaleFormat } from '../../core/services/dataset-stream.service';
+import { IDatasetServiceDatasetConfig, TimeScaleFormat } from '../../core/interfaces/dataset.interfaces';
 import { Component, OnDestroy, ElementRef, viewChild, inject, effect, NgZone, input, untracked, computed, signal, ChangeDetectionStrategy } from '@angular/core';
 import { IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
-import { DatasetStreamService, IDatasetServiceDatapoint, IDatasetServiceDataSourceInfo } from '../../core/services/dataset-stream.service';
+import { DatasetStreamService } from '../../core/services/dataset-stream.service';
+import { IDatasetServiceDatapoint, IDatasetServiceDataSourceInfo } from '../../core/interfaces/dataset.interfaces';
 import { Subscription } from 'rxjs';
 import { CanvasService } from '../../core/services/canvas.service';
 import { UnitsService } from '../../core/services/units.service';

--- a/src/app/widgets/widget-windtrends-chart/widget-windtrends-chart.component.ts
+++ b/src/app/widgets/widget-windtrends-chart/widget-windtrends-chart.component.ts
@@ -2,13 +2,14 @@ import { Component, OnDestroy, ElementRef, viewChild, inject, effect, NgZone, in
 import { BreakpointObserver, Breakpoints, BreakpointState } from '@angular/cdk/layout';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
-import { DatasetStreamService, IDatasetServiceDatapoint, IDatasetServiceDataSourceInfo } from '../../core/services/dataset-stream.service';
+import { DatasetStreamService } from '../../core/services/dataset-stream.service';
+import { IDatasetServiceDatapoint, IDatasetServiceDataSourceInfo } from '../../core/interfaces/dataset.interfaces';
 import { Subscription } from 'rxjs';
 import { CanvasService } from '../../core/services/canvas.service';
 import { UnitsService } from '../../core/services/units.service';
 import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
 import { ITheme } from '../../core/services/app-service';
-import { IDatasetServiceDatasetConfig, TimeScaleFormat } from '../../core/services/dataset-stream.service';
+import { IDatasetServiceDatasetConfig, TimeScaleFormat } from '../../core/interfaces/dataset.interfaces';
 import { WidgetDatasetOrchestratorService } from '../../core/services/widget-dataset-orchestrator.service';
 
 import { Chart, ChartConfiguration, ChartData, ChartType, TimeScale, LinearScale, LineController, PointElement, LineElement, Filler, Title, SubTitle, ChartArea, Scale, ChartTypeRegistry } from 'chart.js';

--- a/src/test.ts
+++ b/src/test.ts
@@ -171,7 +171,7 @@ import type {
   ISignalkPlugin,
 } from './app/core/interfaces/signalk-plugin-config.interfaces';
 import type { IUnitDefaults } from './app/core/services/units.service';
-import type { IDatasetServiceDatasetConfig } from './app/core/services/dataset-stream.service';
+import type { IDatasetServiceDatasetConfig } from './app/core/interfaces/dataset.interfaces';
 // Global provider setup (HttpClient, RouterTestingModule, animation & material stubs, etc.)
 import { TestBed } from '@angular/core/testing';
 import type { Provider } from '@angular/core';


### PR DESCRIPTION
## Why

Four data-contract types are declared *inside* `dataset-stream.service.ts` (the legacy recorder), yet they're imported by modules that must outlive it — the History chart engine, `settings.service`, `chart-window.util`, and `IAppConfig`. A wholesale delete of the recorder (planned in a later #64 PR) can't compile until these move out first. This isolates that mechanical move so the eventual deletion PR stays reviewable.

## What

Move to a new neutral module `src/app/core/interfaces/dataset.interfaces.ts`:

- `IDatasetServiceDatapoint`
- `TimeScaleFormat`
- `IDatasetServiceDatasetConfig`
- `IDatasetServiceDataSourceInfo`

Every importer is re-pointed (mixed `DatasetStreamService` + type imports are split so the service still comes from `dataset-stream.service.ts`). The recorder keeps its own recorder-internal types (`IDatasetServiceDataSource`, `IDatasetServiceObserverRegistration`) and now imports the four moved types like everyone else.

**Pure move — no behavior change**, no runtime code touched.

## Verification

- `npm run build:dev` — clean compile (would fail on any missed importer or wrong path).
- `npm run lint` — clean.

Part of #64.
