### PR TITLE
fix(charts): derive backfill SMA circularly, matching the live tail (#162)

### DIFF
--- a/src/app/core/services/history-chart-stream.service.spec.ts
+++ b/src/app/core/services/history-chart-stream.service.spec.ts
@@ -58,15 +58,48 @@ describe('HistoryChartStreamService', () => {
     expect(Array.isArray(first)).toBe(true);
     expect((first as IDatasetServiceDatapoint[]).map(p => p.data.value)).toEqual([1, 3]);
     expect(history.getValues).toHaveBeenCalledTimes(1);
-    // The Value series is the raw per-bucket `:last` sample (angle-safe, seam-free with the live
-    // tail), plus the `:sma` overlay. The dead `:min`/`:max` columns are no longer requested.
+    // Only the raw per-bucket `:last` sample is requested; the SMA overlay is derived client-side, so
+    // no `:sma`/`:avg`/`:min`/`:max` aggregate columns are asked of the server (#162).
     const query = history.getValues.mock.calls[0][0];
     expect(query.paths).toContain(':last');
-    expect(query.paths).toContain(':sma:');
+    expect(query.paths).not.toContain(':sma');
     expect(query.paths).not.toContain(':avg');
     expect(query.paths).not.toContain(':min');
     expect(query.paths).not.toContain(':max');
     expect(query.from).toBeTruthy();
+  });
+
+  it('derives the backfill SMA circularly for direction paths (no server :sma)', async () => {
+    history.getValues.mockResolvedValue({ context: 'vessels.self', range: {}, values: [], data: [] });
+    // Direction samples straddling the 0/360° wrap: ~355°, ~5°, ~3°.
+    mapper.mapValuesToChartDatapoints.mockReturnValue([
+      { timestamp: 1000, data: { value: 6.19591884457987 } },
+      { timestamp: 2000, data: { value: 0.08726646259971647 } },
+      { timestamp: 3000, data: { value: 0.05235987755982989 } }
+    ]);
+    const params: IHistoryChartStreamParams = { ...PARAMS, angleDomainOverride: 'direction', smoothingPeriod: 3 };
+    const first = await firstValueFrom(make().getBackfillThenLive(params));
+    const points = first as IDatasetServiceDatapoint[];
+    // The 3-sample SMA is the CIRCULAR mean (~1°/0.0175 rad). The server-side arithmetic :sma over
+    // the same radians would be ~2.11 rad — so this proves the smoothing line is angle-correct.
+    expect(points[2].data.sma).toBeCloseTo(0.0174959160, 4);
+    expect(points[2].data.sma).not.toBeCloseTo(2.11, 1);
+  });
+
+  it('derives a scalar backfill SMA as the arithmetic mean of the trailing window (clamps early)', async () => {
+    history.getValues.mockResolvedValue({ context: 'vessels.self', range: {}, values: [], data: [] });
+    mapper.mapValuesToChartDatapoints.mockReturnValue([
+      { timestamp: 1000, data: { value: 2 } },
+      { timestamp: 2000, data: { value: 4 } },
+      { timestamp: 3000, data: { value: 6 } }
+    ]);
+    // Scalar domain (getPathUnitType → null), smoothingPeriod 2.
+    const params: IHistoryChartStreamParams = { ...PARAMS, smoothingPeriod: 2 };
+    const first = await firstValueFrom(make().getBackfillThenLive(params));
+    const points = first as IDatasetServiceDatapoint[];
+    expect(points[0].data.sma).toBe(2); // window clamps to [2]
+    expect(points[1].data.sma).toBe(3); // trailing window [2, 4]
+    expect(points[2].data.sma).toBe(5); // trailing window [4, 6]
   });
 
   it('drops null-valued backfill points', async () => {

--- a/src/app/core/services/history-chart-stream.service.ts
+++ b/src/app/core/services/history-chart-stream.service.ts
@@ -5,7 +5,7 @@ import { HistoryApiClientService, HistoryRequestError } from './history-api-clie
 import { HistoryToChartMapperService } from './history-to-chart-mapper.service';
 import { resolveAngleDomain } from '../utils/angle-domain.util';
 import { IDatasetServiceDatapoint } from '../interfaces/dataset.interfaces';
-import { computeWindowStats, ChartStatsDomain } from '../utils/chart-stats.util';
+import { computeWindowStats, windowSma, ChartStatsDomain } from '../utils/chart-stats.util';
 
 /** Emitted (instead of datapoints) when trend history cannot be served — no history provider. */
 export interface IHistoryUnavailable {
@@ -196,10 +196,9 @@ export class HistoryChartStreamService {
 
   private async fetchBackfill(params: IHistoryChartStreamParams, domain: ChartStatsDomain): Promise<{ points: IDatasetServiceDatapoint[]; offsetMs: number } | null> {
     const normalizedPath = params.path.replace(/^(vessels\.)?self\./, '');
-    const paths = [
-      `${normalizedPath}:sma:${params.smoothingPeriod}`,
-      `${normalizedPath}:last`
-    ].join(',');
+    // Only the raw per-bucket value is fetched; the SMA overlay is derived client-side below so it
+    // uses the same circular-aware smoothing as the live tail (#162).
+    const paths = `${normalizedPath}:last`;
     const resolutionSeconds = Math.max(1, Math.round(params.sampleTime / 1000));
 
     const response = await this.history.getValues({
@@ -220,18 +219,22 @@ export class HistoryChartStreamService {
     const newestServerTs = mapped.length ? mapped[mapped.length - 1].timestamp : NaN;
     const anchorTs = Number.isFinite(serverTo) ? serverTo : newestServerTs;
     const offsetMs = Number.isFinite(anchorTs) ? Date.now() - anchorTs : 0;
-    const points = mapped
-      .filter(m => m.data.value !== null && m.data.value !== undefined)
-      .map(m => ({
-        timestamp: m.timestamp + offsetMs,
-        data: {
-          value: m.data.value as number,
-          sma: m.data.sma ?? undefined,
-          lastAverage: m.data.lastAverage ?? undefined,
-          lastMinimum: m.data.lastMinimum ?? undefined,
-          lastMaximum: m.data.lastMaximum ?? undefined
-        }
-      }));
+    const mappedPoints = mapped.filter(m => m.data.value !== null && m.data.value !== undefined);
+    // Derive the SMA overlay client-side from the :last samples with the same shared trailing-window
+    // smoothing the live tail uses (circular for angle domains), so the line is angle-correct at the
+    // 0/360° wrap and continuous across the backfill→live seam.
+    const values = mappedPoints.map(m => m.data.value as number);
+    const smoothingPeriod = Math.max(1, params.smoothingPeriod);
+    const points = mappedPoints.map((m, i) => ({
+      timestamp: m.timestamp + offsetMs,
+      data: {
+        value: m.data.value as number,
+        sma: windowSma(values.slice(Math.max(0, i - smoothingPeriod + 1), i + 1), domain),
+        lastAverage: m.data.lastAverage ?? undefined,
+        lastMinimum: m.data.lastMinimum ?? undefined,
+        lastMaximum: m.data.lastMaximum ?? undefined
+      }
+    }));
     return { points, offsetMs };
   }
 

--- a/src/app/core/utils/chart-stats.util.ts
+++ b/src/app/core/utils/chart-stats.util.ts
@@ -48,6 +48,19 @@ export function circularMinMaxRad(anglesRad: number[]): { min: number; max: numb
 }
 
 /**
+ * SMA over a trailing window (newest last): arithmetic mean for `scalar`, circular mean wrapped to
+ * the domain for `direction`/`signed`. Shared by the live tail and the History backfill so both
+ * smooth identically. The window must already be sliced to the smoothing period.
+ */
+export function windowSma(window: number[], domain: ChartStatsDomain): number {
+  if (domain === 'scalar') {
+    return window.reduce((s, v) => s + v, 0) / window.length;
+  }
+  const wrap = domain === 'signed' ? normalizeSignedRad : normalizeDirectionRad;
+  return wrap(circularMeanRad(window));
+}
+
+/**
  * Compute value + SMA + window average/min/max over a numeric buffer (newest last). Scalar uses
  * arithmetic aggregates; `direction`/`signed` use circular math and wrap the outputs to their domain.
  * Shared by the History-API chart live tail; mirrors the recorder's per-point statistics.
@@ -58,15 +71,14 @@ export function computeWindowStats(buffer: number[], smoothingPeriod: number, do
 
   if (domain === 'scalar') {
     const avg = buffer.reduce((s, v) => s + v, 0) / buffer.length;
-    const sma = smaWindow.reduce((s, v) => s + v, 0) / smaWindow.length;
-    return { value, sma, lastAverage: avg, lastMinimum: Math.min(...buffer), lastMaximum: Math.max(...buffer) };
+    return { value, sma: windowSma(smaWindow, domain), lastAverage: avg, lastMinimum: Math.min(...buffer), lastMaximum: Math.max(...buffer) };
   }
 
   const wrap = domain === 'signed' ? normalizeSignedRad : normalizeDirectionRad;
   const { min, max } = circularMinMaxRad(buffer);
   return {
     value: wrap(value),
-    sma: wrap(circularMeanRad(smaWindow)),
+    sma: windowSma(smaWindow, domain),
     lastAverage: wrap(circularMeanRad(buffer)),
     lastMinimum: wrap(min),
     lastMaximum: wrap(max)


### PR DESCRIPTION
## Why

PR #161 fixed the History backfill **Value** line (`:last`, angle-correct), but left the **SMA overlay** on the server's arithmetic `:sma` column. On direction/heading/wind-angle charts that mean is wrong at the 0/360° wrap and discontinuous with the live tail's circular SMA — and #161 made the mismatch conspicuous by fixing the Value line beside it. This is the gate on promoting the History engine to default (PR5).

## What

Derive the backfill SMA **client-side** instead of requesting it from the server:

- `fetchBackfill` now requests only `:last` (drops `:sma:N`).
- Each backfill point's `sma` is computed via the shared `computeWindowStats(values.slice(0, i+1), smoothingPeriod, domain)` — the **exact same function the live tail uses** over its buffer. So the backfill SMA is circular for angle domains and identical to what the live tail produces over the same samples: wrap-correct and seam-free.
- **Scalar paths unchanged** — `computeWindowStats` returns an arithmetic mean for `scalar`, so non-angle charts get the same SMA values, now computed client-side.

No server or `kip-plugin` change — the provider still supports `:sma`; the chart path just no longer asks for it.

## Verification

- Updated stream spec: backfill requests `:last` only (no `:sma`/`:avg`/`:min`/`:max`); a new test proves the direction-path SMA is the **circular** mean (~0.0175 rad for samples straddling the wrap), not the arithmetic mean (~2.11 rad) the server `:sma` would have produced.
- `npm run build:dev` + `npm run lint` — clean.

Closes #162. Unblocks PR5 (the default-engine flip).
