### PR TITLE
feat(config): fold chart source config into the Display tab, drop the Dataset tab

### DIFF
--- a/src/app/widget-config/display-chart-options/display-chart-options.component.spec.ts
+++ b/src/app/widget-config/display-chart-options/display-chart-options.component.spec.ts
@@ -14,7 +14,6 @@ describe('ChartOptionsComponent', () => {
             displayName: new UntypedFormControl('Test Chart'),
             showLabel: new UntypedFormControl(true),
             convertUnitTo: new UntypedFormControl(''),
-            datasetUUID: new UntypedFormControl('dataset-1'),
             datasetAverageArray: new UntypedFormControl([]),
             showAverageData: new UntypedFormControl(false),
             showDataPoints: new UntypedFormControl(false),

--- a/src/app/widget-config/display-chart-options/display-chart-options.component.ts
+++ b/src/app/widget-config/display-chart-options/display-chart-options.component.ts
@@ -22,7 +22,6 @@ export class DisplayChartOptionsComponent implements OnInit {
   readonly displayName = input.required<UntypedFormControl>();
   readonly showLabel = input.required<UntypedFormControl>();
   readonly convertUnitTo = input.required<UntypedFormControl>();
-  readonly datasetUUID = input.required<UntypedFormControl>();
   readonly datasetAverageArray = input.required<UntypedFormControl>();
   readonly showAverageData = input.required<UntypedFormControl>();
   readonly showDataPoints = input.required<UntypedFormControl>();

--- a/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.html
+++ b/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.html
@@ -2,12 +2,25 @@
   <h6 mat-dialog-title>{{ titleDialog }}</h6>
   <mat-dialog-content class="widget-config-dialog-content">
     <mat-tab-group class="tab-group-content">
-      <mat-tab label="Display">
+      <mat-tab>
+        <ng-template mat-tab-label>
+          @if (formMaster.controls.datachartPath && !formMaster.controls.datachartPath.valid) {
+            <span class="warning fa fa-exclamation-circle"></span>
+          } Display
+        </ng-template>
         @if ((widgetConfig?.datachartPath !== undefined)) {
+          <config-dataset-chart-options
+            class="tab-content"
+            [filterSelfPaths]="filterSelfPathsToControl"
+            [datachartPath]="datachartPathControl"
+            [datachartSource]="datachartSourceControl"
+            [convertUnitTo]="convertUnitToControl"
+            [datachartAngleRange]="datachartAngleRangeControl"
+            [timeScale]="timeScaleControl"
+            [period]="periodControl" />
           <config-display-chart-options
             class="tab-content"
             [displayName]="displayNameToControl"
-            [datasetUUID]="datasetUUIDToControl"
             [convertUnitTo]="convertUnitToControl"
             [showDataPoints]="showDataPointsToControl"
             [showAverageData]="showAverageDataToControl"
@@ -862,26 +875,6 @@
       }
       <!-- End PUT Requests-->
 
-      <!-- Charts -->
-      @if (widgetConfig?.datachartPath !== undefined) {
-        <mat-tab label="Dataset">
-          <ng-template mat-tab-label>
-            @if (!formMaster.controls.datachartPath.valid) {
-            <span class="warning fa fa-exclamation-circle"></span>
-            } Dataset
-          </ng-template>
-          <config-dataset-chart-options
-            [filterSelfPaths]="filterSelfPathsToControl"
-            [datachartPath]="datachartPathControl"
-            [datachartSource]="datachartSourceControl"
-            [convertUnitTo]="convertUnitToControl"
-            [datachartAngleRange]="datachartAngleRangeControl"
-            [timeScale]="timeScaleControl"
-            [period]="periodControl">
-          </config-dataset-chart-options>
-        </mat-tab>
-      }
-      <!-- end Chart -->
       @if (widgetConfig?.bms) {
         <mat-tab label="BMS">
           <bms-bank-setup formGroupName="bms" class="tab-content" />

--- a/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.ts
+++ b/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.ts
@@ -146,17 +146,14 @@ export class RootModalWidgetConfigComponent implements OnInit {
         if (parent === RootModalWidgetConfigComponent.KEY_CONVERT_UNIT_TO) {
           // If we are building units list
           const unitConfig = (formData as Record<string, unknown>)[key] as IWidgetPath;
-          if (unitConfig && (unitConfig as IWidgetPath).pathType == "number" || ('datasetUUID' in this.widgetConfig)) {
-            groups.addControl(key, new UntypedFormControl(value)); //only add control if it's a number or historical graph. Strings and booleans don't have units and conversions yet...
+          if (unitConfig && (unitConfig as IWidgetPath).pathType == "number") {
+            groups.addControl(key, new UntypedFormControl(value)); //only add control if it's a number. Strings and booleans don't have units and conversions yet...
           }
         } else {
           // not building Units list
           // Use switch in case we will need more Required form validator at some point.
           switch (key) {
             case "path": groups.addControl(key, new UntypedFormControl(value));
-              break;
-
-            case "datasetUUID": groups.addControl(key, new UntypedFormControl(value, Validators.required));
               break;
 
             case "dataTimeout": groups.addControl(key, new UntypedFormControl(value, Validators.required));
@@ -269,10 +266,6 @@ export class RootModalWidgetConfigComponent implements OnInit {
 
   get periodControl(): UntypedFormControl {
     return this.formMaster.get('period') as UntypedFormControl;
-  }
-
-  get datasetUUIDToControl(): UntypedFormControl {
-    return this.formMaster.get('datasetUUID') as UntypedFormControl;
   }
 
   get filterSelfPathsToControl(): UntypedFormControl {


### PR DESCRIPTION
## What

PR7b — the final piece of #64. A chart is now configured by **what it shows**: the path/source/window/units controls move from a separate "Dataset" tab into the **Display** tab, and the standalone dataset-configuration surface is gone.

- **Re-home**: `config-dataset-chart-options` is relocated into the Display tab (rendered above the display options, under the same `datachartPath` gate). It's **moved, not rebuilt**, so its required-path validator, autocomplete, and source/unit enable-disable logic — and the modal's Save gate — keep working unchanged. The invalid-path warning icon is carried onto the Display tab label, guarded so non-chart widgets still show a plain "Display". The standalone "Dataset" tab is deleted.
- **Remove the `datasetUUID` vestige** left by the retired recorder: the `display-chart-options` input, the root-modal `[datasetUUID]` binding, its `Validators.required` form control (the `case "datasetUUID"`), the `datasetUUIDToControl` getter, the now-dead `'datasetUUID' in widgetConfig` unit-group clause (inert since PR7a stripped `datasetUUID` from configs), and the display spec stub.

## Scope notes

- `dataset-chart-options` keeps its name in this PR — a rename to something source-oriented (`config-source-options`) is trivial follow-up polish, not functional.
- A few pre-existing dead `input.required` controls on `display-chart-options` (`datasetAverageArray`, `showDatasetAngleAverageValueLine`, `startScaleAtZero`) are left as-is — they predate #64 and are orthogonal to the dataset model.

## Verification

- `build:dev` green, `lint` clean.
- Specs green: root-modal (2), display-chart-options (4), dataset-chart-options (1). The root-modal spec exercises non-chart (electrical) widgets, covering the shared Display-tab change.
- **Live visual check of the rendered modal not yet done** (needs a data-chart widget config open against a real SK session) — build + component tests cover the functional wiring; happy to deploy to halosdev and screenshot the Display tab before merge if wanted.

Closes #64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zURudCY3TTRcNd2acknJ9