### PR TITLE
refactor(settings): retire the *AsO() observable bridges (#79)

### DIFF
--- a/src/app/core/services/notifications.service.spec.ts
+++ b/src/app/core/services/notifications.service.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
-import { BehaviorSubject, Subject } from 'rxjs';
+import { signal, WritableSignal } from '@angular/core';
+import { Subject } from 'rxjs';
 import { describe, expect, it, vi } from 'vitest';
 import { INotification, INotificationInfo, NotificationsService } from './notifications.service';
 import { DataService } from './data.service';
@@ -46,7 +47,7 @@ function makeDelta(path: string, value: ISignalKNotification | null): ISignalKDa
 }
 
 describe('NotificationsService', () => {
-  let configSubject: BehaviorSubject<INotificationConfig>;
+  let configSignal: WritableSignal<INotificationConfig>;
   let notificationMsg$: Subject<ISignalKDataValueUpdate>;
   let notificationMeta$: Subject<IMeta>;
   let isReset$: Subject<boolean>;
@@ -54,15 +55,15 @@ describe('NotificationsService', () => {
   let service: NotificationsService;
 
   function setup(initialConfig: INotificationConfig = makeConfig()): void {
-    configSubject = new BehaviorSubject<INotificationConfig>(initialConfig);
+    configSignal = signal<INotificationConfig>(initialConfig);
     notificationMsg$ = new Subject<ISignalKDataValueUpdate>();
     notificationMeta$ = new Subject<IMeta>();
     isReset$ = new Subject<boolean>();
     putRequest = vi.fn().mockReturnValue(null);
 
     const settingsStub: Partial<SettingsService> = {
-      getNotificationServiceConfigAsO: () => configSubject.asObservable(),
-      getNotificationConfig: () => configSubject.value,
+      notificationConfig: configSignal,
+      getNotificationConfig: () => configSignal(),
     };
     const dataStub: Partial<DataService> = {
       getNotificationMsgObservable: () => notificationMsg$.asObservable(),
@@ -140,7 +141,8 @@ describe('NotificationsService', () => {
       notificationMsg$.next(makeDelta('notifications.ok', makeValue(States.Normal, [Methods.Visual, Methods.Sound])));
       expect(latestInfo().alarmCount).toBe(0);
 
-      configSubject.next(makeConfig({ showNormalState: true }));
+      configSignal.set(makeConfig({ showNormalState: true }));
+      TestBed.tick();
       expect(latestInfo().alarmCount).toBe(1);
     });
 
@@ -149,7 +151,8 @@ describe('NotificationsService', () => {
       notificationMsg$.next(makeDelta('notifications.fine', makeValue(States.Nominal, [Methods.Visual, Methods.Sound])));
       expect(latestInfo().alarmCount).toBe(0);
 
-      configSubject.next(makeConfig({ showNominalState: true }));
+      configSignal.set(makeConfig({ showNominalState: true }));
+      TestBed.tick();
       expect(latestInfo().alarmCount).toBe(1);
     });
 
@@ -323,7 +326,8 @@ describe('NotificationsService', () => {
       notificationMsg$.next(makeDelta('notifications.a', makeValue(States.Emergency, [Methods.Visual, Methods.Sound])));
       expect(activeTrack()).toBe(1004);
 
-      configSubject.next(makeConfig({ disableSound: true }));
+      configSignal.set(makeConfig({ disableSound: true }));
+      TestBed.tick();
       expect(activeTrack()).toBe(1000);
 
       notificationMsg$.next(makeDelta('notifications.b', makeValue(States.Alarm, [Methods.Visual, Methods.Sound])));
@@ -336,11 +340,22 @@ describe('NotificationsService', () => {
       setup();
       let observed: INotificationConfig | undefined;
       service.observeNotificationConfiguration().subscribe(c => observed = c);
-      expect(observed).toBe(configSubject.value);
+      expect(observed).toBe(configSignal());
 
       const next = makeConfig({ showNormalState: true });
-      configSubject.next(next);
+      configSignal.set(next);
+      TestBed.tick();
       expect(observed).toBe(next);
+    });
+
+    it('does not re-apply the seeded config on the effect first flush (reference guard)', () => {
+      setup();
+      let emissions = 0;
+      service.observeNotificationConfiguration().subscribe(() => emissions++);
+      // The seed applied once at construction; the effect first flush re-reads the same config and
+      // the reference guard must skip it — no duplicate config emission.
+      TestBed.tick();
+      expect(emissions).toBe(1);
     });
 
     it('disabling notifications clears the list and detaches the stream', () => {
@@ -348,7 +363,8 @@ describe('NotificationsService', () => {
       notificationMsg$.next(makeDelta('notifications.a', makeValue(States.Alarm, [Methods.Visual, Methods.Sound])));
       expect(latestNotifications()).toHaveLength(1);
 
-      configSubject.next(makeConfig({ disableNotifications: true }));
+      configSignal.set(makeConfig({ disableNotifications: true }));
+      TestBed.tick();
       expect(latestNotifications()).toHaveLength(0);
       expect(latestInfo()).toMatchObject({ audioSev: 0, visualSev: 0, alarmCount: 0 });
 
@@ -361,7 +377,8 @@ describe('NotificationsService', () => {
       notificationMsg$.next(makeDelta('notifications.a', makeValue(States.Alarm, [Methods.Visual, Methods.Sound])));
       expect(latestNotifications()).toHaveLength(0);
 
-      configSubject.next(makeConfig());
+      configSignal.set(makeConfig());
+      TestBed.tick();
       notificationMsg$.next(makeDelta('notifications.b', makeValue(States.Alarm, [Methods.Visual, Methods.Sound])));
       expect(latestNotifications()).toHaveLength(1);
     });

--- a/src/app/core/services/notifications.service.ts
+++ b/src/app/core/services/notifications.service.ts
@@ -1,7 +1,7 @@
 /**
  * This Service handles app notifications sent by the Signal K server.
  */
-import { Injectable, OnDestroy, inject } from '@angular/core';
+import { Injectable, OnDestroy, effect, inject } from '@angular/core';
 import { BehaviorSubject, map, Observable, Subscription } from 'rxjs';
 import { SettingsService } from "./settings.service";
 import { ToastService } from './toast.service';
@@ -63,7 +63,6 @@ export class NotificationsService implements OnDestroy {
     emergency: { sound: 4, visual: 2 },
   };
 
-  private _notificationSettingsSubscription: Subscription;
   private _notificationDataStreamSubscription: Subscription | null = null;
   private _notificationMetaStreamSubscription: Subscription | null = null;
   private _resetServiceSubscription: Subscription;
@@ -84,24 +83,10 @@ export class NotificationsService implements OnDestroy {
   private _lastEmittedValue: IAlarmInfo | null = null;
 
   constructor() {
-    this._notificationSettingsSubscription = this.settings.getNotificationServiceConfigAsO()
-      .subscribe((config: INotificationConfig) => {
-        this._notificationConfig = config;
-        this.reset();
-        this._notificationConfig$.next(config);
-        if (this._notificationConfig.disableNotifications && !this._notificationDataStreamSubscription?.closed) {
-          this.stopNotificationStream();
-        }
-        if (!this._notificationConfig.disableNotifications &&
-          (this._notificationDataStreamSubscription === null || this._notificationDataStreamSubscription?.closed)) {
-          this.startNotificationStream();
-        }
-        if (this._notificationConfig.sound.disableSound) {
-          this.playAlarm(1000);
-        } else {
-          this.updateNotificationsState();
-        }
-      });
+    // Seed synchronously so the alarm streams and state are configured in the same tick as
+    // construction (the former BehaviorSubject.subscribe fired synchronously), then track changes.
+    this.applyNotificationConfig(this.settings.notificationConfig());
+    effect(() => this.applyNotificationConfig(this.settings.notificationConfig()));
 
     this._resetServiceSubscription = this.data.isResetService().subscribe(reset => {
       if (reset) this.reset();
@@ -109,6 +94,27 @@ export class NotificationsService implements OnDestroy {
 
     // Pre-cache silent track player
     this.getPlayer(1000);
+  }
+
+  private applyNotificationConfig(config: INotificationConfig): void {
+    // The driving effect re-runs once on creation with the already-seeded config; skip that exact
+    // repeat (reference match) so construction does not apply the same config twice.
+    if (config === this._notificationConfig) return;
+    this._notificationConfig = config;
+    this.reset();
+    this._notificationConfig$.next(config);
+    if (this._notificationConfig.disableNotifications && !this._notificationDataStreamSubscription?.closed) {
+      this.stopNotificationStream();
+    }
+    if (!this._notificationConfig.disableNotifications &&
+      (this._notificationDataStreamSubscription === null || this._notificationDataStreamSubscription?.closed)) {
+      this.startNotificationStream();
+    }
+    if (this._notificationConfig.sound.disableSound) {
+      this.playAlarm(1000);
+    } else {
+      this.updateNotificationsState();
+    }
   }
 
   private startNotificationStream() {
@@ -403,7 +409,6 @@ export class NotificationsService implements OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this._notificationSettingsSubscription?.unsubscribe();
     this._resetServiceSubscription?.unsubscribe();
     this._notificationDataStreamSubscription?.unsubscribe();
     this._notificationMetaStreamSubscription?.unsubscribe();

--- a/src/app/core/services/settings.service.spec.ts
+++ b/src/app/core/services/settings.service.spec.ts
@@ -8,7 +8,6 @@ import { ensureLocalStorage } from '../../../test-helpers/local-storage.test-hel
 import { DefaultAppConfig, DefaultConnectionConfig, DefaultThemeConfig } from '../../../default-config/config.blank.const';
 import { IAppConfig, IConfig, IConnectionConfig, INotificationConfig, IThemeConfig } from '../interfaces/app-settings.interfaces';
 import { LATEST_APP_CONFIG_VERSION, CONNECTION_CONFIG_VERSION } from '../constants/config-versions.const';
-import { IUnitDefaults } from './units.service';
 import { Dashboard } from './dashboard.service';
 
 interface DefaultConfigGetters {
@@ -672,34 +671,24 @@ describe('SettingsService — getDefault* localStorage side effects (characteriz
   });
 });
 
-describe('SettingsService — retained observable bridges (units/notifications)', () => {
-  // The two bridges kept for the remaining .subscribe() consumers (units.service,
-  // notifications.service — removed by #79) must replay the current value synchronously to a
-  // fresh subscriber: notifications.service dereferences the emitted config in the same tick.
-  it('a fresh subscriber receives the current value synchronously from both bridges', () => {
+describe('SettingsService — units/notifications reactive signals', () => {
+  // The remaining .subscribe() consumers (units.service, notifications.service) read these signals
+  // directly (#79 retired the observable bridges), so the write path must keep them current.
+  it('exposes the hydrated units and notification config via signals', () => {
     const { service } = setupHydrated({ app: loadedAppConfig(), theme: null, dashboards: [] });
 
-    let units: IUnitDefaults | undefined;
-    service.getDefaultUnitsAsO().subscribe((v) => { units = v; }).unsubscribe();
-    expect(units).toEqual({ Speed: 'knots' });
-
-    let notif: INotificationConfig | undefined;
-    service.getNotificationServiceConfigAsO().subscribe((v) => { notif = v; }).unsubscribe();
-    expect(notif).toEqual(fullNotificationConfig());
+    expect(service.unitDefaults()).toEqual({ Speed: 'knots' });
+    expect(service.notificationConfig()).toEqual(fullNotificationConfig());
   });
 
-  it('the bridges are fed by the write path: a post-write fresh subscriber sees the new value synchronously', () => {
+  it('the write path updates the units and notification signals', () => {
     const { service } = setupHydrated({ app: loadedAppConfig(), theme: null, dashboards: [] });
 
     service.setDefaultUnits({ Speed: 'kph' });
-    let units: IUnitDefaults | undefined;
-    service.getDefaultUnitsAsO().subscribe((v) => { units = v; }).unsubscribe();
-    expect(units).toEqual({ Speed: 'kph' });
+    expect(service.unitDefaults()).toEqual({ Speed: 'kph' });
 
     const updated = { ...fullNotificationConfig(), menuGrouping: false };
     service.setNotificationConfig(updated);
-    let notif: INotificationConfig | undefined;
-    service.getNotificationServiceConfigAsO().subscribe((v) => { notif = v; }).unsubscribe();
-    expect(notif).toEqual(updated);
+    expect(service.notificationConfig()).toEqual(updated);
   });
 });

--- a/src/app/core/services/settings.service.ts
+++ b/src/app/core/services/settings.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { BehaviorSubject, Observable, filter } from 'rxjs';
+import { filter } from 'rxjs';
 import { HttpErrorResponse } from '@angular/common/http';
 import { cloneDeep } from 'lodash-es';
 
@@ -47,13 +47,6 @@ export class SettingsService {
   public readonly isRemoteControl = this._isRemoteControl.asReadonly();
   public readonly instanceName = this._instanceName.asReadonly();
   public readonly browserTabTitle = this._browserTabTitle.asReadonly();
-
-  // Observable bridges for the two remaining .subscribe() consumers (units.service,
-  // notifications.service — removed by #79). A fresh subscriber must receive the current value
-  // synchronously (notifications.service dereferences it in the same tick), which bare
-  // toObservable(signal) does not provide, so the write path feeds these alongside the signals.
-  private readonly unitDefaults$ = new BehaviorSubject<IUnitDefaults>(this._unitDefaults());
-  private readonly notificationConfig$ = new BehaviorSubject<INotificationConfig>(this._notificationConfig());
 
   public proxyEnabled = false;
   public signalKSubscribeAll = false;
@@ -266,16 +259,12 @@ export class SettingsService {
     }
   }
 
-  // Update the two bridged values through one point so the signal and its observable bridge can
-  // never diverge.
   private applyUnitDefaults(value: IUnitDefaults): void {
     this._unitDefaults.set(value);
-    this.unitDefaults$.next(value);
   }
 
   private applyNotificationConfig(value: INotificationConfig): void {
     this._notificationConfig.set(value);
-    this.notificationConfig$.next(value);
   }
 
   /**
@@ -292,9 +281,6 @@ export class SettingsService {
   }
 
   //UnitDefaults
-  public getDefaultUnitsAsO(): Observable<IUnitDefaults> {
-    return this.unitDefaults$.asObservable();
-  }
   public getDefaultUnits(): IUnitDefaults {
     return this.unitDefaults();
   }
@@ -447,9 +433,6 @@ export class SettingsService {
   }
 
   // Notification Service Setting
-  public getNotificationServiceConfigAsO(): Observable<INotificationConfig> {
-    return this.notificationConfig$.asObservable();
-  }
   public getNotificationConfig(): INotificationConfig {
     return this.notificationConfig();
   }

--- a/src/app/core/services/units.service.spec.ts
+++ b/src/app/core/services/units.service.spec.ts
@@ -1,0 +1,37 @@
+import { TestBed } from '@angular/core/testing';
+import { describe, expect, it } from 'vitest';
+import { signal, WritableSignal } from '@angular/core';
+import { UnitsService, IUnitDefaults } from './units.service';
+import { SettingsService } from './settings.service';
+import { DataService } from './data.service';
+
+describe('UnitsService', () => {
+  let unitDefaults: WritableSignal<IUnitDefaults>;
+
+  function setup(initial: IUnitDefaults): UnitsService {
+    unitDefaults = signal<IUnitDefaults>(initial);
+    const settingsStub: Partial<SettingsService> = { unitDefaults };
+    TestBed.configureTestingModule({
+      providers: [
+        UnitsService,
+        { provide: SettingsService, useValue: settingsStub },
+        { provide: DataService, useValue: {} },
+      ],
+    });
+    return TestBed.inject(UnitsService);
+  }
+
+  it('seeds the default units synchronously at construction', () => {
+    const service = setup({ Speed: 'knots' });
+    expect(service.getDefaults()).toEqual({ Speed: 'knots' });
+  });
+
+  it('tracks a runtime change to the default units through the effect', () => {
+    const service = setup({ Speed: 'knots' });
+
+    unitDefaults.set({ Speed: 'kph' });
+    TestBed.tick();
+
+    expect(service.getDefaults()).toEqual({ Speed: 'kph' });
+  });
+});

--- a/src/app/core/services/units.service.ts
+++ b/src/app/core/services/units.service.ts
@@ -1,9 +1,8 @@
 import { DataService } from './data.service';
-import { Injectable, OnDestroy, inject } from '@angular/core';
+import { Injectable, effect, inject } from '@angular/core';
 import Qty from 'js-quantities';
 
 import { SettingsService } from './settings.service';
-import { Subscription } from 'rxjs';
 
 /**
  * All valid Signal K numeric units supported by KIP.
@@ -99,11 +98,10 @@ type UnitConverter = (v: any) => any;
 
 @Injectable()
 
-export class UnitsService implements OnDestroy {
+export class UnitsService {
   private SettingsService = inject(SettingsService);
   private data = inject(DataService);
 
-  private _defaultUnitsSub: Subscription;
 
   /**
    * Definition of available Kip units to be used for conversion.
@@ -452,11 +450,12 @@ export class UnitsService implements OnDestroy {
   private _defaultUnits: IUnitDefaults = {};
 
   constructor() {
-      this._defaultUnitsSub = this.SettingsService.getDefaultUnitsAsO().subscribe(
-        appSettings => {
-          this._defaultUnits = appSettings;
-        }
-      );
+    // Seed synchronously (the former BehaviorSubject replayed its value on subscribe), then keep
+    // it current. The effect's initial run re-assigns the same value, which is a harmless no-op.
+    this._defaultUnits = this.SettingsService.unitDefaults();
+    effect(() => {
+      this._defaultUnits = this.SettingsService.unitDefaults();
+    });
   }
 
   private unitConversionFunctions: Record<string, UnitConverter> = {
@@ -704,7 +703,4 @@ export class UnitsService implements OnDestroy {
     }
   }
 
-  ngOnDestroy(): void {
-    this._defaultUnitsSub?.unsubscribe();
-  }
 }


### PR DESCRIPTION
## What & why
Packet D1 of the #257 backlog. The settings-store rewrite (#17) left two `BehaviorSubject` bridges — `getDefaultUnitsAsO()` and `getNotificationServiceConfigAsO()` — as a transitional API over the `unitDefaults` / `notificationConfig` signals. This retires them: their only two consumers now read the signals directly.

## Changes
- **units.service** — `_defaultUnits` seeds synchronously (matching the former `BehaviorSubject` replay) and tracks changes via `effect()`. Drops the subscription + `OnDestroy`.
- **notifications.service** — config applied synchronously at construction (preserving the same-tick stream-setup contract), then tracked via `effect()`. A reference-equality guard skips the effect's redundant initial run while still applying a config that changed before the first flush.
- **settings.service** — the two subjects, their write-path `.next()` mirroring, and both getters are deleted.
- Specs updated: the notifications spec stubs the config as a signal and flushes effects with `TestBed.tick()`; the settings spec asserts the signals directly.

## Verification
Local `npm run ci` green: lint, betterer:ci (183 issues, unchanged), 1161 vitest, 7 plugin.

Closes #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
