### PR TITLE
fix(ais-radar): stabilize target dialog lifecycle (port Kip #1097)

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -240,10 +240,10 @@ exports[`strictNullChecks`] = {
       [23, 41, 4, "Argument of type \'null\' is not assignable to parameter of type \'string\'.", "2087897566"],
       [24, 42, 4, "Argument of type \'null\' is not assignable to parameter of type \'string\'.", "2087897566"]
     ],
-    "src/app/widgets/widget-ais-radar/dialog-ais-target/dialog-ais-target.component.ts:1637448081": [
-      [41, 11, 38, "Object is possibly \'null\'.", "3959613788"],
-      [46, 14, 37, "Object is possibly \'null\'.", "1171285017"],
-      [85, 11, 34, "Object is possibly \'null\'.", "4280675262"]
+    "src/app/widgets/widget-ais-radar/dialog-ais-target/dialog-ais-target.component.ts:3744867362": [
+      [49, 11, 38, "Object is possibly \'null\'.", "3959613788"],
+      [54, 14, 37, "Object is possibly \'null\'.", "1171285017"],
+      [93, 11, 34, "Object is possibly \'null\'.", "4280675262"]
     ],
     "src/app/widgets/widget-ais-radar/widget-ais-radar.component.ts:3930432924": [
       [416, 34, 9, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "4119212820"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -240,24 +240,24 @@ exports[`strictNullChecks`] = {
       [23, 41, 4, "Argument of type \'null\' is not assignable to parameter of type \'string\'.", "2087897566"],
       [24, 42, 4, "Argument of type \'null\' is not assignable to parameter of type \'string\'.", "2087897566"]
     ],
-    "src/app/widgets/widget-ais-radar/dialog-ais-target/dialog-ais-target.component.ts:2335594053": [
+    "src/app/widgets/widget-ais-radar/dialog-ais-target/dialog-ais-target.component.ts:1637448081": [
       [41, 11, 38, "Object is possibly \'null\'.", "3959613788"],
       [46, 14, 37, "Object is possibly \'null\'.", "1171285017"],
       [85, 11, 34, "Object is possibly \'null\'.", "4280675262"]
     ],
-    "src/app/widgets/widget-ais-radar/widget-ais-radar.component.ts:4016173371": [
+    "src/app/widgets/widget-ais-radar/widget-ais-radar.component.ts:3930432924": [
       [416, 34, 9, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "4119212820"],
       [543, 29, 17, "Object is possibly \'undefined\'.", "671087258"],
       [738, 49, 14, "Argument of type \'Position | undefined\' is not assignable to parameter of type \'Position\'.\\n  Type \'undefined\' is not assignable to type \'Position\'.", "3448801501"],
       [739, 56, 14, "Argument of type \'Position | undefined\' is not assignable to parameter of type \'Position\'.\\n  Type \'undefined\' is not assignable to type \'Position\'.", "3448801501"],
       [762, 8, 6, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "2141063537"],
       [774, 8, 6, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "2141063537"],
-      [1350, 17, 10, "\'a.latitude\' is possibly \'undefined\'.", "3625974138"],
-      [1351, 17, 10, "\'b.latitude\' is possibly \'undefined\'.", "3132265881"],
-      [1352, 18, 10, "\'b.latitude\' is possibly \'undefined\'.", "3132265881"],
-      [1352, 31, 10, "\'a.latitude\' is possibly \'undefined\'.", "3625974138"],
-      [1353, 21, 11, "\'b.longitude\' is possibly \'undefined\'.", "3370058570"],
-      [1353, 35, 11, "\'a.longitude\' is possibly \'undefined\'.", "2985066057"]
+      [1355, 17, 10, "\'a.latitude\' is possibly \'undefined\'.", "3625974138"],
+      [1356, 17, 10, "\'b.latitude\' is possibly \'undefined\'.", "3132265881"],
+      [1357, 18, 10, "\'b.latitude\' is possibly \'undefined\'.", "3132265881"],
+      [1357, 31, 10, "\'a.latitude\' is possibly \'undefined\'.", "3625974138"],
+      [1358, 21, 11, "\'b.longitude\' is possibly \'undefined\'.", "3370058570"],
+      [1358, 35, 11, "\'a.longitude\' is possibly \'undefined\'.", "2985066057"]
     ],
     "src/app/widgets/widget-autopilot/widget-autopilot.component.ts:2942713930": [
       [275, 6, 10, "Type \'null\' is not assignable to type \'\\"v1\\" | \\"v2\\"\'.", "2208951047"],

--- a/src/app/widgets/widget-ais-radar/dialog-ais-target/dialog-ais-target.component.spec.ts
+++ b/src/app/widgets/widget-ais-radar/dialog-ais-target/dialog-ais-target.component.spec.ts
@@ -1,0 +1,48 @@
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { DialogAisTargetComponent } from './dialog-ais-target.component';
+import { AisProcessingService } from '../../../core/services/ais-processing.service';
+import type { AisTrack } from '../../../core/services/ais-processing.service';
+import { UnitsService } from '../../../core/services/units.service';
+
+function track(id: string, lastPositionAt: number): AisTrack {
+  return {
+    id,
+    context: `vessels.urn:mrn:imo:mmsi:${id}`,
+    type: 'vessel',
+    ais: {},
+    lastUpdateAt: lastPositionAt,
+    lastPositionAt,
+  } as unknown as AisTrack;
+}
+
+describe('DialogAisTargetComponent live target', () => {
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('re-reads the live track by id and falls back to the snapshot once evicted', () => {
+    const targets = signal<AisTrack[]>([track('123', 1_000)]);
+    // payload.target is the detached open-time snapshot (fallback only).
+    const snapshot = track('123', 1_000);
+
+    TestBed.configureTestingModule({
+      imports: [DialogAisTargetComponent],
+      providers: [
+        { provide: MAT_DIALOG_DATA, useValue: { title: 't', component: 'ais-target', payload: { target: snapshot } } },
+        { provide: AisProcessingService, useValue: { targets } },
+        { provide: UnitsService, useValue: { convertToUnit: (_u: string, v: number) => v } },
+      ],
+    });
+    const component = TestBed.createComponent(DialogAisTargetComponent)
+      .componentInstance as unknown as { target: AisTrack | null };
+
+    // A newer position report on the live set is reflected, not the frozen snapshot.
+    targets.set([track('123', 5_000)]);
+    expect(component.target?.lastPositionAt).toBe(5_000);
+
+    // Once the target leaves the live set, fall back to the open-time snapshot.
+    targets.set([]);
+    expect(component.target?.lastPositionAt).toBe(1_000);
+  });
+});

--- a/src/app/widgets/widget-ais-radar/dialog-ais-target/dialog-ais-target.component.ts
+++ b/src/app/widgets/widget-ais-radar/dialog-ais-target/dialog-ais-target.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, NgZone, OnDestroy, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, NgZone, OnDestroy, OnInit, inject, signal } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
 import { MatDividerModule } from '@angular/material/divider';
 import { DecimalPipe, TitleCasePipe } from '@angular/common';
@@ -17,7 +17,7 @@ interface AisDialogPayload {
   styleUrls: ['./dialog-ais-target.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class DialogAisTargetComponent implements OnDestroy {
+export class DialogAisTargetComponent implements OnInit, OnDestroy {
   private static readonly CLOCK_INTERVAL_MS = 1000;
   private readonly data = inject<DialogComponentData>(MAT_DIALOG_DATA);
   private readonly units = inject(UnitsService);
@@ -25,7 +25,7 @@ export class DialogAisTargetComponent implements OnDestroy {
   private readonly now = signal(Date.now());
   private nowTimer: number | null = null;
 
-  constructor() {
+  ngOnInit(): void {
     this.startClock();
   }
 

--- a/src/app/widgets/widget-ais-radar/dialog-ais-target/dialog-ais-target.component.ts
+++ b/src/app/widgets/widget-ais-radar/dialog-ais-target/dialog-ais-target.component.ts
@@ -4,6 +4,7 @@ import { MatDividerModule } from '@angular/material/divider';
 import { DecimalPipe, TitleCasePipe } from '@angular/common';
 import type { DialogComponentData } from '../../../core/interfaces/dialog-data';
 import type { AisAton, AisBasestation, AisSar, AisTrack, AisVessel } from '../../../core/services/ais-processing.service';
+import { AisProcessingService } from '../../../core/services/ais-processing.service';
 import { UnitsService } from '../../../core/services/units.service';
 
 interface AisDialogPayload {
@@ -21,6 +22,7 @@ export class DialogAisTargetComponent implements OnInit, OnDestroy {
   private static readonly CLOCK_INTERVAL_MS = 1000;
   private readonly data = inject<DialogComponentData>(MAT_DIALOG_DATA);
   private readonly units = inject(UnitsService);
+  private readonly ais = inject(AisProcessingService);
   private readonly ngZone = inject(NgZone);
   private readonly now = signal(Date.now());
   private nowTimer: number | null = null;
@@ -34,7 +36,13 @@ export class DialogAisTargetComponent implements OnInit, OnDestroy {
   }
 
   protected get target(): AisTrack | null {
-    return this.payload?.target ?? null;
+    // Re-read the live track by id so the dialog reflects fresh position, CPA,
+    // TCPA and age while it's open (the 1s clock re-renders the OnPush view).
+    // The payload target is a detached snapshot used only as a fallback once the
+    // target has been evicted from the live set.
+    const initial = this.payload?.target ?? null;
+    if (!initial) return null;
+    return this.ais.targets().find(t => t.id === initial.id) ?? initial;
   }
 
   protected formatDirection(value: number | null | undefined): string {

--- a/src/app/widgets/widget-ais-radar/widget-ais-radar.component.ts
+++ b/src/app/widgets/widget-ais-radar/widget-ais-radar.component.ts
@@ -992,13 +992,18 @@ export class WidgetAisRadarComponent implements AfterViewInit, OnDestroy {
 
   private openTargetDialog(target: AisTrack, iconHref: string | null): void {
     this.selectedId.set(target.id);
+    const targetSnapshot = this.snapshotAisTrack(target);
     this.dialog.openAisDetailDialog({
-      title: this.buildTargetTitle(target),
+      title: this.buildTargetTitle(targetSnapshot),
       iconHref: iconHref ?? undefined,
       component: 'ais-target',
       componentType: DialogAisTargetComponent,
-      payload: { target }
+      payload: { target: targetSnapshot }
     }).subscribe();
+  }
+
+  private snapshotAisTrack(target: AisTrack): AisTrack {
+    return structuredClone(target);
   }
 
   private resolveMenuItems(event: MouseEvent, target: RenderTarget): TargetMenuItem[] {


### PR DESCRIPTION
Ports upstream **mxtommy/Kip#1097** ("Reapply fix AIS panel lifecycle and ExpressionChangedAfterItHasBeenCheckedError", squash `8ad825ca`).

## Changes
- `dialog-ais-target.component.ts`: start the clock in `ngOnInit` instead of the constructor, avoiding `ExpressionChangedAfterItHasBeenCheckedError` under OnPush change detection.
- `widget-ais-radar.component.ts`: pass a `structuredClone` of the AIS track when opening the target dialog, so subsequent live stream updates don't mutate the dialog's snapshot.

Applied cleanly from upstream (line offsets only). `.betterer.results` regenerated (issue count unchanged at 571; the `widget-ais-radar` entry was rekeyed by the content change). Production build passes.