### PR TITLE
feat(config): migrate older configs on import (Kip→Skip onboarding)

### DIFF
--- a/src/app/core/components/options/configuration/config.component.spec.ts
+++ b/src/app/core/components/options/configuration/config.component.spec.ts
@@ -143,6 +143,36 @@ describe('SettingsConfigComponent', () => {
     expect(toastMock.show).toHaveBeenCalledWith('boom', 0, false, 'error');
   });
 
+  it('reports a migration in the import success toast when the config was migrated', async () => {
+    profileMock.importProfile.mockResolvedValueOnce(true);
+    const file = new File(
+      [JSON.stringify({ app: { configVersion: 11 }, theme: { themeName: '' }, dashboards: [] })],
+      'c.json', { type: 'application/json' });
+    const input = { files: [file], value: 'x' } as unknown as HTMLInputElement;
+
+    component.uploadJsonConfig({ target: input } as unknown as Event);
+
+    await vi.waitFor(() => expect(toastMock.show).toHaveBeenCalled());
+    const [message, , , severity] = toastMock.show.mock.calls.at(-1) ?? [];
+    expect(message).toMatch(/migrat/i);
+    expect(severity).toBe('success');
+  });
+
+  it('omits migration wording in the success toast when no migration was needed', async () => {
+    profileMock.importProfile.mockResolvedValueOnce(false);
+    const file = new File(
+      [JSON.stringify({ app: { configVersion: 13 }, theme: { themeName: '' }, dashboards: [] })],
+      'c.json', { type: 'application/json' });
+    const input = { files: [file], value: 'x' } as unknown as HTMLInputElement;
+
+    component.uploadJsonConfig({ target: input } as unknown as Event);
+
+    await vi.waitFor(() => expect(toastMock.show).toHaveBeenCalled());
+    const message = toastMock.show.mock.calls.at(-1)?.[0] as string;
+    expect(message).toMatch(/imported/i);
+    expect(message).not.toMatch(/migrat/i);
+  });
+
   it('exports the server-held config, never a stale localStorage copy', () => {
     const settings = TestBed.inject(SettingsService) as unknown as {
       getAppConfig: ReturnType<typeof vi.fn>;

--- a/src/app/core/components/options/configuration/config.component.ts
+++ b/src/app/core/components/options/configuration/config.component.ts
@@ -189,12 +189,19 @@ export class SettingsConfigComponent {
             return;
           }
           try {
-            await this.profileService.importProfile(result.name, parsed);
-            this.toast.show(`Profile "${result.name}" imported`, 1000, true, 'success');
+            const migrated = await this.profileService.importProfile(result.name, parsed);
+            const message = migrated
+              ? `Profile "${result.name}" imported and migrated to the current version`
+              : `Profile "${result.name}" imported`;
+            this.toast.show(message, 1000, true, 'success');
           } catch (err) {
             this.reportError(err);
           }
         });
+    };
+    reader.onerror = () => {
+      this.toast.show('Could not read the selected file.', 0, false, 'error');
+      console.error('File read error:', reader.error);
     };
     reader.readAsText(file);
     input.value = '';

--- a/src/app/core/services/configuration-upgrade.service.spec.ts
+++ b/src/app/core/services/configuration-upgrade.service.spec.ts
@@ -1,8 +1,17 @@
 import { TestBed } from '@angular/core/testing';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { ConfigurationUpgradeService } from './configuration-upgrade.service';
+import { ConfigurationUpgradeService, MIN_IMPORTABLE_APP_CONFIG_VERSION } from './configuration-upgrade.service';
 import { StorageService } from './storage.service';
 import { SettingsService } from './settings.service';
