### PR TITLE
feat: expose Skip as a Freeboard-SK plotter-extension panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 ## New Features
+* Freeboard-SK panel: Skip registers itself as a Freeboard-SK plotter extension, so a supporting Freeboard-SK (3.0.0-beta or later) shows a toolbar button that opens Skip in a side panel. Ships as a Signal K server plugin bundled in the Skip package, enabled by default.
 * Same-origin Signal K sign-in (SSO): when KIP is served by a Signal K server on the same origin, it authenticates with the server's session cookie instead of its own username/password form. With an OIDC/SSO server, KIP joins the existing session and redirects to the server login when needed — no second sign-in, and OIDC-provisioned users (who have no server-local password) can use KIP. Cross-origin standalone use (a PWA pointed at a remote server) keeps the existing token sign-in.
 ## Improvements
 * The Connectivity settings show your Signal K session identity in same-origin mode (including a read-only-session indicator) instead of a credential form.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,10 +74,10 @@ The mock serves Skip's full session/config surface (`loginStatus`, `applicationD
 
 ## Fork-specific gotchas
 
-- **The package name is the serving path.** `angular.json` `baseHref`, the `dev` serve-path, and `src/manifest.json` `id`/`scope`/`start_url` must all stay `/@halos-org/skip/`. Branding lives in `brand/` (vector master, repo-only), `src/assets/` (favicon/icon set), `src/manifest.json`, and `signalk.displayName` in `package.json`.
+- **The package name is the serving path.** `angular.json` `baseHref`, the `dev` serve-path, `src/manifest.json` `id`/`scope`/`start_url`, and `SKIP_URL` in `plugin/index.js` must all stay `/@halos-org/skip/`. Branding lives in `brand/` (vector master, repo-only), `src/assets/` (favicon/icon set), `src/manifest.json`, and `signalk.displayName` in `package.json`.
 - **`gh` defaults PRs to the `upstream` remote.** Always pass `--repo halos-org/skip` to `gh pr create` / `gh pr merge`. (The clone is set up with `gh repo set-default halos-org/skip` and a disabled upstream push URL, but pass it explicitly anyway.)
 - **Upstream's own vitest CI is red**; a rebase onto `mxtommy/kip` can re-introduce test failures. The fork's fixes are small and live in `src/test.ts` stubs plus a few specs — re-apply them rather than disabling tests.
-- Not published to npm (publishing would list it in the Signal K app store). Deploy by placing the built `public/` output where the SK server serves the webapp.
+- Not published to npm (publishing would list it in the Signal K app store). Deploy by placing the package where the SK server serves it: the built `public/` output (the webapp) **and** `plugin/` (the bundled Freeboard-SK panel plugin, referenced by `main`) alongside `package.json`. A `public/`-only copy leaves `main` dangling and the plugin fails to load.
 
 ## Inherited upstream docs — treat skeptically
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@halos-org/skip",
   "version": "4.8.0",
+  "main": "plugin/index.js",
   "publishConfig": {
     "access": "public"
   },
@@ -32,6 +33,7 @@
   },
   "keywords": [
     "signalk-webapp",
+    "signalk-node-server-plugin",
     "signalk-category-instruments",
     "signalk-category-notifications",
     "signalk-category-ais",
@@ -46,8 +48,10 @@
     "appIcon": "assets/icon-72x72.png",
     "displayName": "Skip"
   },
