### PR TITLE
fix(boolean-button): momentary button emits immediately on press (#241a)

### DIFF
--- a/src/app/widgets/svg-boolean-button/svg-boolean-button.component.spec.ts
+++ b/src/app/widgets/svg-boolean-button/svg-boolean-button.component.spec.ts
@@ -1,0 +1,135 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SvgBooleanButtonComponent } from './svg-boolean-button.component';
+import type { IDynamicControl } from '../../core/interfaces/widgets-interface';
+import type { IDimensions } from '../widget-boolean-switch/widget-boolean-switch.component';
+
+const controlMock: IDynamicControl = {
+  ctrlLabel: 'Bilge Pump',
+  type: '2',
+  pathID: 'test-path',
+  value: false,
+  color: 'contrast',
+  isNumeric: false
+};
+
+const dimensionsMock: IDimensions = { width: 180, height: 70 };
+
+function pointerAt(clientX: number, clientY: number): PointerEvent {
+  return { clientX, clientY } as unknown as PointerEvent;
+}
+
+describe('SvgBooleanButtonComponent momentary emit', () => {
+  let fixture: ComponentFixture<SvgBooleanButtonComponent>;
+  let component: SvgBooleanButtonComponent;
+  let emitted: IDynamicControl[];
+
+  const setup = (controlData: IDynamicControl | null = controlMock, render = true) => {
+    TestBed.configureTestingModule({ imports: [SvgBooleanButtonComponent] });
+    fixture = TestBed.createComponent(SvgBooleanButtonComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('controlData', controlData);
+    fixture.componentRef.setInput('theme', null);
+    fixture.componentRef.setInput('dimensions', dimensionsMock);
+    emitted = [];
+    component.toggleClick.subscribe((v) => emitted.push(v));
+    if (render) fixture.detectChanges();
+  };
+
+  beforeEach(() => TestBed.resetTestingModule());
+  afterEach(() => {
+    vi.useRealTimers();
+    TestBed.resetTestingModule();
+    vi.clearAllMocks();
+  });
+
+  it('actuates after the short hold, not before', () => {
+    setup();
+    vi.useFakeTimers();
+
+    component.handleClickDown(pointerAt(10, 10));
+    expect(emitted).toHaveLength(0);
+    vi.advanceTimersByTime(74);
+    expect(emitted).toHaveLength(0);
+
+    vi.advanceTimersByTime(1);
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].value).toBe(true);
+  });
+
+  it('does not actuate when a swipe cancels within the hold window', () => {
+    setup();
+    vi.useFakeTimers();
+
+    component.handleClickDown(pointerAt(10, 10));
+    // A scroll/swipe crossing the threshold before the hold elapses must suppress actuation entirely.
+    component.handlePointerMove(pointerAt(60, 12));
+    vi.advanceTimersByTime(500);
+
+    expect(emitted).toHaveLength(0);
+  });
+
+  it('does not actuate on a quick tap released within the hold window', () => {
+    setup();
+    vi.useFakeTimers();
+
+    component.handleClickDown(pointerAt(10, 10));
+    component.handleClickUp();
+    vi.advanceTimersByTime(500);
+
+    expect(emitted).toHaveLength(0);
+  });
+
+  it('repeats every 100ms while held', () => {
+    setup();
+    vi.useFakeTimers();
+
+    component.handleClickDown(pointerAt(10, 10));
+    vi.advanceTimersByTime(75);
+    expect(emitted).toHaveLength(1);
+
+    vi.advanceTimersByTime(100);
+    expect(emitted).toHaveLength(2);
+    vi.advanceTimersByTime(100);
+    expect(emitted).toHaveLength(3);
+  });
+
+  it('keeps the press when movement stays below the swipe threshold', () => {
+    setup();
+    vi.useFakeTimers();
+
+    component.handleClickDown(pointerAt(10, 10));
+    // 25px/5px move — under the 30px threshold, so it must not cancel.
+    component.handlePointerMove(pointerAt(35, 15));
+    vi.advanceTimersByTime(75);
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].value).toBe(true);
+  });
+
+  it('stops repeating once the pointer is released', () => {
+    setup();
+    vi.useFakeTimers();
+
+    component.handleClickDown(pointerAt(10, 10));
+    vi.advanceTimersByTime(75);
+    expect(emitted).toHaveLength(1);
+
+    // A lifted finger clears the repeat interval, so actuation stops.
+    component.handleClickUp();
+    vi.advanceTimersByTime(500);
+    expect(emitted).toHaveLength(1);
+  });
+
+  it('emits nothing and starts no timers when controlData is null', () => {
+    // The template dereferences data(); it is never rendered with null in practice,
+    // so exercise the handler guard directly without a render.
+    setup(null, false);
+    vi.useFakeTimers();
+
+    component.handleClickDown(pointerAt(10, 10));
+    vi.advanceTimersByTime(500);
+
+    expect(emitted).toHaveLength(0);
+  });
+});

