### PR TITLE
Retire useSharedConfig; fix v11 upgrade loop and stale export (#17 PR-2)

### DIFF
--- a/perf-harness/lib/kip-config.mjs
+++ b/perf-harness/lib/kip-config.mjs
@@ -42,7 +42,7 @@ export function connectionConfig(subscribeAll = false) {
     configVersion: 13, kipUUID: '00000000-0000-4000-8000-000000000001',
     signalKUrl: '__ORIGIN__', // replaced with the served origin at inject time
     proxyEnabled: false, signalKSubscribeAll: subscribeAll,
-    useSharedConfig: true, sharedConfigName: 'default',
+    sharedConfigName: 'default',
     isRemoteControl: false, instanceName: '',
   };
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -216,28 +216,17 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
 
       this.missingConfigPromptShown = true;
       const cfgName = issue.sharedConfigName || 'default';
-      const canUpgradeLegacy = issue.legacyUpgradeAvailable === true;
-      const actionLabel = canUpgradeLegacy ? 'Upgrade' : 'Create';
-      const message = canUpgradeLegacy
-        ? `Server is reachable, but no current version shared configuration '${cfgName}' exists for this user. A legacy configuration was found and can be upgraded. Upgrade now?`
-        : `Server is reachable, but no shared configuration '${cfgName}' exists for this user. Create a default configuration now?`;
       const ref = this.toast.show(
-        message,
+        `Server is reachable, but no shared configuration '${cfgName}' exists for this user. Create a default configuration now?`,
         0,
         true,
         'warn',
-        actionLabel
+        'Create'
       );
 
       ref.onAction()
         .pipe(takeUntilDestroyed(this._destroyRef))
-        .subscribe(() => {
-          if (canUpgradeLegacy) {
-            this.upgrade.runUpgrade();
-          } else {
-            this.settings.resetSettings();
-          }
-        });
+        .subscribe(() => this.settings.resetSettings());
     });
 
     // Cookie-mode auth blocked (SSO auto-login looped out of budget, or sign-in required): offer an

