### PR TITLE
fix(horizon): correct frame visibility logic (port Kip #1128)

### DIFF
--- a/src/app/widgets/widget-horizon/widget-horizon.component.spec.ts
+++ b/src/app/widgets/widget-horizon/widget-horizon.component.spec.ts
@@ -1,0 +1,53 @@
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { WidgetHorizonComponent } from './widget-horizon.component';
+import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
+import { WidgetStreamsDirective } from '../../core/directives/widget-streams.directive';
+import type { IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
+
+// The "Show Frame" checkbox binds directly to gauge.noFrameVisible (no inversion),
+// so noFrameVisible === true means "draw the frame". Two consumers must stay in
+// agreement: buildOptions().frameVisible (the steelseries gauge option) and
+// frameVisibleView() (drives the wrapper padding). A regression that negates one
+// but not the other inverts the padding relative to the frame.
+interface HorizonInternals {
+  frameVisibleView: () => boolean;
+  buildOptions: (cfg: IWidgetSvcConfig, size: number) => void;
+  gaugeOptions: { frameVisible?: boolean };
+}
+
+function mount(noFrameVisible: boolean) {
+  const options = signal<IWidgetSvcConfig | undefined>({ gauge: { type: 'horizon', noFrameVisible } });
+  TestBed.configureTestingModule({
+    imports: [WidgetHorizonComponent],
+    providers: [
+      { provide: WidgetRuntimeDirective, useValue: { options } },
+      { provide: WidgetStreamsDirective, useValue: { observe: vi.fn() } },
+    ],
+  });
+  const fixture = TestBed.createComponent(WidgetHorizonComponent);
+  fixture.componentRef.setInput('id', 'test-horizon');
+  fixture.componentRef.setInput('type', 'widget-horizon');
+  fixture.componentRef.setInput('theme', null);
+  fixture.detectChanges();
+  return fixture.componentInstance as unknown as HorizonInternals;
+}
+
+describe('WidgetHorizonComponent frame visibility', () => {
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('draws the frame and pads the wrapper when Show Frame is on (noFrameVisible=true)', () => {
+    const c = mount(true);
+    c.buildOptions({ gauge: { type: 'horizon', noFrameVisible: true } } as IWidgetSvcConfig, 200);
+    expect(c.gaugeOptions.frameVisible).toBe(true);
+    expect(c.frameVisibleView()).toBe(true);
+  });
+
+  it('hides the frame and drops the wrapper padding when Show Frame is off (noFrameVisible=false)', () => {
+    const c = mount(false);
+    c.buildOptions({ gauge: { type: 'horizon', noFrameVisible: false } } as IWidgetSvcConfig, 200);
+    expect(c.gaugeOptions.frameVisible).toBe(false);
+    expect(c.frameVisibleView()).toBe(false);
+  });
+});

--- a/src/app/widgets/widget-horizon/widget-horizon.component.ts
+++ b/src/app/widgets/widget-horizon/widget-horizon.component.ts
@@ -114,7 +114,7 @@ export class WidgetHorizonComponent implements AfterViewInit, OnDestroy {
   // Gauge internals
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   protected gaugeOptions: any = {};
-  protected readonly frameVisibleView = computed(() => !(this.runtime.options()?.gauge?.noFrameVisible ?? false));
+  protected readonly frameVisibleView = computed(() => (this.runtime.options()?.gauge?.noFrameVisible ?? false));
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private gauge: any = null;
   // Structural options cache key removed – always rebuild on size / config change for simplicity

--- a/src/app/widgets/widget-horizon/widget-horizon.component.ts
+++ b/src/app/widgets/widget-horizon/widget-horizon.component.ts
@@ -249,7 +249,7 @@ export class WidgetHorizonComponent implements AfterViewInit, OnDestroy {
     const pointerMap = getSteelPointerColors(steelseries);
     this.gaugeOptions = {
       pointerColor: pointerMap.Red,
-      frameVisible: !(cfg.gauge?.noFrameVisible ?? false),
+      frameVisible: (cfg.gauge?.noFrameVisible ?? false),
       frameDesign: frameMap[cfg.gauge?.faceColor ?? 'anthracite'],
       foregroundVisible: false,
       size


### PR DESCRIPTION
Ports upstream **mxtommy/Kip#1128** ("correct frame visibility logic for WidgetHorizonComponent", squash `8c7b2ad6`).

## Problem
The Horizon widget config has a **"Show Frame"** checkbox bound directly to the `noFrameVisible` field (`root-modal-widget-config.component.html:720`, no inversion). `buildOptions` computed `frameVisible: !(cfg.gauge?.noFrameVisible ?? false)`, so checking "Show Frame" set the field `true` and then *hid* the frame — the opposite of what the label promises.

## Fix
Drop the negation: `frameVisible: (cfg.gauge?.noFrameVisible ?? false)`, matching the checkbox. One-line manual edit (skip's surrounding `frameDesign` line differs from upstream, so the patch was applied by hand). Betterer/lint clean.