### PR TITLE
fix(data): guard delta emission against missing source/timestamp/path

### DIFF
--- a/src/app/core/services/signalk-delta.service.spec.ts
+++ b/src/app/core/services/signalk-delta.service.spec.ts
@@ -489,6 +489,84 @@ describe('SignalKDeltaService', () => {
           { context: CTX, path: 'navigation.speedOverGround', meta: value },
         ]);
       });
+
+      it('drops a value whose update is missing $source without throwing', () => {
+        const { service } = setup();
+        const out = collectData(service);
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        const noSource = { timestamp: TS, values: [{ path: 'navigation.speedOverGround', value: 1 }] } as unknown as ISignalKUpdateMessage;
+        expect(() => parse(service, { context: CTX, updates: [noSource] })).not.toThrow();
+        expect(out).toEqual([]);
+        expect(warn).toHaveBeenCalled();
+        warn.mockRestore();
+      });
+
+      it('drops a value whose update is missing timestamp without throwing', () => {
+        const { service } = setup();
+        const out = collectData(service);
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        const noTs = { $source: 'src.1', values: [{ path: 'navigation.speedOverGround', value: 1 }] } as unknown as ISignalKUpdateMessage;
+        expect(() => parse(service, { context: CTX, updates: [noTs] })).not.toThrow();
+        expect(out).toEqual([]);
+        expect(warn).toHaveBeenCalled();
+        warn.mockRestore();
+      });
+
+      it('still emits a sibling update with a valid $source and timestamp when another update is invalid', () => {
+        const { service } = setup();
+        const out = collectData(service);
+        const noSource = { timestamp: TS, values: [{ path: 'navigation.courseOverGround', value: 1 }] } as unknown as ISignalKUpdateMessage;
+        parse(service, { context: CTX, updates: [noSource, update([{ path: 'navigation.speedOverGround', value: 2 }])] });
+        expect(out).toEqual([
+          { context: CTX, path: 'navigation.speedOverGround', source: 'src.1', timestamp: TS, value: 2 },
+        ]);
+      });
+
+      it('warns once per update, not once per value, when a multi-value update lacks $source', () => {
+        const { service } = setup();
+        const out = collectData(service);
+        const notes: ISignalKDataValueUpdate[] = [];
+        service.subscribeNotificationsUpdates().subscribe(v => notes.push(v));
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        const note = { path: 'notifications.mob', value: { state: 'alarm', message: 'MOB' } };
+        const noSource = { timestamp: TS, values: [
+          { path: 'navigation.speedOverGround', value: 1 },
+          { path: 'navigation.courseOverGround', value: 2 },
+          note,
+        ] } as unknown as ISignalKUpdateMessage;
+        parse(service, { context: CTX, updates: [noSource] });
+        expect(out).toEqual([]);
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(notes).toEqual([note]);
+        warn.mockRestore();
+      });
+
+      it('drops a meta item whose path is missing without throwing', () => {
+        const { service } = setup();
+        const metas: IMeta[] = [];
+        service.subscribeMetadataUpdates().subscribe(v => metas.push(v));
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        const meta = [{ value: { units: 'm/s', description: 'Speed over ground' } } as unknown as ISignalKMeta];
+        expect(() => parse(service, { context: CTX, updates: [update([], { meta })] })).not.toThrow();
+        expect(metas).toEqual([]);
+        expect(warn).toHaveBeenCalled();
+        warn.mockRestore();
+      });
+
+      it('still emits a sibling meta item with a valid path when another lacks one', () => {
+        const { service } = setup();
+        const metas: IMeta[] = [];
+        service.subscribeMetadataUpdates().subscribe(v => metas.push(v));
+        const sogMeta = { units: 'm/s', description: 'Speed over ground' };
+        const meta = [
+          { value: { units: 'rad', description: 'Latitude' } } as unknown as ISignalKMeta,
+          skMeta('navigation.speedOverGround', sogMeta),
+        ];
+        parse(service, { context: CTX, updates: [update([], { meta })] });
+        expect(metas).toEqual([
+          { context: CTX, path: 'navigation.speedOverGround', meta: sogMeta },
+        ]);
+      });
     });
   });
 });

--- a/src/app/core/services/signalk-delta.service.ts
+++ b/src/app/core/services/signalk-delta.service.ts
@@ -360,16 +360,14 @@ export class SignalKDeltaService implements OnDestroy {
   }
 
   private parseUpdates(updates: ISignalKUpdateMessage[], context: string | undefined): void {
-    // if (context != this._selfUrn) {    // remove non self root nodes
-    //   return;
-    // }
-
     updates.forEach(update => {
       if (Array.isArray(update?.meta)) {
         update.meta.forEach(meta => this.parseSkMeta(meta, context));
       }
 
       if (Array.isArray(update?.values)) {
+        const hasValidSource = typeof update.$source === 'string' && typeof update.timestamp === 'string';
+        let sourceWarned = false;
         update.values.forEach(item => {
           if (typeof item?.path !== 'string') {
             console.warn("[Delta Service] Dropping value update without a string path:", item);
@@ -379,6 +377,13 @@ export class SignalKDeltaService implements OnDestroy {
             this._skNotificationsMsg$.next(item);
           } else {
             // It's a path value source update.
+            if (!hasValidSource) {
+              if (!sourceWarned) {
+                console.warn("[Delta Service] Dropping value update without a valid $source or timestamp:", update);
+                sourceWarned = true;
+              }
+              return;
+            }
             if ((typeof(item.value) == 'object') && (item.value !== null)) {
               if (this.DO_NOT_FLATTEN_PATHS.some(sub_string => item.path.includes(sub_string))) {
                 // Skip flattening, treat as a single value
@@ -486,6 +491,10 @@ export class SignalKDeltaService implements OnDestroy {
   private parseSkMeta(metadata: ISignalKMeta, context: string | undefined) {
     if (metadata?.value == null) {
       console.warn("[Delta Service] Dropping metadata update without a value:", metadata);
+      return;
+    }
+    if (typeof metadata.path !== 'string') {
+      console.warn("[Delta Service] Dropping metadata update without a path:", metadata);
       return;
     }
     if (metadata.value.properties != null) {


### PR DESCRIPTION
## Why
Follow-up to #24. Two emission-boundary gaps remained in `SignalKDeltaService`:
- `parseUpdates` emitted `IPathValueData` carrying `update.$source` / `update.timestamp` without checking they exist — a discriminator-valid frame lacking either pushed `undefined` source/timestamp into the data pipeline.
- `parseSkMeta` emitted an `undefined.key`-style path when `metadata.path` was missing.

## How
Two guards in the existing #24 drop-and-log style (`console.warn` + skip, no throw). Validation is **per-value / per-item**, not whole-frame: a sibling value or meta item with valid fields still emits. Notifications routing is untouched.

## Verification
- Malformed-frames spec suite extended: missing-`$source`, missing-timestamp, missing-meta-path drop cases + sibling-valid-still-emits (across updates and meta items); new specs fail against the old code.
- Local static gate: `lint` ✓, `betterer:ci` ✓ (183, unchanged), `tsc --noEmit` ✓. Unit specs run in CI.

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)
