### PR TITLE
fix(dashboard): correct page-nav method semantics and align hotkeys with swipe

### DIFF
--- a/src/app/core/components/dashboard/dashboard.component.html
+++ b/src/app/core/components/dashboard/dashboard.component.html
@@ -4,8 +4,8 @@
   [options]="gridOptions()"
   (addedCB)="onGridItemsChanged()"
   (removedCB)="onGridItemsChanged()"
-  (swipeup)="previousDashboard()"
-  (swipedown)="nextDashboard()"
+  (swipeup)="nextDashboard()"
+  (swipedown)="previousDashboard()"
   (press)="addNewWidget($event)"
 >
 </gridstack>
@@ -16,8 +16,8 @@
     [mode]="dashboardStatic === true ? 'dashboard' : 'editor'"
     [enablePress]="dashboardStatic === false"
     [enableDoubleTap]="false"
-    (swipeup)="previousDashboard()"
-    (swipedown)="nextDashboard()"
+    (swipeup)="nextDashboard()"
+    (swipedown)="previousDashboard()"
     (press)="addNewWidget($event)"
   >
     <div class="dashboard-empty-state-action">

--- a/src/app/core/services/dashboard.service.spec.ts
+++ b/src/app/core/services/dashboard.service.spec.ts
@@ -289,21 +289,21 @@ describe('DashboardService', () => {
   describe('dashboard cycling', () => {
     beforeEach(() => setup());
 
-    // Direction is pinned as implemented and is inverted relative to the method
-    // names and their JSDoc: previousDashboard advances, nextDashboard retreats.
-    it('previousDashboard advances the active index, wrapping to the first', () => {
+    // Correctly named: nextDashboard advances (wraps last -> first),
+    // previousDashboard retreats (wraps first -> last).
+    it('nextDashboard advances the active index, wrapping to the first', () => {
       service.setActiveDashboardIndex(1);
-      service.previousDashboard();
+      service.nextDashboard();
       expect(service.activeDashboard()).toBe(2);
-      service.previousDashboard();
+      service.nextDashboard();
       expect(service.activeDashboard()).toBe(0);
     });
 
-    it('nextDashboard retreats the active index, wrapping to the last', () => {
+    it('previousDashboard retreats the active index, wrapping to the last', () => {
       service.setActiveDashboardIndex(1);
-      service.nextDashboard();
+      service.previousDashboard();
       expect(service.activeDashboard()).toBe(0);
-      service.nextDashboard();
+      service.previousDashboard();
       expect(service.activeDashboard()).toBe(2);
     });
   });
@@ -325,19 +325,18 @@ describe('DashboardService', () => {
       expect(consoleError).toHaveBeenCalled();
     });
 
-    // Same pinned direction swap as previousDashboard/nextDashboard.
-    it('navigateToNextDashboard routes backward and navigateToPreviousDashboard forward, with wrap', () => {
+    it('navigateToNextDashboard routes forward and navigateToPreviousDashboard backward, with wrap', () => {
       service.setActiveDashboardIndex(0);
       service.navigateToNextDashboard();
-      expect(router.navigate).toHaveBeenLastCalledWith(['/dashboard', 2]);
-      service.navigateToPreviousDashboard();
       expect(router.navigate).toHaveBeenLastCalledWith(['/dashboard', 1]);
+      service.navigateToPreviousDashboard();
+      expect(router.navigate).toHaveBeenLastCalledWith(['/dashboard', 2]);
       service.setActiveDashboardIndex(2);
       service.navigateToPreviousDashboard();
-      expect(router.navigate).toHaveBeenLastCalledWith(['/dashboard', 0]);
+      expect(router.navigate).toHaveBeenLastCalledWith(['/dashboard', 1]);
       service.setActiveDashboardIndex(1);
       service.navigateToNextDashboard();
-      expect(router.navigate).toHaveBeenLastCalledWith(['/dashboard', 0]);
+      expect(router.navigate).toHaveBeenLastCalledWith(['/dashboard', 2]);
     });
   });
 

--- a/src/app/core/services/dashboard.service.ts
+++ b/src/app/core/services/dashboard.service.ts
@@ -272,10 +272,10 @@ export class DashboardService {
    * This only updates the internal state and does NOT trigger navigation or URL changes.
    */
   public previousDashboard(): void {
-    if ((this.activeDashboard() + 1) > (this.dashboards().length) - 1) {
-      this.activeDashboard.set(0);
+    if ((this.activeDashboard() - 1) < 0) {
+      this.activeDashboard.set(this.dashboards().length - 1);
     } else {
-      this.activeDashboard.set(this.activeDashboard() + 1);
+      this.activeDashboard.set(this.activeDashboard() - 1);
     }
   }
 
@@ -285,10 +285,10 @@ export class DashboardService {
    * This only updates the internal state and does NOT trigger navigation or URL changes.
    */
   public nextDashboard(): void {
-    if ((this.activeDashboard() - 1) < 0) {
-      this.activeDashboard.set(this.dashboards().length - 1);
+    if ((this.activeDashboard() + 1) > (this.dashboards().length) - 1) {
+      this.activeDashboard.set(0);
     } else {
-      this.activeDashboard.set(this.activeDashboard() - 1);
+      this.activeDashboard.set(this.activeDashboard() + 1);
     }
   }
 
@@ -315,30 +315,30 @@ export class DashboardService {
 
   /**
    * Navigates to the next dashboard in the list.
-   * If the current dashboard is the first one, wraps around to the last dashboard.
+   * If the current dashboard is the last one, wraps around to the first dashboard.
    * This updates the browser URL and triggers Angular routing.
    */
   public navigateToNextDashboard(): void {
     let nextDashboard: number = null;
-    if ((this.activeDashboard() - 1) < 0) {
-      nextDashboard = this.dashboards().length - 1;
+    if ((this.activeDashboard() + 1) >= this.dashboards().length) {
+      nextDashboard = 0;
     } else {
-      nextDashboard = this.activeDashboard() - 1;
+      nextDashboard = this.activeDashboard() + 1;
     }
     this._router.navigate(['/dashboard', nextDashboard]);
   }
 
   /**
    * Navigates to the previous dashboard in the list.
-   * If the current dashboard is the last one, wraps around to the first dashboard.
+   * If the current dashboard is the first one, wraps around to the last dashboard.
    * This updates the browser URL and triggers Angular routing.
    */
   public navigateToPreviousDashboard(): void {
     let nextDashboard: number = null;
-    if ((this.activeDashboard() + 1) >= this.dashboards().length) {
-      nextDashboard = 0;
+    if ((this.activeDashboard() - 1) < 0) {
+      nextDashboard = this.dashboards().length - 1;
     } else {
-      nextDashboard = this.activeDashboard() + 1;
+      nextDashboard = this.activeDashboard() - 1;
     }
     this._router.navigate(['/dashboard', nextDashboard]);
   }

--- a/src/app/widgets/widget-anchor-alarm/widget-anchor-alarm.component.ts
+++ b/src/app/widgets/widget-anchor-alarm/widget-anchor-alarm.component.ts
@@ -78,10 +78,10 @@ export class WidgetAnchorAlarmComponent implements AfterViewInit, OnDestroy {
     if (event.data.gesture) {
       switch (event.data.gesture) {
         case 'swipeup':
-          this._dashboard.navigateToPreviousDashboard();
+          this._dashboard.navigateToNextDashboard();
           break;
         case 'swipedown':
-          this._dashboard.navigateToNextDashboard();
+          this._dashboard.navigateToPreviousDashboard();
           break;
         case 'swipeleft': {
           const leftSidebarEvent = new Event('openLeftSidenav', { bubbles: true, cancelable: true });

--- a/src/app/widgets/widget-freeboardsk/widget-freeboardsk.component.ts
+++ b/src/app/widgets/widget-freeboardsk/widget-freeboardsk.component.ts
@@ -123,10 +123,10 @@ export class WidgetFreeboardskComponent implements AfterViewInit, OnDestroy {
     if (event.data.gesture && event.data.eventData?.instanceId === instanceId) {
       switch (event.data.gesture) {
         case 'swipeup':
-          if (this.dashboard.isDashboardStatic()) this.dashboard.navigateToPreviousDashboard();
+          if (this.dashboard.isDashboardStatic()) this.dashboard.navigateToNextDashboard();
           break;
         case 'swipedown':
-          if (this.dashboard.isDashboardStatic()) this.dashboard.navigateToNextDashboard();
+          if (this.dashboard.isDashboardStatic()) this.dashboard.navigateToPreviousDashboard();
           break;
         case 'swipeleft':
           window.document.dispatchEvent(new Event('openLeftSidenav', { bubbles: true, cancelable: true }));

--- a/src/app/widgets/widget-iframe/widget-iframe.component.spec.ts
+++ b/src/app/widgets/widget-iframe/widget-iframe.component.spec.ts
@@ -63,18 +63,18 @@ describe('WidgetIframeComponent', () => {
   it('acts on a gesture message from its own iframe', () => {
     const { fixture, dashboard } = mount();
     swipeDownFrom(iframeWindow(fixture), window.location.origin);
-    expect(dashboard.navigateToNextDashboard).toHaveBeenCalledTimes(1);
+    expect(dashboard.navigateToPreviousDashboard).toHaveBeenCalledTimes(1);
   });
 
   it('ignores a gesture message from a foreign window source', () => {
     const { dashboard } = mount();
     swipeDownFrom(window, window.location.origin);
-    expect(dashboard.navigateToNextDashboard).not.toHaveBeenCalled();
+    expect(dashboard.navigateToPreviousDashboard).not.toHaveBeenCalled();
   });
 
   it('ignores a gesture message whose origin is not the iframe origin', () => {
     const { fixture, dashboard } = mount();
     swipeDownFrom(iframeWindow(fixture), 'https://evil.invalid');
-    expect(dashboard.navigateToNextDashboard).not.toHaveBeenCalled();
+    expect(dashboard.navigateToPreviousDashboard).not.toHaveBeenCalled();
   });
 });

--- a/src/app/widgets/widget-iframe/widget-iframe.component.ts
+++ b/src/app/widgets/widget-iframe/widget-iframe.component.ts
@@ -104,10 +104,10 @@ export class WidgetIframeComponent implements AfterViewInit, OnDestroy {
     if (event.data.gesture) {
       switch (event.data.gesture) {
         case 'swipeup':
-          this._dashboard.navigateToPreviousDashboard();
+          this._dashboard.navigateToNextDashboard();
           break;
         case 'swipedown':
-          this._dashboard.navigateToNextDashboard();
+          this._dashboard.navigateToPreviousDashboard();
           break;
         case 'swipeleft': {
           const leftSidebarEvent = new Event('openLeftSidenav', { bubbles: true, cancelable: true });


### PR DESCRIPTION
## What

Corrects the page-navigation method semantics in `DashboardService` and aligns the keyboard hotkeys with swipe direction.

The methods were **misnamed**: `nextDashboard`/`navigateToNextDashboard` retreated (`index-1`) while `previousDashboard`/`navigateToPreviousDashboard` advanced (`index+1`) — the opposite of their names and JSDoc. This PR swaps the bodies so `next` advances (wrapping last→first) and `previous` retreats (wrapping first→last).

## Why

The redesign (#183) converges every page-nav entry point on this API, so the semantics must be honest first. This also fixes a real pre-existing bug: **swipe-up and `Ctrl+↑` navigated in opposite directions**.

## Behaviour change

- **Swipe unchanged** — swipe-up still advances, swipe-down retreats (call sites in the dashboard grid and the three navigation-coupled iframe widgets were swapped to preserve this).
- **Hotkeys fixed** — `Ctrl+↑` now advances and `Ctrl+↓` retreats, matching swipe. Previously they were inverted.

## Scope

`widget-iframe`, `widget-freeboardsk`, `widget-anchor-alarm` all call these methods directly, so their swipe handlers were updated in lockstep. `RemoteDashboardsService` uses absolute `navigateTo(idx)` and is unaffected.

## Tests

Re-pinned the direction assertions that previously locked in the inverted behaviour:
- `dashboard.service.spec.ts` — cycling + router-navigation direction.
- `widget-iframe.component.spec.ts` — swipe-down now routes via `navigateToPreviousDashboard`.

Verified locally: `npm run lint` clean; `dashboard.service.spec` (33), `widget-iframe.component.spec` (5), `dashboard.component.spec` (16) all pass.

Part of #183 · Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDu7zsKECA9SvBR5DLdUex
