### PR TITLE
feat(charts): make History the default engine, drop the recorder branch

### DIFF
--- a/src/app/widgets/widget-data-chart/widget-data-chart.component.spec.ts
+++ b/src/app/widgets/widget-data-chart/widget-data-chart.component.spec.ts
@@ -30,8 +30,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { EMPTY, Subject } from 'rxjs';
 import { WidgetDataChartComponent } from './widget-data-chart.component';
 import { IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
-import { DatasetStreamService } from '../../core/services/dataset-stream.service';
-import { WidgetDatasetOrchestratorService } from '../../core/services/widget-dataset-orchestrator.service';
 import { HistoryChartStreamService, HISTORY_UNAVAILABLE } from '../../core/services/history-chart-stream.service';
 import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
 import { UnitsService } from '../../core/services/units.service';
@@ -52,33 +50,17 @@ describe('WidgetDataChartComponent', () => {
   let fixture: ComponentFixture<WidgetDataChartComponent>;
 
   const runtimeMock = { options: vi.fn() };
-  const dsServiceMock = {
-    syncDataChartDataset: vi.fn(),
-    getDatasetConfig: vi.fn(),
-    getDataSourceInfo: vi.fn(),
-    getDatasetBatchThenLiveObservable: vi.fn()
-  };
-  const orchestratorMock = { syncDataChartDataset: vi.fn() };
   const historyMock = { getBackfillThenLive: vi.fn() };
   const unitsMock = { convertToUnit: (_unit: string, value: number) => value };
   const canvasMock = { releaseCanvas: vi.fn() };
 
   const setup = async (config: IWidgetSvcConfig): Promise<void> => {
     runtimeMock.options.mockReturnValue(config);
-    // Recorder path reads a live dataset config + source info before it streams.
-    dsServiceMock.getDatasetConfig.mockReturnValue({
-      uuid: 'w1', path: config.datachartPath, pathSource: 'default',
-      baseUnit: '', timeScaleFormat: 'minute', period: 10, label: ''
-    });
-    dsServiceMock.getDataSourceInfo.mockReturnValue({ sampleTime: 500, maxDataPoints: 100, smoothingPeriod: 5 });
-    dsServiceMock.getDatasetBatchThenLiveObservable.mockReturnValue(EMPTY);
 
     await TestBed.configureTestingModule({
       imports: [WidgetDataChartComponent],
       providers: [
         { provide: WidgetRuntimeDirective, useValue: runtimeMock },
-        { provide: DatasetStreamService, useValue: dsServiceMock },
-        { provide: WidgetDatasetOrchestratorService, useValue: orchestratorMock },
         { provide: HistoryChartStreamService, useValue: historyMock },
         { provide: UnitsService, useValue: unitsMock },
         { provide: CanvasService, useValue: canvasMock }
@@ -98,10 +80,6 @@ describe('WidgetDataChartComponent', () => {
     vi.spyOn(HTMLCanvasElement.prototype, 'getContext')
       .mockReturnValue({} as unknown as CanvasRenderingContext2D);
     runtimeMock.options.mockReset();
-    dsServiceMock.syncDataChartDataset.mockReset();
-    dsServiceMock.getDatasetConfig.mockReset();
-    dsServiceMock.getDataSourceInfo.mockReset();
-    dsServiceMock.getDatasetBatchThenLiveObservable.mockReset();
     historyMock.getBackfillThenLive.mockReset().mockReturnValue(EMPTY);
   });
 
@@ -111,32 +89,14 @@ describe('WidgetDataChartComponent', () => {
     TestBed.resetTestingModule();
   });
 
-  it('dispatches to the recorder engine for an explicit chartEngine of "recorder"', async () => {
-    await setup(makeConfig({ chartEngine: 'recorder' }));
-    expect(dsServiceMock.getDatasetBatchThenLiveObservable).toHaveBeenCalledWith('w1');
-    expect(historyMock.getBackfillThenLive).not.toHaveBeenCalled();
-  });
-
-  it('dispatches to the recorder engine when chartEngine is undefined (default)', async () => {
-    await setup(makeConfig({ chartEngine: undefined }));
-    expect(dsServiceMock.getDatasetBatchThenLiveObservable).toHaveBeenCalledWith('w1');
-    expect(historyMock.getBackfillThenLive).not.toHaveBeenCalled();
-  });
-
-  it('dispatches to the history engine for an explicit chartEngine of "history"', async () => {
-    await setup(makeConfig({ chartEngine: 'history' }));
+  it('streams from the History engine — the only engine', async () => {
+    await setup(makeConfig());
     expect(historyMock.getBackfillThenLive).toHaveBeenCalled();
-    expect(dsServiceMock.getDatasetBatchThenLiveObservable).not.toHaveBeenCalled();
   });
 
-  it('lets the localStorage chartEngine override beat the per-widget config', async () => {
-    vi.stubGlobal('localStorage', {
-      getItem: (key: string) => (key === 'skip.chartEngine' ? 'history' : null)
-    });
-    // Config asks for the recorder, but the override forces the history engine.
+  it('routes a stale chartEngine:"recorder" config to the History engine (field ignored)', async () => {
     await setup(makeConfig({ chartEngine: 'recorder' }));
     expect(historyMock.getBackfillThenLive).toHaveBeenCalled();
-    expect(dsServiceMock.getDatasetBatchThenLiveObservable).not.toHaveBeenCalled();
   });
 
   it('renders the "History data unavailable" empty state on a HISTORY_UNAVAILABLE emission', async () => {

--- a/src/app/widgets/widget-data-chart/widget-data-chart.component.ts
+++ b/src/app/widgets/widget-data-chart/widget-data-chart.component.ts
@@ -1,17 +1,14 @@
 import { IDatasetServiceDatasetConfig, TimeScaleFormat } from '../../core/interfaces/dataset.interfaces';
 import { Component, OnDestroy, ElementRef, viewChild, inject, effect, NgZone, input, untracked, computed, signal, ChangeDetectionStrategy } from '@angular/core';
 import { IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
-import { DatasetStreamService } from '../../core/services/dataset-stream.service';
 import { IDatasetServiceDatapoint, IDatasetServiceDataSourceInfo } from '../../core/interfaces/dataset.interfaces';
 import { Subscription } from 'rxjs';
 import { CanvasService } from '../../core/services/canvas.service';
 import { UnitsService } from '../../core/services/units.service';
 import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
 import { ITheme } from '../../core/services/app-service';
-import { WidgetDatasetOrchestratorService } from '../../core/services/widget-dataset-orchestrator.service';
 import { HistoryChartStreamService, IHistoryChartStreamParams, isHistoryUnavailable } from '../../core/services/history-chart-stream.service';
 import { resolveWindowMs, deriveDataSourceInfo } from '../../core/utils/chart-window.util';
-import { CHART_ENGINE_OVERRIDE_KEY } from '../../core/constants/config-storage.const';
 
 import { Chart, ChartConfiguration, ChartData, ChartType, TimeUnit, TimeScale, LinearScale, LineController, PointElement, LineElement, Filler, Title, SubTitle } from 'chart.js';
 import annotationPlugin from 'chartjs-plugin-annotation';
@@ -51,11 +48,9 @@ export class WidgetDataChartComponent implements OnDestroy {
   // Host2 runtime directive (merged config)
   private readonly runtime = inject(WidgetRuntimeDirective);
 
-  private readonly dsService = inject(DatasetStreamService);
   private readonly ngZone = inject(NgZone);
   private readonly canvasService = inject(CanvasService);
   private readonly unitsService = inject(UnitsService);
-  private readonly datasetLifecycle = inject(WidgetDatasetOrchestratorService);
   private readonly historyStream = inject(HistoryChartStreamService);
   readonly widgetDataChart = viewChild('widgetDataChart', { read: ElementRef });
   public static readonly DEFAULT_CONFIG: IWidgetSvcConfig = {
@@ -68,7 +63,7 @@ export class WidgetDataChartComponent implements OnDestroy {
     convertUnitTo: null,
     timeScale: 'minute', // second | minute | hour
     period: 10,
-    chartEngine: 'recorder', // 'recorder' | 'history' (#64 prototype)
+    chartEngine: 'history',
     numDecimal: 1,
     inverseYAxis: false,
     datasetAverageArray: 'sma', // sma | ema | dema | avg
@@ -98,7 +93,7 @@ export class WidgetDataChartComponent implements OnDestroy {
   };
   public lineChartType: ChartType = 'line';
   private chart: Chart;
-  private dsServiceSub: Subscription | null = null;
+  private streamSub: Subscription | null = null;
   private datasetConfig: IDatasetServiceDatasetConfig | null = null;
   private dataSourceInfo: IDatasetServiceDataSourceInfo | null = null;
   private lastVerticalChart: boolean | null = null;
@@ -106,17 +101,7 @@ export class WidgetDataChartComponent implements OnDestroy {
     const cfg = this.runtime.options();
     return !!cfg?.datachartPath;
   });
-  // #64 A/B toggle. A global override (localStorage['skip.chartEngine'] = 'history' | 'recorder',
-  // applied on reload) flips every data-chart at once for live testing; otherwise the per-widget
-  // config field wins, defaulting to the recorder.
-  protected chartEngine = computed<'recorder' | 'history'>(() => {
-    const cfg = this.runtime.options();
-    let override: string | null = null;
-    try { override = localStorage.getItem(CHART_ENGINE_OVERRIDE_KEY); } catch { override = null; }
-    if (override === 'history' || override === 'recorder') return override;
-    return cfg?.chartEngine ?? 'recorder';
-  });
-  // History engine only: true when no history provider is available, so the widget shows the
+  // True when no history provider is available, so the widget shows the
   // "history unavailable" empty state instead of a blank chart (no recorder live-only fallback).
   protected historyUnavailable = signal<boolean>(false);
   private pathSignature = computed<string | undefined>(() => {
@@ -124,7 +109,7 @@ export class WidgetDataChartComponent implements OnDestroy {
     if (!cfg.datachartPath) {
       return undefined;
     }
-    return [cfg.datachartPath, cfg.convertUnitTo, cfg.datachartSource, cfg.timeScale, cfg.period, cfg.datachartAngleRange, cfg.chartEngine].join('|');
+    return [cfg.datachartPath, cfg.convertUnitTo, cfg.datachartSource, cfg.timeScale, cfg.period, cfg.datachartAngleRange].join('|');
   });
   private previousPathSignature: string | undefined = undefined;
 
@@ -179,31 +164,24 @@ export class WidgetDataChartComponent implements OnDestroy {
     if (!cfg.datachartPath) return; // Widget not yet configured
     if (!this.widgetDataChart()) return; // View not ready yet
 
-    this.dsServiceSub?.unsubscribe(); // Cleanup old subscription & chart data
+    this.streamSub?.unsubscribe(); // Cleanup old subscription & chart data
     this.lineChartData.datasets = [];
     this.historyUnavailable.set(false);
 
-    if (this.chartEngine() === 'history') {
-      // History-API path: no recorder dataset; synthesize the config + cadence the axis/streaming
-      // options expect, derived from the same window as the recorder would use.
-      const windowMs = resolveWindowMs(cfg.timeScale as TimeScaleFormat, cfg.period);
-      this.dataSourceInfo = deriveDataSourceInfo(windowMs);
-      this.datasetConfig = {
-        uuid: this.id(),
-        path: cfg.datachartPath,
-        pathSource: cfg.datachartSource ?? 'default',
-        baseUnit: '',
-        timeScaleFormat: cfg.timeScale as TimeScaleFormat,
-        period: cfg.period,
-        label: '',
-        angleDomainOverride: cfg.datachartAngleRange ?? undefined
-      };
-    } else {
-      this.datasetLifecycle.syncDataChartDataset(this.id(), cfg, this.pathSignature());
-      this.datasetConfig = this.dsService.getDatasetConfig(this.id());
-      this.dataSourceInfo = this.dsService.getDataSourceInfo(this.id());
-      if (!this.datasetConfig) return; // dataset not ready yet
-    }
+    // Synthesize the config + cadence the axis/streaming options expect, derived from the widget's
+    // display window.
+    const windowMs = resolveWindowMs(cfg.timeScale as TimeScaleFormat, cfg.period);
+    this.dataSourceInfo = deriveDataSourceInfo(windowMs);
+    this.datasetConfig = {
+      uuid: this.id(),
+      path: cfg.datachartPath,
+      pathSource: cfg.datachartSource ?? 'default',
+      baseUnit: '',
+      timeScaleFormat: cfg.timeScale as TimeScaleFormat,
+      period: cfg.period,
+      label: '',
+      angleDomainOverride: cfg.datachartAngleRange ?? undefined
+    };
     this.createDatasets(cfg);
     this.setChartOptions(cfg);
     // Always recreate chart instance on rebuild to ensure orientation/scale axis changes apply
@@ -773,34 +751,28 @@ export class WidgetDataChartComponent implements OnDestroy {
   private startStreaming(): void {
     const cfg = this.runtime.options();
     if (!cfg?.datachartPath) return;
-    this.dsServiceSub?.unsubscribe();
+    this.streamSub?.unsubscribe();
 
-    if (this.chartEngine() === 'history') {
-      const info = this.dataSourceInfo;
-      const params: IHistoryChartStreamParams = {
-        path: cfg.datachartPath,
-        source: cfg.datachartSource ?? 'default',
-        angleDomainOverride: cfg.datachartAngleRange === 'signed' || cfg.datachartAngleRange === 'direction'
-          ? cfg.datachartAngleRange
-          : undefined,
-        windowMs: resolveWindowMs(cfg.timeScale as TimeScaleFormat, cfg.period),
-        sampleTime: info.sampleTime,
-        maxDataPoints: info.maxDataPoints,
-        smoothingPeriod: info.smoothingPeriod
-      };
-      this.dsServiceSub = this.historyStream.getBackfillThenLive(params).subscribe(emission => {
-        if (isHistoryUnavailable(emission)) {
-          this.historyUnavailable.set(true);
-          return;
-        }
-        this.historyUnavailable.set(false);
-        this.handleDatasetEmission(emission, cfg);
-      });
-      return;
-    }
-
-    const batchThenLive$ = this.dsService.getDatasetBatchThenLiveObservable(this.id());
-    this.dsServiceSub = batchThenLive$?.subscribe(dsPointOrBatch => this.handleDatasetEmission(dsPointOrBatch, cfg));
+    const info = this.dataSourceInfo;
+    const params: IHistoryChartStreamParams = {
+      path: cfg.datachartPath,
+      source: cfg.datachartSource ?? 'default',
+      angleDomainOverride: cfg.datachartAngleRange === 'signed' || cfg.datachartAngleRange === 'direction'
+        ? cfg.datachartAngleRange
+        : undefined,
+      windowMs: resolveWindowMs(cfg.timeScale as TimeScaleFormat, cfg.period),
+      sampleTime: info.sampleTime,
+      maxDataPoints: info.maxDataPoints,
+      smoothingPeriod: info.smoothingPeriod
+    };
+    this.streamSub = this.historyStream.getBackfillThenLive(params).subscribe(emission => {
+      if (isHistoryUnavailable(emission)) {
+        this.historyUnavailable.set(true);
+        return;
+      }
+      this.historyUnavailable.set(false);
+      this.handleDatasetEmission(emission, cfg);
+    });
   }
 
   private handleDatasetEmission(dsPointOrBatch: IDatasetServiceDatapoint[] | IDatasetServiceDatapoint, cfg: IWidgetSvcConfig): void {
@@ -896,7 +868,7 @@ export class WidgetDataChartComponent implements OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.dsServiceSub?.unsubscribe();
+    this.streamSub?.unsubscribe();
     this.chart?.destroy();
     const canvas = this.widgetDataChart?.()?.nativeElement as HTMLCanvasElement | undefined;
     this.canvasService.releaseCanvas(canvas, { clear: true, removeFromDom: true });


### PR DESCRIPTION
## Why

All recorder-only consumers are migrated (minichart #164, windtrends #165) and the History backfill is now angle-correct end to end (`:last` #161, circular SMA #162). So the History engine can become the default, and `widget-data-chart`'s opt-in A/B branch — the last recorder code path — can go.

## What

In `widget-data-chart`:

- **Flip** `DEFAULT_CONFIG.chartEngine` to `'history'`.
- **Remove** the `chartEngine` A/B `computed` and its `skip.chartEngine` localStorage override — the widget no longer chooses an engine.
- **Delete** the recorder branches in `rebuildForDataset` (the `syncDataChartDataset` + `getDatasetConfig`/`getDataSourceInfo` path) and `startStreaming` (the `getDatasetBatchThenLiveObservable` tail). Both now unconditionally use the History path.
- **Drop** the `DatasetStreamService` and `WidgetDatasetOrchestratorService` injections/imports (no longer referenced here). Renamed the now-misleading `dsServiceSub` field to `streamSub`.

Deliberately **left for PR7** (the config migration): the vestigial `chartEngine` config field, the `CHART_ENGINE_OVERRIDE_KEY` constant in `config-storage.const.ts`, and clearing any stale `skip.chartEngine` localStorage value.

After this, `widget-data-chart` no longer references the recorder — **PR6 can delete `DatasetStreamService` + the orchestrator.**

## Depends on

Must merge **after #167** (the circular-SMA fix, #162) — already merged — so the now-default engine's smoothing line is angle-correct.

## Verification

- `npm run build:dev` + `npm run lint` — clean.
- Spec updated: the four engine-dispatch/override tests collapse to one ("streams from the History engine — the only engine"); the `HISTORY_UNAVAILABLE` empty-state test stays. Recorder mocks/providers removed.

Part of #64.
