### PR TITLE
fix(dashboard): center overlay content with space-evenly (port Kip #1103)

### DIFF
--- a/src/app/core/components/dashboard/dashboard.component.scss
+++ b/src/app/core/components/dashboard/dashboard.component.scss
@@ -65,7 +65,7 @@
   flex-direction: column;
   flex-wrap: nowrap;
   align-items: center;
-  justify-content: space-around; /* centered instead of space-around to avoid implicit extra space */
+  justify-content: space-evenly;
   padding: 1.5rem; /* balanced padding, overlay does not affect container size */
   text-align: center;
   box-sizing: border-box;


### PR DESCRIPTION
Ports upstream **mxtommy/Kip#1103** ("Center content in dashboard overlay", squash `fc5a51ec`).

Changes the dashboard overlay's `justify-content` from `space-around` to `space-evenly` so content is evenly centered. One-line CSS change in `src/app/core/components/dashboard/dashboard.component.scss`; applied cleanly from upstream.