--- a/src/app/core/components/options/configuration/config.component.spec.ts
+++ b/src/app/core/components/options/configuration/config.component.spec.ts
@@ -66,7 +66,6 @@ describe('SettingsConfigComponent', () => {
         {
           provide: SettingsService,
           useValue: {
-            useSharedConfig: true,
             getAppConfig: vi.fn(),
             getDashboardConfig: vi.fn(),
             getThemeConfig: vi.fn(),
@@ -143,5 +142,28 @@ describe('SettingsConfigComponent', () => {
     profileMock.switchProfile.mockRejectedValueOnce(new Error('boom'));
     await component['switchProfile']('cockpit');
     expect(toastMock.show).toHaveBeenCalledWith('boom', 0, false, 'error');
+  });
+
+  it('exports the server-held config, never a stale localStorage copy', () => {
+    const settings = TestBed.inject(SettingsService) as unknown as {
+      getAppConfig: ReturnType<typeof vi.fn>;
+      getDashboardConfig: ReturnType<typeof vi.fn>;
+      getThemeConfig: ReturnType<typeof vi.fn>;
+      loadConfigFromLocalStorage: ReturnType<typeof vi.fn>;
+    };
+    const serverApp = { configVersion: 12, browserTabTitle: 'Server' };
+    settings.getAppConfig.mockReturnValue(serverApp);
+    settings.getDashboardConfig.mockReturnValue([{ id: 'dash-1' }]);
+    settings.getThemeConfig.mockReturnValue({ themeName: 'dark' });
+    settings.loadConfigFromLocalStorage.mockReturnValue({ stale: true });
+
+    const exported = component.getActiveConfig();
+
+    expect(exported).toEqual({
+      app: serverApp,
+      dashboards: [{ id: 'dash-1' }],
+      theme: { themeName: 'dark' }
+    });
+    expect(settings.loadConfigFromLocalStorage).not.toHaveBeenCalled();
   });
 });

--- a/src/app/core/components/options/configuration/config.component.ts
+++ b/src/app/core/components/options/configuration/config.component.ts
@@ -143,22 +143,10 @@ export class SettingsConfigComponent {
   }
 
   public getActiveConfig(): IConfig {
-    return this.settings.useSharedConfig ? this.getLocalConfigFromMemory() : this.getLocalConfigFromLocalStorage();
-  }
-
-  public getLocalConfigFromMemory(): IConfig {
     return {
       app: this.settings.getAppConfig(),
       dashboards: this.settings.getDashboardConfig(),
       theme: this.settings.getThemeConfig()
-    };
-  }
-
-  public getLocalConfigFromLocalStorage(): IConfig {
-    return {
-      app: this.settings.loadConfigFromLocalStorage('appConfig'),
-      dashboards: this.settings.loadConfigFromLocalStorage('dashboardsConfig'),
-      theme: this.settings.loadConfigFromLocalStorage('themeConfig')
     };
   }
 

--- a/src/app/core/interfaces/app-settings.interfaces.ts
+++ b/src/app/core/interfaces/app-settings.interfaces.ts
@@ -8,7 +8,6 @@ export interface IConnectionConfig {
   signalKUrl: string;
   proxyEnabled: boolean;
   signalKSubscribeAll: boolean;
-  useSharedConfig: boolean;
   sharedConfigName: string;
   // Remote-control identity is per-device: a profile switch must not change whether this display
   // participates in remote control or the name it advertises.

--- a/src/app/core/services/app-initNetwork.service.spec.ts
+++ b/src/app/core/services/app-initNetwork.service.spec.ts
@@ -148,9 +148,9 @@ describe('AppNetworkInitService', () => {
     }
 
     describe('migrateRemoteControlToDevice (connectionConfig v12 -> v13)', () => {
-        const baseV12: Partial<IConnectionConfig> = { configVersion: 12, useSharedConfig: true, isRemoteControl: false, instanceName: '' };
+        const baseV12: Partial<IConnectionConfig> = { configVersion: 12, isRemoteControl: false, instanceName: '' };
 
-        it('shared boot lifts the profile identity and stamps v13 once', () => {
+        it('boot with a loaded profile lifts its identity and stamps v13 once', () => {
             localStorage.removeItem('skip.connectionConfig');
             setConnConfig({ ...baseV12 });
             migrate({ app: { isRemoteControl: true, instanceName: 'Helm' } } as unknown as IConfig);
@@ -159,22 +159,24 @@ describe('AppNetworkInitService', () => {
             expect(storedConn()?.configVersion).toBe(13);
         });
 
-        it('local boot lifts the identity from the local appConfig', () => {
+        it('boot without a profile lifts the identity from the legacy local appConfig', () => {
             localStorage.removeItem('skip.connectionConfig');
             localStorage.setItem('skip.appConfig', JSON.stringify({ isRemoteControl: true, instanceName: 'Mast' }));
-            setConnConfig({ ...baseV12, useSharedConfig: false });
+            setConnConfig({ ...baseV12 });
             migrate(null);
             expect(storedConn()?.isRemoteControl).toBe(true);
             expect(storedConn()?.instanceName).toBe('Mast');
             expect(storedConn()?.configVersion).toBe(13);
         });
 
-        it('degraded shared boot (no profile) defers: version stays 12, nothing persisted', () => {
+        it('boot with neither profile nor local appConfig migrates with identity defaults', () => {
             localStorage.removeItem('skip.connectionConfig');
-            setConnConfig({ ...baseV12, useSharedConfig: true });
+            localStorage.removeItem('skip.appConfig');
+            setConnConfig({ ...baseV12, isRemoteControl: true, instanceName: 'stale' });
             migrate(null);
-            expect(storedConn()).toBeNull();
-            expect((service as unknown as { config: IConnectionConfig }).config.configVersion).toBe(12);
+            expect(storedConn()?.isRemoteControl).toBe(false);
+            expect(storedConn()?.instanceName).toBe('');
+            expect(storedConn()?.configVersion).toBe(13);
         });
 
         it('is a no-op when already migrated (version >= 13)', () => {
@@ -354,6 +356,25 @@ describe('AppNetworkInitService', () => {
             await service.initNetworkServices();
 
             expect(mockConnectionStateMachine.startWebSocketConnection).not.toHaveBeenCalled();
+        });
+
+        it('classifies a genuine storage 404 as missing-shared-config (recovery toast reachable)', async () => {
+            mockAuth.refreshLoginStatus.mockImplementation(async () => { isLoggedIn$.next(true); return { status: 'loggedIn' }; });
+            mockStorage.getConfig.mockRejectedValue({ status: 404 });
+
+            await service.initNetworkServices();
+
+            expect(latestIssue()).toEqual({ reason: 'missing-shared-config', statusCode: 404, sharedConfigName: 'default' });
+        });
+
+        it('classifies a discovery 404 as unknown — config recovery must not be offered', async () => {
+            // A 404 from GET /signalk/ (SK serving the app but not the API) reaches the same
+            // bootstrap catch; only the config fetch's own 404 may claim missing-shared-config.
+            mockConnection.initializeConnection.mockRejectedValueOnce({ status: 404 });
+
+            await service.initNetworkServices();
+
+            expect(latestIssue()).toEqual({ reason: 'unknown', statusCode: 404 });
         });
 
         it('starts the WebSocket once from a fresh HTTPConnected state', async () => {

--- a/src/app/core/services/app-initNetwork.service.ts
+++ b/src/app/core/services/app-initNetwork.service.ts
@@ -33,7 +33,6 @@ export interface IBootstrapIssue {
   reason: TBootstrapIssueReason;
   statusCode?: number;
   sharedConfigName?: string;
-  legacyUpgradeAvailable?: boolean;
   cause?: TAuthBlockedCause;
 }
 
@@ -160,11 +159,9 @@ export class AppNetworkInitService implements OnDestroy {
             // the real "no shared configuration yet" signal. Surface recovery here; the 404 catch
             // branch below remains only for servers that genuinely answer 404.
             startupDegraded = true;
-            const legacyUpgradeAvailable = await this.probeLegacyUpgradeAvailability(this.config.sharedConfigName);
             this._bootstrapIssue$.next({
               reason: 'missing-shared-config',
-              sharedConfigName: this.config.sharedConfigName,
-              legacyUpgradeAvailable
+              sharedConfigName: this.config.sharedConfigName
             });
             this._bootstrapStatus$.next('degraded');
             return;
@@ -191,12 +188,10 @@ export class AppNetworkInitService implements OnDestroy {
     } catch (error) {
       startupDegraded = true;
       if (error?.status === 404 && this.config?.useSharedConfig) {
-        const legacyUpgradeAvailable = await this.probeLegacyUpgradeAvailability(this.config.sharedConfigName);
         this._bootstrapIssue$.next({
           reason: 'missing-shared-config',
           statusCode: 404,
-          sharedConfigName: this.config.sharedConfigName,
-          legacyUpgradeAvailable
+          sharedConfigName: this.config.sharedConfigName
         });
       } else if (error?.status === 0) {
         this._bootstrapIssue$.next({ reason: 'network-unreachable', statusCode: 0 });
@@ -311,20 +306,6 @@ export class AppNetworkInitService implements OnDestroy {
         resolve(state);
       });
     });
-  }
-
-  private async probeLegacyUpgradeAvailability(sharedConfigName: string): Promise<boolean> {
-    if (!sharedConfigName) {
-      return false;
-    }
-
-    try {
-      const legacyConfig = await this.storage.getConfig('user', sharedConfigName, 9) as IConfig;
-      const legacyConfigVersion = legacyConfig?.app?.configVersion;
-      return legacyConfigVersion === 10;
-    } catch {
-      return false;
-    }
   }
 
   private setLocalStorageConfig(): void {

--- a/src/app/core/services/app-initNetwork.service.ts
+++ b/src/app/core/services/app-initNetwork.service.ts
@@ -153,11 +153,26 @@ export class AppNetworkInitService implements OnDestroy {
         if (!storageReady) {
           throw new Error('[AppInit Network Service] StorageService did not become ready in time. Cannot bootstrap remote configuration.');
         } else {
-          remoteConfig = await this.storage.getConfig('user', this.config.sharedConfigName, configFileVersion);
+          try {
+            remoteConfig = await this.storage.getConfig('user', this.config.sharedConfigName, configFileVersion);
+          } catch (error) {
+            // Only a 404 from the config fetch itself means "no shared configuration"; 404s from
+            // earlier bootstrap steps (e.g. /signalk/ discovery) must not offer config recovery.
+            if (error?.status === 404) {
+              startupDegraded = true;
+              this._bootstrapIssue$.next({
+                reason: 'missing-shared-config',
+                statusCode: 404,
+                sharedConfigName: this.config.sharedConfigName
+              });
+              this._bootstrapStatus$.next('degraded');
+              return;
+            }
+            throw error;
+          }
           if (!remoteConfig?.app) {
             // SK answers a never-created slot with 200 {} rather than a 404, so an appless config is
-            // the real "no shared configuration yet" signal. Surface recovery here; the 404 catch
-            // branch below remains only for servers that genuinely answer 404.
+            // the real "no shared configuration yet" signal.
             startupDegraded = true;
             this._bootstrapIssue$.next({
               reason: 'missing-shared-config',
@@ -175,8 +190,8 @@ export class AppNetworkInitService implements OnDestroy {
         }
       }
 
-      // Lift remote-control identity to the per-device connectionConfig (once). Runs after the
-      // profile is loaded; skipped on a degraded shared boot (remoteConfig null) so it retries later.
+      // Lift remote-control identity to the per-device connectionConfig (once). Identity comes from
+      // the loaded profile, else the legacy local appConfig blob, else identity defaults.
       this.migrateRemoteControlToDevice(remoteConfig);
 
       this._bootstrapIssue$.next({ reason: 'none' });
@@ -187,13 +202,7 @@ export class AppNetworkInitService implements OnDestroy {
 
     } catch (error) {
       startupDegraded = true;
-      if (error?.status === 404 && this.config?.useSharedConfig) {
-        this._bootstrapIssue$.next({
-          reason: 'missing-shared-config',
-          statusCode: 404,
-          sharedConfigName: this.config.sharedConfigName
-        });
-      } else if (error?.status === 0) {
+      if (error?.status === 0) {
         this._bootstrapIssue$.next({ reason: 'network-unreachable', statusCode: 0 });
       } else if (error?.status === 401) {
         this._bootstrapIssue$.next({ reason: 'unauthorized', statusCode: 401 });
@@ -315,9 +324,9 @@ export class AppNetworkInitService implements OnDestroy {
   /**
    * One-time migration (connectionConfig version < 13 → 13): the remote-control identity
    * (isRemoteControl, instanceName) moved from the profile (IAppConfig) to the per-device
-   * connectionConfig. Lift the existing values from the active profile (shared mode) or the local
-   * appConfig (local mode). On a degraded shared boot the profile is unavailable, so the lift is
-   * deferred (version stays < 13) and retried on a later successful boot.
+   * connectionConfig. Lift the existing values from the profile loaded this boot, falling back to
+   * the legacy local appConfig blob when no profile is available; absent both, migrate with the
+   * identity defaults.
    *
    * @param {IConfig | null} remoteConfig The profile loaded this boot, or null when unavailable.
    */
@@ -328,15 +337,12 @@ export class AppNetworkInitService implements OnDestroy {
     // The fields still exist at runtime in pre-migration stored configs, but were removed from IAppConfig.
     let app: { isRemoteControl?: boolean; instanceName?: string } | null =
       (remoteConfig?.app as unknown as { isRemoteControl?: boolean; instanceName?: string }) ?? null;
-    if (!app && !this.config.useSharedConfig) {
+    if (!app) {
       try {
         app = JSON.parse(localStorage.getItem(LOCAL_CONFIG_KEYS.appConfig) ?? 'null');
       } catch {
         app = null;
       }
-    }
-    if (!app && this.config.useSharedConfig) {
-      return; // shared mode but the profile is not loaded (degraded) — retry on a later boot
     }
     this.config.isRemoteControl = app?.isRemoteControl ?? false;
     this.config.instanceName = app?.instanceName ?? '';

--- a/src/app/core/services/configuration-upgrade.service.spec.ts
+++ b/src/app/core/services/configuration-upgrade.service.spec.ts
@@ -15,7 +15,6 @@ describe('ConfigurationUpgradeService', () => {
     };
 
     const mockAppSettings = {
-        useSharedConfig: true,
         reloadApp: vi.fn(),
         getAppConfig: vi.fn().mockReturnValue({}),
         getDashboardConfig: vi.fn().mockReturnValue([]),
@@ -68,6 +67,65 @@ describe('ConfigurationUpgradeService', () => {
 
         expect(mockStorage.listConfigs).toHaveBeenCalledWith(9);
         expect(service.error()).toBeNull();
+    });
+
+    it('v11 upgrade backs up and persists every slot to the server (anti-loop)', async () => {
+        mockStorage.listConfigs.mockResolvedValueOnce([{ scope: 'user', name: 'default' }]);
+        mockStorage.getConfig.mockResolvedValue({
+            app: { configVersion: 11 },
+            theme: { themeName: '' },
+            dashboards: []
+        });
+
+        await service.runUpgrade(11);
+
+        // Original v11 config is backed up to the 11.99 file version first...
+        expect(mockStorage.setConfig).toHaveBeenCalledWith(
+            'user', 'default',
+            expect.objectContaining({ app: expect.objectContaining({ configVersion: 11 }) }),
+            11.99);
+        // ...then the upgraded v12 result lands on the server's active file version. If the
+        // server copy stays v11 the upgrade re-triggers on every boot.
+        expect(mockStorage.setConfig).toHaveBeenCalledWith(
+            'user', 'default',
+            expect.objectContaining({ app: expect.objectContaining({ configVersion: 12 }) }));
+    });
+
+    it('v11 upgrade reloads the app exactly once after the slots are persisted', async () => {
+        vi.useFakeTimers();
+        try {
+            mockStorage.listConfigs.mockResolvedValueOnce([{ scope: 'user', name: 'default' }]);
+            mockStorage.getConfig.mockResolvedValue({
+                app: { configVersion: 11 },
+                theme: { themeName: '' },
+                dashboards: []
+            });
+
+            await service.runUpgrade(11);
+            vi.advanceTimersByTime(1500);
+
+            expect(mockAppSettings.reloadApp).toHaveBeenCalledTimes(1);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('clears the blocking overlay when the v11 slot listing fails, without reloading', async () => {
+        vi.useFakeTimers();
+        try {
+            mockStorage.listConfigs.mockRejectedValueOnce(new Error('offline'));
+
+            await service.runUpgrade(11);
+
+            // The overlay is gated solely on upgrading(); leaving it set wedges the app behind
+            // a spinner with no dismiss. No reload either: the server still holds v11, so the
+            // upgrade retries next boot instead of reload-looping on a dead link.
+            expect(service.upgrading()).toBe(false);
+            vi.advanceTimersByTime(5000);
+            expect(mockAppSettings.reloadApp).not.toHaveBeenCalled();
+        } finally {
+            vi.useRealTimers();
+        }
     });
 
     it('startFresh retires BOTH global and user legacy configs via an awaited write before resetting', async () => {

--- a/src/app/core/services/configuration-upgrade.service.ts
+++ b/src/app/core/services/configuration-upgrade.service.ts
@@ -107,7 +107,7 @@ export class ConfigurationUpgradeService {
         this.pushError('Error fetching configuration data: ' + (error as Error).message);
       }
 
-    } else if (version === 11 && this._settings.useSharedConfig) {
+    } else if (version === 11) {
       // Remote (Signal K) configs
       try {
         const configsList: Config[] = await this._storage.listConfigs(11);
@@ -144,27 +144,11 @@ export class ConfigurationUpgradeService {
         setTimeout(() => this._settings.reloadApp(), 1500);
       } catch (error) {
         this.pushError('Error fetching configuration data. Aborting upgrade. Details: ' + (error as Error).message);
+        // Clear the blocking overlay so the error is visible; no reload — the server still holds
+        // v11, so the upgrade retries on the next boot instead of reload-looping on a dead link.
+        this.upgrading.set(false);
       }
 
-    } else if (version === 11 && !this._settings.useSharedConfig) {
-      // LocalStorage upgrade path for config version 11
-      const upgradedConfig: IConfig = { app: null, dashboards: null, theme: null };
-      upgradedConfig.app = this._settings.getAppConfig();
-      upgradedConfig.dashboards = this._settings.getDashboardConfig();
-      upgradedConfig.theme = this._settings.getThemeConfig();
-
-      upgradedConfig.app.configVersion = this.targetConfigVersion;
-      this.removeSplitShellConfigKeys(upgradedConfig.app);
-      const datasetInfo = this.extractAppDatasets(upgradedConfig.app);
-      this.upgradeDashboardWidgets(upgradedConfig.dashboards);
-      this.migrateDatasetsToDataCharts(datasetInfo, upgradedConfig.dashboards);
-      this.migrateUseNeedleToEnableNeedle(upgradedConfig.dashboards);
-
-      localStorage.setItem(LOCAL_CONFIG_KEYS.appConfig, JSON.stringify(upgradedConfig.app));
-      localStorage.setItem(LOCAL_CONFIG_KEYS.dashboardsConfig, JSON.stringify(upgradedConfig.dashboards));
-      localStorage.setItem(LOCAL_CONFIG_KEYS.themeConfig, JSON.stringify(upgradedConfig.theme));
-      setTimeout(() => this._settings.reloadApp(), 1500);
-      this.upgrading.set(false);
     } else {
       // LocalStorage upgrade path for config version 10
       const localStorageConfig: v10IConfig = { app: null, widget: null, layout: null, theme: null };
@@ -480,64 +464,6 @@ export class ConfigurationUpgradeService {
     delete raw['splitShellSide'];
     delete raw['splitShellWidth'];
     delete raw['splitShellSwipeDisabled'];
-  }
-
-  private upgradeDashboardWidgets(dashboards: Dashboard[]): void {
-    // Iterate dashboards:
-    // 1. Force widget selector to 'widget-host2'
-    // 2. Double grid metrics (x,y,w,h) if non-zero (leave zeros untouched)
-    let selectorUpdatedCount = 0;
-    let dimensionUpdatedCount = 0;
-    if (Array.isArray(dashboards)) {
-      for (const dash of dashboards) {
-        if (!dash || !Array.isArray(dash.configuration)) continue;
-        for (const widget of dash.configuration) {
-          if (!widget || typeof widget !== 'object') continue;
-
-          // Ensure selector
-          if (widget.selector !== 'widget-host2') {
-            widget.selector = 'widget-host2';
-            selectorUpdatedCount++;
-          }
-
-          // Helper to safely double a numeric property if > 0 (handles undefined and numeric strings)
-          const maybeDouble = (prop: string) => {
-            const raw = widget[prop] as unknown;
-            const numVal = typeof raw === 'string' ? Number(raw) : (raw as number);
-            if (Number.isFinite(numVal) && numVal !== 0) {
-              widget[prop] = numVal * 2;
-              dimensionUpdatedCount++;
-            }
-          };
-          maybeDouble('w');
-          maybeDouble('h');
-          maybeDouble('x');
-          maybeDouble('y');
-
-          // If width/height were missing, add them using minW/minH (or 2) and scale to new grid (x2)
-          if (widget['w'] === undefined || widget['w'] === null) {
-            const minWRaw = widget['minW'] as unknown;
-            const minW = typeof minWRaw === 'string' ? Number(minWRaw) : (minWRaw as number);
-            const baseW = Number.isFinite(minW) && minW! > 0 ? (minW as number) : 2;
-            widget['w'] = baseW * 2;
-            dimensionUpdatedCount++;
-          }
-          if (widget['h'] === undefined || widget['h'] === null) {
-            const minHRaw = widget['minH'] as unknown;
-            const minH = typeof minHRaw === 'string' ? Number(minHRaw) : (minHRaw as number);
-            const baseH = Number.isFinite(minH) && minH! > 0 ? (minH as number) : 2;
-            widget['h'] = baseH * 2;
-            dimensionUpdatedCount++;
-          }
-        }
-      }
-    }
-    if (selectorUpdatedCount) {
-      this.pushMsg(`[Upgrade] Updated ${selectorUpdatedCount} localStorage widget selector(s) to 'widget-host2'.`);
-    }
-    if (dimensionUpdatedCount) {
-      this.pushMsg(`[Upgrade] Doubled grid metrics for ${dimensionUpdatedCount} non-zero (w/h/x/y) entries.`);
-    }
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/app/core/services/settings.service.spec.ts
+++ b/src/app/core/services/settings.service.spec.ts
@@ -15,7 +15,6 @@ interface DefaultConfigGetters {
 
 interface SeedOpts {
   sharedConfigName?: string;
-  useSharedConfig?: boolean;
   isRemoteControl?: boolean;
   instanceName?: string;
 }
@@ -28,7 +27,6 @@ function seedConfig(opts: SeedOpts = {}): void {
     signalKUrl: 'https://boat.example:3443',
     proxyEnabled: false,
     signalKSubscribeAll: false,
-    useSharedConfig: opts.useSharedConfig ?? false,
     sharedConfigName: opts.sharedConfigName ?? 'profileA',
     isRemoteControl: opts.isRemoteControl ?? false,
     instanceName: opts.instanceName ?? ''
@@ -64,7 +62,6 @@ function seedConnectionConfig(extra: Record<string, unknown> = {}): void {
       signalKSubscribeAll: false,
       useDeviceToken: false,
       loginName: 'pi',
-      useSharedConfig: true,
       sharedConfigName: 'default',
       ...extra
     })
@@ -120,9 +117,9 @@ describe('SettingsService — storage routing (server applicationData only)', ()
   beforeEach(() => ensureLocalStorage());
 
   // SKip runs same-origin with the SK server (SSO session), so config always persists to the
-  // server's applicationData regardless of the useSharedConfig flag.
-  function setup(connExtra: Record<string, unknown>) {
-    seedConnectionConfig(connExtra);
+  // server's applicationData.
+  function setup() {
+    seedConnectionConfig();
     localStorage.setItem('skip.appConfig', JSON.stringify({ configVersion: 12, dataSets: [], unitDefaults: {}, notificationConfig: {} }));
     localStorage.setItem('skip.dashboardsConfig', JSON.stringify([]));
     localStorage.setItem('skip.themeConfig', JSON.stringify({ themeName: '' }));
@@ -133,8 +130,8 @@ describe('SettingsService — storage routing (server applicationData only)', ()
     return { service, patchSpy };
   }
 
-  it('shared config routes a setting write to server applicationData, not localStorage', () => {
-    const { service, patchSpy } = setup({ useSharedConfig: true });
+  it('routes a setting write to server applicationData, not localStorage', () => {
+    const { service, patchSpy } = setup();
     localStorage.removeItem('skip.themeConfig');
 
     service.setThemeName('shared-theme');
@@ -143,20 +140,10 @@ describe('SettingsService — storage routing (server applicationData only)', ()
     expect(localStorage.getItem('skip.themeConfig')).toBeNull();
   });
 
-  it('local (useSharedConfig:false) also routes to server applicationData (single same-origin store)', () => {
-    const { service, patchSpy } = setup({ useSharedConfig: false });
-    localStorage.removeItem('skip.themeConfig');
-
-    service.setThemeName('local-theme');
-
-    expect(patchSpy).toHaveBeenCalledWith('IThemeConfig', { themeName: 'local-theme' });
-    expect(localStorage.getItem('skip.themeConfig')).toBeNull();
-  });
-
-  it('setBrowserTabTitle routes to server applicationData like every other setter (useSharedConfig:false)', () => {
+  it('setBrowserTabTitle routes to server applicationData like every other setter', () => {
     // Regression guard: setBrowserTabTitle must not diverge from the always-server invariant, or the
     // title would write to localStorage and be lost on the next (server-loaded) reload.
-    const { service, patchSpy } = setup({ useSharedConfig: false });
+    const { service, patchSpy } = setup();
     localStorage.removeItem('skip.appConfig');
 
     service.setBrowserTabTitle('Helm');
@@ -170,7 +157,7 @@ describe('SettingsService — config save failure reporting', () => {
   beforeEach(() => ensureLocalStorage());
 
   it('surfaces a snackbar when a routine config save to the server fails', async () => {
-    const service = createService({ useSharedConfig: true, sharedConfigName: 'profileA' });
+    const service = createService({ sharedConfigName: 'profileA' });
     const storage = TestBed.inject(StorageService);
     const http = TestBed.inject(HttpTestingController);
     const snack = TestBed.inject(MatSnackBar);
@@ -189,7 +176,7 @@ describe('SettingsService — config save failure reporting', () => {
   });
 
   it('does not raise the alarm toast for an expected read-only 401 save denial', async () => {
-    const service = createService({ useSharedConfig: true, sharedConfigName: 'profileA' });
+    const service = createService({ sharedConfigName: 'profileA' });
     const storage = TestBed.inject(StorageService);
     const http = TestBed.inject(HttpTestingController);
     const snack = TestBed.inject(MatSnackBar);
@@ -213,11 +200,11 @@ describe('SettingsService', () => {
     expect(createService({})).toBeTruthy();
   });
 
-  describe('active profile (local mode)', () => {
+  describe('active profile', () => {
     let service: SettingsService;
 
     beforeEach(() => {
-      service = createService({ useSharedConfig: false, sharedConfigName: 'profileA' });
+      service = createService({ sharedConfigName: 'profileA' });
     });
 
     it('getActiveProfileName returns the booted slot name', () => {
@@ -279,11 +266,11 @@ describe('SettingsService', () => {
     });
   });
 
-  describe('loadDemoConfig storage-readiness guard (server mode)', () => {
+  describe('loadDemoConfig storage-readiness guard', () => {
     beforeEach(() => { (window as unknown as Record<string, unknown>)['__KIP_TEST__'] = true; });
 
     it('does not write the demo config to the server when storage is not ready', () => {
-      const service = createService({ useSharedConfig: true, sharedConfigName: 'profileA' });
+      const service = createService({ sharedConfigName: 'profileA' });
       const storage = TestBed.inject(StorageService);
       storage.storageServiceReady$.next(false);
       const setSpy = vi.spyOn(storage, 'setConfig').mockImplementation(() => undefined);
@@ -292,7 +279,7 @@ describe('SettingsService', () => {
     });
 
     it('writes the demo config to the server when storage is ready', () => {
-      const service = createService({ useSharedConfig: true, sharedConfigName: 'profileA' });
+      const service = createService({ sharedConfigName: 'profileA' });
       const storage = TestBed.inject(StorageService);
       storage.storageServiceReady$.next(true);
       const setSpy = vi.spyOn(storage, 'setConfig').mockResolvedValue(undefined);
@@ -302,7 +289,7 @@ describe('SettingsService', () => {
     });
 
     it('reloads only after the demo config save resolves', async () => {
-      const service = createService({ useSharedConfig: true, sharedConfigName: 'profileA' });
+      const service = createService({ sharedConfigName: 'profileA' });
       const storage = TestBed.inject(StorageService);
       storage.storageServiceReady$.next(true);
       let resolveSave!: (value: unknown) => void;
@@ -325,7 +312,7 @@ describe('SettingsService', () => {
     });
 
     it('does not reload and surfaces an error when the demo config save fails', async () => {
-      const service = createService({ useSharedConfig: true, sharedConfigName: 'profileA' });
+      const service = createService({ sharedConfigName: 'profileA' });
       const storage = TestBed.inject(StorageService);
       storage.storageServiceReady$.next(true);
       vi.spyOn(storage, 'setConfig').mockRejectedValue(new Error('network down'));

--- a/src/app/core/services/settings.service.ts
+++ b/src/app/core/services/settings.service.ts
@@ -42,7 +42,6 @@ export class SettingsService {
 
   public proxyEnabled = false;
   public signalKSubscribeAll = false;
-  public useSharedConfig = true;
   private sharedConfigName = 'default';
   // True once the user explicitly changes the remote-control identity this session; until then a
   // connection write preserves the stored (possibly migration-written) identity rather than the
@@ -121,7 +120,6 @@ export class SettingsService {
     this.signalkUrl = {url: config.signalKUrl, new: false};
     this.proxyEnabled = config.proxyEnabled;
     this.signalKSubscribeAll = config.signalKSubscribeAll;
-    this.useSharedConfig = config.useSharedConfig;
     this.sharedConfigName = config.sharedConfigName;
     this.kipUUID = config.kipUUID;
 
@@ -274,7 +272,6 @@ export class SettingsService {
   }
 
   public setConnectionConfig(value: IConnectionConfig) {
-    this.useSharedConfig = value.useSharedConfig;
     this.proxyEnabled = value.proxyEnabled;
     this.signalKSubscribeAll = value.signalKSubscribeAll;
     if (this.signalkUrl) {
@@ -551,7 +548,6 @@ export class SettingsService {
       signalKUrl: this.signalkUrl?.url ?? '',
       proxyEnabled: this.proxyEnabled,
       signalKSubscribeAll: this.signalKSubscribeAll,
-      useSharedConfig: this.useSharedConfig,
       sharedConfigName: this.sharedConfigName,
       // Preserve the stored (possibly migration-written) identity unless the user changed it this
       // session, so a connection write around the migration cannot revert the lifted value.

--- a/src/default-config/config.blank.const.ts
+++ b/src/default-config/config.blank.const.ts
@@ -32,7 +32,6 @@ export const DefaultConnectionConfig: Readonly<IConnectionConfig> = {
   "signalKUrl": null, // get's overwritten with host at getDefaultConnectionConfig()
   "proxyEnabled": false,
   "signalKSubscribeAll": false,
-  "useSharedConfig": false,
   "sharedConfigName": "default",
   "isRemoteControl": false,
   "instanceName": ""

--- a/src/test.ts
+++ b/src/test.ts
@@ -335,7 +335,6 @@ class SettingsServiceStub {
     signalKUrl: 'http://localhost',
     proxyEnabled: false,
     signalKSubscribeAll: false,
-    useSharedConfig: false,
     sharedConfigName: '',
     kipUUID: 'test-uuid',
     isRemoteControl: false,

--- a/src/test.ts
+++ b/src/test.ts
@@ -215,7 +215,7 @@ class MatBottomSheetRefStub { dismiss(): void { /* noop */ } }
 class MatDialogRefStub { close(): void { /* noop */ } }
 class AppNetworkInitServiceStub {
   private _bootstrapStatusSubject = new BehaviorSubject<'starting' | 'ready' | 'degraded'>('ready');
-  private _bootstrapIssueSubject = new BehaviorSubject<{ reason: 'none' | 'missing-shared-config' | 'network-unreachable' | 'unauthorized' | 'unknown' | 'auth-blocked'; statusCode?: number; sharedConfigName?: string; legacyUpgradeAvailable?: boolean; cause?: 'budget-exhausted' | 'sign-in-required' }>({ reason: 'none' });
+  private _bootstrapIssueSubject = new BehaviorSubject<{ reason: 'none' | 'missing-shared-config' | 'network-unreachable' | 'unauthorized' | 'unknown' | 'auth-blocked'; statusCode?: number; sharedConfigName?: string; cause?: 'budget-exhausted' | 'sign-in-required' }>({ reason: 'none' });
 
   public bootstrapStatus$ = this._bootstrapStatusSubject.asObservable();
   public bootstrapIssue$ = this._bootstrapIssueSubject.asObservable();


### PR DESCRIPTION
PR-2 of the #17 settings.service rewrite (plan v2.1 in the issue body): retire the `useSharedConfig` flag. The flag has been frozen `false` since #82 removed its toggle UI, nothing in settings.service branches on it, and its six surviving peripheral read sites hid two live defects — both fixed here with tests written red-first against the defective behavior.

## The two defect fixes

- **v11 upgrade boot loop**: a same-origin install holding a v11 server profile transformed the config in memory but wrote the result *only to localStorage* before reloading — the server profile stayed v11, so the upgrade re-triggered on every boot, forever. The upgrade now runs the server pipeline for every install: `listConfigs(11)` → back up each slot to 11.99 → `upgradeConfig` → `setConfig`, so all v11 slots upgrade, not just the active one. Anti-loop test asserts the v12 result lands via `setConfig`.
- **Stale config export**: backup/export read localStorage (where nothing has been written since #82) while all writes go to the server. `getActiveConfig` now always builds from the server-backed config; the orphaned `getLocalConfigFrom*` helpers are deleted. Red-run proof: the old path exported a planted stale blob.

## The retirement itself

- Field removed from `IConnectionConfig`, `DefaultConnectionConfig`, settings.service (hydration, write-through, serialization). Stray keys in stored connection blobs are ignored on load — no connection-version bump needed.
- The 404 classification is un-gated: a genuine storage 404 now classifies as `missing-shared-config` and reaches the recovery toast (previously flag-false installs degraded to `unknown` with no recovery path).
- `migrateRemoteControlToDevice` collapses exactly to its pinned-false paths (the flag-true "defer the lift" branch was unreachable).
- Dead legacy-upgrade machinery removed (first commit): `probeLegacyUpgradeAvailability` probes fileVersion-9 configs under the `skip` appid, but v9/v10 configs only ever existed under upstream KIP's `kip` appid — it could never return true, making the "Upgrade" recovery-toast variant dead UI. The live "Create default" variant is untouched. `upgradeDashboardWidgets` went with its sole (deleted) caller.
- Forced updates: the four flag-referencing specs, the `src/test.ts` stub literal, and the perf-harness config seeder.

Deliberately kept: `v10-config-interface.ts` still models the historical stored shape (it describes old data, not current behavior); the v10 localStorage upgrade arm survives per the plan's decision 5.

## Verification

`npm run lint` clean; full suite 135 files / 960 tests green (main baseline 958, −1 collapsed shared/local matrix duplicate, +3 corrective tests); `npm run build:dev` clean. All three corrective tests verified red against the pre-change code.

Refs #17 (PR-2 of 4; plan and sequencing in the issue body).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
