### PR TITLE
feat(config): migrate app config to v13, retiring the recorder's dataset model

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -103,7 +103,7 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
       if (this.settings.configUpgrade()) {
         const liveVersion = this.settings.getConfigVersion();
 
-        if (liveVersion === 11) {
+        if (liveVersion === 11 || liveVersion === 12) {
           this.upgrade.runUpgrade(liveVersion);
         }
 

--- a/src/app/core/components/options/configuration/config.component.spec.ts
+++ b/src/app/core/components/options/configuration/config.component.spec.ts
@@ -151,7 +151,7 @@ describe('SettingsConfigComponent', () => {
       getThemeConfig: ReturnType<typeof vi.fn>;
       loadConfigFromLocalStorage: ReturnType<typeof vi.fn>;
     };
-    const serverApp = { configVersion: 12, browserTabTitle: 'Server' };
+    const serverApp = { configVersion: 13, browserTabTitle: 'Server' };
     settings.getAppConfig.mockReturnValue(serverApp);
     settings.getDashboardConfig.mockReturnValue([{ id: 'dash-1' }]);
     settings.getThemeConfig.mockReturnValue({ themeName: 'dark' });

--- a/src/app/core/constants/config-storage.const.ts
+++ b/src/app/core/constants/config-storage.const.ts
@@ -28,6 +28,3 @@ export const SSO_REDIRECT_BUDGET_KEY = 'skip.ssoRedirectAttempts';
 
 /** Gesture-diagnostics debug flag key. */
 export const GESTURES_DEBUG_KEY = 'skip.gesturesDebug';
-
-/** Chart-engine A/B override flag key (#64 History-API prototype). */
-export const CHART_ENGINE_OVERRIDE_KEY = 'skip.chartEngine';

--- a/src/app/core/constants/config-versions.const.ts
+++ b/src/app/core/constants/config-versions.const.ts
@@ -21,7 +21,7 @@ export const REMOTE_CONFIG_FILE_VERSION = 11;
  * its legacy transforms pin their own MIGRATION_OUTPUT_VERSION so that bumping this constant
  * cannot silently re-label old migration output as current — add a chained migration instead.
  */
-export const LATEST_APP_CONFIG_VERSION = 12;
+export const LATEST_APP_CONFIG_VERSION = 13;
 
 /**
  * Per-device connectionConfig schema version (its own version space, decoupled from the app config

--- a/src/app/core/interfaces/app-settings.interfaces.ts
+++ b/src/app/core/interfaces/app-settings.interfaces.ts
@@ -1,4 +1,3 @@
-import { IDatasetServiceDatasetConfig } from './dataset.interfaces';
 import { IUnitDefaults } from '../services/units.service';
 import { Dashboard } from './../services/dashboard.service';
 
@@ -26,7 +25,6 @@ export interface IAppConfig {
   autoNightMode: boolean;
   redNightMode: boolean;
   nightModeBrightness: number;
-  dataSets: IDatasetServiceDatasetConfig[];
   unitDefaults: IUnitDefaults;
   notificationConfig: INotificationConfig;
   browserTabTitle?: string;

--- a/src/app/core/interfaces/widgets-interface.ts
+++ b/src/app/core/interfaces/widgets-interface.ts
@@ -402,8 +402,6 @@ export interface IWidgetSvcConfig {
   timeScale?: string;
   /** Used by datachart & windtrend chart Widget to set period configuration */
   period?: number;
-  /** widget-data-chart data engine: 'recorder' (client-side sampler, default) or 'history' (SK History API backfill + live delta tail). #64 prototype toggle. */
-  chartEngine?: 'recorder' | 'history';
   /** Specifies if the chart should track against the average dataset instead of the value (default setting) */
   trackAgainstAverage?: boolean;
   /** Specifies which average data points property (1=avg, 2=ema or 3=dema) the chart dataset will be built with */

--- a/src/app/core/services/configuration-upgrade.service.spec.ts
+++ b/src/app/core/services/configuration-upgrade.service.spec.ts
@@ -128,6 +128,62 @@ describe('ConfigurationUpgradeService', () => {
         }
     });
 
+    it('v12 upgrade drops the dataset registry, strips widget recorder vestige, and stamps v13', async () => {
+        mockStorage.listConfigs.mockResolvedValueOnce([{ scope: 'user', name: 'default' }]);
+        mockStorage.getConfig.mockResolvedValue({
+            app: { configVersion: 12, dataSets: [{ uuid: 'x' }] },
+            theme: { themeName: '' },
+            dashboards: [
+                { id: 'd0', configuration: [
+                    { input: { widgetProperties: { config: { datasetUUID: 'x', chartEngine: 'recorder', datachartPath: 'self.foo' } } } }
+                ] }
+            ]
+        });
+
+        await service.runUpgrade(12);
+
+        const written = mockStorage.setConfig.mock.calls.at(-1)[2];
+        expect(written.app.configVersion).toBe(13);
+        expect('dataSets' in written.app).toBe(false);
+        const widgetCfg = written.dashboards[0].configuration[0].input.widgetProperties.config;
+        expect('datasetUUID' in widgetCfg).toBe(false);
+        expect('chartEngine' in widgetCfg).toBe(false);
+        // Genuine chart inputs survive.
+        expect(widgetCfg.datachartPath).toBe('self.foo');
+    });
+
+    it('v12 upgrade reloads the app exactly once after persisting', async () => {
+        vi.useFakeTimers();
+        try {
+            mockStorage.listConfigs.mockResolvedValueOnce([{ scope: 'user', name: 'default' }]);
+            mockStorage.getConfig.mockResolvedValue({
+                app: { configVersion: 12, dataSets: [] },
+                theme: { themeName: '' },
+                dashboards: []
+            });
+
+            await service.runUpgrade(12);
+            vi.advanceTimersByTime(1500);
+
+            expect(mockAppSettings.reloadApp).toHaveBeenCalledTimes(1);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('v12 upgrade skips a slot that is not at version 12 (no re-stamp)', async () => {
+        mockStorage.listConfigs.mockResolvedValueOnce([{ scope: 'user', name: 'default' }]);
+        mockStorage.getConfig.mockResolvedValue({
+            app: { configVersion: 13 },
+            theme: { themeName: '' },
+            dashboards: []
+        });
+
+        await service.runUpgrade(12);
+
+        expect(mockStorage.setConfig).not.toHaveBeenCalled();
+    });
+
     it('startFresh retires BOTH global and user legacy configs via an awaited write before resetting', async () => {
         mockStorage.initConfig = null; // remote (Signal K) path
         mockStorage.listConfigs.mockResolvedValueOnce([

--- a/src/app/core/services/configuration-upgrade.service.ts
+++ b/src/app/core/services/configuration-upgrade.service.ts
@@ -7,20 +7,18 @@ import { v10IConfig, v10IThemeConfig } from '../interfaces/v10-config-interface'
 import { NgGridStackWidget } from 'gridstack/dist/angular';
 import { Dashboard } from './dashboard.service';
 import { LOCAL_CONFIG_KEYS } from '../constants/config-storage.const';
-
-interface DataChartConfigUpdate {
-  datachartPath: string;
-  datachartSource: string;
-  period: number;
-  timeScale: string;
-  datasetUUID: string;
-}
+import { REMOTE_CONFIG_FILE_VERSION } from '../constants/config-versions.const';
 
 // The app-config schema version the legacy v10/v11 transforms produce. Pinned on purpose:
 // bumping LATEST_APP_CONFIG_VERSION must not change what these transforms stamp — a newer
 // schema needs a chained migration step here, not a re-labeled output. Divergence fails loud:
 // a stamped config below latest re-raises the upgrade flag instead of masquerading as current.
 const MIGRATION_OUTPUT_VERSION = 12;
+
+// The v12 -> v13 transform output. Pinned the same way as MIGRATION_OUTPUT_VERSION: a fixed 13,
+// never LATEST_APP_CONFIG_VERSION, so a future schema bump re-raises the upgrade flag for a v13
+// config instead of relabeling it as current.
+const V13_MIGRATION_OUTPUT_VERSION = 13;
 
 // NOTE: This service encapsulates the app-config upgrades — the legacy migration (remote file
 // version 9 / app-config version 10) and the v11 remote upgrade — each stamping the upgraded
@@ -155,6 +153,30 @@ export class ConfigurationUpgradeService {
         this.upgrading.set(false);
       }
 
+    } else if (version === 12) {
+      // Remote (Signal K) configs. v12 slots live in the same active file version as v11.
+      try {
+        const configsList: Config[] = await this._storage.listConfigs(REMOTE_CONFIG_FILE_VERSION);
+
+        for (const item of configsList) {
+          try {
+            const config = await this._storage.getConfig(item.scope, item.name, REMOTE_CONFIG_FILE_VERSION);
+            this.pushMsg(`[Upgrade] ${item.scope}/${item.name} -> v${V13_MIGRATION_OUTPUT_VERSION}.`);
+            const migratedConfig = this.upgradeConfigV12toV13(config);
+            if (!migratedConfig) continue; // skip if not a v12 slot
+
+            await this._storage.setConfig(item.scope, item.name, migratedConfig);
+          } catch (error) {
+            this.pushError(`[Upgrade] Error upgrading ${item.scope}/${item.name}: ${(error as Error).message}`);
+          }
+        }
+        this.pushMsg(`[Upgrade] Reloading app to finalize upgrade...`);
+        setTimeout(() => this._settings.reloadApp(), 1500);
+      } catch (error) {
+        this.pushError('Error fetching configuration data. Aborting upgrade. Details: ' + (error as Error).message);
+        this.upgrading.set(false);
+      }
+
     } else {
       // LocalStorage upgrade path for config version 10
       const localStorageConfig: v10IConfig = { app: null, widget: null, layout: null, theme: null };
@@ -164,7 +186,6 @@ export class ConfigurationUpgradeService {
       localStorageConfig.theme = this._settings.loadConfigFromLocalStorage('themeConfig');
 
       const transformedApp = this.transformApp(localStorageConfig.app as IAppConfig);
-      const datasetInfo = this.extractAppDatasets(transformedApp);
       const transformedTheme = this.transformTheme(localStorageConfig.theme);
       const rootSplits = localStorageConfig.layout?.rootSplits || [];
       const splitSets = localStorageConfig.layout?.splitSets || [];
@@ -175,7 +196,6 @@ export class ConfigurationUpgradeService {
         return { id: rootSplitUUID, name: `Dashboard ${i + 1}`, configuration };
       });
 
-      this.migrateDatasetsToDataCharts(datasetInfo, dashboards);
       this.migrateUseNeedleToEnableNeedle(dashboards);
 
       localStorage.setItem(LOCAL_CONFIG_KEYS.appConfig, JSON.stringify(transformedApp));
@@ -239,7 +259,6 @@ export class ConfigurationUpgradeService {
       return null;
     }
     const transformedApp = this.transformApp(config.app as IAppConfig);
-    const datasetInfo = this.extractAppDatasets(transformedApp);
     const transformedTheme = this.transformTheme(config.theme);
     const rootSplits = config.layout?.rootSplits || [];
     const splitSets = config.layout?.splitSets || [];
@@ -248,7 +267,6 @@ export class ConfigurationUpgradeService {
       const configuration = this.extractWidgetsFromSplitSets(splitSets, widgets, rootSplitUUID);
       return { id: rootSplitUUID, name: `Dashboard ${i + 1}`, configuration };
     });
-    this.migrateDatasetsToDataCharts(datasetInfo, dashboards);
     this.migrateUseNeedleToEnableNeedle(dashboards);
     const oldConf: v10IConfig = cloneDeep(config);
     oldConf.app.configVersion = 0; // retired
@@ -258,70 +276,6 @@ export class ConfigurationUpgradeService {
       newConfiguration: { app: transformedApp, theme: transformedTheme, dashboards },
       oldConfiguration: oldConf
     };
-  }
-
-  private extractAppDatasets(transformedApp: IAppConfig): DataChartConfigUpdate[] {
-    if (!transformedApp || !Array.isArray(transformedApp.dataSets)) return [];
-    let updatedDatasetCount = 0;
-
-    // Find indices of datasets to extract and remove
-    const indicesToRemove: number[] = [];
-    const updates: DataChartConfigUpdate[] = [];
-
-    transformedApp.dataSets.forEach((ds, idx) => {
-      if (ds.editable === true || ds.editable === undefined) {
-        updates.push({
-          period: ds.period,
-          datachartPath: ds.path,
-          datachartSource: ds.pathSource,
-          timeScale: ds.timeScaleFormat,
-          datasetUUID: ds.uuid
-        });
-        indicesToRemove.push(idx);
-        updatedDatasetCount++;
-      }
-    });
-
-    // Remove in reverse order to avoid index shifting
-    for (let i = indicesToRemove.length - 1; i >= 0; i--) {
-      transformedApp.dataSets.splice(indicesToRemove[i], 1);
-    }
-
-    if (updatedDatasetCount) {
-      this.pushMsg(`[Upgrade] Retired ${updatedDatasetCount} Dataset(s).`);
-    }
-
-    return updates;
-  }
-
-  private migrateDatasetsToDataCharts(datasetInfo: DataChartConfigUpdate[], dashboards: Dashboard[]): void {
-    if (!Array.isArray(datasetInfo) || datasetInfo.length === 0) return;
-    if (!Array.isArray(dashboards)) return;
-
-    dashboards.forEach(dashboard => {
-      let updatedDatachartCount = 0;
-      if (dashboard && Array.isArray(dashboard.configuration)) {
-        dashboard.configuration.forEach((widget: NgGridStackWidget) => {
-          if (widget && typeof widget === 'object' && widget.input?.widgetProperties?.config) {
-            const dataset = datasetInfo.find(ds => ds.datasetUUID === widget.input?.widgetProperties?.config.datasetUUID);
-            if (dataset) {
-              // Add or replace all dataset properties except 'datasetUUID'
-              Object.entries(dataset).forEach(([key, value]) => {
-                if (key !== 'datasetUUID') {
-                  widget.input.widgetProperties.config[key] = value;
-                }
-              });
-              delete widget.input.widgetProperties.config?.datasetUUID;
-              delete widget.input.widgetProperties.config?.timeScaleFormat;
-              updatedDatachartCount++;
-            }
-          }
-        });
-        if (updatedDatachartCount) {
-          this.pushMsg(`[Upgrade] Migrated ${updatedDatachartCount} Realtime Data Chart widget(s).`);
-        }
-      }
-    });
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -369,8 +323,6 @@ export class ConfigurationUpgradeService {
         return null;
       }
       this.removeSplitShellConfigKeys(config.app);
-      const datasetInfo = this.extractAppDatasets(config.app);
-      this.migrateDatasetsToDataCharts(datasetInfo, config.dashboards);
       this.migrateUseNeedleToEnableNeedle(config.dashboards);
       // Iterate dashboards and force widget selector to 'widget-host2'
       let updatedWidgetCount = 0;
@@ -431,6 +383,42 @@ export class ConfigurationUpgradeService {
 
     } catch (error) {
       this.pushError(`[Upgrade Service] Error upgrading ${config.app.configVersion}: ${(error as Error).message}`);
+      return null;
+    }
+  }
+
+  /**
+   * v12 -> v13: retire the recorder's config footprint. The client-side chart recorder was removed,
+   * so the app-level dataset registry and the per-widget `datasetUUID` / `chartEngine` fields it fed
+   * are dead. Strip them and stamp v13. Genuine chart inputs (path/source/window/units) are untouched.
+   */
+  private upgradeConfigV12toV13(config: IConfig): IConfig | null {
+    try {
+      if (config.app.configVersion !== 12) {
+        this.pushError(`[Upgrade Service] Config version ${config.app.configVersion} is not an upgradable v12 config. Skipping...`);
+        return null;
+      }
+
+      delete (config.app as unknown as Record<string, unknown>).dataSets;
+
+      if (Array.isArray(config.dashboards)) {
+        for (const dash of config.dashboards) {
+          if (!dash || !Array.isArray(dash.configuration)) continue;
+          for (const widget of dash.configuration) {
+            const cfg = (widget as { input?: { widgetProperties?: { config?: Record<string, unknown> } } })
+              ?.input?.widgetProperties?.config;
+            if (cfg && typeof cfg === 'object') {
+              delete cfg.datasetUUID;
+              delete cfg.chartEngine;
+            }
+          }
+        }
+      }
+
+      config.app.configVersion = V13_MIGRATION_OUTPUT_VERSION;
+      return { app: config.app, theme: config.theme, dashboards: config.dashboards };
+    } catch (error) {
+      this.pushError(`[Upgrade Service] Error upgrading v12->v13: ${(error as Error).message}`);
       return null;
     }
   }

--- a/src/app/core/services/profile.service.spec.ts
+++ b/src/app/core/services/profile.service.spec.ts
@@ -6,7 +6,7 @@ import { SettingsService } from './settings.service';
 import { IConfig } from '../interfaces/app-settings.interfaces';
 
 const cfg = (theme = 'x'): IConfig => ({
-  app: { configVersion: 12 } as IConfig['app'],
+  app: { configVersion: 13 } as IConfig['app'],
   theme: { themeName: theme },
   dashboards: [{ id: 'd' }]
 });

--- a/src/app/core/services/settings.service.spec.ts
+++ b/src/app/core/services/settings.service.spec.ts
@@ -8,7 +8,6 @@ import { ensureLocalStorage } from '../../../test-helpers/local-storage.test-hel
 import { DefaultAppConfig, DefaultConnectionConfig, DefaultThemeConfig } from '../../../default-config/config.blank.const';
 import { IAppConfig, IConfig, IConnectionConfig, INotificationConfig, IThemeConfig } from '../interfaces/app-settings.interfaces';
 import { LATEST_APP_CONFIG_VERSION, CONNECTION_CONFIG_VERSION } from '../constants/config-versions.const';
-import { IDatasetServiceDatasetConfig } from '../interfaces/dataset.interfaces';
 import { IUnitDefaults } from './units.service';
 import { Dashboard } from './dashboard.service';
 
@@ -36,11 +35,10 @@ function seedConfig(opts: SeedOpts = {}): void {
     instanceName: opts.instanceName ?? ''
   }));
   localStorage.setItem('skip.appConfig', JSON.stringify({
-    configVersion: 12,
+    configVersion: 13,
     autoNightMode: false,
     redNightMode: false,
     nightModeBrightness: 1,
-    dataSets: [],
     unitDefaults: {},
     notificationConfig: {
       disableNotifications: true,
@@ -94,7 +92,6 @@ function loadedAppConfig(omit: string[] = []): Record<string, unknown> {
     autoNightMode: true,
     redNightMode: true,
     nightModeBrightness: 0.65,
-    dataSets: [{ uuid: 'ds-loaded' }],
     unitDefaults: { Speed: 'knots' },
     notificationConfig: fullNotificationConfig(),
     browserTabTitle: 'My Boat'
@@ -180,7 +177,7 @@ describe('SettingsService — storage routing (server applicationData only)', ()
   // server's applicationData.
   function setup() {
     seedConnectionConfig();
-    localStorage.setItem('skip.appConfig', JSON.stringify({ configVersion: 12, dataSets: [], unitDefaults: {}, notificationConfig: {} }));
+    localStorage.setItem('skip.appConfig', JSON.stringify({ configVersion: 13, unitDefaults: {}, notificationConfig: {} }));
     localStorage.setItem('skip.dashboardsConfig', JSON.stringify([]));
     localStorage.setItem('skip.themeConfig', JSON.stringify({ themeName: '' }));
     TestBed.configureTestingModule({ providers: [SettingsService, StorageService] });
@@ -434,7 +431,7 @@ describe('SettingsService — default config isolation', () => {
 
 describe('SettingsService — hydration (pushSettings) characterization', () => {
   const APP_CONFIG_KEYS = [
-    'autoNightMode', 'browserTabTitle', 'configVersion', 'dataSets',
+    'autoNightMode', 'browserTabTitle', 'configVersion',
     'nightModeBrightness', 'notificationConfig', 'redNightMode', 'unitDefaults'
   ];
 
@@ -451,7 +448,6 @@ describe('SettingsService — hydration (pushSettings) characterization', () => 
     expect(service.getNightModeBrightness()).toBe(0.65);
     expect(service.getBrowserTabTitle()).toBe('My Boat');
     expect(service.getThemeName()).toBe('dark');
-    expect(service.getDataSets()).toEqual([{ uuid: 'ds-loaded' }]);
     expect(service.getDefaultUnits()).toEqual({ Speed: 'knots' });
     expect(service.getNotificationConfig()).toEqual(fullNotificationConfig());
     expect(service.getDashboardConfig()).toEqual([{ id: 'd1' }]);
@@ -478,7 +474,6 @@ describe('SettingsService — hydration (pushSettings) characterization', () => 
       expect(Object.keys(blob).sort()).toEqual(APP_CONFIG_KEYS);
       // ...that preserves the loaded configVersion, with the already-hydrated fields riding along.
       expect(blob.configVersion).toBe(LOADED_CONFIG_VERSION);
-      expect(blob.dataSets).toEqual([{ uuid: 'ds-loaded' }]);
       expect(blob.unitDefaults).toEqual({ Speed: 'knots' });
       expect(blob.notificationConfig).toEqual(fullNotificationConfig());
       expect(read(service)).toBe(bootstrapDefault);
@@ -548,10 +543,6 @@ describe('SettingsService — app-config version preservation on every write pat
     service.setDefaultUnits({ Speed: 'kph' });
     expect(patchSpy).toHaveBeenLastCalledWith('Array<IUnitDefaults>', { Speed: 'kph' });
 
-    const dataSets = [{ uuid: 'ds-new' }] as unknown as IDatasetServiceDatasetConfig[];
-    service.saveDataSets(dataSets);
-    expect(patchSpy).toHaveBeenLastCalledWith('Array<IDatasetDef>', dataSets);
-
     const notif = fullNotificationConfig();
     service.setNotificationConfig(notif);
     expect(patchSpy).toHaveBeenLastCalledWith('INotificationConfig', notif);
@@ -593,19 +584,6 @@ describe('SettingsService — granular patch dispatch (end-to-end through Storag
     storage.sharedConfigName = 'profileA';
     return { service, http };
   }
-
-  it('saveDataSets dispatches a JSON Patch replacing the profile app/dataSets sub-path', () => {
-    const { service, http } = setupLive();
-    const dataSets = [{ uuid: 'ds-1', path: 'self.speed' }] as unknown as IDatasetServiceDatasetConfig[];
-
-    service.saveDataSets(dataSets);
-
-    const req = http.expectOne((r) => r.method === 'POST');
-    expect(req.request.body).toEqual([{ op: 'replace', path: '/profileA/app/dataSets', value: [{ uuid: 'ds-1', path: 'self.speed' }] }]);
-    req.flush(null);
-    expect(service.getDataSets()).toEqual(dataSets);
-    http.verify();
-  });
 
   it('setNotificationConfig dispatches a JSON Patch replacing the profile app/notificationConfig sub-path', () => {
     const { service, http } = setupLive();

--- a/src/app/core/services/settings.service.ts
+++ b/src/app/core/services/settings.service.ts
@@ -4,7 +4,6 @@ import { BehaviorSubject, Observable, filter } from 'rxjs';
 import { HttpErrorResponse } from '@angular/common/http';
 import { cloneDeep } from 'lodash-es';
 
-import { IDatasetServiceDatasetConfig } from '../interfaces/dataset.interfaces';
 import { IUnitDefaults } from './units.service';
 import { UUID } from '../utils/uuid.util';
 
@@ -69,7 +68,6 @@ export class SettingsService {
   private kipUUID = '';
   public signalkUrl: ISignalKUrl | undefined;
   private _dashboards: Dashboard[] = [];
-  private dataSets: IDatasetServiceDatasetConfig[] = [];
   public configUpgrade = signal<boolean>(false);
   private configVersion: number | undefined; // store actual config version from config version property in config
   private disablePathValidation = false; // used to disable path validation in path control component in widget options.
@@ -227,7 +225,6 @@ export class SettingsService {
     if (this.activeConfig.theme) {
       this._themeName.set(this.activeConfig.theme.themeName);
     }
-    this.dataSets = this.activeConfig.app.dataSets;
     this.applyUnitDefaults(this.activeConfig.app.unitDefaults);
     this.applyNotificationConfig(this.activeConfig.app.notificationConfig);
 
@@ -442,15 +439,6 @@ export class SettingsService {
     this._dashboards = dashboards;
   }
 
-  // DataSets
-  public saveDataSets(dataSets: IDatasetServiceDatasetConfig[]) {
-    this.dataSets = dataSets;
-    this.saveConfigSection('Array<IDatasetDef>', dataSets);
-  }
-  public getDataSets() {
-    return this.dataSets;
-  }
-
   // Notification Service Setting
   public getNotificationServiceConfigAsO(): Observable<INotificationConfig> {
     return this.notificationConfig$.asObservable();
@@ -553,7 +541,6 @@ export class SettingsService {
       autoNightMode: this.autoNightMode(),
       redNightMode: this.redNightMode(),
       nightModeBrightness: this.nightModeBrightness(),
-      dataSets: this.dataSets,
       unitDefaults: this.unitDefaults(),
       notificationConfig: this.notificationConfig(),
       browserTabTitle: this.browserTabTitle()

--- a/src/app/core/services/storage.service.spec.ts
+++ b/src/app/core/services/storage.service.spec.ts
@@ -384,15 +384,6 @@ describe('StorageService — applicationData URLs, scope & version gate (charact
     req.flush(null);
   });
 
-  it('patchConfig maps Array<IDatasetDef> to the app/dataSets sub-path', () => {
-    const { service } = setup();
-    service.patchConfig('Array<IDatasetDef>', [{ uuid: 'ds-1' }]);
-    const req = http.expectOne(`${ENDPOINT}user/skip/11`);
-    expect(req.request.method).toBe('POST');
-    expect(req.request.body).toEqual([{ op: 'replace', path: '/cockpit/app/dataSets', value: [{ uuid: 'ds-1' }] }]);
-    req.flush(null);
-  });
-
   it('patchConfig maps INotificationConfig to the app/notificationConfig sub-path', () => {
     const { service } = setup();
     service.patchConfig('INotificationConfig', { disableNotifications: true });

--- a/src/app/core/services/storage.service.ts
+++ b/src/app/core/services/storage.service.ts
@@ -19,7 +19,7 @@ export interface Config {
 
 export type TConfigObjectType =
   'IAppConfig' | 'IThemeConfig' | 'Dashboards' |
-  'Array<IUnitDefaults>' | 'Array<IDatasetDef>' | 'INotificationConfig';
+  'Array<IUnitDefaults>' | 'INotificationConfig';
 
 export interface IPatchFailure {
   // Config target that failed to persist — patchConfig's ObjType, when known.
@@ -451,15 +451,6 @@ export class StorageService {
           [{
             "op": "replace",
             "path": `/${this.sharedConfigName}/app/unitDefaults`,
-            "value": value
-          }]
-        break;
-
-      case "Array<IDatasetDef>":
-        document =
-          [{
-            "op": "replace",
-            "path": `/${this.sharedConfigName}/app/dataSets`,
             "value": value
           }]
         break;

--- a/src/app/widgets/widget-data-chart/widget-data-chart.component.spec.ts
+++ b/src/app/widgets/widget-data-chart/widget-data-chart.component.spec.ts
@@ -94,16 +94,11 @@ describe('WidgetDataChartComponent', () => {
     expect(historyMock.getBackfillThenLive).toHaveBeenCalled();
   });
 
-  it('routes a stale chartEngine:"recorder" config to the History engine (field ignored)', async () => {
-    await setup(makeConfig({ chartEngine: 'recorder' }));
-    expect(historyMock.getBackfillThenLive).toHaveBeenCalled();
-  });
-
   it('renders the "History data unavailable" empty state on a HISTORY_UNAVAILABLE emission', async () => {
     const emissions$ = new Subject<typeof HISTORY_UNAVAILABLE>();
     historyMock.getBackfillThenLive.mockReturnValue(emissions$);
 
-    await setup(makeConfig({ chartEngine: 'history' }));
+    await setup(makeConfig());
     expect(historyMock.getBackfillThenLive).toHaveBeenCalled();
 
     emissions$.next(HISTORY_UNAVAILABLE);

--- a/src/app/widgets/widget-data-chart/widget-data-chart.component.ts
+++ b/src/app/widgets/widget-data-chart/widget-data-chart.component.ts
@@ -63,7 +63,6 @@ export class WidgetDataChartComponent implements OnDestroy {
     convertUnitTo: null,
     timeScale: 'minute', // second | minute | hour
     period: 10,
-    chartEngine: 'history',
     numDecimal: 1,
     inverseYAxis: false,
     datasetAverageArray: 'sma', // sma | ema | dema | avg

--- a/src/assets/kip-dashboard-schema.json
+++ b/src/assets/kip-dashboard-schema.json
@@ -541,7 +541,7 @@
   },
   "meta": {
     "configFileVersion": 11,
-    "configVersion": 12,
+    "configVersion": 13,
     "kipVersion": "4.8.0",
     "schemaVersion": 1
   },

--- a/src/default-config/config.blank.const.ts
+++ b/src/default-config/config.blank.const.ts
@@ -11,7 +11,6 @@ export const DefaultAppConfig: Readonly<IAppConfig> = {
   "autoNightMode": true,
   "redNightMode": false,
   "nightModeBrightness": 0.27,
-  "dataSets": [],
   "unitDefaults": DefaultUnitsConfig,
   "notificationConfig": DefaultNotificationConfig,
   "browserTabTitle": "SKip"

--- a/src/default-config/config.demo.const.ts
+++ b/src/default-config/config.demo.const.ts
@@ -8,18 +8,6 @@ export const DemoAppConfig: IAppConfig = {
   "autoNightMode": false,
   "redNightMode": false,
   "nightModeBrightness": 0.27,
-  "dataSets": [
-    {
-      "uuid": "339698a7-2cff-4ab9-9b50-d8056f971471",
-      "path": "self.environment.depth.belowTransducer",
-      "pathSource": "default",
-      "baseUnit": "m",
-      "timeScaleFormat": "minute",
-      "period": 0.2,
-      "label": "simple-chart-339698a7-2cff-4ab9-9b50-d8056f971471",
-      "editable": false
-    }
-  ],
   "unitDefaults": {
     "Unitless": "unitless",
     "Speed": "knots",

--- a/src/test.ts
+++ b/src/test.ts
@@ -171,7 +171,6 @@ import type {
   ISignalkPlugin,
 } from './app/core/interfaces/signalk-plugin-config.interfaces';
 import type { IUnitDefaults } from './app/core/services/units.service';
-import type { IDatasetServiceDatasetConfig } from './app/core/interfaces/dataset.interfaces';
 // Global provider setup (HttpClient, RouterTestingModule, animation & material stubs, etc.)
 import { TestBed } from '@angular/core/testing';
 import type { Provider } from '@angular/core';
@@ -323,7 +322,6 @@ class SettingsServiceStub {
   private dashboards: unknown[] = [];
   private unitDefaultsSubject = new BehaviorSubject<Record<string, string>>({});
   private instanceNameSubject = new BehaviorSubject<string>('');
-  private dataSets: unknown[] = [];
   private _isRemoteControlSubject = new BehaviorSubject<boolean>(false);
   private _configUpgradeSubject = new BehaviorSubject<boolean>(false);
   private nightModeBrightnessSubject = new BehaviorSubject<number>(0.2);
@@ -383,10 +381,6 @@ class SettingsServiceStub {
   getInstanceName(): string { return this.instanceNameSubject.value; }
   setInstanceName(v: string): void { this.instanceNameSubject.next(v); this.instanceName.set(v); }
 
-  // DataSets config registry accessors (mirror SettingsService)
-  getDataSets(): unknown[] { return this.dataSets; }
-  saveDataSets(d: unknown[]): void { this.dataSets = d; }
-
   // Remote control mode flag used by RemoteDashboardsService and others
   getIsRemoteControl(): boolean { return this._isRemoteControlSubject.value; }
   setIsRemoteControl(v: boolean): void { this._isRemoteControlSubject.next(v); this.isRemoteControl.set(v); }
@@ -405,11 +399,10 @@ class SettingsServiceStub {
   // App-level getters used by multiple services
   public getAppConfig(): IAppConfig {
     return {
-      configVersion: 12,
+      configVersion: 13,
       autoNightMode: this.autoNightModeSubject.value,
       redNightMode: this.redNightModeSubject.value,
       nightModeBrightness: this.nightModeBrightnessSubject.value,
-      dataSets: this.dataSets as IDatasetServiceDatasetConfig[],
       unitDefaults: this.unitDefaultsSubject.value as IUnitDefaults,
       notificationConfig: this._notificationConfig.value,
     };


### PR DESCRIPTION
## What

PR7a of the #64 recorder-retirement epic (the migration half; the dataset-config UI removal is PR7b). Retires the client-side recorder's now-dead config footprint and migrates stored configs **v12 → v13**.

- **v12→v13 migration** in `ConfigurationUpgradeService` + its `app.component` trigger arm: drops the app-level `dataSets` registry and strips residual per-widget `datasetUUID`/`chartEngine`, stamping v13. `MIGRATION_OUTPUT_VERSION` stays pinned at 12 (legacy transforms keep stamping 12; the new step stamps 13 itself, so a future bump re-raises the upgrade flag rather than relabeling).
- Bump `LATEST_APP_CONFIG_VERSION` 12→13 and the dashboard schema `configVersion`.
- Remove `IAppConfig.dataSets` and all its plumbing (settings field/read/write, `getDataSets`/`saveDataSets`, the storage `Array<IDatasetDef>` patch case, the demo/blank defaults, the test stub) — nothing consumed it after the recorder was deleted.
- Remove the vestigial `chartEngine` field and the dead `CHART_ENGINE_OVERRIDE_KEY`.
- Delete the legacy dataset-migration code (`extractAppDatasets`/`migrateDatasetsToDataCharts`): it only fed the pre-fork Kip named-dataset model, unreachable under Skip's own storage namespace (`SERVER_CONFIG_APPID='skip'` + `skip.*` localStorage) and not a supported input.

`IDatasetServiceDatasetConfig` is kept — still the chart-widget config type.

## Verification against reality (the handoff plan was materially stale)

A cold verification pass corrected several plan assumptions before implementation: there's no generic upgrade loop (a hardcoded dispatcher + an `app.component` trigger that only handled v11 — a v12 bump would otherwise strand configs on the upgrade gate); `settings.service` has no own version constant; there is **no** StorageService version-write-suppression to guard against; the schema has no `app`/`dataSets`/`chartEngine` keys to drop; and `buildAppStorageObject` re-serializes `dataSets` on every write (the repopulation trap — handled by removing the field).

## Migration chain

v11 configs chain to v13 across two boots (v11→v12 stamps 12 → reload → v12→v13 stamps 13). Import (`profile.service.importProfile`) still rejects non-current versions by design; in-place stored profiles auto-migrate.

## Tests

- `npm run lint` — clean. `npm run build:dev` — green.
- New v12→v13 migration tests (TDD: drop registry, strip vestige, stamp v13, reload-once, skip non-v12).
- Green locally: configuration-upgrade (10), settings (22), profile (32), config-component (10), storage (33), widget-data-chart (2), app.component (1). Version-gate seed bumps applied to profile/config-component/settings specs.

Part of #64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zURudCY3TTRcNd2acknJ9