### PR TITLE
feat(charts): stream the numeric mini-chart from the History engine

### DIFF
--- a/src/app/widgets/minichart/minichart.component.spec.ts
+++ b/src/app/widgets/minichart/minichart.component.spec.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Chart.js and its plugins cannot instantiate under jsdom. Mock them self-contained (no
+// importOriginal, no outer references) so the vi.mock hoisting does not trip a TDZ. The mock
+// Chart carries a truthy `ctx` so the streaming callback's ctx guard passes.
+vi.mock('chart.js', () => {
+  class MockChart {
+    public static register(): void { /* noop */ }
+    public ctx = {};
+    public data: { datasets: { data: unknown[] }[] };
+    public options: unknown;
+    constructor(_ctx: unknown, config: { data: { datasets: { data: unknown[] }[] }; options: unknown }) {
+      this.data = config.data;
+      this.options = config.options;
+    }
+    public update(): void { /* noop */ }
+    public destroy(): void { /* noop */ }
+  }
+  return {
+    Chart: MockChart,
+    TimeScale: {}, LinearScale: {}, LineController: {}, PointElement: {},
+    LineElement: {}, Filler: {}, CategoryScale: {}
+  };
+});
+vi.mock('chartjs-adapter-date-fns', () => ({}));
+vi.mock('@aziham/chartjs-plugin-streaming', () => ({ default: {} }));
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Subject } from 'rxjs';
+import { MinichartComponent } from './minichart.component';
+import { HistoryChartStreamService, HISTORY_UNAVAILABLE } from '../../core/services/history-chart-stream.service';
+import { UnitsService } from '../../core/services/units.service';
+import { CanvasService } from '../../core/services/canvas.service';
+import type { ITheme } from '../../core/services/app-service';
+import type { IDatasetServiceDatapoint } from '../../core/interfaces/dataset.interfaces';
+
+const themeMock = new Proxy({}, { get: () => '#000000' }) as unknown as ITheme;
+
+function chartValueData(component: MinichartComponent): unknown[] {
+  return (component as unknown as { chart: { data: { datasets: { data: unknown[] }[] } } }).chart.data.datasets[0].data;
+}
+
+describe('MinichartComponent', () => {
+  let fixture: ComponentFixture<MinichartComponent>;
+  let component: MinichartComponent;
+  const historyMock = { getBackfillThenLive: vi.fn() };
+  const unitsMock = { convertToUnit: (_unit: string, value: number) => value };
+  const canvasMock = { releaseCanvas: vi.fn() };
+
+  beforeEach(async () => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({} as unknown as CanvasRenderingContext2D);
+    historyMock.getBackfillThenLive.mockReset().mockReturnValue(new Subject());
+
+    await TestBed.configureTestingModule({
+      imports: [MinichartComponent],
+      providers: [
+        { provide: HistoryChartStreamService, useValue: historyMock },
+        { provide: UnitsService, useValue: unitsMock },
+        { provide: CanvasService, useValue: canvasMock }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MinichartComponent);
+    fixture.componentRef.setInput('theme', themeMock);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    TestBed.resetTestingModule();
+  });
+
+  it('streams from the History engine using the fixed 12s mini-chart window', () => {
+    component.dataPath = 'self.navigation.speedOverGround';
+    component.dataSource = 'default';
+    component.startChart();
+
+    expect(historyMock.getBackfillThenLive).toHaveBeenCalledTimes(1);
+    const params = historyMock.getBackfillThenLive.mock.calls[0][0];
+    expect(params.path).toBe('self.navigation.speedOverGround');
+    expect(params.source).toBe('default');
+    // resolveWindowMs('minute', 0.2) → deriveDataSourceInfo: 12000ms / 100ms / 120pts / smoothing 30.
+    expect(params.windowMs).toBe(12_000);
+    expect(params.sampleTime).toBe(100);
+    expect(params.maxDataPoints).toBe(120);
+    expect(params.smoothingPeriod).toBe(30);
+  });
+
+  it('does not stream without a data path', () => {
+    component.dataPath = null;
+    component.startChart();
+    expect(historyMock.getBackfillThenLive).not.toHaveBeenCalled();
+  });
+
+  it('handles a HISTORY_UNAVAILABLE emission cleanly (empty sparkline, no crash)', () => {
+    const stream = new Subject();
+    historyMock.getBackfillThenLive.mockReturnValue(stream);
+    component.dataPath = 'self.navigation.speedOverGround';
+    component.startChart();
+
+    expect(() => stream.next(HISTORY_UNAVAILABLE)).not.toThrow();
+    expect(chartValueData(component).length).toBe(0);
+  });
+
+  it('plots a backfill batch and then a live point off the history stream', () => {
+    const stream = new Subject();
+    historyMock.getBackfillThenLive.mockReturnValue(stream);
+    component.dataPath = 'self.navigation.speedOverGround';
+    component.startChart();
+
+    const batch: IDatasetServiceDatapoint[] = [
+      { timestamp: 1000, data: { value: 1 } },
+      { timestamp: 2000, data: { value: 2 } }
+    ];
+    stream.next(batch);
+    stream.next({ timestamp: 3000, data: { value: 3 } });
+
+    expect(chartValueData(component).length).toBe(3);
+  });
+});

--- a/src/app/widgets/minichart/minichart.component.ts
+++ b/src/app/widgets/minichart/minichart.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnDestroy, ElementRef, viewChild, inject, effect, NgZone, input, untracked, ChangeDetectionStrategy } from '@angular/core';
-import { DatasetStreamService } from '../../core/services/dataset-stream.service';
-import { IDatasetServiceDatapoint, IDatasetServiceDataSourceInfo, IDatasetServiceDatasetConfig } from '../../core/interfaces/dataset.interfaces';
+import { HistoryChartStreamService, IHistoryChartStreamParams, isHistoryUnavailable } from '../../core/services/history-chart-stream.service';
+import { IDatasetServiceDatapoint, TimeScaleFormat } from '../../core/interfaces/dataset.interfaces';
+import { resolveWindowMs, deriveDataSourceInfo, IChartDataSourceInfo } from '../../core/utils/chart-window.util';
 import { Subscription } from 'rxjs';
 import { CanvasService } from '../../core/services/canvas.service';
 import { ITheme } from '../../core/services/app-service';
