### PR TITLE
fix(gauge-steel): clear resize timer on destroy (port Kip #1126)

### DIFF
--- a/src/app/widgets/gauge-steel/gauge-steel.component.spec.ts
+++ b/src/app/widgets/gauge-steel/gauge-steel.component.spec.ts
@@ -50,4 +50,26 @@ describe('GaugeSteelComponent', () => {
     // NaN section that does not draw; the upper is converted (identity mock -> 11.5).
     expect(sectionSpy).toHaveBeenCalledWith(10, 11.5, 'red');
   });
+
+  it('clears the pending resize timer on destroy so the debounced rebuild cannot fire afterwards', () => {
+    vi.useFakeTimers();
+    try {
+      fixture.componentRef.setInput('subType', 'radial');
+      fixture.detectChanges();
+      const internals = component as unknown as { onResized: (e: ResizeObserverEntry) => void; startGauge: (f?: boolean) => void; resizeTimer: number | null };
+      const rebuild = vi.spyOn(internals, 'startGauge').mockImplementation(() => { /* no-op */ });
+
+      // A real resize arms the 120ms debounce.
+      internals.onResized({ contentRect: { width: 120, height: 120 } } as ResizeObserverEntry);
+      expect(internals.resizeTimer).not.toBeNull();
+
+      component.ngOnDestroy();
+      expect(internals.resizeTimer).toBeNull();
+
+      vi.advanceTimersByTime(200);
+      expect(rebuild).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/app/widgets/gauge-steel/gauge-steel.component.ts
+++ b/src/app/widgets/gauge-steel/gauge-steel.component.ts
@@ -313,6 +313,12 @@ export class GaugeSteelComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    // Clear pending resize debounce callback so it cannot fire after destroy
+    if (this.resizeTimer !== null) {
+      window.clearTimeout(this.resizeTimer);
+      this.resizeTimer = null;
+    }
+
     // Stop any running animations before cleanup
     if (this.gauge && this.gauge.setValue) {
       // Call setValue to stop any running setValueAnimated animations


### PR DESCRIPTION
Ports upstream **mxtommy/Kip#1126** ("Fix minor gauge steel memory leak", squash `bf6bb874`).

## Problem
`GaugeSteelComponent.onResized` arms a 120 ms debounce timer (`resizeTimer`) but `ngOnDestroy` never cleared it. A resize landing just before destruction leaves the callback scheduled to run against a torn-down gauge instance.

## Fix
Clear the pending `resizeTimer` at the top of `ngOnDestroy`. Single hunk in `src/app/widgets/gauge-steel/gauge-steel.component.ts`; applied cleanly from upstream (line offset only). No betterer/lint impact.