### PR TITLE
fix(security): sanitize dialog title icon src (port Kip #1114)

### DIFF
--- a/src/app/core/components/dialog-frame/dialog-frame.component.html
+++ b/src/app/core/components/dialog-frame/dialog-frame.component.html
@@ -2,7 +2,7 @@
   <div class="dialog-title">
     <h5 mat-dialog-title>
       @if (data.iconHref) {
-        <img class="dialog-title-icon" [attr.src]="data.iconHref" alt="" aria-hidden="true" />
+        <img class="dialog-title-icon" [src]="data.iconHref" alt="" aria-hidden="true" />
       }
     {{data.title}}</h5>
   </div>


### PR DESCRIPTION
Ports upstream **mxtommy/Kip#1114** ("Potential DOM-based XSS via Dialog Data", squash `a7e95b66`).

## Problem
The dialog title icon bound the image URL with `[attr.src]="data.iconHref"`. A raw attribute binding bypasses Angular's URL sanitizer, so a `javascript:`/`data:` value in `iconHref` would be written verbatim to the `src` attribute.

## Fix
Bind via `[src]` (the `HTMLImageElement.src` property) instead, so Angular's built-in URL sanitizer strips dangerous schemes.

One-line change in `src/app/core/components/dialog-frame/dialog-frame.component.html`. Applies cleanly from upstream; this file had not diverged in skip.