### PR TITLE
Fix Data Chart options: display-options block pushed off-screen by fold

### DIFF
--- a/src/app/widget-config/dataset-chart-options/dataset-chart-options.component.scss
+++ b/src/app/widget-config/dataset-chart-options/dataset-chart-options.component.scss
@@ -1,6 +1,5 @@
 .display-content {
   display: block;
-  height: 100%;
   width: 100%;
   padding-top: 15px;
   padding-bottom: 10px;

--- a/src/app/widget-config/display-chart-options/display-chart-options.component.html
+++ b/src/app/widget-config/display-chart-options/display-chart-options.component.html
@@ -1,23 +1,4 @@
 <div class="tab-content">
-  <div class="chart-flex-container">
-
-    <div class="chart-panel-group">
-      <mat-form-field class="full-width">
-        <mat-label>Widget Label</mat-label>
-        <input matInput placeholder="Enter a label to display"
-          name="displayName"
-          [formControl]="displayName()">
-      </mat-form-field>
-    </div>
-
-    <div class="chart-panel-group">
-      <mat-checkbox class="full-width"
-        name="showLabel"
-        [formControl]="showLabel()">
-          Show Label
-      </mat-checkbox>
-    </div>
-  </div>
 
   <div class="chart-flex-container">
     <mat-form-field class="full-width">

--- a/src/app/widget-config/display-chart-options/display-chart-options.component.spec.ts
+++ b/src/app/widget-config/display-chart-options/display-chart-options.component.spec.ts
@@ -11,8 +11,6 @@ describe('ChartOptionsComponent', () => {
 
     const applyRequiredInputs = (targetFixture: ComponentFixture<DisplayChartOptionsComponent>, overrides: Record<string, UntypedFormControl> = {}): Record<string, UntypedFormControl> => {
         const controls: Record<string, UntypedFormControl> = {
-            displayName: new UntypedFormControl('Test Chart'),
-            showLabel: new UntypedFormControl(true),
             convertUnitTo: new UntypedFormControl(''),
             datasetAverageArray: new UntypedFormControl([]),
             showAverageData: new UntypedFormControl(false),

--- a/src/app/widget-config/display-chart-options/display-chart-options.component.ts
+++ b/src/app/widget-config/display-chart-options/display-chart-options.component.ts
@@ -19,8 +19,6 @@ import { MatRadioChange, MatRadioModule } from '@angular/material/radio';
 export class DisplayChartOptionsComponent implements OnInit {
   private app = inject(AppService);
 
-  readonly displayName = input.required<UntypedFormControl>();
-  readonly showLabel = input.required<UntypedFormControl>();
   readonly convertUnitTo = input.required<UntypedFormControl>();
   readonly datasetAverageArray = input.required<UntypedFormControl>();
   readonly showAverageData = input.required<UntypedFormControl>();

--- a/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.html
+++ b/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.html
@@ -9,6 +9,20 @@
           } Display
         </ng-template>
         @if ((widgetConfig?.datachartPath !== undefined)) {
+          <div class="flex-container">
+            <div class="panel-group">
+              <mat-form-field class="full-width">
+                <mat-label>Widget Label</mat-label>
+                <input matInput placeholder="Enter a label to display"
+                  name="displayName" formControlName="displayName" />
+              </mat-form-field>
+            </div>
+            <div class="panel-group">
+              <mat-checkbox class="full-width" name="showLabel" formControlName="showLabel">
+                Show Label
+              </mat-checkbox>
+            </div>
+          </div>
           <config-dataset-chart-options
             class="tab-content"
             [filterSelfPaths]="filterSelfPathsToControl"
@@ -20,7 +34,6 @@
             [period]="periodControl" />
           <config-display-chart-options
             class="tab-content"
-            [displayName]="displayNameToControl"
             [convertUnitTo]="convertUnitToControl"
             [showDataPoints]="showDataPointsToControl"
             [showAverageData]="showAverageDataToControl"
@@ -31,7 +44,6 @@
             [showDatasetAverageValueLine]="showDatasetAverageValueLineToControl"
             [showDatasetAngleAverageValueLine]="showDatasetAngleAverageValueLineToControl"
             [startScaleAtZero]="startScaleAtZeroToControl"
-            [showLabel]="showLabelToControl"
             [showTimeScale]="showTimeScaleToControl"
             [showYScale]="showYScaleToControl"
             [yScaleSuggestedMin]="yScaleSuggestedMinToControl"

--- a/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.ts
+++ b/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.ts
@@ -312,10 +312,6 @@ export class RootModalWidgetConfigComponent implements OnInit {
     return this.formMaster.get('startScaleAtZero') as UntypedFormControl;
   }
 
-  get showLabelToControl(): UntypedFormControl {
-    return this.formMaster.get('showLabel') as UntypedFormControl;
-  }
-
   get showTimeScaleToControl(): UntypedFormControl {
     return this.formMaster.get('showTimeScale') as UntypedFormControl;
   }
@@ -350,9 +346,6 @@ export class RootModalWidgetConfigComponent implements OnInit {
 
   get showAverageDataToControl(): UntypedFormControl {
     return this.formMaster.get('showAverageData') as UntypedFormControl;
-  }
-  get displayNameToControl(): UntypedFormControl {
-    return this.formMaster.get('displayName') as UntypedFormControl;
   }
 
   get numDecimalToControl(): UntypedFormControl {


### PR DESCRIPTION
The Data Chart widget's options modal was broken by the `d3bd7c0d` fold ("fold chart source config into the Display tab, drop the Dataset tab"). Two defects, both fixed here. Reported in #181.

## 1. Display-options block rendered off-screen (invisible)

`config-display-chart-options` (Widget Label, Show Label, Colour, series, scales) was in the DOM but pushed ~540px below the visible dialog. `config-dataset-chart-options`'s root `.display-content` kept `height: 100%` from when it was the sole content of the standalone Dataset tab; folded in above the display options, it filled the whole tab body and shoved everything below the fold. No console error.

Fix: drop that `height: 100%` so the dataset options size to their content.

Geometry, verified with a headless Playwright run booting the real app with the exact affected device config: dataset **890px → 346px**, display-options `top` **1178px → 635px** (into view).

## 2. Widget Label was near the bottom

Even once visible, the Widget Label sat below all the path/source/timescale controls — the widget's name should be first, as it is for every other widget. Before the fold, the Display tab started with it.

Fix: hoist the Widget Label + Show Label group above `config-dataset-chart-options`, binding directly to the form controls; remove the now-unused `displayName`/`showLabel` inputs from `config-display-chart-options` and their dead getters. Field order is now: **Widget Label / Show Label → path/source/window → chart display detail (colour, series, scales)**. Verified in-browser (first field is "Widget Label").

## Verification

`npm run lint`, `npm run build:prod`, and the `display-chart-options` spec pass. Both fixes reproduced and confirmed with a headless Playwright run against the real app + the exact device config.

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zURudCY3TTRcNd2acknJ9