### PR TITLE
refactor(charts): shared Chart.js registration; gate annotations on finite values

### DIFF
--- a/src/app/core/components/widget-history-chart-dialog/widget-history-chart-dialog.component.ts
+++ b/src/app/core/components/widget-history-chart-dialog/widget-history-chart-dialog.component.ts
@@ -2,8 +2,9 @@ import { AfterViewInit, ChangeDetectionStrategy, Component, DestroyRef, ElementR
 import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { Chart, ChartConfiguration, ChartDataset, Color, LegendItem, LineController, LineElement, LinearScale, PointElement, TimeScale, Tooltip, Legend } from 'chart.js';
+import { Chart, ChartConfiguration, ChartDataset, Color, LegendItem } from 'chart.js';
 import 'chartjs-adapter-date-fns';
+import { registerChartComponents } from '../../utils/chart-registration.util';
 import { IWidget } from '../../interfaces/widgets-interface';
 import { IKipSeriesDefinition } from '../../services/kip-series-api-client.service';
 import { isKipTemplateSeriesDefinition, type IKipConcreteSeriesDefinition, type IKipTemplateSeriesDefinition } from '../../contracts/kip-series-contract';
@@ -26,7 +27,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { FormsModule} from '@angular/forms';
 
-Chart.register(LineController, LineElement, LinearScale, PointElement, TimeScale, Tooltip, Legend);
+registerChartComponents();
 
 interface ChartPoint {
   x: number;

--- a/src/app/core/utils/chart-registration.util.spec.ts
+++ b/src/app/core/utils/chart-registration.util.spec.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Chart.js cannot instantiate under jsdom; the only behaviour under test is the module-level
+// register-once guard. The suite shares module state, so other chart specs may have already
+// imported (and tripped) the util — reset the module registry inside the test and re-import
+// fresh so the guard starts clean regardless of run order.
+vi.mock('chart.js', () => ({ Chart: { register: vi.fn() }, registerables: [] }));
+vi.mock('chartjs-plugin-annotation', () => ({ default: {} }));
+vi.mock('@aziham/chartjs-plugin-streaming', () => ({ default: {} }));
+
+describe('registerChartComponents', () => {
+  it('registers the Chart.js components only once across repeated calls', async () => {
+    vi.resetModules();
+    const { Chart } = await import('chart.js');
+    const { registerChartComponents } = await import('./chart-registration.util');
+
+    registerChartComponents();
+    registerChartComponents();
+
+    expect(vi.mocked(Chart.register)).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/core/utils/chart-registration.util.ts
+++ b/src/app/core/utils/chart-registration.util.ts
@@ -1,0 +1,19 @@
+import { Chart, registerables } from 'chart.js';
+import annotationPlugin from 'chartjs-plugin-annotation';
+import ChartStreaming from '@aziham/chartjs-plugin-streaming';
+
+let registered = false;
+
+/**
+ * Registers every Chart.js building block plus the annotation and streaming
+ * plugins exactly once for the whole app. Chart consumers call this at module
+ * load instead of each running their own `Chart.register`, so a chart is never
+ * created before its controller/scale/plugin set is present.
+ */
+export function registerChartComponents(): void {
+  if (registered) {
+    return;
+  }
+  registered = true;
+  Chart.register(...registerables, annotationPlugin, ChartStreaming);
+}

--- a/src/app/widgets/minichart/minichart.component.spec.ts
+++ b/src/app/widgets/minichart/minichart.component.spec.ts
@@ -18,11 +18,13 @@ vi.mock('chart.js', () => {
   }
   return {
     Chart: MockChart,
+    registerables: [],
     TimeScale: {}, LinearScale: {}, LineController: {}, PointElement: {},
     LineElement: {}, Filler: {}, CategoryScale: {}
   };
 });
 vi.mock('chartjs-adapter-date-fns', () => ({}));
+vi.mock('chartjs-plugin-annotation', () => ({ default: {} }));
 vi.mock('@aziham/chartjs-plugin-streaming', () => ({ default: {} }));
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';

--- a/src/app/widgets/minichart/minichart.component.ts
+++ b/src/app/widgets/minichart/minichart.component.ts
@@ -7,12 +7,11 @@ import { CanvasService } from '../../core/services/canvas.service';
 import { ITheme } from '../../core/services/app-service';
 import { UnitsService } from '../../core/services/units.service';
 
-import { Chart, ChartConfiguration, ChartData, ChartType, TimeUnit, TimeScale, LinearScale, LineController, PointElement, LineElement, Filler, CategoryScale } from 'chart.js';
+import { Chart, ChartConfiguration, ChartData, ChartType, TimeUnit } from 'chart.js';
 import 'chartjs-adapter-date-fns';
-import ChartStreaming from '@aziham/chartjs-plugin-streaming';
+import { registerChartComponents } from '../../core/utils/chart-registration.util';
 
-
-Chart.register(ChartStreaming, TimeScale, LinearScale, LineController, PointElement, LineElement, Filler, CategoryScale);
+registerChartComponents();
 
 interface IChartColors {
   valueLine: string | undefined,

--- a/src/app/widgets/widget-data-chart/widget-data-chart.component.spec.ts
+++ b/src/app/widgets/widget-data-chart/widget-data-chart.component.spec.ts
@@ -18,6 +18,7 @@ vi.mock('chart.js', () => {
   }
   return {
     Chart: MockChart,
+    registerables: [],
     TimeScale: {}, LinearScale: {}, LineController: {}, PointElement: {},
     LineElement: {}, Filler: {}, Title: {}, SubTitle: {}
   };
@@ -31,6 +32,7 @@ import { EMPTY, Subject } from 'rxjs';
 import { WidgetDataChartComponent } from './widget-data-chart.component';
 import { IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
 import { HistoryChartStreamService, HISTORY_UNAVAILABLE } from '../../core/services/history-chart-stream.service';
+import type { IDatasetServiceDatapoint } from '../../core/interfaces/dataset.interfaces';
 import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
 import { UnitsService } from '../../core/services/units.service';
 import { CanvasService } from '../../core/services/canvas.service';
@@ -105,5 +107,56 @@ describe('WidgetDataChartComponent', () => {
     fixture.detectChanges();
 
     expect(fixture.nativeElement.textContent).toContain('History data unavailable');
+  });
+
+  interface AnnLineState { display?: boolean; value?: number; label?: { display?: boolean; content?: string } }
+  const readAnnotation = (name: string): AnnLineState | undefined =>
+    (fixture.componentInstance.lineChartOptions.plugins as unknown as {
+      annotation?: { annotations?: Record<string, AnnLineState> };
+    }).annotation?.annotations?.[name];
+
+  it('keeps an enabled annotation line hidden while its value is non-finite, then reveals it once finite', async () => {
+    const emissions$ = new Subject<IDatasetServiceDatapoint>();
+    historyMock.getBackfillThenLive.mockReturnValue(emissions$);
+
+    // Average line enabled, but the rolling average is not yet available: the finite gate — not the
+    // enabled flag — must keep the line and its label hidden (drops if Number.isFinite is removed).
+    await setup(makeConfig({ showDatasetAverageValueLine: true, numDecimal: 1 }));
+
+    emissions$.next({ timestamp: 1000, data: { value: 5 } });
+
+    let averageLine = readAnnotation('averageLine');
+    expect(averageLine?.display).toBe(false);
+    expect(averageLine?.label?.display).toBe(false);
+
+    // A finite average now streams: the same line becomes visible with the formatted content.
+    emissions$.next({ timestamp: 2000, data: { value: 7, lastAverage: 7 } });
+
+    averageLine = readAnnotation('averageLine');
+    expect(averageLine?.display).toBe(true);
+    expect(averageLine?.label?.display).toBe(true);
+    expect(averageLine?.label?.content).toBe('7.0');
+  });
+
+  it('keeps an already-enabled annotation line visible after a theme change with data present', async () => {
+    const emissions$ = new Subject<IDatasetServiceDatapoint>();
+    historyMock.getBackfillThenLive.mockReturnValue(emissions$);
+
+    await setup(makeConfig({ showDatasetAverageValueLine: true, numDecimal: 1 }));
+
+    emissions$.next({ timestamp: 1000, data: { value: 5, lastAverage: 5 } });
+    expect(readAnnotation('averageLine')?.display).toBe(true);
+
+    // A theme change re-runs the display/theme effect, which rebuilds the annotation plugin via
+    // setChartOptions; the enabled line must survive that rebuild rather than blanking until the
+    // next emission.
+    fixture.componentRef.setInput('theme', new Proxy({}, { get: () => '#111111' }) as unknown as ITheme);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const averageLine = readAnnotation('averageLine');
+    expect(averageLine?.display).toBe(true);
+    expect(averageLine?.label?.display).toBe(true);
+    expect(averageLine?.label?.content).toBe('5.0');
   });
 });

--- a/src/app/widgets/widget-data-chart/widget-data-chart.component.ts
+++ b/src/app/widgets/widget-data-chart/widget-data-chart.component.ts
@@ -10,16 +10,20 @@ import { ITheme } from '../../core/services/app-service';
 import { HistoryChartStreamService, IHistoryChartStreamParams, isHistoryUnavailable } from '../../core/services/history-chart-stream.service';
 import { resolveWindowMs, deriveDataSourceInfo } from '../../core/utils/chart-window.util';
 
-import { Chart, ChartConfiguration, ChartData, ChartType, TimeUnit, TimeScale, LinearScale, LineController, PointElement, LineElement, Filler, Title, SubTitle } from 'chart.js';
-import annotationPlugin from 'chartjs-plugin-annotation';
+import { Chart, ChartConfiguration, ChartData, ChartType, TimeUnit } from 'chart.js';
 import 'chartjs-adapter-date-fns';
-import ChartStreaming from '@aziham/chartjs-plugin-streaming';
+import { registerChartComponents } from '../../core/utils/chart-registration.util';
 
-Chart.register(annotationPlugin, ChartStreaming, Filler, Title, SubTitle, TimeScale, LinearScale, LineController, PointElement, LineElement,);
+registerChartComponents();
 
+interface AnnLine {
+  display?: boolean;
+  value?: number;
+  label: { display?: boolean; content?: string };
+}
 interface AnnPlugin {
   annotation?: {
-    annotations?: Record<string, { value?: number; label: { content?: string } }>
+    annotations?: Record<string, AnnLine>
   }
 }
 interface IChartColors {
@@ -96,6 +100,11 @@ export class WidgetDataChartComponent implements OnDestroy {
   private datasetConfig: IDatasetServiceDatasetConfig | null = null;
   private dataSourceInfo: IDatasetServiceDataSourceInfo | null = null;
   private lastVerticalChart: boolean | null | undefined = null;
+  // Latest finite annotation values; NaN until real data arrives, which keeps the
+  // min/max/average lines and their labels hidden instead of drawing at a placeholder 0.
+  private lastAverageValue = NaN;
+  private lastMinimumValue = NaN;
+  private lastMaximumValue = NaN;
   protected hasPath = computed<boolean>(() => {
     const cfg = this.runtime.options();
     return !!cfg?.datachartPath;
@@ -140,11 +149,13 @@ export class WidgetDataChartComponent implements OnDestroy {
           this.lastVerticalChart = cfg.verticalChart;
           this.rebuildForDataset(cfg);
         } else if (this.chart) {
-          // Styling / axis / annotation toggles / showAverageData
+          // Styling / axis / annotation toggles / showAverageData. setChartOptions rebuilds the
+          // annotation plugin wholesale, so annotation visibility is re-applied after it — otherwise
+          // an already-enabled avg/min/max line is reset to hidden until the next stream emission.
           this.ensureAverageDatasetPresence();
-          this.updateAnnotationVisibility();
           this.applyDynamicTrackAverageStyling();
           this.setChartOptions(cfg);
+          this.updateAnnotationVisibility();
           this.setDatasetsColors();
           this.ngZone.runOutsideAngular(() => this.chart?.update('none'));
         }
@@ -168,6 +179,9 @@ export class WidgetDataChartComponent implements OnDestroy {
 
     this.streamSub?.unsubscribe(); // Cleanup old subscription & chart data
     this.lineChartData.datasets = [];
+    this.lastAverageValue = NaN;
+    this.lastMinimumValue = NaN;
+    this.lastMaximumValue = NaN;
     this.historyUnavailable.set(false);
 
     // Synthesize the config + cadence the axis/streaming options expect, derived from the widget's
@@ -379,11 +393,11 @@ export class WidgetDataChartComponent implements OnDestroy {
           minimumLine: {
             type: 'line',
             scaleID: cfg.verticalChart ? 'x' : 'y',
-            display: cfg.showDatasetMinimumValueLine,
+            display: false,
             value: undefined,
             drawTime: 'afterDatasetsDraw',
             label: {
-              display: true,
+              display: false,
               position: "start",
               yAdjust: 12,
               padding: 4,
@@ -394,11 +408,11 @@ export class WidgetDataChartComponent implements OnDestroy {
           maximumLine: {
             type: 'line',
             scaleID: cfg.verticalChart ? 'x' : 'y',
-            display: cfg.showDatasetMaximumValueLine,
+            display: false,
             value: undefined,
             drawTime: 'afterDatasetsDraw',
             label: {
-              display: true,
+              display: false,
               position: "start",
               yAdjust: -12,
               padding: 4,
@@ -409,13 +423,13 @@ export class WidgetDataChartComponent implements OnDestroy {
           averageLine: {
             type: 'line',
             scaleID: cfg.verticalChart ? 'x' : 'y',
-            display: cfg.showDatasetAverageValueLine,
+            display: false,
             value: undefined,
             borderDash: [6, 6],
             borderColor: this.getThemeColors().averageChartLine,
             drawTime: 'afterDatasetsDraw',
             label: {
-              display: true,
+              display: false,
               position: "start",
               padding: 4,
               color: this.getThemeColors().chartValue,
@@ -558,11 +572,24 @@ export class WidgetDataChartComponent implements OnDestroy {
   private updateAnnotationVisibility(): void {
     const cfg = this.runtime.options();
     if (!cfg || !this.chart) return;
-    const annCfg = (this.chart.options.plugins as unknown as { annotation?: { annotations?: Record<string, { display?: boolean }> } }).annotation?.annotations;
+    const annCfg = (this.chart.options.plugins as unknown as AnnPlugin).annotation?.annotations;
     if (!annCfg) return;
-    if (annCfg.minimumLine) annCfg.minimumLine.display = cfg.showDatasetMinimumValueLine;
-    if (annCfg.maximumLine) annCfg.maximumLine.display = cfg.showDatasetMaximumValueLine;
-    if (annCfg.averageLine) annCfg.averageLine.display = cfg.showDatasetAverageValueLine;
+    this.applyAnnotationLine(annCfg.minimumLine, cfg.showDatasetMinimumValueLine, this.lastMinimumValue, cfg.numDecimal);
+    this.applyAnnotationLine(annCfg.maximumLine, cfg.showDatasetMaximumValueLine, this.lastMaximumValue, cfg.numDecimal);
+    this.applyAnnotationLine(annCfg.averageLine, cfg.showDatasetAverageValueLine, this.lastAverageValue, cfg.numDecimal);
+  }
+
+  // The line and its label stay hidden until the tracked value is finite, so an enabled line never
+  // renders at a placeholder 0 with an empty label before real data arrives.
+  private applyAnnotationLine(line: AnnLine | undefined, enabled: boolean | undefined, value: number, numDecimal: number | undefined): void {
+    if (!line) return;
+    const visible = Boolean(enabled) && Number.isFinite(value);
+    line.display = visible;
+    line.label.display = visible;
+    if (visible) {
+      line.value = value;
+      line.label.content = value.toFixed(numDecimal);
+    }
   }
 
   private getThemeColors(): IChartColors {
@@ -838,24 +865,11 @@ export class WidgetDataChartComponent implements OnDestroy {
     const lastMinimum = this.unitsService.convertToUnit(unit, point.data.lastMinimum ?? NaN);
     const lastMaximum = this.unitsService.convertToUnit(unit, point.data.lastMaximum ?? NaN);
 
-    const plugins = this.chart.options.plugins as unknown as AnnPlugin;
-    const ann = plugins.annotation?.annotations;
-    if (!ann) return;
+    if (lastAverage !== null && Number.isFinite(lastAverage)) this.lastAverageValue = lastAverage;
+    if (lastMinimum !== null && Number.isFinite(lastMinimum)) this.lastMinimumValue = lastMinimum;
+    if (lastMaximum !== null && Number.isFinite(lastMaximum)) this.lastMaximumValue = lastMaximum;
 
-    if (lastAverage !== null && Number.isFinite(lastAverage) && ann.averageLine?.value !== lastAverage) {
-      ann.averageLine.value = lastAverage;
-      ann.averageLine.label.content = `${lastAverage.toFixed(cfg.numDecimal)}`;
-    }
-
-    if (lastMinimum !== null && Number.isFinite(lastMinimum) && ann.minimumLine?.value !== lastMinimum) {
-      ann.minimumLine.value = lastMinimum;
-      ann.minimumLine.label.content = `${lastMinimum.toFixed(cfg.numDecimal)}`;
-    }
-
-    if (lastMaximum !== null && Number.isFinite(lastMaximum) && ann.maximumLine?.value !== lastMaximum) {
-      ann.maximumLine.value = lastMaximum;
-      ann.maximumLine.label.content = `${lastMaximum.toFixed(cfg.numDecimal)}`;
-    }
+    this.updateAnnotationVisibility();
   }
 
   private transformDatasetRows(rows: IDatasetServiceDatapoint[], datasetType): IDataSetRow[] {

--- a/src/app/widgets/widget-windtrends-chart/widget-windtrends-chart.component.spec.ts
+++ b/src/app/widgets/widget-windtrends-chart/widget-windtrends-chart.component.spec.ts
@@ -17,11 +17,13 @@ vi.mock('chart.js', () => {
   }
   return {
     Chart: MockChart,
+    registerables: [],
     TimeScale: {}, LinearScale: {}, LineController: {}, PointElement: {},
     LineElement: {}, Filler: {}, Title: {}, SubTitle: {}
   };
 });
 vi.mock('chartjs-adapter-date-fns', () => ({}));
+vi.mock('chartjs-plugin-annotation', () => ({ default: {} }));
 vi.mock('@aziham/chartjs-plugin-streaming', () => ({ default: {} }));
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';

--- a/src/app/widgets/widget-windtrends-chart/widget-windtrends-chart.component.ts
+++ b/src/app/widgets/widget-windtrends-chart/widget-windtrends-chart.component.ts
@@ -12,11 +12,11 @@ import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.dir
 import { ITheme } from '../../core/services/app-service';
 import { TimeScaleFormat } from '../../core/interfaces/dataset.interfaces';
 
-import { Chart, ChartConfiguration, ChartData, ChartType, TimeScale, LinearScale, LineController, PointElement, LineElement, Filler, Title, SubTitle, ChartArea, Scale, ChartTypeRegistry } from 'chart.js';
+import { Chart, ChartConfiguration, ChartData, ChartType, ChartArea, Scale, ChartTypeRegistry } from 'chart.js';
 import 'chartjs-adapter-date-fns';
-import ChartStreaming from '@aziham/chartjs-plugin-streaming';
+import { registerChartComponents } from '../../core/utils/chart-registration.util';
 
-Chart.register(ChartStreaming, TimeScale, LinearScale, LineController, PointElement, LineElement, Filler, Title, SubTitle);
+registerChartComponents();
 
 /** Windtrends plots two fixed wind paths (direction + speed) over the widget's configured window. */
 const WINDTRENDS_PERIOD = 30;


### PR DESCRIPTION
## Why
Chart.js was registered per-component in four consumers (data-chart, minichart, windtrends, history-dialog), and the data-chart threshold annotation line/label rendered at a placeholder 0 before finite data arrived (#239).

## How
- One idempotent `registerChartComponents()` (registerables ∪ annotation ∪ streaming) in `src/app/core/utils/chart-registration.util.ts`, called once by each of the four consumers; the per-component `Chart.register` calls are deleted.
- data-chart annotation lines **and** labels start hidden and show only once their tracked value is `Number.isFinite`.

## Verification
- Full vitest suite green locally (1158 tests); `lint` ✓, `betterer:ci` 183 ✓.
- New data-chart specs: a default-enabled line stays hidden with no data, then shows with its value once a finite value streams.

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)
