### PR TITLE
fix(dashboard): send invalid /page/:id deep links to page 0

### DIFF
--- a/src/app/core/services/dashboard.service.spec.ts
+++ b/src/app/core/services/dashboard.service.spec.ts
@@ -133,6 +133,23 @@ describe('DashboardService', () => {
       expect(service.activeDashboard()).toBe(0);
     });
 
+    it('defaults to 0 when the first NavigationEnd param is a finite but out-of-range index', () => {
+      setup();
+      router.setIdParam('9');
+      router.emitNavigationEnd();
+      expect(service.activeDashboard()).toBe(0);
+      // The rejected id is still logged once; the fallback to page 0 is silent.
+      expect(consoleError).toHaveBeenCalledTimes(1);
+    });
+
+    it('defaults to 0 when the first NavigationEnd param is a fractional index', () => {
+      setup();
+      router.setIdParam('1.5');
+      router.emitNavigationEnd();
+      expect(service.activeDashboard()).toBe(0);
+      expect(consoleError).toHaveBeenCalledTimes(1);
+    });
+
     it('follows id param changes on later navigations', () => {
       setup();
       router.emitNavigationEnd();

--- a/src/app/core/services/dashboard.service.ts
+++ b/src/app/core/services/dashboard.service.ts
@@ -123,23 +123,30 @@ export class DashboardService {
       return;
     }
 
-    this.setActiveDashboardIndex(parsed);
+    // A finite but out-of-range or non-integer id (e.g. a stale /page/9 deep link)
+    // is rejected by setActiveDashboardIndex; on the initial (default-to-zero) path,
+    // land on page 0 rather than leaving the dashboard unset and rendering blank.
+    if (!this.setActiveDashboardIndex(parsed) && defaultToZero) {
+      this.setActiveDashboardIndex(0);
+    }
   }
 
   /**
    * Sets the active dashboard index in the service.
    * This only updates the internal state and does NOT trigger navigation or URL changes.
    * @param itemIndex The index of the dashboard to activate.
+   * @returns true if the index was valid and applied (or already active); false if rejected.
    */
-  public setActiveDashboardIndex(itemIndex: number): void {
-    if (itemIndex === this.activeDashboard()) return;
+  public setActiveDashboardIndex(itemIndex: number): boolean {
     // No change if the same dashboard is selected to prevent unnecessary cascading updates
+    if (itemIndex === this.activeDashboard()) return true;
 
     if (Number.isInteger(itemIndex) && itemIndex >= 0 && itemIndex < this.dashboards().length) {
       this.activeDashboard.set(itemIndex);
-    } else {
-      console.error(`[Dashboard Service] Invalid dashboard ID: ${itemIndex}`);
+      return true;
     }
+    console.error(`[Dashboard Service] Invalid dashboard ID: ${itemIndex}`);
+    return false;
   }
 
   /**


### PR DESCRIPTION
## What

An invalid `/page/:id` deep link — out-of-range (e.g. `/page/9` after dashboards were removed) or fractional (`/page/1.5`) — left the dashboard **blank and stuck** on that URL instead of falling back to page 0.

## Why

`applyDashboardParam` only fell back to page 0 for `null`/empty/`NaN` ids. A finite-but-invalid id parses as a real number, so it was handed to `setActiveDashboardIndex`, which correctly rejects it — but that left `activeDashboard` at `null`, and the component renders an empty dashboard.

This is the remaining half of #205. The component-level crash guard (`loadDashboard` dereferencing `undefined`) already landed in `374402e2`; this fixes the leftover blank-page behaviour so a stale deep link lands on page 0.

## How

- `setActiveDashboardIndex` now returns whether it applied the index.
- `applyDashboardParam` falls back to page 0 on the initial (default-to-zero) path when the finite id is rejected — treating out-of-range/fractional ids the same as `NaN`.
- Later in-app navigations keep the current page on a bad id, unchanged (the `console.error` diagnostic is preserved on that path).

## Tests

Added two `dashboard.service.spec.ts` cases — first `NavigationEnd` with `/page/9` and `/page/1.5` → page 0. Existing route / `setActiveDashboardIndex` tests are unchanged.

## Verification note

Not run locally: the on-boat host this was authored on has no `node_modules`, and the HaLOS test-device policy forbids installing/building there. Relying on CI (Node 24: lint + betterer:ci + tests) to verify. `dashboard.service.ts` is not in `.betterer.results`, so the ratchet is unaffected.

Closes #205
