### PR TITLE
fix(app): apply auto night mode immediately when enabled late

### DIFF
--- a/src/app/core/services/app-service.spec.ts
+++ b/src/app/core/services/app-service.spec.ts
@@ -201,9 +201,9 @@ describe('AppService', () => {
       expect(toggle).toHaveBeenCalledTimes(1);
     });
 
-    // The mode effect only reacts to mode changes; enabling the setting alone
-    // leaves an already-active night mode unapplied until the next transition.
-    it('does not apply the current night mode when auto night mode is enabled later', () => {
+    // Enabling the setting while the environment is already night applies the
+    // current mode immediately, without waiting for the next transition.
+    it('applies the current night mode when auto night mode is enabled later', () => {
       const service = createService();
       envMode$.next(modeUpdate('night'));
       TestBed.tick();
@@ -211,7 +211,9 @@ describe('AppService', () => {
 
       settings.autoNightMode.set(true);
       TestBed.tick();
-      expect(service.isNightMode()).toBe(false);
+      expect(service.isNightMode()).toBe(true);
+      expect(document.body.style.getPropertyValue('--kip-nightModeBrightness')).toBe('0.27');
+      expect(document.body.style.getPropertyValue('--kip-nightModeFilters')).toContain('sepia(0.5)');
 
       envMode$.next(modeUpdate('day'));
       TestBed.tick();

--- a/src/app/core/services/app-service.ts
+++ b/src/app/core/services/app-service.ts
@@ -77,6 +77,7 @@ export class AppService {
   private _environmentMode = toSignal(this._data.subscribePath(this.MODE_PATH, 'default'));
 
   private previousEnvironmentMode: string | null = null;
+  private previousUseAutoNightMode = false;
 
   public readonly appVersion = signal<string>(packageInfo.version);
   public readonly browserVersion = signal<string>('Unknown');
@@ -99,30 +100,30 @@ export class AppService {
 
     effect(() => {
       const environmentMode = this._environmentMode();
+      const useAutoNightMode = this._useAutoNightMode();
 
       untracked(() => {
         if (!environmentMode) return;
         const mode = environmentMode.data.value;
-        if (this.previousEnvironmentMode === mode) return; // No change in mode
+        const modeChanged = this.previousEnvironmentMode !== mode;
+        const autoNightModeJustEnabled = useAutoNightMode && !this.previousUseAutoNightMode;
 
         this.previousEnvironmentMode = mode;
+        this.previousUseAutoNightMode = useAutoNightMode;
 
-        if (this._useAutoNightMode()) {
-          this.isNightMode.set(mode === "night");
-          this.toggleDayNightMode();
-        }
+        if (!useAutoNightMode) return;
+        if (!modeChanged && !autoNightModeJustEnabled) return;
+
+        this.isNightMode.set(mode === "night");
+        this.toggleDayNightMode();
       });
     });
 
     effect(() => {
-      const redNightMode = this._redNightMode();
+      this._redNightMode();
 
       untracked(() => {
-        if (redNightMode) {
-          this.toggleDayNightMode();
-        } else {
-          this.toggleDayNightMode();
-        }
+        this.toggleDayNightMode();
       });
     });
 


### PR DESCRIPTION
## Why
Surfaced by the #27 characterization pass. Two defects in `app-service.ts`:
1. The `redNightMode` effect's `if`/`else` branches were **identical** (both call `toggleDayNightMode()`) — a dead conditional.
2. The environment-mode effect read `_useAutoNightMode()` only inside `untracked()`, so enabling auto night mode while the environment was already `night` did nothing until the mode value next changed.

## How
- Collapse the dead `redNightMode` conditional to its single actual behavior (no invented red-night branch).
- The environment-mode effect now **tracks** the auto-night-mode setting, so toggling it on applies the current environment immediately.

## Verification
- The pinning spec ("does not apply the current night mode when auto night mode is enabled later") is flipped to assert it now **does** apply.
- Local static gate: `lint` ✓, `betterer:ci` ✓, `tsc --noEmit` ✓. Unit specs run in CI.

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)
