### PR TITLE
feat(charts): stream the wind-trends chart from two History feeds

### DIFF
--- a/src/app/widgets/widget-windtrends-chart/widget-windtrends-chart.component.spec.ts
+++ b/src/app/widgets/widget-windtrends-chart/widget-windtrends-chart.component.spec.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Chart.js cannot instantiate under jsdom. Mock it self-contained (no importOriginal / outer refs)
+// so vi.mock hoisting does not trip a TDZ. The mock Chart carries a truthy `ctx`.
+vi.mock('chart.js', () => {
+  class MockChart {
+    public static register(): void { /* noop */ }
+    public ctx = {};
+    public data: { datasets: { data: unknown[] }[] };
+    public options: { plugins?: Record<string, unknown>; scales?: Record<string, unknown> } = {};
+    constructor(_ctx: unknown, config: { data: { datasets: { data: unknown[] }[] }; options: unknown }) {
+      this.data = config.data;
+      this.options = (config.options ?? {}) as typeof this.options;
+    }
+    public update(): void { /* noop */ }
+    public destroy(): void { /* noop */ }
+  }
+  return {
+    Chart: MockChart,
+    TimeScale: {}, LinearScale: {}, LineController: {}, PointElement: {},
+    LineElement: {}, Filler: {}, Title: {}, SubTitle: {}
+  };
+});
+vi.mock('chartjs-adapter-date-fns', () => ({}));
+vi.mock('@aziham/chartjs-plugin-streaming', () => ({ default: {} }));
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Subject, of } from 'rxjs';
+import { BreakpointObserver } from '@angular/cdk/layout';
+import { WidgetWindTrendsChartComponent } from './widget-windtrends-chart.component';
+import { HistoryChartStreamService, HISTORY_UNAVAILABLE } from '../../core/services/history-chart-stream.service';
+import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
+import { UnitsService } from '../../core/services/units.service';
+import { CanvasService } from '../../core/services/canvas.service';
+import type { ITheme } from '../../core/services/app-service';
+import type { IDatasetServiceDatapoint } from '../../core/interfaces/dataset.interfaces';
+
+const themeMock = new Proxy({}, { get: () => '#000000' }) as unknown as ITheme;
+
+describe('WidgetWindTrendsChartComponent', () => {
+  let fixture: ComponentFixture<WidgetWindTrendsChartComponent>;
+
+  const runtimeMock = { options: vi.fn() };
+  const historyMock = { getBackfillThenLive: vi.fn() };
+  const unitsMock = { convertToUnit: (_unit: string, value: number) => value };
+  const canvasMock = { registerCanvas: vi.fn(), releaseCanvas: vi.fn(), unregisterCanvas: vi.fn() };
+  const breakpointMock = { observe: vi.fn().mockReturnValue(of({ matches: false, breakpoints: {} })) };
+
+  const setup = async (timeScale = 'Last 30 Minutes'): Promise<void> => {
+    runtimeMock.options.mockReturnValue({ timeScale, color: 'contrast' });
+
+    await TestBed.configureTestingModule({
+      imports: [WidgetWindTrendsChartComponent],
+      providers: [
+        { provide: WidgetRuntimeDirective, useValue: runtimeMock },
+        { provide: HistoryChartStreamService, useValue: historyMock },
+        { provide: UnitsService, useValue: unitsMock },
+        { provide: CanvasService, useValue: canvasMock },
+        { provide: BreakpointObserver, useValue: breakpointMock }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(WidgetWindTrendsChartComponent);
+    fixture.componentRef.setInput('id', 'w1');
+    fixture.componentRef.setInput('type', 'widget-windtrends-chart');
+    fixture.componentRef.setInput('theme', themeMock);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  };
+
+  beforeEach(() => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({} as unknown as CanvasRenderingContext2D);
+    runtimeMock.options.mockReset();
+    historyMock.getBackfillThenLive.mockReset().mockReturnValue(new Subject());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    TestBed.resetTestingModule();
+  });
+
+  it('opens two History streams — direction and speed — with the derived window params', async () => {
+    await setup('Last 30 Minutes');
+
+    expect(historyMock.getBackfillThenLive).toHaveBeenCalledTimes(2);
+    const paths = historyMock.getBackfillThenLive.mock.calls.map(c => c[0].path);
+    expect(paths).toContain('self.environment.wind.directionTrue');
+    expect(paths).toContain('self.environment.wind.speedTrue');
+
+    const params = historyMock.getBackfillThenLive.mock.calls[0][0];
+    expect(params.source).toBe('default');
+    // resolveWindowMs('Last 30 Minutes', 30) → 1_800_000ms → deriveDataSourceInfo: 3600 / 500 / 125.
+    expect(params.windowMs).toBe(1_800_000);
+    expect(params.sampleTime).toBe(3_600);
+    expect(params.maxDataPoints).toBe(500);
+    expect(params.smoothingPeriod).toBe(125);
+  });
+
+  it('handles a HISTORY_UNAVAILABLE emission on either stream without crashing', async () => {
+    const dir = new Subject();
+    const spd = new Subject();
+    historyMock.getBackfillThenLive
+      .mockReturnValueOnce(dir)
+      .mockReturnValueOnce(spd);
+    await setup('Last 30 Minutes');
+
+    expect(() => dir.next(HISTORY_UNAVAILABLE)).not.toThrow();
+    expect(() => spd.next(HISTORY_UNAVAILABLE)).not.toThrow();
+  });
+
+  it('plots direction and speed backfill batches without crashing', async () => {
+    const dir = new Subject();
+    const spd = new Subject();
+    historyMock.getBackfillThenLive
+      .mockReturnValueOnce(dir)
+      .mockReturnValueOnce(spd);
+    await setup('Last 30 Minutes');
+
+    const batch: IDatasetServiceDatapoint[] = [
+      { timestamp: 1000, data: { value: 10, sma: 10, lastAverage: 10, lastMinimum: 10, lastMaximum: 10 } },
+      { timestamp: 2000, data: { value: 350, sma: 340, lastAverage: 345, lastMinimum: 10, lastMaximum: 350 } }
+    ];
+    expect(() => { dir.next(batch); spd.next(batch); }).not.toThrow();
+  });
+});

--- a/src/app/widgets/widget-windtrends-chart/widget-windtrends-chart.component.ts
+++ b/src/app/widgets/widget-windtrends-chart/widget-windtrends-chart.component.ts
@@ -2,21 +2,26 @@ import { Component, OnDestroy, ElementRef, viewChild, inject, effect, NgZone, in
 import { BreakpointObserver, Breakpoints, BreakpointState } from '@angular/cdk/layout';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
-import { DatasetStreamService } from '../../core/services/dataset-stream.service';
-import { IDatasetServiceDatapoint, IDatasetServiceDataSourceInfo } from '../../core/interfaces/dataset.interfaces';
+import { HistoryChartStreamService, IHistoryChartStreamParams, isHistoryUnavailable } from '../../core/services/history-chart-stream.service';
+import { IDatasetServiceDatapoint } from '../../core/interfaces/dataset.interfaces';
+import { resolveWindowMs, deriveDataSourceInfo, IChartDataSourceInfo } from '../../core/utils/chart-window.util';
 import { Subscription } from 'rxjs';
 import { CanvasService } from '../../core/services/canvas.service';
 import { UnitsService } from '../../core/services/units.service';
 import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
 import { ITheme } from '../../core/services/app-service';
-import { IDatasetServiceDatasetConfig, TimeScaleFormat } from '../../core/interfaces/dataset.interfaces';
-import { WidgetDatasetOrchestratorService } from '../../core/services/widget-dataset-orchestrator.service';
+import { TimeScaleFormat } from '../../core/interfaces/dataset.interfaces';
 
 import { Chart, ChartConfiguration, ChartData, ChartType, TimeScale, LinearScale, LineController, PointElement, LineElement, Filler, Title, SubTitle, ChartArea, Scale, ChartTypeRegistry } from 'chart.js';
 import 'chartjs-adapter-date-fns';
 import ChartStreaming from '@aziham/chartjs-plugin-streaming';
 
 Chart.register(ChartStreaming, TimeScale, LinearScale, LineController, PointElement, LineElement, Filler, Title, SubTitle);
+
+/** Windtrends plots two fixed wind paths (direction + speed) over the widget's configured window. */
+const WINDTRENDS_PERIOD = 30;
+const WINDTRENDS_TWD_PATH = 'self.environment.wind.directionTrue';
+const WINDTRENDS_TWS_PATH = 'self.environment.wind.speedTrue';
 
 interface IChartColors {
   valueLine: string,
@@ -53,8 +58,7 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
     timeScale: 'Last 30 Minutes'
   };
   private readonly ngZone = inject(NgZone);
-  private readonly _dataset = inject(DatasetStreamService);
-  private readonly datasetLifecycle = inject(WidgetDatasetOrchestratorService);
+  private readonly historyStream = inject(HistoryChartStreamService);
   private readonly canvasService = inject(CanvasService);
   private readonly unitsService = inject(UnitsService);
   private readonly responsive = inject(BreakpointObserver);
@@ -84,8 +88,8 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
   private _dsSpeedSub: Subscription = null;
   /** Pending coalesced chart recompute+repaint frame id (one per animation frame across both streams). */
   private _chartUpdateRafId: number | null = null;
-  private datasetConfig: IDatasetServiceDatasetConfig = null;
-  private dataSourceInfo: IDatasetServiceDataSourceInfo = null;
+  private timeScale: TimeScaleFormat = null;
+  private dataSourceInfo: IChartDataSourceInfo = null;
   private xCenter: number | null = null;
   private xStep: number | null = null;
   private xCenterSpeed: number | null = null;
@@ -310,7 +314,7 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
       const cfg = this.runtime?.options();
       if (!theme || !cfg) return;
       untracked(() => {
-        if (this.datasetConfig && this.chart) {
+        if (this.timeScale && this.chart) {
           this.setChartOptions();
           this.setDatasetsColors();
           this.ngZone.runOutsideAngular(() => this.chart?.update('none'));
@@ -322,9 +326,8 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
     effect(() => {
       const cfg = this.runtime?.options();
       if (!cfg) return;
-      const needsDataset = !this.datasetConfig || this.datasetConfig.timeScaleFormat !== cfg.timeScale;
-      if (needsDataset) {
-        this.syncServiceDatasets();
+      const needsRebuild = this.timeScale !== cfg.timeScale;
+      if (needsRebuild) {
         this.startWidget();
       } else if (this.chart) {
         // color-only change already handled above, but ensure labels updated
@@ -336,9 +339,10 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
   private startWidget(): void {
     // Guard until canvas view is ready
     if (!this.widgetDataChart()) return;
-    this.datasetConfig = this._dataset.getDatasetConfig(`${this.id()}-twd`);
-    this.dataSourceInfo = this._dataset.getDataSourceInfo(`${this.id()}-twd`);
-    if (!this.datasetConfig) return;
+    const cfg = this.runtime?.options();
+    if (!cfg || !cfg.timeScale) return;
+    this.timeScale = cfg.timeScale as TimeScaleFormat;
+    this.dataSourceInfo = deriveDataSourceInfo(resolveWindowMs(this.timeScale, WINDTRENDS_PERIOD));
     this.createDatasets();
     this.setChartOptions();
     if (!this.chart) {
@@ -353,12 +357,6 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
       this.ngZone.runOutsideAngular(() => this.chart?.update('none'));
     }
     this.startStreaming();
-  }
-
-  private syncServiceDatasets(): void {
-    const cfg = this.runtime?.options();
-    if (!cfg || cfg.timeScale === '') return;
-    this.datasetLifecycle.syncWindTrendsDatasets(this.id(), cfg.timeScale as TimeScaleFormat);
   }
 
   private setChartOptions() {
@@ -384,7 +382,7 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
         reverse: true, // 0 (now) at top; older increases downward
         title: {
           display: true,
-          text: `${this.datasetConfig.timeScaleFormat}`,
+          text: `${this.timeScale}`,
           align: "center"
         },
         ticks: {
@@ -396,7 +394,7 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
           font: this.isPhonePortrait().matches ? { size: 12 } : { size: 16 },
           callback: (value: number) => {
             const ms = Number(value);
-            const fmt = this.datasetConfig?.timeScaleFormat;
+            const fmt = this.timeScale;
             const windowMs = this.getWindowMs(fmt);
             // 5-minute scale: show whole minutes
             if (fmt === 'Last 5 Minutes') {
@@ -555,7 +553,7 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
       streaming: {
         duration: this.dataSourceInfo.maxDataPoints * this.dataSourceInfo.sampleTime,
         delay: this.dataSourceInfo.sampleTime,
-        frameRate: this.datasetConfig.timeScaleFormat === "day" ? 5 : this.datasetConfig.timeScaleFormat === "hour" ? 8 : this.datasetConfig.timeScaleFormat === "minute" ? 15 : 30,
+        frameRate: this.timeScale === "day" ? 5 : this.timeScale === "hour" ? 8 : this.timeScale === "minute" ? 15 : 30,
       }
     }
 
@@ -714,14 +712,24 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
     this._dsDirectionSub?.unsubscribe();
     this._dsSpeedSub?.unsubscribe();
 
-    const batchThenLiveDir$ = this._dataset.getDatasetBatchThenLiveObservable(`${this.id()}-twd`);
-    const batchThenLiveSpd$ = this._dataset.getDatasetBatchThenLiveObservable(`${this.id()}-tws`);
+    const info = this.dataSourceInfo;
+    const baseParams = {
+      source: 'default',
+      windowMs: resolveWindowMs(this.timeScale, WINDTRENDS_PERIOD),
+      sampleTime: info.sampleTime,
+      maxDataPoints: info.maxDataPoints,
+      smoothingPeriod: info.smoothingPeriod
+    };
+    // TWD is a direction path; the History engine auto-resolves its circular domain from the unit.
+    const twdParams: IHistoryChartStreamParams = { ...baseParams, path: WINDTRENDS_TWD_PATH };
+    const twsParams: IHistoryChartStreamParams = { ...baseParams, path: WINDTRENDS_TWS_PATH };
 
-    this._dsDirectionSub = batchThenLiveDir$?.subscribe(dsPointOrBatch => {
-      if (Array.isArray(dsPointOrBatch)) {
-        this.pushRowsToDatasets(dsPointOrBatch);
+    this._dsDirectionSub = this.historyStream.getBackfillThenLive(twdParams).subscribe(emission => {
+      if (isHistoryUnavailable(emission)) return;
+      if (Array.isArray(emission)) {
+        this.pushRowsToDatasets(emission);
       } else {
-        this.pushRowsToDatasets([dsPointOrBatch]);
+        this.pushRowsToDatasets([emission]);
         if (this.chart.data.datasets[0].data.length > this.dataSourceInfo.maxDataPoints) {
           for (let i = 0; i <= 4; i++) this.chart.data.datasets[i].data.shift();
         }
@@ -729,11 +737,12 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
       this.scheduleChartUpdate();
     });
 
-    this._dsSpeedSub = batchThenLiveSpd$?.subscribe(dsPointOrBatch => {
-      if (Array.isArray(dsPointOrBatch)) {
-        this.pushRowsToSpeedDatasets(dsPointOrBatch);
+    this._dsSpeedSub = this.historyStream.getBackfillThenLive(twsParams).subscribe(emission => {
+      if (isHistoryUnavailable(emission)) return;
+      if (Array.isArray(emission)) {
+        this.pushRowsToSpeedDatasets(emission);
       } else {
-        this.pushRowsToSpeedDatasets([dsPointOrBatch]);
+        this.pushRowsToSpeedDatasets([emission]);
         if (this.chart.data.datasets[5].data.length > this.dataSourceInfo.maxDataPoints) {
           for (let i = 5; i <= 9; i++) this.chart.data.datasets[i].data.shift();
         }
@@ -934,7 +943,7 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
     }
 
     // Fixed, non-scrolling y-axis window (relative age)
-    const windowMs = this.getWindowMs(this.datasetConfig?.timeScaleFormat);
+    const windowMs = this.getWindowMs(this.timeScale);
     const data0 = this.chart.data.datasets[0].data as (IDataSetRow[]);
     if (data0.length > 0) {
       const nowTs = Date.now();
@@ -950,7 +959,7 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
       this.chart.options.scales.y.max = windowMs;
       // Explicit step per selected window
       let step: number;
-      const fmt = this.datasetConfig?.timeScaleFormat;
+      const fmt = this.timeScale;
       switch (fmt) {
         case 'Last Minute':
           step = 15_000; // 15 seconds


### PR DESCRIPTION
## Why

`widget-windtrends-chart` was the last recorder-only consumer. It read two pre-recorded datasets (`-twd` direction, `-tws` speed) by UUID from `DatasetStreamService`, with no History-engine path — so deleting the recorder would blank it.

## What

Re-point it onto **two independent `HistoryChartStreamService.getBackfillThenLive` streams**, one per path, composed in the widget:

- **No new engine capability.** The two wind series (`self.environment.wind.directionTrue`, `self.environment.wind.speedTrue`) are separate paths, so two ordinary single-path streams — each with its own backfill + live tail, sharing the realtime time axis — cover it. `HistoryChartStreamService` stays single-purpose.
- **Window/sampling** derive from the widget's configured `timeScale` (period 30) via the shared `resolveWindowMs` + `deriveDataSourceInfo` — the same values the recorder used (the orchestrator created both datasets with `timeScale`/period 30).
- **TWD's circular domain** is auto-resolved from the path's unit (no explicit override), matching the recorder's behavior.
- Drops the orchestrator dataset sync (`syncWindTrendsDatasets`) and the `-twd`/`-tws` UUID lookups. A no-provider emission on either stream leaves that series empty (`isHistoryUnavailable` guard). The manual `maxDataPoints` trim is preserved.

Mirrors the minichart migration (#164) with two streams.

## Verification

- `npm run build:dev` + `npm run lint` — clean.
- New `widget-windtrends-chart.component.spec.ts` (the widget's first tests): asserts two streams open with the direction/speed paths and derived window params (`Last 30 Minutes` → 1,800,000ms / 3600 / 500 / 125), clean `HISTORY_UNAVAILABLE` on either stream, and batch plotting for both series.

Part of #64.