+  "signalk-plugin-enabled-by-default": true,
   "files": [
     "public/**",
+    "plugin/**",
     "README.md",
     "LICENSE",
     "CHANGELOG.md",

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -1,0 +1,79 @@
+// Signal K server plugin bundled with the Skip webapp package.
+//
+// It registers Skip as a Freeboard-SK "plotter extension" panel: a read-only
+// `plotterExtensions` resource whose manifest tells a supporting chartplotter
+// (Freeboard-SK) to offer a toolbar button that opens Skip in a side panel.
+// See https://github.com/SignalK/freeboard-sk/blob/master/docs/api/plotter_extension_provider_plugins.md
+//
+// The panel iframe is the Skip webapp served by this same package, so the URL is
+// the package's fixed serving path and the same-origin session authenticates it.
+
+const { version } = require('../package.json');
+
+const PLUGIN_ID = 'skip-plotter-panel';
+const SKIP_URL = '/@halos-org/skip/';
+
+module.exports = function (app) {
+  let running = false;
+
+  function buildManifest() {
+    return {
+      name: 'Skip',
+      description: 'Opens the Skip instrument panel inside Freeboard-SK.',
+      version,
+      apiVersion: '1',
+      requires: [],
+      optional: [],
+      panels: [
+        {
+          id: 'skip-panel',
+          title: 'Skip',
+          type: 'iframe',
+          url: SKIP_URL,
+          lifecycle: 'keepAlive'
+        }
+      ],
+      buttons: [
+        {
+          id: 'skip-open',
+          title: 'Skip',
+          slot: 'primary',
+          icon: 'insights',
+          action: { type: 'togglePanel', panel: 'skip-panel' }
+        }
+      ]
+    };
+  }
+
+  return {
+    id: PLUGIN_ID,
+    name: 'Skip Freeboard Panel',
+    description: 'Registers Skip as a Freeboard-SK plotter-extension panel.',
+    schema: { type: 'object', properties: {} },
+    start() {
+      app.registerResourceProvider({
+        type: 'plotterExtensions',
+        methods: {
+          listResources: async () => (running ? { [PLUGIN_ID]: buildManifest() } : {}),
+          getResource: async (id) => {
+            if (!running || id !== PLUGIN_ID) {
+              throw new Error(`No such plotterExtensions resource: ${id}`);
+            }
+            return buildManifest();
+          },
+          setResource: async () => {
+            throw new Error(`${PLUGIN_ID} is a read-only provider`);
+          },
+          deleteResource: async () => {
+            throw new Error(`${PLUGIN_ID} is a read-only provider`);
+          }
+        }
+      });
+      running = true;
+      app.setPluginStatus(`Skip panel registered at ${SKIP_URL}`);
+    },
+    stop() {
+      running = false;
+    }
+  };
+};


### PR DESCRIPTION
## What

Bundles a small Signal K server plugin in the Skip package that registers a read-only `plotterExtensions` resource. A supporting Freeboard-SK (`3.0.0-beta`+) reads it and shows a **"Skip" toolbar button** that opens Skip in a side panel — Skip and Freeboard side by side, without leaving the chartplotter.

## Why this shape

Freeboard's [plotter-extension mechanism](https://github.com/SignalK/freeboard-sk/blob/master/docs/api/plotter_extension_provider_plugins.md) is delivered by a server plugin (the resource is only creatable via `registerResourceProvider`; there's no webapp-only path). A **panel** is just an iframe of arbitrary content with host-owned chrome, and Skip already connects to Signal K over its same-origin session — so the panel needs no bundle, no `signalk-plotterext-bus`, and no asset route. The manifest URL is server-relative, so it points straight at Skip's own serving path.

Folded into the webapp package (rather than a standalone plugin) so it's version-locked to Skip, always points at the correct `/@halos-org/skip/` path, and ships/deploys with Skip — no second package to wire into an image story Skip doesn't have yet. The plugin removed in #178 was Kip's heavyweight server-side *history provider*; this is an unrelated read-only UI registration.

## Changes

- `plugin/index.js` — the plugin: registers `plotterExtensions` with one panel (`/@halos-org/skip/`, `keepAlive`) + a toggle button.
- `package.json` — `signalk-node-server-plugin` keyword, `main`, and `plugin/**` in `files`.
- CHANGELOG entry under Unreleased.

## Verification

Proven end-to-end on halpi.hurma (Freeboard `3.0.0-beta.0`, SK `2.27.0`): SK loads Skip as a plugin, the resource serves the manifest, Freeboard renders the "Skip" button, and clicking it opens the panel with live Skip (authenticated same-origin path confirmed working). CI-relevant checks run locally green (`build:prod`; lint/betterer untouched — plugin is non-`src` JS).

## Scope / follow-ups

v1 points the panel at Skip's existing responsive shell (its phone-width layout fits the drawer). Tracked separately:
- #216 — a chromeless/embedded Skip route as the panel target.
- #217 — Skip's SSO redirect breaks when framed without a session (happy path unaffected).

## Deploy note

The Skip package now ships `plugin/`, so deployment must copy it (not just `public/` + `package.json`). The plugin must be **enabled** on the Signal K server to activate.

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)
