### PR TITLE
fix(windsteer): base laylines and wind sectors on true wind

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -225,15 +225,15 @@ exports[`strictNullChecks`] = {
       [42, 57, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"],
       [43, 57, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"]
     ],
-    "src/app/widgets/svg-windsteer/svg-windsteer.component.ts:3669162095": [
+    "src/app/widgets/svg-windsteer/svg-windsteer.component.ts:3559272095": [
       [28, 59, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"],
-      [39, 50, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"],
-      [44, 46, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"],
-      [45, 47, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"],
-      [46, 51, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"],
-      [48, 57, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"],
+      [40, 50, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"],
+      [45, 46, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"],
+      [46, 47, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"],
+      [47, 51, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"],
       [49, 57, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"],
-      [50, 57, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"]
+      [50, 57, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"],
+      [51, 57, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"]
     ],
     "src/app/widgets/svg-zone-states/svg-zone-states.component.ts:1762718998": [
       [17, 41, 4, "No overload matches this call.\\n  Overload 1 of 5, \'(initialValue: IDynamicControl, opts?: InputOptionsWithoutTransform<IDynamicControl> | undefined): InputSignal<...>\', gave the following error.\\n    Argument of type \'null\' is not assignable to parameter of type \'IDynamicControl\'.\\n  Overload 2 of 5, \'(initialValue: undefined, opts: InputOptionsWithoutTransform<IDynamicControl>): InputSignal<IDynamicControl | undefined>\', gave the following error.\\n    Argument of type \'null\' is not assignable to parameter of type \'undefined\'.", "2087897566"],
@@ -563,12 +563,11 @@ exports[`strictNullChecks`] = {
       [148, 8, 15, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "4102914388"],
       [154, 29, 3, "\'cfg\' is possibly \'undefined\'.", "193415815"]
     ],
-    "src/app/widgets/widget-windsteer/widget-windsteer.component.ts:608910485": [
-      [205, 34, 9, "\'cfg.paths\' is possibly \'undefined\'.", "4139429943"],
-      [206, 35, 9, "\'cfg.paths\' is possibly \'undefined\'.", "4139429943"],
-      [290, 17, 10, "\'cfg.paths\' is possibly \'undefined\'.", "1351545128"],
-      [355, 33, 22, "Object is possibly \'undefined\'.", "576852750"],
-      [355, 33, 46, "Object is possibly \'undefined\'.", "1732614759"]
+    "src/app/widgets/widget-windsteer/widget-windsteer.component.ts:293317480": [
+      [206, 34, 9, "\'cfg.paths\' is possibly \'undefined\'.", "4139429943"],
+      [207, 35, 9, "\'cfg.paths\' is possibly \'undefined\'.", "4139429943"],
+      [369, 33, 22, "Object is possibly \'undefined\'.", "576852750"],
+      [369, 33, 46, "Object is possibly \'undefined\'.", "1732614759"]
     ],
     "src/app/widgets/widget-windtrends-chart/widget-windtrends-chart.component.ts:3621756652": [
       [86, 10, 15, "Type \'null\' is not assignable to type \'Subscription\'.", "2233656204"],

--- a/src/app/widgets/svg-windsteer/svg-windsteer.component.spec.ts
+++ b/src/app/widgets/svg-windsteer/svg-windsteer.component.spec.ts
@@ -85,4 +85,130 @@ describe('SvgWindsteerComponent', () => {
             };
         }).wpt.newValue).toBe(0);
     });
+
+    // Geometry helpers: recover the dial-local angle (degrees, 0 = up, clockwise) from a
+    // drawn SVG path. drawLayline/computeSectorPath place points at (R*sinθ+C, -R*cosθ+C).
+    const CENTER = 500;
+    const norm = (a: number): number => ((a % 360) + 360) % 360;
+    const angleOf = (x: number, y: number): number => norm((Math.atan2(x - CENTER, CENTER - y) * 180) / Math.PI);
+    const firstPointAngle = (path: string): number => {
+        const m = path.match(/L\s*([\d.-]+),([\d.-]+)/);
+        return angleOf(parseFloat(m![1]), parseFloat(m![2]));
+    };
+
+    it('centers close-hauled lines on the true wind, not the apparent wind', () => {
+        // heading 0 => the true-wind input value is also the boat-relative TWA.
+        setRequiredInputs({
+            compassHeading: 0,
+            trueWindAngle: 40,
+            appWindAngle: 20, // deliberately different from true wind
+            closeHauledLineEnabled: true,
+            laylineAngle: 30,
+            trueWindActive: true
+        });
+        fixture.detectChanges();
+
+        const angles = [
+            firstPointAngle((component as unknown as { closeHauledLinePortPath: () => string }).closeHauledLinePortPath()),
+            firstPointAngle((component as unknown as { closeHauledLineStbdPath: () => string }).closeHauledLineStbdPath())
+        ].sort((a, b) => a - b);
+
+        // True-wind based: 40 ± 30 => 10 and 70. (Apparent-based would give 20 ± 30.)
+        expect(angles[0]).toBeCloseTo(10, 0);
+        expect(angles[1]).toBeCloseTo(70, 0);
+    });
+
+    it('hides laylines when true wind is unavailable', () => {
+        setRequiredInputs({ closeHauledLineEnabled: true, laylineAngle: 30, trueWindActive: false });
+        fixture.detectChanges();
+        const layer = fixture.nativeElement.querySelector('#LayerLayline') as SVGGElement;
+        expect(layer.style.display).toBe('none');
+
+        fixture.componentRef.setInput('trueWindActive', true);
+        fixture.detectChanges();
+        expect(layer.style.display).toBe('inline');
+    });
+
+    it('positions wind sectors from the true wind DIRECTION (compass), not boat-relative', () => {
+        // Stored min/mid/max are compass true-wind directions; with heading 30 the min at
+        // TWD 100 must render at dial-local 100 (screen 70 = boat-relative). A boat-relative
+        // reading of the same value would land at 130.
+        setRequiredInputs({
+            compassHeading: 30,
+            windSectorEnabled: true,
+            closeHauledLineEnabled: false,
+            laylineAngle: 0,
+            trueWindMinHistoric: 100,
+            trueWindMidHistoric: 110,
+            trueWindMaxHistoric: 120,
+            trueWindActive: true
+        });
+        fixture.detectChanges();
+
+        const sectorMin = firstPointAngle((component as unknown as { portWindSectorPath: () => string }).portWindSectorPath());
+        expect(sectorMin).toBeCloseTo(100, 0);
+    });
+
+    it('converts wind sectors to boat-relative in simple mode using the real heading', () => {
+        // Simple/bow-fixed mode forces compass.newValue to 0, so the conversion must read the
+        // compassHeading input. Stored TWD 100 at heading 30 renders boat-relative at 70, not the
+        // absolute 100 (the pre-fix bug displaced the sector by the heading).
+        setRequiredInputs({
+            compassModeEnabled: false,
+            compassHeading: 30,
+            windSectorEnabled: true,
+            closeHauledLineEnabled: false,
+            laylineAngle: 0,
+            trueWindMinHistoric: 100,
+            trueWindMidHistoric: 110,
+            trueWindMaxHistoric: 120,
+            trueWindActive: true
+        });
+        fixture.detectChanges();
+
+        const sectorMin = firstPointAngle((component as unknown as { portWindSectorPath: () => string }).portWindSectorPath());
+        expect(sectorMin).toBeCloseTo(70, 0);
+    });
+
+    it('centers laylines on the true wind in simple mode', () => {
+        setRequiredInputs({
+            compassModeEnabled: false,
+            compassHeading: 30,
+            trueWindAngle: 40, // boat-relative TWA in simple mode
+            closeHauledLineEnabled: true,
+            laylineAngle: 30,
+            trueWindActive: true
+        });
+        fixture.detectChanges();
+
+        const angles = [
+            firstPointAngle((component as unknown as { closeHauledLinePortPath: () => string }).closeHauledLinePortPath()),
+            firstPointAngle((component as unknown as { closeHauledLineStbdPath: () => string }).closeHauledLineStbdPath())
+        ].sort((a, b) => a - b);
+        expect(angles[0]).toBeCloseTo(10, 0);
+        expect(angles[1]).toBeCloseTo(70, 0);
+    });
+
+    it('clears the wind sector when true wind data drops out', () => {
+        setRequiredInputs({
+            compassHeading: 0,
+            windSectorEnabled: true,
+            closeHauledLineEnabled: false,
+            laylineAngle: 0,
+            trueWindMinHistoric: 100,
+            trueWindMidHistoric: 110,
+            trueWindMaxHistoric: 120,
+            trueWindActive: true
+        });
+        fixture.detectChanges();
+        expect((component as unknown as { portWindSectorPath: () => string }).portWindSectorPath()).not.toBe('');
+
+        fixture.componentRef.setInput('trueWindMinHistoric', undefined);
+        fixture.componentRef.setInput('trueWindMidHistoric', undefined);
+        fixture.componentRef.setInput('trueWindMaxHistoric', undefined);
+        fixture.detectChanges();
+
+        expect((component as unknown as { portWindSectorPath: () => string }).portWindSectorPath()).toBe('');
+        expect((component as unknown as { stbdWindSectorPath: () => string }).stbdWindSectorPath()).toBe('');
+    });
 });

--- a/src/app/widgets/svg-windsteer/svg-windsteer.component.svg
+++ b/src/app/widgets/svg-windsteer/svg-windsteer.component.svg
@@ -554,14 +554,12 @@
         }
       </g>
       <!-- Moved inside rotating dial so they rotate passively with the boat -->
-      <g id="LayerLayline" [style.display]="closeHauledLineEnabled() ? 'inline' : 'none'">
+      <g id="LayerLayline" [style.display]="closeHauledLineEnabled() && trueWindActive() ? 'inline' : 'none'">
         <path id="PortLayline"
-          [style.display]="appWindAngle() != null ? 'inline' : 'none'"
           [attr.d]="closeHauledLineStbdPath()"
           style="fill:none;stroke-width:5;stroke-dasharray:40, 20;stroke-dashoffset:0;stroke-opacity:0.6"
           class="laylines" />
         <path id="StbdLayline"
-          [style.display]="appWindAngle() != null ? 'inline' : 'none'"
           [attr.d]="closeHauledLinePortPath()"
           class="laylines"
           style="fill:none;stroke-width:5;stroke-dasharray:40, 20;stroke-dashoffset:0;stroke-opacity:0.6" />

--- a/src/app/widgets/svg-windsteer/svg-windsteer.component.ts
+++ b/src/app/widgets/svg-windsteer/svg-windsteer.component.ts
@@ -29,6 +29,7 @@ export class SvgWindsteerComponent implements OnDestroy {
   protected readonly courseOverGroundAngle = input<number>(undefined);
   protected readonly courseOverGroundEnabled = input.required<boolean>();
   protected readonly trueWindAngle = input.required<number>();
+  protected readonly trueWindActive = input<boolean>(false);
   protected readonly twsEnabled = input.required<boolean>();
   protected readonly twaEnabled = input.required<boolean>();
   protected readonly trueWindSpeed = input.required<number>();
@@ -218,8 +219,6 @@ export class SvgWindsteerComponent implements OnDestroy {
             animateRotation(this.awaIndicator().nativeElement, this.awa.oldValue, this.awa.newValue, this.ANIMATION_DURATION, undefined, this.animationFrameIds, undefined, this.ngZone);
           }
         }
-        // Laylines align to apparent wind; recompute on AWA
-        this.updateCloseHauledLines(!isFirstAwa);
       });
     });
 
@@ -230,10 +229,11 @@ export class SvgWindsteerComponent implements OnDestroy {
       if (trueWindAngle == null) return;
 
       untracked(() => {
+        const isFirstTwa = !this.twaInitialized;
         this.trueWindHeading = trueWindAngle;
         const headingOffset = modeEnabled ? (this.compass.newValue * -1) : 0;
         const nextTwa = this.addHeading(this.trueWindHeading, headingOffset);
-        if (!this.twaInitialized) {
+        if (isFirstTwa) {
           this.twa.oldValue = nextTwa;
           this.twa.newValue = nextTwa;
           this.twaInitialized = true;
@@ -242,12 +242,14 @@ export class SvgWindsteerComponent implements OnDestroy {
           this.twa.newValue = nextTwa;
         }
         if (this.twaIndicator()?.nativeElement) {
-          if (!this.twaInitialized || this.twa.oldValue === this.twa.newValue) {
+          if (isFirstTwa || this.twa.oldValue === this.twa.newValue) {
             this.setRotationImmediate(this.twaIndicator().nativeElement, this.twa.newValue);
           } else {
             animateRotation(this.twaIndicator().nativeElement, this.twa.oldValue, this.twa.newValue, this.ANIMATION_DURATION, undefined, this.animationFrameIds, undefined, this.ngZone);
           }
         }
+        // Laylines are centered on the true wind; recompute whenever TWA changes
+        this.updateCloseHauledLines(!isFirstTwa);
       });
     });
 
@@ -258,8 +260,6 @@ export class SvgWindsteerComponent implements OnDestroy {
       if (!this.closeHauledLineEnabled()) return;
       untracked(() => this.updateCloseHauledLines());
     });
-
-  // Recompute laylines when AWA changes (already handled in AWA effect) and when laylineAngle changes (below)
 
     effect(() => {
       const raw = this.driftSet();
@@ -310,24 +310,25 @@ export class SvgWindsteerComponent implements OnDestroy {
     });
   }
 
+  // Dial-local placement: convert a boat-relative angle into the rotating dial's local frame
+  // so the dial's -heading rotation (compass mode) yields the correct boat-relative result.
+  private toDialLocal(boatRelative: number): number {
+    const heading = this.compassModeEnabled() ? (Number(this.compass.newValue) || 0) : 0;
+    return this.addHeading(heading, boatRelative);
+  }
+
   private updateCloseHauledLines(animate = true): void {
     if (!this.closeHauledLineEnabled()) return;
 
-    // Dial-local angle must include heading so that dial rotation (-heading) yields boat-relative result
-    const modeEnabled = this.compassModeEnabled();
-    const heading = modeEnabled ? (Number(this.compass.newValue) || 0) : 0;
-    const boatBase = modeEnabled ? (Number(this.awa.newValue) || 0) : 0;
+    // Close-hauled lines straddle the true wind: boat-relative TWA ± laylineAngle.
+    const base = Number(this.twa.newValue) || 0;
     const lay = Number(this.laylineAngle()) || 0;
-    const portLaylineRotate = modeEnabled
-      ? this.addHeading(heading, this.addHeading(boatBase, lay * -1))
-      : this.addHeading(boatBase, lay * -1);
+
+    const portLaylineRotate = this.toDialLocal(this.addHeading(base, lay * -1));
     this.animateLayline(this.portLaylinePrev, portLaylineRotate, true, animate);
     this.portLaylinePrev = portLaylineRotate;
 
-    // Animate Starboard Layline
-    const stbdLaylineRotate = modeEnabled
-      ? this.addHeading(heading, this.addHeading(boatBase, lay))
-      : this.addHeading(boatBase, lay);
+    const stbdLaylineRotate = this.toDialLocal(this.addHeading(base, lay));
     this.animateLayline(this.stbdLaylinePrev, stbdLaylineRotate, false, animate);
     this.stbdLaylinePrev = stbdLaylineRotate;
   }
@@ -381,6 +382,16 @@ export class SvgWindsteerComponent implements OnDestroy {
       this.trueWindMidHistoric() == null ||
       this.trueWindMaxHistoric() == null
     ) {
+      // No sector data (e.g. true wind absent): cancel any in-flight sector animation and clear
+      // the paths, mirroring the disable branch, so a running frame can't overwrite the cleared
+      // path and leave a stale sector on screen.
+      if (this.portSectorAnimId) cancelAnimationFrame(this.portSectorAnimId);
+      if (this.stbdSectorAnimId) cancelAnimationFrame(this.stbdSectorAnimId);
+      this.portSectorAnimId = null;
+      this.stbdSectorAnimId = null;
+      this.windSectorsInitialized = false;
+      this.portWindSectorPath.set('');
+      this.stbdWindSectorPath.set('');
       return;
     }
 
@@ -511,20 +522,13 @@ export class SvgWindsteerComponent implements OnDestroy {
   private computeSectorPath(state: { min: number, mid: number, max: number }, isPort: boolean): string {
     const lay = Number(this.laylineAngle()) || 0;
     const offset = lay * (isPort ? -1 : 1);
-    const modeEnabled = this.compassModeEnabled();
-    const heading = modeEnabled ? (Number(this.compass.newValue) || 0) : 0;
-    const awaBase = Number(this.awa.newValue) || 0;
-    // Dial-local = heading + boat-relative (AWA min/mid/max + lay offset)
-    // When compass mode is off, position sectors relative to laylines (remove AWA base)
-    const minAngle = modeEnabled
-      ? this.addHeading(heading, this.addHeading(state.min, offset))
-      : this.addHeading(offset, this.addHeading(state.min, awaBase * -1));
-    const midAngle = modeEnabled
-      ? this.addHeading(heading, this.addHeading(state.mid, offset))
-      : this.addHeading(offset, this.addHeading(state.mid, awaBase * -1));
-    const maxAngle = modeEnabled
-      ? this.addHeading(heading, this.addHeading(state.max, offset))
-      : this.addHeading(offset, this.addHeading(state.max, awaBase * -1));
+    // Sector min/mid/max are the true wind DIRECTION (absolute compass). Convert to boat-relative
+    // using the actual boat heading -- not compass.newValue, which the dial forces to 0 in simple
+    // mode -- then place in the dial's local frame via toDialLocal.
+    const heading = Number(this.compassHeading()) || 0;
+    const minAngle = this.toDialLocal(this.addHeading(this.addHeading(state.min, -heading), offset));
+    const midAngle = this.toDialLocal(this.addHeading(this.addHeading(state.mid, -heading), offset));
+    const maxAngle = this.toDialLocal(this.addHeading(this.addHeading(state.max, -heading), offset));
 
     const minX = this.RADIUS * Math.sin((minAngle * Math.PI) / 180) + this.CENTER;
     const minY = (this.RADIUS * Math.cos((minAngle * Math.PI) / 180) * -1) + this.CENTER;

--- a/src/app/widgets/widget-windsteer/widget-windsteer.component.html
+++ b/src/app/widgets/widget-windsteer/widget-windsteer.component.html
@@ -4,6 +4,7 @@
   [courseOverGroundAngle]="courseOverGroundAngle()"
   [courseOverGroundEnabled]="runtime.options()?.courseOverGroundEnable"
   [trueWindAngle]="trueWindAngle()"
+  [trueWindActive]="trueWindActive()"
   [twsEnabled]="runtime.options()?.twsEnable"
   [twaEnabled]="runtime.options()?.twaEnable"
   [trueWindSpeed]="trueWindSpeed()"

--- a/src/app/widgets/widget-windsteer/widget-windsteer.component.spec.ts
+++ b/src/app/widgets/widget-windsteer/widget-windsteer.component.spec.ts
@@ -95,3 +95,55 @@ describe('WidgetWindComponent live compass-mode toggle (#73)', () => {
     expect(twa()).toBe(135); // compass mode: heading (90) added to the cached angle (45)
   });
 });
+
+/**
+ * Wind sectors and layline gating are driven by TRUE wind, not apparent wind.
+ * The sector history must be fed only from the true-wind stream, and trueWindActive
+ * must track whether the configured true-wind path is currently delivering a value.
+ */
+describe('WidgetWindComponent true-wind sector source', () => {
+  let component: WidgetWindComponent;
+  let options: WritableSignal<IWidgetSvcConfig | undefined>;
+  let callbacks: Map<string, (u: IPathUpdate) => void>;
+
+  const makeConfig = (): IWidgetSvcConfig => ({
+    ...WidgetWindComponent.DEFAULT_CONFIG,
+    compassModeEnabled: true,
+    windSectorEnable: true
+  });
+  const update = (value: number | null): IPathUpdate => ({ data: { value, timestamp: null }, state: 'normal' });
+  const sampleCount = (): number => (component as unknown as { windSamples: unknown[] }).windSamples.length;
+  const active = (): boolean => (component as unknown as { trueWindActive: () => boolean }).trueWindActive();
+
+  beforeEach(() => {
+    options = signal<IWidgetSvcConfig | undefined>(makeConfig());
+    callbacks = new Map<string, (u: IPathUpdate) => void>();
+    const streamsMock = {
+      observe: (pathName: string, next: (u: IPathUpdate) => void) => { callbacks.set(pathName, next); }
+    };
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: WidgetRuntimeDirective, useValue: { options } },
+        { provide: WidgetStreamsDirective, useValue: streamsMock }
+      ]
+    });
+    component = TestBed.runInInjectionContext(() => new WidgetWindComponent());
+    TestBed.tick();
+  });
+
+  it('feeds the sector history from true wind and not from apparent wind', () => {
+    callbacks.get('appWindAngle')!(update(30));
+    expect(sampleCount()).toBe(0); // apparent wind no longer feeds the sector history
+
+    callbacks.get('trueWindAngle')!(update(40));
+    expect(sampleCount()).toBe(1); // true wind does
+  });
+
+  it('tracks true-wind availability in trueWindActive', () => {
+    expect(active()).toBe(false); // nothing received yet
+    callbacks.get('trueWindAngle')!(update(40));
+    expect(active()).toBe(true);
+    callbacks.get('trueWindAngle')!(update(null));
+    expect(active()).toBe(false); // explicit null -> laylines hide
+  });
+});

--- a/src/app/widgets/widget-windsteer/widget-windsteer.component.ts
+++ b/src/app/widgets/widget-windsteer/widget-windsteer.component.ts
@@ -175,6 +175,7 @@ export class WidgetWindComponent implements OnDestroy {
   protected appWindSpeed = signal(0);
   protected appWindSpeedUnit = signal('');
   protected trueWindAngle = signal(0);
+  protected trueWindActive = signal(false);
   protected trueWindSpeed = signal(0);
   protected trueWindSpeedUnit = signal('');
   protected driftFlow = signal(0);
@@ -259,8 +260,6 @@ export class WidgetWindComponent implements OnDestroy {
     const next = this.normalizeAngle(raw);
     if (!this.hasAWA || this.angleDelta(this.appWindAngle(), next) >= this.DEG_EPSILON) {
       this.appWindAngle.set(next); this.hasAWA = true;
-      const cfg = this.runtime.options();
-      if (cfg?.windSectorEnable) this.addHistoricalWindDirection(this.normalizeAngle(raw));
     }
   };
   private onAppWindSpeed = (u: IPathUpdate) => {
@@ -278,18 +277,33 @@ export class WidgetWindComponent implements OnDestroy {
     }
   };
   private onTrueWindAngle = (u: IPathUpdate) => {
+    const present = u.data.value != null;
     if (u.data.value == null) u.data.value = 0;
     this.lastRawTrueWindAngle = u.data.value;
+    this.trueWindActive.set(present);
     const next = this.normalizeAngle(this.computeTrueWindBase(u.data.value));
     if (!this.hasTWA || this.angleDelta(this.trueWindAngle(), next) >= this.DEG_EPSILON) {
       this.trueWindAngle.set(next); this.hasTWA = true;
     }
+    const cfg = this.runtime.options();
+    if (present && cfg?.windSectorEnable) {
+      this.addHistoricalWindDirection(this.normalizeAngle(this.computeTrueWindDirection(u.data.value)));
+    }
   };
 
+  private trueWindPath(): string {
+    return this.runtime.options()?.paths?.['trueWindAngle']?.path || '';
+  }
+
   private computeTrueWindBase(rawAngle: number): number {
-    const cfg = this.runtime.options();
-    const path = cfg?.paths['trueWindAngle'].path || '';
-    return computeTrueWindBaseAngle(path, rawAngle, this.currentHeading(), !!cfg?.compassModeEnabled);
+    const compassMode = !!this.runtime.options()?.compassModeEnabled;
+    return computeTrueWindBaseAngle(this.trueWindPath(), rawAngle, this.currentHeading(), compassMode);
+  }
+
+  // Wind sectors track the true wind DIRECTION (compass frame) so heading and boat-speed
+  // changes don't smear the oscillation range; only real wind shifts move it.
+  private computeTrueWindDirection(rawAngle: number): number {
+    return computeTrueWindBaseAngle(this.trueWindPath(), rawAngle, this.currentHeading(), true);
   }
 
   private applyTrueWindBase() {


### PR DESCRIPTION
## Why

The windsteer widget's close-hauled ("layline") lines were centered on the **apparent** wind angle, and the wind-shift sectors were built from **apparent** wind stored **boat-relative**. Both are the wrong reference:

- Close-hauled/beating angle is a true-wind quantity. Drawing the lines at `AWA ± laylineAngle` puts them off the **A** indicator instead of the **T** indicator, shifted toward the bow by `TWA − AWA` (10–20° when beating). When you're actually sailing the layline, your bow doesn't touch it.
- A wind-shift sector should track the **true wind direction** (compass), so only real shifts move it. Stored boat-relative, it smeared under heading changes.

This is upstream KIP behavior (`mxtommy/kip`); the sibling **racesteer** widget already uses true wind for its laylines. Fixing it here is a deliberate divergence.

## What

- **Laylines** now center on the boat-relative true wind (`TWA ± laylineAngle`) and recompute on the TWA stream. The compass/simple-mode branch collapses into a shared `toDialLocal()` helper, so simple mode tracks the wind too (it previously pinned to ±angle off the bow).
- **Hide, don't fake.** Laylines are hidden when the *configured* true-wind path produces no value, instead of drawing a bogus apparent-derived line. Gated by a new `trueWindActive` signal — keyed off whatever path the widget is configured with, nothing hardcoded.
- **Sectors** are fed from the true wind **direction** (compass frame) and converted to boat-relative at render through the same `toDialLocal()` helper, keeping laylines and sectors in one frame. Stale sectors are cleared when true wind drops out.

## Verification

- New unit tests encode the fix: close-hauled lines center on true wind (not apparent), hide when true wind is unavailable, and sectors position from the compass true-wind direction. `6/6` svg + `5/5` widget specs pass.
- `lint`, `build:prod`, and the `strictNullChecks` betterer ratchet all clean (ratchet tightened by one).
- Deployed to a live device (halpi.hurma) and confirmed visually: laylines render centered on the true wind, and hide when the configured path is absent.