--- a/src/app/widgets/svg-boolean-button/svg-boolean-button.component.ts
+++ b/src/app/widgets/svg-boolean-button/svg-boolean-button.component.ts
@@ -21,7 +21,8 @@ export class SvgBooleanButtonComponent implements DoCheck, OnDestroy {
   private toggleOn = "0 0 180 35";
   private oldTheme: ITheme | null = null;
 
-  private holdTimeoutId: ReturnType<typeof setTimeout> | null = null; // delay before starting momentary emit
+  private static readonly HOLD_DELAY_MS = 75;
+  private holdTimeoutId: ReturnType<typeof setTimeout> | null = null; // brief hold before actuating; a swipe cancels it
   private emitIntervalId: ReturnType<typeof setInterval> | null = null; // repeating emit while pressed
   private pressed = false;
   private isSwiping = false;
@@ -55,40 +56,34 @@ export class SvgBooleanButtonComponent implements DoCheck, OnDestroy {
     this.pointerStartX = event.clientX;
     this.pointerStartY = event.clientY;
 
-    // Wait 250ms before emitting the state
     this.clearTimers();
+
+    const data = this.data();
+    if (!data) return;
+
+    // Brief hold before actuating so a swipe/scroll starting on the button cancels before any emit.
     this.holdTimeoutId = setTimeout(() => {
-      if (!this.isSwiping) {
-        // Momentary mode
-        this.pressed = true;
-
-        const data = this.data();
-        if (!data) return;
-        const state: IDynamicControl = cloneDeep(data);
-        state.value = this.pressed;
-
-        // Start emitting the state every 100ms
+      this.holdTimeoutId = null;
+      if (this.isSwiping) return;
+      this.pressed = true;
+      const state: IDynamicControl = cloneDeep(data);
+      state.value = this.pressed;
+      this.toggleClick.emit(state);
+      this.emitIntervalId = setInterval(() => {
         this.toggleClick.emit(state);
-        this.emitIntervalId = setInterval(() => {
-          this.toggleClick.emit(state);
-        }, 100);
-      }
-    }, 200);
+      }, 100);
+    }, SvgBooleanButtonComponent.HOLD_DELAY_MS);
   }
 
   public handlePointerMove(event: PointerEvent): void {
     const deltaX = Math.abs(event.clientX - this.pointerStartX);
     const deltaY = Math.abs(event.clientY - this.pointerStartY);
 
-    // Mark as swiping if movement exceeds a threshold
+    // Mark as swiping if movement exceeds a threshold and cancel the emit
     if (deltaX > 30 || deltaY > 30) {
       this.isSwiping = true;
-
-      // Cancel the timeout if swiping is detected
-      if (this.holdTimeoutId) {
-        clearTimeout(this.holdTimeoutId);
-        this.holdTimeoutId = null;
-      }
+      this.pressed = false;
+      this.clearTimers();
     }
   }
 
@@ -100,16 +95,7 @@ export class SvgBooleanButtonComponent implements DoCheck, OnDestroy {
     }
 
     this.pressed = false;
-
-    // Clear the interval if it was set
-    if (this.emitIntervalId) {
-      clearInterval(this.emitIntervalId);
-      this.emitIntervalId = null;
-    }
-    if (this.holdTimeoutId) {
-      clearTimeout(this.holdTimeoutId);
-      this.holdTimeoutId = null;
-    }
+    this.clearTimers();
   }
 
   private getColors(color: string): void {


### PR DESCRIPTION
## Why
The momentary boolean button waited 200ms before its first emit, adding noticeable latency to a boat control (#241a, the momentary half of #241).

## How
Cut the pre-emit hold to **~75ms**: a deliberate press actuates in ~75ms (feels instant), while a swipe/scroll that crosses the 30px threshold within the window still cancels before any emit reaches the actuator — so an accidental scroll starting on the button does not fire it. The 100ms repeat while held, swipe-cancel, release teardown, and the null-safe `data()` guard are unchanged.

**Skip-specific choice** (per review): upstream Kip PR #1107 removed the delay entirely; on marine momentary actuators we keep a short guard window to avoid spurious actuation on touch scroll.

## Verification
- New spec: actuates after the hold not before; swipe-within-window cancels (no emit); quick-tap-in-window no-actuate; 100ms repeat while held; sub-threshold move doesn't cancel; release stops the interval; null `data()` no-op. Fake timers.
- Local static gate: `lint` ✓, `betterer:ci` ✓, `tsc --noEmit` ✓. Vitest runs in CI.

Scope is #241a only — OFF-state visuals (#241b) remain separate, so #241 stays open. Pre-existing `IDimensions` coupling surfaced in review filed as #263.

Part of #241 (#241a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