+import { IConfig } from '../interfaces/app-settings.interfaces';
+import { LATEST_APP_CONFIG_VERSION } from '../constants/config-versions.const';
+
+const importConfig = (version: unknown): IConfig =>
+    ({
+        app: version === undefined ? {} : { configVersion: version },
+        theme: { themeName: '' },
+        dashboards: []
+    } as unknown as IConfig);
 
 describe('ConfigurationUpgradeService', () => {
     let service: ConfigurationUpgradeService;
@@ -226,6 +235,82 @@ describe('ConfigurationUpgradeService', () => {
         // transformConfig returns null for the app-less slot, so nothing is persisted and
         // the prior config.app.configVersion TypeError no longer fires.
         expect(mockStorage.setConfig).not.toHaveBeenCalled();
+    });
+
+    describe('migrateImportedConfig (in-memory import migration matrix)', () => {
+        it('accepts a current-version config unchanged, running no migration and no slot I/O', () => {
+            const result = service.migrateImportedConfig(importConfig(LATEST_APP_CONFIG_VERSION));
+
+            expect(result.migrated).toBe(false);
+            expect(result.config.app?.configVersion).toBe(LATEST_APP_CONFIG_VERSION);
+            expect(mockStorage.setConfig).not.toHaveBeenCalled();
+            expect(mockStorage.getConfig).not.toHaveBeenCalled();
+            expect(mockStorage.listConfigs).not.toHaveBeenCalled();
+            expect(mockAppSettings.reloadApp).not.toHaveBeenCalled();
+        });
+
+        it('migrates a floor (v11) config up to the current version purely in memory — no slot I/O, no reload', () => {
+            const original = importConfig(MIN_IMPORTABLE_APP_CONFIG_VERSION);
+
+            const result = service.migrateImportedConfig(original);
+
+            expect(result.migrated).toBe(true);
+            expect(result.config.app?.configVersion).toBe(LATEST_APP_CONFIG_VERSION);
+            // The migration must not touch storage or reload the app — that is the reload trap #175 pins.
+            expect(mockStorage.setConfig).not.toHaveBeenCalled();
+            expect(mockStorage.getConfig).not.toHaveBeenCalled();
+            expect(mockStorage.listConfigs).not.toHaveBeenCalled();
+            expect(mockAppSettings.reloadApp).not.toHaveBeenCalled();
+            // The caller's object is left untouched (the chain works on a clone).
+            expect(original.app?.configVersion).toBe(MIN_IMPORTABLE_APP_CONFIG_VERSION);
+        });
+
+        it('migrates an intermediate (v12) config up to the current version', () => {
+            const result = service.migrateImportedConfig(importConfig(12));
+
+            expect(result.migrated).toBe(true);
+            expect(result.config.app?.configVersion).toBe(LATEST_APP_CONFIG_VERSION);
+        });
+
+        it('rejects a below-floor config with a distinct "too old" error and no write', () => {
+            expect(() => service.migrateImportedConfig(importConfig(10))).toThrow(/too old/i);
+            expect(mockStorage.setConfig).not.toHaveBeenCalled();
+        });
+
+        it('rejects a config with no recognizable version with a distinct error and no write', () => {
+            expect(() => service.migrateImportedConfig(importConfig(undefined))).toThrow(/recognizable version/i);
+            expect(mockStorage.setConfig).not.toHaveBeenCalled();
+        });
+
+        it('rejects a too-new config with a distinct "newer" error and no write', () => {
+            expect(() => service.migrateImportedConfig(importConfig(LATEST_APP_CONFIG_VERSION + 1))).toThrow(/newer/i);
+            expect(mockStorage.setConfig).not.toHaveBeenCalled();
+        });
+
+        it('has an upgrade transform for every version from the import floor up to latest (guards future LATEST bumps)', () => {
+            const dispatch = service as unknown as {
+                migrateOneAppVersion(config: IConfig, from: number): IConfig | null;
+            };
+            for (let from = MIN_IMPORTABLE_APP_CONFIG_VERSION; from < LATEST_APP_CONFIG_VERSION; from++) {
+                const upgraded = dispatch.migrateOneAppVersion(importConfig(from), from);
+                // A bump of LATEST_APP_CONFIG_VERSION that forgets to register the new transform lands
+                // here: the dispatch returns null for the now-in-range version, which would make every
+                // current export non-importable through the migration loop.
+                expect(upgraded, `no upgrade transform registered for config version ${from}`).not.toBeNull();
+                expect(upgraded?.app?.configVersion).toBeGreaterThan(from);
+            }
+        });
+
+        it('throws the distinct loop-reject error when an in-range version has no working transform', () => {
+            const dispatch = service as unknown as {
+                migrateOneAppVersion(config: IConfig, from: number): IConfig | null;
+            };
+            vi.spyOn(dispatch, 'migrateOneAppVersion').mockReturnValue(null);
+
+            expect(() => service.migrateImportedConfig(importConfig(MIN_IMPORTABLE_APP_CONFIG_VERSION)))
+                .toThrow(/could not be migrated from version 11/i);
+            expect(mockStorage.setConfig).not.toHaveBeenCalled();
+        });
     });
 
     it('startFresh skips a legacy slot missing its app section and still retires the rest', async () => {

--- a/src/app/core/services/configuration-upgrade.service.ts
+++ b/src/app/core/services/configuration-upgrade.service.ts
@@ -7,7 +7,7 @@ import { v10IConfig, v10IThemeConfig } from '../interfaces/v10-config-interface'
 import { NgGridStackWidget } from 'gridstack/dist/angular';
 import { Dashboard } from './dashboard.service';
 import { LOCAL_CONFIG_KEYS } from '../constants/config-storage.const';
-import { REMOTE_CONFIG_FILE_VERSION } from '../constants/config-versions.const';
+import { LATEST_APP_CONFIG_VERSION, REMOTE_CONFIG_FILE_VERSION } from '../constants/config-versions.const';
 
 // The app-config schema version the legacy v10/v11 transforms produce. Pinned on purpose:
 // bumping LATEST_APP_CONFIG_VERSION must not change what these transforms stamp — a newer
@@ -23,6 +23,20 @@ const V13_MIGRATION_OUTPUT_VERSION = 13;
 // NOTE: This service encapsulates the app-config upgrades — the legacy migration (remote file
 // version 9 / app-config version 10) and the v11 remote upgrade — each stamping the upgraded
 // config with MIGRATION_OUTPUT_VERSION.
+
+/**
+ * Lowest app-config version an uploaded config can be migrated from on import. Deliberately the
+ * fork's own floor: v11 reaches fork-era KIP exports, while the pre-fork v9/v10 localStorage
+ * transforms are dead in Skip's storage namespace and so are out of scope for import.
+ */
+export const MIN_IMPORTABLE_APP_CONFIG_VERSION = 11;
+
+/** Outcome of an in-memory import migration: the ready-to-store config and whether any step ran. */
+export interface ImportedConfigMigration {
+  config: IConfig;
+  migrated: boolean;
+}
+
 @Injectable({ providedIn: 'root' })
 export class ConfigurationUpgradeService {
   private _storage = inject(StorageService);
@@ -131,7 +145,7 @@ export class ConfigurationUpgradeService {
             );
 
             this.pushMsg(`[Upgrade] ${item.scope}/${item.name} -> v${MIGRATION_OUTPUT_VERSION}.`);
-            const migratedConfig = this.upgradeConfig(config);
+            const migratedConfig = this.migrateOneAppVersion(config, 11);
             if (!migratedConfig) continue; // skip if not eligible
 
             this.pushMsg(`[Upgrade] Saving upgraded configurations...`);
@@ -163,7 +177,7 @@ export class ConfigurationUpgradeService {
           try {
             const config = await this._storage.getConfig(item.scope, item.name, REMOTE_CONFIG_FILE_VERSION);
             this.pushMsg(`[Upgrade] ${item.scope}/${item.name} -> v${V13_MIGRATION_OUTPUT_VERSION}.`);
-            const migratedConfig = this.upgradeConfigV12toV13(config);
+            const migratedConfig = this.migrateOneAppVersion(config, 12);
             if (!migratedConfig) continue; // skip if not a v12 slot
 
             await this._storage.setConfig(item.scope, item.name, migratedConfig);
@@ -259,6 +273,54 @@ export class ConfigurationUpgradeService {
       localStorage.removeItem(LOCAL_CONFIG_KEYS.widgetConfig);
       localStorage.removeItem(LOCAL_CONFIG_KEYS.layoutConfig);
       this.upgrading.set(false);
+    }
+  }
+
+  /**
+   * Upgrade an uploaded config to the current app-config version PURELY IN MEMORY — no slot I/O,
+   * no reload. The boot-time paths in runUpgrade() read/write server slots and reload the app;
+   * import must do neither, so this reuses only the per-version transforms against the passed
+   * object. Returns the ready-to-store config and whether any step ran, and throws a distinct,
+   * actionable error for a below-floor, unrecognized, or too-new version. The caller is expected
+   * to have already validated the config's shape.
+   */
+  public migrateImportedConfig(config: IConfig): ImportedConfigMigration {
+    const version = config.app?.configVersion;
+    if (typeof version !== 'number' || !Number.isInteger(version)) {
+      throw new Error('This configuration has no recognizable version number and cannot be imported.');
+    }
+    if (version === LATEST_APP_CONFIG_VERSION) {
+      return { config, migrated: false };
+    }
+    if (version > LATEST_APP_CONFIG_VERSION) {
+      throw new Error(`This configuration is version ${version}, which is newer than this version of KIP supports (version ${LATEST_APP_CONFIG_VERSION}). Update KIP and try again.`);
+    }
+    if (version < MIN_IMPORTABLE_APP_CONFIG_VERSION) {
+      throw new Error(`This configuration is version ${version}, which is too old to import automatically (the minimum is version ${MIN_IMPORTABLE_APP_CONFIG_VERSION}). Load it into an older KIP, export it again, then import it here.`);
+    }
+
+    let working = cloneDeep(config);
+    let current = version;
+    while (current < LATEST_APP_CONFIG_VERSION) {
+      const upgraded = this.migrateOneAppVersion(working, current);
+      const nextVersion = upgraded?.app?.configVersion;
+      if (!upgraded || typeof nextVersion !== 'number' || nextVersion <= current) {
+        throw new Error(`This configuration could not be migrated from version ${current}.`);
+      }
+      working = upgraded;
+      current = nextVersion;
+    }
+    return { config: working, migrated: true };
+  }
+
+  // Single source of truth for the per-version upgrade dispatch: both the boot-time slot upgrades
+  // (runUpgrade) and the in-memory import chain (migrateImportedConfig) route through here, so a new
+  // LATEST_APP_CONFIG_VERSION can only be reached by adding its transform to this one switch.
+  private migrateOneAppVersion(config: IConfig, fromVersion: number): IConfig | null {
+    switch (fromVersion) {
+      case 11: return this.upgradeConfig(config);
+      case 12: return this.upgradeConfigV12toV13(config);
+      default: return null;
     }
   }
 

--- a/src/app/core/services/profile.service.spec.ts
+++ b/src/app/core/services/profile.service.spec.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ProfileService } from './profile.service';
 import { StorageService } from './storage.service';
 import { SettingsService } from './settings.service';
+import { ConfigurationUpgradeService } from './configuration-upgrade.service';
 import { IConfig } from '../interfaces/app-settings.interfaces';
 import { DefaultDashboard } from '../../../default-config/config.blank.dashboard';
 
@@ -47,6 +48,7 @@ describe('ProfileService', () => {
     TestBed.configureTestingModule({
       providers: [
         ProfileService,
+        ConfigurationUpgradeService, // real service: its migrateImportedConfig is pure (no storage/settings I/O)
         { provide: StorageService, useValue: storage },
         { provide: SettingsService, useValue: settings }
       ]
@@ -142,10 +144,21 @@ describe('ProfileService', () => {
   });
 
   describe('import', () => {
-    it('imports a valid config as a new profile (no auto-switch)', async () => {
+    it('imports a current-version config as a new profile (no migration, no auto-switch)', async () => {
       await service.refresh();
-      await service.importProfile('imported', cfg('imp'));
+      const migrated = await service.importProfile('imported', cfg('imp'));
+      expect(migrated).toBe(false);
       expect(storage.setConfig).toHaveBeenCalledWith('user', 'imported', expect.objectContaining({ theme: { themeName: 'imp' } }));
+      expect(settings.setActiveProfile).not.toHaveBeenCalled();
+    });
+
+    it('migrates an older-but-supported config to the current version before writing, and reports it', async () => {
+      await service.refresh();
+      const older = { app: { configVersion: 11 }, theme: { themeName: 'old' }, dashboards: [] };
+      const migrated = await service.importProfile('imported', older);
+      expect(migrated).toBe(true);
+      const written = storage.setConfig.mock.calls.at(-1)?.[2] as IConfig;
+      expect(written.app?.configVersion).toBe(13);
       expect(settings.setActiveProfile).not.toHaveBeenCalled();
     });
 
@@ -155,10 +168,17 @@ describe('ProfileService', () => {
       expect(storage.setConfig).not.toHaveBeenCalled();
     });
 
-    it('rejects a shape-valid config with an unsupported version without writing', async () => {
+    it('rejects a shape-valid but below-floor config without writing', async () => {
       await service.refresh();
       const stale = { app: { configVersion: 9 }, theme: { themeName: 'old' }, dashboards: [] };
-      await expect(service.importProfile('imported', stale)).rejects.toThrow(/version/i);
+      await expect(service.importProfile('imported', stale)).rejects.toThrow(/too old/i);
+      expect(storage.setConfig).not.toHaveBeenCalled();
+    });
+
+    it('rejects a shape-valid config with no recognizable version without writing', async () => {
+      await service.refresh();
+      const versionless = { app: {}, theme: { themeName: 'old' }, dashboards: [] };
+      await expect(service.importProfile('imported', versionless)).rejects.toThrow(/recognizable version/i);
       expect(storage.setConfig).not.toHaveBeenCalled();
     });
 

--- a/src/app/core/services/profile.service.ts
+++ b/src/app/core/services/profile.service.ts
@@ -3,6 +3,7 @@ import { cloneDeep } from 'lodash-es';
 import { IConfig } from '../interfaces/app-settings.interfaces';
 import { StorageService } from './storage.service';
 import { SettingsService } from './settings.service';
+import { ConfigurationUpgradeService } from './configuration-upgrade.service';
 import { defaultConfig } from '../../../default-config/config.blank.const';
 import { DefaultDashboard } from '../../../default-config/config.blank.dashboard';
 import { UUID } from '../utils/uuid.util';
@@ -30,6 +31,7 @@ const PROFILE_SCOPE = 'user';
 export class ProfileService {
   private readonly storage = inject(StorageService);
   private readonly settings = inject(SettingsService);
+  private readonly upgrade = inject(ConfigurationUpgradeService);
 
   private readonly _profiles = signal<IProfileSummary[]>([]);
   public readonly profiles = this._profiles.asReadonly();
@@ -77,23 +79,23 @@ export class ProfileService {
 
   /**
    * Import an arbitrary config as a NEW profile (never overwrites an existing one, never
-   * auto-switches). The config is structurally validated AND its version checked before it is written,
-   * so a shape-valid but unsupported-version file cannot become a switchable, unbootable slot.
+   * auto-switches). The config is structurally validated, then an older-but-supported version is
+   * migrated to the current version PURELY IN MEMORY before it is written — so onboarding an older
+   * Skip or fork-era KIP export never yields a switchable, unbootable slot. Resolves to whether a
+   * migration ran, so the caller can tell the user. Below-floor, unrecognized, and too-new versions
+   * are rejected with distinct, actionable errors.
    */
-  public async importProfile(name: string, config: unknown): Promise<void> {
+  public async importProfile(name: string, config: unknown): Promise<boolean> {
     return this.exclusive(async () => {
       await this.refresh();
       const normalized = this.validateNewName(name);
       if (!this.isValidConfigShape(config)) {
         throw new Error('The selected file is not a valid KIP configuration.');
       }
-      const supported = defaultConfig.app?.configVersion;
-      const version = config.app?.configVersion;
-      if (version !== supported) {
-        throw new Error(`This configuration is version ${version ?? 'unknown'}, but this version of KIP supports version ${supported}. Re-export it from a current KIP and try again.`);
-      }
-      await this.storage.setConfig(PROFILE_SCOPE, normalized, config);
+      const { config: prepared, migrated } = this.upgrade.migrateImportedConfig(config);
+      await this.storage.setConfig(PROFILE_SCOPE, normalized, prepared);
       await this.refresh();
+      return migrated;
     });
   }
 


### PR DESCRIPTION
## Why
Importing a config from an older version hard-rejected, blocking onboarding — including Kip users migrating to Skip (Kip is Skip's prospective user pool) (#175).

## How
- New `ConfigurationUpgradeService.migrateImportedConfig()` runs a **pure in-memory** upgrade chain (no slot I/O, no reload — the pinned trap) from the v11 floor up to current, reusing the existing per-version transforms.
- accept / migrate / reject matrix with distinct error messages; the import success toast notes when a migration ran.

## Verification
- Full vitest suite green locally (1158 tests); `lint` ✓, `betterer:ci` 183 ✓.
- Spec matrix: current = accept; ≥ v11 = migrate; below-floor / unknown / malformed = reject with distinct messages.

Prerequisite for S2-0 (#21). Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)
