### PR TITLE
fix(data): scope path timeout reset to the timed-out source

### DIFF
--- a/src/app/core/directives/widget-streams.directive.spec.ts
+++ b/src/app/core/directives/widget-streams.directive.spec.ts
@@ -14,6 +14,7 @@ class FakeDataService {
     subjects = new Map<string, Subject<IPathUpdate>>();
     timeoutCalls: {
         path: string;
+        source: string;
         pathType: string;
     }[] = [];
 
@@ -27,8 +28,8 @@ class FakeDataService {
         return this.subjects.get(key)!.asObservable();
     }
 
-    timeoutPathObservable(path: string, pathType: string): void {
-        this.timeoutCalls.push({ path, pathType });
+    timeoutPathObservable(path: string, source: string, pathType: string): void {
+        this.timeoutCalls.push({ path, source, pathType });
     }
 }
 
@@ -365,7 +366,22 @@ describe('WidgetStreamsDirective', () => {
         // Do not emit anything; advance virtual time beyond 20ms to trigger timeout
         await vi.advanceTimersByTimeAsync(30);
         expect(dataSvc.timeoutCalls.length).toBe(1);
-        expect(dataSvc.timeoutCalls[0]).toEqual({ path: 'env.to', pathType: 'string' });
+        expect(dataSvc.timeoutCalls[0]).toEqual({ path: 'env.to', source: 'default', pathType: 'string' });
+    });
+
+    it('forwards a configured non-default source into timeoutPathObservable', async () => {
+        vi.useFakeTimers();
+        vi.spyOn(console, 'log');
+        const cfg = makeCfg({ path: 'env.to', source: 'n2k-1', pathType: 'string', sampleTime: 100, displayName: 'Test', enableTimeout: true, dataTimeout: 0.02 });
+        directive.setStreamsConfig(cfg);
+
+        const hits: string[] = [];
+        directive.observe('p', u => hits.push(String(u?.data?.value)));
+
+        // The stream's effective source must reach the reset so a source-bound widget
+        // clears its own registration, not the default bucket (#206).
+        await vi.advanceTimersByTimeAsync(30);
+        expect(dataSvc.timeoutCalls[0]).toEqual({ path: 'env.to', source: 'n2k-1', pathType: 'string' });
     });
 
     it('applies convertUnitTo to numeric values (initial + sampled)', async () => {
@@ -486,7 +502,7 @@ describe('WidgetStreamsDirective', () => {
  */
 class TtlFakeDataService {
     subjects = new Map<string, BehaviorSubject<IPathUpdate>>();
-    timeoutCalls: { path: string; pathType: string }[] = [];
+    timeoutCalls: { path: string; source: string; pathType: string }[] = [];
 
     private keyFor(path: string, source?: string): string {
         return `${path}|${source?.trim() || 'default'}`;
@@ -502,10 +518,10 @@ class TtlFakeDataService {
         return this.subjects.get(key)!.asObservable();
     }
 
-    timeoutPathObservable(path: string, pathType: string): void {
-        this.timeoutCalls.push({ path, pathType });
-        // Mirror the real DataService: a TTL timeout resets the path value to null.
-        this.subjects.get(this.keyFor(path))?.next(
+    timeoutPathObservable(path: string, source: string, pathType: string): void {
+        this.timeoutCalls.push({ path, source, pathType });
+        // Mirror the real DataService: a TTL timeout resets the timed-out source's value to null.
+        this.subjects.get(this.keyFor(path, source))?.next(
             { data: { value: null, timestamp: null }, state: 'normal' } as IPathUpdate
         );
     }

--- a/src/app/core/directives/widget-streams.directive.ts
+++ b/src/app/core/directives/widget-streams.directive.ts
@@ -98,9 +98,10 @@ export class WidgetStreamsDirective {
     // Build base observable if missing, or refresh when path/source changed
     this.ensureStreamsMap();
     const baseKey = this.computeBaseKey(normalizedPath, pathCfg.source);
+    const effectiveSource = pathCfg.source?.trim() || 'default';
     const currentBaseKey = this.baseSignatures.get(pathName);
     if (!this.streams!.has(pathName) || currentBaseKey !== baseKey) {
-      this.streams!.set(pathName, this.dataService.subscribePath(normalizedPath, pathCfg.source?.trim() || 'default'));
+      this.streams!.set(pathName, this.dataService.subscribePath(normalizedPath, effectiveSource));
       this.baseSignatures.set(pathName, baseKey);
     }
     const base$ = this.streams!.get(pathName)!;
@@ -154,7 +155,7 @@ export class WidgetStreamsDirective {
           each: dataTimeout,
           with: () => throwError(() => {
             console.log(timeoutErrorMsg + normalizedPath);
-            this.dataService.timeoutPathObservable(normalizedPath, pathType);
+            this.dataService.timeoutPathObservable(normalizedPath, effectiveSource, pathType);
           })
         }),
         retryWhen(error => error.pipe(

--- a/src/app/core/services/data.service.spec.ts
+++ b/src/app/core/services/data.service.spec.ts
@@ -308,39 +308,53 @@ describe('DataService', () => {
     });
     expect(latest!.data.value).toBe(5.5);
 
-    service.timeoutPathObservable('self.environment.wind.speedApparent', 'number');
+    service.timeoutPathObservable('self.environment.wind.speedApparent', 'default', 'number');
 
     expect(latest!.data.value).toBeNull();
     expect(latest!.data.timestamp).toBeNull();
     expect(latest!.state).toBe(States.Normal);
   });
 
-  it('resets every source registration for a path on timeout, not just the first', () => {
+  it('resets only the timed-out source registration, leaving sibling sources live', () => {
     let latestDefault: IPathUpdate | undefined;
-    let latestSource: IPathUpdate | undefined;
+    let latestSourceA: IPathUpdate | undefined;
+    let latestSourceB: IPathUpdate | undefined;
     service
       .subscribePath('self.electrical.batteries.10.voltage', 'default')
       .subscribe(update => (latestDefault = update));
     service
-      .subscribePath('self.electrical.batteries.10.voltage', 'test-source')
-      .subscribe(update => (latestSource = update));
+      .subscribePath('self.electrical.batteries.10.voltage', 'test-source-a')
+      .subscribe(update => (latestSourceA = update));
+    service
+      .subscribePath('self.electrical.batteries.10.voltage', 'test-source-b')
+      .subscribe(update => (latestSourceB = update));
 
     dataPathUpdates$.next({
       context: 'self',
       path: 'electrical.batteries.10.voltage',
-      source: 'test-source',
+      source: 'test-source-a',
       timestamp: '2026-01-01T00:00:01.000Z',
       value: 12.5,
     });
-    expect(latestDefault!.data.value).toBe(12.5);
-    expect(latestSource!.data.value).toBe(12.5);
+    dataPathUpdates$.next({
+      context: 'self',
+      path: 'electrical.batteries.10.voltage',
+      source: 'test-source-b',
+      timestamp: '2026-01-01T00:00:02.000Z',
+      value: 13.0,
+    });
+    expect(latestSourceA!.data.value).toBe(12.5);
+    expect(latestSourceB!.data.value).toBe(13.0);
+    expect(latestDefault!.data.value).toBe(13.0);
 
-    service.timeoutPathObservable('self.electrical.batteries.10.voltage', 'number');
+    // Only test-source-a's stream timed out; its live siblings (test-source-b and
+    // the default bucket, still fed by test-source-b) must be left untouched.
+    service.timeoutPathObservable('self.electrical.batteries.10.voltage', 'test-source-a', 'number');
 
-    // Both the default bucket and the per-source registration must clear on timeout.
-    expect(latestDefault!.data.value).toBeNull();
-    expect(latestSource!.data.value).toBeNull();
-    expect(latestSource!.state).toBe(States.Normal);
+    expect(latestSourceA!.data.value).toBeNull();
+    expect(latestSourceA!.state).toBe(States.Normal);
+    expect(latestSourceB!.data.value).toBe(13.0);
+    expect(latestDefault!.data.value).toBe(13.0);
   });
 
   it('does not emit on timeout for an unrecognised pathType', () => {
@@ -350,7 +364,7 @@ describe('DataService', () => {
       .subscribe(update => updates.push(update));
 
     const countBefore = updates.length;
-    service.timeoutPathObservable('self.navigation.position', 'object');
+    service.timeoutPathObservable('self.navigation.position', 'default', 'object');
 
     expect(updates.length).toBe(countBefore);
     expect(updates.every(update => update !== undefined)).toBe(true);

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -715,15 +715,21 @@ export class DataService implements OnDestroy {
    * timeout a path value and reset it to null. This is useful for widgets
    * that need to know if a path has timed out.
    *
+   * Only the registration matching `source` is reset: one source timing out
+   * must not null a sibling widget bound to a different, still-live source of
+   * the same path (e.g. redundant GPS or wind sensors).
+   *
    * @param {string} path The Signal K path to timeout
+   * @param {string} source The source whose stream timed out; only its registration is reset
    * @param {string} pathType The type of the path value (string, Date, number, multiple, etc)
    * @memberof SignalKDataService
    */
-  public timeoutPathObservable(path: string, pathType: string): void {
+  public timeoutPathObservable(path: string, source: string, pathType: string): void {
     if (!['string', 'Date', 'number', 'multiple'].includes(pathType)) return;
     const registrations = this._pathRegisterByPath.get(path);
     if (!registrations) return;
     for (const registration of registrations) {
+      if (registration.source !== source) continue;
       registration.pathDataUpdate$.next({
         data: {
           value: null,


### PR DESCRIPTION
## What

`DataService.timeoutPathObservable` nulled **every** registration for a path when any one source's stream timed out. On a vessel with redundant sensors (two GPS, two wind) shown by separate widgets bound to different `$source`s, a dead source's timeout also cleared the still-live sibling and the `default` bucket — a visible blank flicker (and a momentary alarm/warn → Normal revert) exactly during the partial failure redundant sensors exist to smooth over.

Closes #206.

## Why it was like this

#155 (PR #201) fixed a real bug where a first-match-by-path lookup reset only *one* of a path's registrations. It over-corrected to "reset all". #206 refines that: reset only the registration for the source that actually timed out.

## How

- `timeoutPathObservable(path, pathType)` → `timeoutPathObservable(path, source, pathType)`; it resets only the registration whose `source` matches.
- `WidgetStreamsDirective` passes the stream's effective source (the same `pathCfg.source?.trim() || 'default'` it already subscribes with) into the timeout call.

Correctness is preserved for a genuinely-silent path: each `(path, source)` stream has its own timeout, so when the whole path goes quiet every widget's stream self-times-out and clears its own registration — the `default` bucket included (default is fed by every source, so it only times out once all sources are silent).

## Tests

- `data.service.spec.ts`: the old *"resets every source registration… not just the first"* test (which pinned the #201 all-at-once behavior) is rewritten to *"resets only the timed-out source registration, leaving sibling sources live"* — two sources + default, time out one, assert the other two are untouched. The default-timeout and unrecognised-pathType tests are updated to the new signature.
- `widget-streams.directive.spec.ts`: both fake-DataService stubs updated to the 3-arg signature; the timeout-call assertion now checks the source (`default`) is passed; the #1069 TTL stub nulls the timed-out source's subject.

## Verification note

Not run locally (this on-boat host has no `node_modules`; HaLOS policy forbids installing/building here). Relying on CI (Node 24: lint + betterer:ci + tests). Neither changed source file is in `.betterer.results`, so the ratchet is unaffected.
