### PR TITLE
feat(widgets): add Hoeken's Anchor Alarm widget (port Kip #1127)

### DIFF
--- a/src/app/core/services/widget.service.ts
+++ b/src/app/core/services/widget.service.ts
@@ -138,6 +138,7 @@ export class WidgetService {
     WidgetGaugeNgLinearComponent: () => import('../../widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component').then(m => m.WidgetGaugeNgLinearComponent),
     WidgetGaugeNgCompassComponent: () => import('../../widgets/widget-gauge-ng-compass/widget-gauge-ng-compass.component').then(m => m.WidgetGaugeNgCompassComponent),
     WidgetFreeboardskComponent: () => import('../../widgets/widget-freeboardsk/widget-freeboardsk.component').then(m => m.WidgetFreeboardskComponent),
+    WidgetHoekensAnchorAlarmComponent: () => import('../../widgets/widget-hoekens-anchor-alarm/widget-hoekens-anchor-alarm.component').then(m => m.WidgetHoekensAnchorAlarmComponent),
     WidgetAnchorAlarmComponent: () => import('../../widgets/widget-anchor-alarm/widget-anchor-alarm.component').then(m => m.WidgetAnchorAlarmComponent),
     WidgetDatetimeComponent: () => import('../../widgets/widget-datetime/widget-datetime.component').then(m => m.WidgetDatetimeComponent),
     WidgetDataChartComponent: () => import('../../widgets/widget-data-chart/widget-data-chart.component').then(m => m.WidgetDataChartComponent),
@@ -494,8 +495,21 @@ export class WidgetService {
       componentClassName: 'WidgetDataChartComponent'
     },
     {
-      name: 'Anchor Watch',
-      description: 'Monitors your anchor position and triggers an alarm if you drift outside a configured radius (anchor drag). Set the anchor point, watch radius, and alarm behavior (sound/notification) in the widget config. Requires internet connectivity to view map.',
+      name: "Hoeken's Anchor Alarm",
+      description: "Map-first anchor alarm experience for Signal K with advanced watch-zone tools (circle, sector, polygon), interactive setup, tracks/fleet overlays, scope calculator, and optional engine-start auto-silence for practical onboard use.",
+      icon: 'anchorWatch',
+      minWidth: 6,
+      minHeight: 8,
+      defaultWidth: 6,
+      defaultHeight: 14,
+      category: 'Component',
+      requiredPlugins: ['hoekens-anchor-alarm'],
+      selector: 'widget-hoekens-anchor-alarm',
+      componentClassName: 'WidgetHoekensAnchorAlarmComponent'
+    },
+    {
+      name: "Anchor Watch",
+      description: "Classic anchor monitoring focused on reliable server-side drift detection: configurable alarm radius, automatic radius calculation from rode/depth, intelligent anchor-position detection, position history, multiple warning/alarm types, GPS bow-offset compensation, plus REST API and Signal K PUT integration.",
       icon: 'anchorWatch',
       minWidth: 6,
       minHeight: 8,

--- a/src/app/widgets/widget-hoekens-anchor-alarm/widget-hoekens-anchor-alarm.component.html
+++ b/src/app/widgets/widget-hoekens-anchor-alarm/widget-hoekens-anchor-alarm.component.html
@@ -1,0 +1,9 @@
+<iframe
+  #plainIframe
+  [src]="widgetUrl"
+  width="100%"
+  height="100%"
+  frameborder="0"
+  class="widgetIframe"
+></iframe>
+<div class="widgetOverlay" [style.display]="displayTransparentOverlay()"></div>

--- a/src/app/widgets/widget-hoekens-anchor-alarm/widget-hoekens-anchor-alarm.component.scss
+++ b/src/app/widgets/widget-hoekens-anchor-alarm/widget-hoekens-anchor-alarm.component.scss
@@ -1,0 +1,17 @@
+:host {
+  overflow: hidden;
+}
+
+.widgetIframe {
+  background-color: white;
+  border-radius: var(--mat-card-elevated-container-shape, var(--mat-sys-corner-medium));
+}
+
+.widgetOverlay {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  right: 0;
+  bottom: 0;
+  color: transparent;
+}

--- a/src/app/widgets/widget-hoekens-anchor-alarm/widget-hoekens-anchor-alarm.component.spec.ts
+++ b/src/app/widgets/widget-hoekens-anchor-alarm/widget-hoekens-anchor-alarm.component.spec.ts
@@ -1,0 +1,114 @@
+import { signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { WidgetHoekensAnchorAlarmComponent } from './widget-hoekens-anchor-alarm.component';
+import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
+import { DashboardService } from '../../core/services/dashboard.service';
+import { ChromeVisibilityService } from '../../core/services/chrome-visibility.service';
+import type { IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
+
+const INSTANCE_ID = 'test-hoekens-id';
+
+function gestureFrom(gesture: string, source: MessageEventSource | null, origin: string): void {
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      data: { gesture, eventData: { instanceId: INSTANCE_ID } },
+      origin,
+      source
+    })
+  );
+}
+
+function mount(isStatic = true) {
+  const options = signal<IWidgetSvcConfig | undefined>({});
+  const dashboard = {
+    isDashboardStatic: () => isStatic,
+    navigateToNextDashboard: vi.fn(),
+    navigateToPreviousDashboard: vi.fn()
+  };
+  const chrome = { reveal: vi.fn(), hide: vi.fn() };
+  TestBed.configureTestingModule({
+    imports: [WidgetHoekensAnchorAlarmComponent],
+    providers: [
+      { provide: WidgetRuntimeDirective, useValue: { options } },
+      { provide: DashboardService, useValue: dashboard },
+      { provide: ChromeVisibilityService, useValue: chrome }
+    ]
+  });
+  const fixture = TestBed.createComponent(WidgetHoekensAnchorAlarmComponent);
+  fixture.componentRef.setInput('id', INSTANCE_ID);
+  fixture.componentRef.setInput('type', 'widget-hoekens-anchor-alarm');
+  fixture.componentRef.setInput('theme', null);
+  fixture.detectChanges();
+  return { fixture, dashboard, chrome };
+}
+
+function iframeWindow(fixture: ComponentFixture<WidgetHoekensAnchorAlarmComponent>): Window {
+  const iframe = fixture.nativeElement.querySelector('iframe') as HTMLIFrameElement | null;
+  const win = iframe?.contentWindow ?? null;
+  expect(win).toBeTruthy();
+  return win as Window;
+}
+
+describe('WidgetHoekensAnchorAlarmComponent', () => {
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('should create', () => {
+    expect(mount().fixture.componentInstance).toBeTruthy();
+  });
+
+  it('hides the chrome on an upward gesture from its own iframe', () => {
+    const { fixture, chrome } = mount();
+    gestureFrom('swipeup', iframeWindow(fixture), window.location.origin);
+    expect(chrome.hide).toHaveBeenCalledTimes(1);
+  });
+
+  it('reveals the chrome on a downward gesture from its own iframe', () => {
+    const { fixture, chrome } = mount();
+    gestureFrom('swipedown', iframeWindow(fixture), window.location.origin);
+    expect(chrome.reveal).toHaveBeenCalledTimes(1);
+  });
+
+  it('navigates to the next page on a leftward gesture from its own iframe', () => {
+    const { fixture, dashboard } = mount();
+    gestureFrom('swipeleft', iframeWindow(fixture), window.location.origin);
+    expect(dashboard.navigateToNextDashboard).toHaveBeenCalledTimes(1);
+  });
+
+  it('navigates to the previous page on a rightward gesture from its own iframe', () => {
+    const { fixture, dashboard } = mount();
+    gestureFrom('swiperight', iframeWindow(fixture), window.location.origin);
+    expect(dashboard.navigateToPreviousDashboard).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not page-navigate on a horizontal gesture while the dashboard is unlocked', () => {
+    const { fixture, dashboard } = mount(false);
+    gestureFrom('swipeleft', iframeWindow(fixture), window.location.origin);
+    expect(dashboard.navigateToNextDashboard).not.toHaveBeenCalled();
+  });
+
+  it('ignores a gesture message from a foreign window source', () => {
+    const { dashboard, chrome } = mount();
+    gestureFrom('swipeup', window, window.location.origin);
+    expect(chrome.hide).not.toHaveBeenCalled();
+    expect(dashboard.navigateToNextDashboard).not.toHaveBeenCalled();
+  });
+
+  it('ignores a gesture message whose origin is not the app origin', () => {
+    const { fixture, chrome } = mount();
+    gestureFrom('swipeup', iframeWindow(fixture), 'https://evil.invalid');
+    expect(chrome.hide).not.toHaveBeenCalled();
+  });
+
+  it('ignores a gesture whose instanceId does not match this widget', () => {
+    const { fixture, chrome } = mount();
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { gesture: 'swipeup', eventData: { instanceId: 'someone-else' } },
+        origin: window.location.origin,
+        source: iframeWindow(fixture)
+      })
+    );
+    expect(chrome.hide).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/widgets/widget-hoekens-anchor-alarm/widget-hoekens-anchor-alarm.component.ts
+++ b/src/app/widgets/widget-hoekens-anchor-alarm/widget-hoekens-anchor-alarm.component.ts
@@ -1,0 +1,144 @@
+import { AfterViewInit, Component, effect, ElementRef, inject, OnDestroy, signal, viewChild, input, untracked } from '@angular/core';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
+import { DashboardService } from '../../core/services/dashboard.service';
+import { SettingsService } from '../../core/services/settings.service';
+import { generateSwipeScript } from '../../core/utils/iframe-inputs-inject.utils';
+import { IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
+import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
+import { ITheme } from '../../core/services/app-service';
+
+@Component({
+  selector: 'widget-hoekens-anchor-alarm',
+  templateUrl: './widget-hoekens-anchor-alarm.component.html',
+  styleUrls: ['./widget-hoekens-anchor-alarm.component.scss']
+})
+export class WidgetHoekensAnchorAlarmComponent implements AfterViewInit, OnDestroy {
+  // Functional Host2 inputs
+  public id = input.required<string>();
+  public type = input.required<string>();
+  public theme = input.required<ITheme>();
+
+  // Runtime directive (config merge done by container)
+  protected readonly runtime = inject(WidgetRuntimeDirective);
+  protected readonly _dashboard = inject(DashboardService);
+  private readonly _sanitizer = inject(DomSanitizer);
+  private readonly settings = inject(SettingsService);
+
+  // Static default config (legacy parity)
+  public static readonly DEFAULT_CONFIG: IWidgetSvcConfig = {
+  };
+
+  protected iframe = viewChild.required<ElementRef<HTMLIFrameElement>>('plainIframe');
+  protected widgetUrl: SafeResourceUrl | null = null;
+  protected displayTransparentOverlay = signal<string>('block');
+
+  constructor() {
+    const pluginUrl = new URL('/hoekens-anchor-alarm/', window.location.origin);
+    this.widgetUrl = this.toSafeResourceUrl(pluginUrl);
+
+    // Effect to derive overlay state from dashboard edit/static + config.allowInput
+    effect(() => {
+      const cfg = this.runtime.options();
+      const dashIsStatic = this._dashboard.isDashboardStatic();
+      if (!cfg) return;
+      untracked(() => {
+        if (!dashIsStatic) this.displayTransparentOverlay.set('block');
+        else this.displayTransparentOverlay.set('none');
+      });
+    });
+
+    // Register message listener once
+    window.addEventListener('message', this.handleIframeGesture);
+  }
+
+  private toSafeResourceUrl(url: URL): SafeResourceUrl | null {
+    // Only allow same-origin URLs for iframe content.
+    if (url.origin !== window.location.origin) return null;
+    // Anchor alarm plugin is expected to live under this fixed path.
+    if (!url.pathname.startsWith('/hoekens-anchor-alarm/')) return null;
+    return this._sanitizer.bypassSecurityTrustResourceUrl(url.toString());
+  }
+
+  ngAfterViewInit(): void {
+    if (!this.iframe()) return;
+    this.iframe().nativeElement.onload = () => this.injectSwipeScript();
+    // Attempt injection if iframe already loaded (cached load edge case)
+    try {
+      const doc = this.iframe().nativeElement.contentDocument;
+      if (doc && (doc.readyState === 'complete' || doc.readyState === 'interactive')) this.injectSwipeScript();
+    } catch { /* ignore */ }
+  }
+
+  private handleIframeGesture = (event: MessageEvent) => {
+    if (!event.data) return;
+
+    const instanceId = event.data?.eventData?.instanceId || event.data?.keyEventData?.instanceId;
+    if (!instanceId || instanceId !== this.id()) return;
+
+    // Handle gestures
+    if (event.data.gesture) {
+      switch (event.data.gesture) {
+        case 'swipeup':
+          this._dashboard.navigateToPreviousDashboard();
+          break;
+        case 'swipedown':
+          this._dashboard.navigateToNextDashboard();
+          break;
+        case 'swipeleft': {
+          const leftSidebarEvent = new Event('openLeftSidenav', { bubbles: true, cancelable: true });
+          window.document.dispatchEvent(leftSidebarEvent);
+          break;
+        }
+        case 'swiperight': {
+          const rightSidebarEvent = new Event('openRightSidenav', { bubbles: true, cancelable: true });
+          window.document.dispatchEvent(rightSidebarEvent);
+          break;
+        }
+        default:
+          break;
+      }
+    }
+    // Handle keydown events
+    if (event.data.type === 'keydown' && event.data.keyEventData) {
+      const { key, ctrlKey, shiftKey } = event.data.keyEventData;
+      const keyboardEvent = new KeyboardEvent('keydown', { key, ctrlKey, shiftKey, bubbles: true, cancelable: true });
+      document.dispatchEvent(keyboardEvent);
+    }
+  };
+
+  private injectSwipeScript() {
+    const iframeWindow = this.iframe().nativeElement.contentWindow;
+    const iframeDocument = this.iframe().nativeElement.contentDocument;
+    if (!iframeDocument || !iframeWindow) {
+      console.error('[WidgetIframe] Iframe contentDocument or contentWindow is undefined. Possible cross-origin issue or iframe not fully loaded.');
+      return;
+    }
+    try {
+      const id = `kip-gesture-inject-${this.id()}`;
+      // Avoid double-injecting the same script
+      if (iframeDocument.getElementById(id)) return;
+      const scriptText = generateSwipeScript({ instanceId: this.id() });
+      const script = iframeDocument.createElement('script');
+      script.id = id;
+      script.textContent = scriptText;
+      iframeDocument.body.appendChild(script);
+    } catch (e) {
+      console.warn('[WidgetIframe] Failed to inject swipe script into iframe:', e);
+    }
+  }
+
+  ngOnDestroy(): void {
+    window.removeEventListener('message', this.handleIframeGesture);
+    // Clear iframe onload to release closure references
+    if (this.iframe()) this.iframe().nativeElement.onload = null;
+    // Remove injected script from iframe (if same-origin) to avoid lingering closures
+    try {
+      const iframeDoc = this.iframe()?.nativeElement.contentDocument;
+      if (iframeDoc) {
+        const id = `kip-gesture-inject-${this.id()}`;
+        const existing = iframeDoc.getElementById(id);
+        if (existing && existing.parentNode) existing.parentNode.removeChild(existing);
+      }
+    } catch { /* ignore cross-origin or access errors */ }
+  }
+}

--- a/src/app/widgets/widget-hoekens-anchor-alarm/widget-hoekens-anchor-alarm.component.ts
+++ b/src/app/widgets/widget-hoekens-anchor-alarm/widget-hoekens-anchor-alarm.component.ts
@@ -1,7 +1,7 @@
-import { AfterViewInit, Component, effect, ElementRef, inject, OnDestroy, signal, viewChild, input, untracked } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, effect, ElementRef, inject, OnDestroy, signal, viewChild, input, untracked } from '@angular/core';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { DashboardService } from '../../core/services/dashboard.service';
-import { SettingsService } from '../../core/services/settings.service';
+import { ChromeVisibilityService } from '../../core/services/chrome-visibility.service';
 import { generateSwipeScript } from '../../core/utils/iframe-inputs-inject.utils';
 import { IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
 import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
@@ -9,6 +9,7 @@ import { ITheme } from '../../core/services/app-service';
 
 @Component({
   selector: 'widget-hoekens-anchor-alarm',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './widget-hoekens-anchor-alarm.component.html',
   styleUrls: ['./widget-hoekens-anchor-alarm.component.scss']
 })
@@ -16,15 +17,14 @@ export class WidgetHoekensAnchorAlarmComponent implements AfterViewInit, OnDestr
   // Functional Host2 inputs
   public id = input.required<string>();
   public type = input.required<string>();
-  public theme = input.required<ITheme>();
+  public theme = input.required<ITheme | null>();
 
   // Runtime directive (config merge done by container)
   protected readonly runtime = inject(WidgetRuntimeDirective);
   protected readonly _dashboard = inject(DashboardService);
+  private readonly _chrome = inject(ChromeVisibilityService);
   private readonly _sanitizer = inject(DomSanitizer);
-  private readonly settings = inject(SettingsService);
 
-  // Static default config (legacy parity)
   public static readonly DEFAULT_CONFIG: IWidgetSvcConfig = {
   };
 
@@ -36,7 +36,7 @@ export class WidgetHoekensAnchorAlarmComponent implements AfterViewInit, OnDestr
     const pluginUrl = new URL('/hoekens-anchor-alarm/', window.location.origin);
     this.widgetUrl = this.toSafeResourceUrl(pluginUrl);
 
-    // Effect to derive overlay state from dashboard edit/static + config.allowInput
+    // Overlay passes pointer input to the iframe only while the dashboard is static.
     effect(() => {
       const cfg = this.runtime.options();
       const dashIsStatic = this._dashboard.isDashboardStatic();
@@ -54,7 +54,7 @@ export class WidgetHoekensAnchorAlarmComponent implements AfterViewInit, OnDestr
   private toSafeResourceUrl(url: URL): SafeResourceUrl | null {
     // Only allow same-origin URLs for iframe content.
     if (url.origin !== window.location.origin) return null;
-    // Anchor alarm plugin is expected to live under this fixed path.
+    // The Hoeken's anchor alarm plugin is expected to live under this fixed path.
     if (!url.pathname.startsWith('/hoekens-anchor-alarm/')) return null;
     return this._sanitizer.bypassSecurityTrustResourceUrl(url.toString());
   }
@@ -72,6 +72,18 @@ export class WidgetHoekensAnchorAlarmComponent implements AfterViewInit, OnDestr
   private handleIframeGesture = (event: MessageEvent) => {
     if (!event.data) return;
 
+    // Only accept messages from this widget's own iframe; a foreign window that
+    // guessed the widget UUID must not drive navigation, toggle chrome, or
+    // inject synthetic key events. The plugin iframe is always same-origin.
+    let iframeWindow: Window | null = null;
+    try {
+      iframeWindow = this.iframe()?.nativeElement?.contentWindow ?? null;
+    } catch {
+      iframeWindow = null;
+    }
+    if (!iframeWindow || event.source !== iframeWindow) return;
+    if (event.origin !== window.location.origin) return;
+
     const instanceId = event.data?.eventData?.instanceId || event.data?.keyEventData?.instanceId;
     if (!instanceId || instanceId !== this.id()) return;
 
@@ -79,21 +91,17 @@ export class WidgetHoekensAnchorAlarmComponent implements AfterViewInit, OnDestr
     if (event.data.gesture) {
       switch (event.data.gesture) {
         case 'swipeup':
-          this._dashboard.navigateToPreviousDashboard();
+          this._chrome.hide();
           break;
         case 'swipedown':
-          this._dashboard.navigateToNextDashboard();
+          this._chrome.reveal();
           break;
-        case 'swipeleft': {
-          const leftSidebarEvent = new Event('openLeftSidenav', { bubbles: true, cancelable: true });
-          window.document.dispatchEvent(leftSidebarEvent);
+        case 'swipeleft':
+          if (this._dashboard.isDashboardStatic()) this._dashboard.navigateToNextDashboard();
           break;
-        }
-        case 'swiperight': {
-          const rightSidebarEvent = new Event('openRightSidenav', { bubbles: true, cancelable: true });
-          window.document.dispatchEvent(rightSidebarEvent);
+        case 'swiperight':
+          if (this._dashboard.isDashboardStatic()) this._dashboard.navigateToPreviousDashboard();
           break;
-        }
         default:
           break;
       }
@@ -110,7 +118,7 @@ export class WidgetHoekensAnchorAlarmComponent implements AfterViewInit, OnDestr
     const iframeWindow = this.iframe().nativeElement.contentWindow;
     const iframeDocument = this.iframe().nativeElement.contentDocument;
     if (!iframeDocument || !iframeWindow) {
-      console.error('[WidgetIframe] Iframe contentDocument or contentWindow is undefined. Possible cross-origin issue or iframe not fully loaded.');
+      console.error('[WidgetHoekensAnchorAlarm] Iframe contentDocument or contentWindow is undefined. Possible cross-origin issue or iframe not fully loaded.');
       return;
     }
     try {
@@ -123,7 +131,7 @@ export class WidgetHoekensAnchorAlarmComponent implements AfterViewInit, OnDestr
       script.textContent = scriptText;
       iframeDocument.body.appendChild(script);
     } catch (e) {
-      console.warn('[WidgetIframe] Failed to inject swipe script into iframe:', e);
+      console.warn('[WidgetHoekensAnchorAlarm] Failed to inject swipe script into iframe:', e);
     }
   }
 


### PR DESCRIPTION
Ports upstream **mxtommy/Kip#1127** ("add Hoeken's Anchor Alarm widget", squash `c3631ed4`).

Adds a new **Hoeken's Anchor Alarm** widget — a map-first iframe embedding of the external `hoekens-anchor-alarm` Signal K plugin (`/hoekens-anchor-alarm/`), gated via `requiredPlugins` like skip's other third-party-plugin widgets. It is a distinct widget from skip's existing `widget-anchor-alarm` (the `anchoralarm`-plugin "Anchor Watch").

## Changes
- **New** `src/app/widgets/widget-hoekens-anchor-alarm/` (`.ts`/`.html`/`.scss`) — structurally a clone of skip's existing `widget-freeboardsk` iframe pattern; reuses `generateSwipeScript`, `WidgetRuntimeDirective`, and `DashboardService` navigation helpers already present.
- `widget.service.ts` — lazy-load import + registry entry; also refreshes the existing "Anchor Watch" description.

Applied cleanly from upstream for both paths (skipped the upstream `package.json` author-name reorder). Production build passes; lint and betterer clean. The widget only functions when the `hoekens-anchor-alarm` plugin is installed on the SK server.