### PR TITLE
chore(branding): rename app display name to "Skip"

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   ],
   "signalk": {
     "appIcon": "assets/icon-72x72.png",
-    "displayName": "Skip Instrument MFD"
+    "displayName": "Skip"
   },
   "files": [
     "public/**",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,7 +5,7 @@
   "display": "fullscreen",
   "scope": "/@halos-org/skip/",
   "start_url": "/@halos-org/skip/",
-  "name": "Skip Instrument MFD",
+  "name": "Skip",
   "short_name": "Skip",
   "description": "An advanced and versatile marine instrumentation package to display Signal K data.",
   "orientation": "landscape",


### PR DESCRIPTION
Renames the app display name from "Skip Instrument MFD" to "Skip".

- `package.json` → `signalk.displayName`: drives the Signal K webapps API and the Homarr dashboard tile.
- `src/manifest.json` → `name`: the PWA/app name (`short_name` was already "Skip").

Both branding locations now read "Skip".