@@ -27,6 +28,10 @@ interface IDataSetRow {
   y: number
 }
 
+/** The numeric widget's background sparkline always shows the same short fixed window. */
+const MINICHART_TIME_SCALE: TimeScaleFormat = 'minute';
+const MINICHART_PERIOD = 0.2;
+
 @Component({
   selector: 'minichart',
   imports: [],
@@ -45,9 +50,8 @@ export class MinichartComponent implements OnDestroy {
   public yScaleMax: number = null;
   public inverseYAxis = false;
   public verticalChart = null;
-  public datasetUUID: string = null;
   protected unitsService = inject(UnitsService);
-  private readonly dsService = inject(DatasetStreamService);
+  private readonly historyStream = inject(HistoryChartStreamService);
   private readonly ngZone = inject(NgZone);
   private readonly canvasService = inject(CanvasService);
   readonly widgetDataChart = viewChild('widgetDataChart', { read: ElementRef });
@@ -71,9 +75,8 @@ export class MinichartComponent implements OnDestroy {
   }
   public lineChartType: ChartType = 'line';
   private chart;
-  private dsServiceSub: Subscription = null;
-  private datasetConfig: IDatasetServiceDatasetConfig = null;
-  private dataSourceInfo: IDatasetServiceDataSourceInfo = null;
+  private streamSub: Subscription = null;
+  private dataSourceInfo: IChartDataSourceInfo = null;
   private isDestroyed = false;
   private lastChartSignature: string | null = null;
 
@@ -92,7 +95,7 @@ export class MinichartComponent implements OnDestroy {
       const theme = this.theme();
       if (theme) {
         untracked(() => {
-          if (this.datasetConfig) {
+          if (this.chart) {
             this.setChartOptions();
             this.setDatasetsColors();
           }
@@ -102,41 +105,38 @@ export class MinichartComponent implements OnDestroy {
   }
 
   public startChart(): void {
-    if (this.isDestroyed || !this.datasetUUID) return;
-    this.datasetConfig = this.dsService.getDatasetConfig(this.datasetUUID);
-    this.dataSourceInfo = this.dsService.getDataSourceInfo(this.datasetUUID);
+    if (this.isDestroyed || !this.dataPath) return;
+    const windowMs = resolveWindowMs(MINICHART_TIME_SCALE, MINICHART_PERIOD);
+    this.dataSourceInfo = deriveDataSourceInfo(windowMs);
 
-    if (this.datasetConfig) {
-      const chartSignature = this.buildChartSignature();
-      if (this.chart && chartSignature === this.lastChartSignature) {
-        return;
-      }
-
-      if (this.chart && chartSignature !== this.lastChartSignature) {
-        this.destroyChart();
-      }
-
-      this.setChartOptions();
-      this.createDatasets();
-      const canvasEl = this.widgetDataChart()?.nativeElement as HTMLCanvasElement | undefined;
-      const ctx = canvasEl?.getContext('2d');
-      if (!ctx) return;
-
-      this.chart = new Chart(ctx, {
-        type: this.lineChartType,
-        data: this.lineChartData,
-        options: this.lineChartOptions
-      });
-
-      this.lastChartSignature = chartSignature;
-
-      this.startStreaming();
+    const chartSignature = this.buildChartSignature();
+    if (this.chart && chartSignature === this.lastChartSignature) {
+      return;
     }
+
+    if (this.chart && chartSignature !== this.lastChartSignature) {
+      this.destroyChart();
+    }
+
+    this.setChartOptions();
+    this.createDatasets();
+    const canvasEl = this.widgetDataChart()?.nativeElement as HTMLCanvasElement | undefined;
+    const ctx = canvasEl?.getContext('2d');
+    if (!ctx) return;
+
+    this.chart = new Chart(ctx, {
+      type: this.lineChartType,
+      data: this.lineChartData,
+      options: this.lineChartOptions
+    });
+
+    this.lastChartSignature = chartSignature;
+
+    this.startStreaming();
   }
 
   private buildChartSignature(): string {
     return [
-      this.datasetUUID,
       this.dataPath,
       this.dataSource,
       this.convertUnitTo,
@@ -191,7 +191,7 @@ export class MinichartComponent implements OnDestroy {
             display: false
           },
           time: {
-            unit: this.datasetConfig.timeScaleFormat as TimeUnit,
+            unit: MINICHART_TIME_SCALE as TimeUnit,
             minUnit: "second",
             round: "second",
             displayFormats: {
@@ -225,7 +225,7 @@ export class MinichartComponent implements OnDestroy {
             display: false
           },
           time: {
-            unit: this.datasetConfig.timeScaleFormat as TimeUnit,
+            unit: MINICHART_TIME_SCALE as TimeUnit,
             minUnit: "second",
             round: "second",
             displayFormats: {
@@ -286,7 +286,7 @@ export class MinichartComponent implements OnDestroy {
        streaming: {
         duration: this.dataSourceInfo.maxDataPoints * this.dataSourceInfo.sampleTime,
         delay: this.dataSourceInfo.sampleTime,
-        frameRate: this.datasetConfig.timeScaleFormat === "day" ? 5 : this.datasetConfig.timeScaleFormat === "hour" ? 8 : this.datasetConfig.timeScaleFormat === "minute" ? 15 : 30,
+        frameRate: MINICHART_TIME_SCALE === "day" ? 5 : MINICHART_TIME_SCALE === "hour" ? 8 : MINICHART_TIME_SCALE === "minute" ? 15 : 30,
        }
     }
   }
@@ -495,39 +495,41 @@ export class MinichartComponent implements OnDestroy {
   }
 
   private startStreaming(): void {
-    this.dsServiceSub?.unsubscribe();
+    this.streamSub?.unsubscribe();
 
-    const batchThenLive$ = this.dsService.getDatasetBatchThenLiveObservable(
-      this.datasetUUID
-    );
+    const info = this.dataSourceInfo;
+    const params: IHistoryChartStreamParams = {
+      path: this.dataPath,
+      source: this.dataSource ?? 'default',
+      windowMs: resolveWindowMs(MINICHART_TIME_SCALE, MINICHART_PERIOD),
+      sampleTime: info.sampleTime,
+      maxDataPoints: info.maxDataPoints,
+      smoothingPeriod: info.smoothingPeriod
+    };
 
-    this.dsServiceSub = batchThenLive$?.subscribe(dsPointOrBatch => {
+    this.streamSub = this.historyStream.getBackfillThenLive(params).subscribe(emission => {
       if (this.isDestroyed || !this.chart) return;
       const chartWithCtx = this.chart as { ctx?: CanvasRenderingContext2D | null };
       if (!chartWithCtx.ctx) return;
+      // No history provider: leave the sparkline empty rather than crashing.
+      if (isHistoryUnavailable(emission)) return;
 
-      if (Array.isArray(dsPointOrBatch)) {
-        // Initial batch: fill the chart with the last N points
-        const valueRows = this.transformDatasetRows(dsPointOrBatch, 0);
+      if (Array.isArray(emission)) {
+        // Initial backfill: fill the chart with the window's points.
+        const valueRows = this.transformDatasetRows(emission, 0);
         this.chart.data.datasets[0].data.push(...valueRows);
         if (this.config.showAverageData) {
-          const avgRows = this.transformDatasetRows(dsPointOrBatch, this.config.datasetAverageArray);
+          const avgRows = this.transformDatasetRows(emission, this.config.datasetAverageArray);
           this.chart.data.datasets[1].data.push(...avgRows);
         }
       } else {
         // Live: handle new single datapoint
-        const valueRow = this.transformDatasetRows([dsPointOrBatch], 0)[0];
+        const valueRow = this.transformDatasetRows([emission], 0)[0];
         this.chart.data.datasets[0].data.push(valueRow);
-        /* if (this.chart.data.datasets[0].data.length > this.dataSourceInfo.maxDataPoints) {
-          this.chart.data.datasets[0].data.shift();
-        } */
 
         if (this.config.showAverageData) {
-          const avgRow = this.transformDatasetRows([dsPointOrBatch], this.config.datasetAverageArray)[0];
+          const avgRow = this.transformDatasetRows([emission], this.config.datasetAverageArray)[0];
           this.chart.data.datasets[1].data.push(avgRow);
-          /* if (this.chart.data.datasets[1].data.length > this.dataSourceInfo.maxDataPoints) {
-            this.chart.data.datasets[1].data.shift();
-          } */
         }
       }
 
@@ -541,8 +543,8 @@ export class MinichartComponent implements OnDestroy {
   }
 
   private destroyChart(): void {
-    this.dsServiceSub?.unsubscribe();
-    this.dsServiceSub = null;
+    this.streamSub?.unsubscribe();
+    this.streamSub = null;
     this.chart?.destroy();
     this.chart = null;
     this.lastChartSignature = null;

--- a/src/app/widgets/widget-numeric/widget-numeric.component.ts
+++ b/src/app/widgets/widget-numeric/widget-numeric.component.ts
@@ -6,7 +6,6 @@ import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.dir
 import { WidgetStreamsDirective } from '../../core/directives/widget-streams.directive';
 import { IPathUpdate } from '../../core/services/data.service';
 import { CanvasService } from '../../core/services/canvas.service';
-import { WidgetDatasetOrchestratorService } from '../../core/services/widget-dataset-orchestrator.service';
 import { ITheme } from '../../core/services/app-service';
 import { getColors } from '../../core/utils/themeColors.utils';
 import { States } from '../../core/interfaces/signalk-interfaces';
@@ -57,7 +56,6 @@ export class WidgetNumericComponent implements OnInit, AfterViewInit, OnDestroy 
   private readonly stream = inject(WidgetStreamsDirective);
 
   private readonly canvas = inject(CanvasService);
-  private readonly datasetLifecycle = inject(WidgetDatasetOrchestratorService);
   protected miniChart = viewChild(MinichartComponent);
   private canvasMainRef = viewChild.required<ElementRef<HTMLCanvasElement>>('canvasMainRef');
 
@@ -163,7 +161,7 @@ export class WidgetNumericComponent implements OnInit, AfterViewInit, OnDestroy 
         if (sig) {
           this.stream?.observe('numericPath', this.onNumericValue);
           this.streamRegistered = true;
-          this.manageDatasetAndChart();
+          this.updateMiniChartVisibility();
         }
       });
     });
@@ -216,7 +214,7 @@ export class WidgetNumericComponent implements OnInit, AfterViewInit, OnDestroy 
     if (!this.streamRegistered && this.subscriptionSignature()) {
       this.stream?.observe('numericPath', this.onNumericValue);
       this.streamRegistered = true;
-      this.manageDatasetAndChart();
+      this.updateMiniChartVisibility();
     }
   }
 
@@ -227,18 +225,8 @@ export class WidgetNumericComponent implements OnInit, AfterViewInit, OnDestroy 
     this.maxMinMaxTextHeight = Math.floor(this.cssHeight * 0.1);
   }
 
-  private manageDatasetAndChart(): void {
-    const cfg = this.runtime.options();
-    const pathInfo = cfg.paths['numericPath'];
-    const show = !!cfg.showMiniChart;
-    this.showMiniChart.set(show);
-    if (!show) {
-      this.datasetLifecycle.removeDatasetIfExists(this.id(), false);
-      return;
-    }
-    if (!pathInfo || !pathInfo.path) return;
-    const source = pathInfo.source ?? 'default';
-    this.datasetLifecycle.syncNumericMiniChartDataset(this.id(), pathInfo.path, source);
+  private updateMiniChartVisibility(): void {
+    this.showMiniChart.set(!!this.runtime.options().showMiniChart);
   }
 
   private setMiniChart(): void {
@@ -253,7 +241,6 @@ export class WidgetNumericComponent implements OnInit, AfterViewInit, OnDestroy 
     this.miniChart().yScaleMax = cfg.yScaleMax;
     this.miniChart().inverseYAxis = cfg.inverseYAxis;
     this.miniChart().verticalChart = cfg.verticalChart;
-    this.miniChart().datasetUUID = this.id();
   }
 
   private setColors(): void {
@@ -384,7 +371,6 @@ export class WidgetNumericComponent implements OnInit, AfterViewInit, OnDestroy 
 
   ngOnDestroy(): void {
     this.isDestroyed = true;
-    this.datasetLifecycle.removeDatasetIfExists(this.id(), false);
     try { this.canvas.unregisterCanvas(this.canvasElement); } catch { /* ignore */ }
   }
 }


### PR DESCRIPTION
## Why

The numeric widget's background sparkline (`MinichartComponent`) was the last **recorder-only** consumer besides windtrends — it read a pre-recorded dataset by `datasetUUID` from `DatasetStreamService` and had no History-engine path. Deleting the recorder (a later #64 PR) would silently blank it. This migrates it first so the recorder can go without a regression.

## What

- **`MinichartComponent`** now streams from `HistoryChartStreamService.getBackfillThenLive` instead of `dsService.getDatasetBatchThenLiveObservable(datasetUUID)`. Its window is the same fixed 12s (`minute` / `0.2`) the recorder used, derived through the shared `resolveWindowMs` + `deriveDataSourceInfo` — the recorder derived sampling the exact same way (`dataset-stream.service.ts:136-137`), so cadence, buffer size and rendering are unchanged (12000ms → 100ms / 120pts / smoothing 30).
- **`widget-numeric`** drops its orchestrator dataset sync (`syncNumericMiniChartDataset` / `removeDatasetIfExists`) and the `datasetUUID` wiring — the sparkline no longer needs a user-managed dataset. The now-misnamed `manageDatasetAndChart` becomes `updateMiniChartVisibility`.
- **No-provider** emissions leave the sparkline empty instead of crashing (`isHistoryUnavailable` guard).

Mirrors the already-reviewed history branch in `widget-data-chart`.

## Verification

- `npm run build:dev` + `npm run lint` — clean.
- New `minichart.component.spec.ts` (the component's first tests): asserts the derived History params (path/source/window/sampleTime/points/smoothing), the no-path guard, clean `HISTORY_UNAVAILABLE` handling, and batch-then-live plotting. `widget-numeric`'s change is a pure removal, covered by the compile and the mini-chart's data-path spec.

Part of #64.
