### PR TITLE
fix(notifications): clear stale alarms on reconnect; exclude unknown states from count (#151)

### DIFF
--- a/src/app/core/services/notifications.service.spec.ts
+++ b/src/app/core/services/notifications.service.spec.ts
@@ -6,6 +6,7 @@ import { INotification, INotificationInfo, NotificationsService } from './notifi
 import { DataService } from './data.service';
 import { SettingsService } from './settings.service';
 import { SignalkRequestsService } from './signalk-requests.service';
+import { ConnectionState, ConnectionStateMachine } from './connection-state-machine.service';
 import { INotificationConfig } from '../interfaces/app-settings.interfaces';
 import { ISignalKDataValueUpdate, ISignalKNotification, ISkMetadata, Methods, States, TMethod, TState } from '../interfaces/signalk-interfaces';
 import { IMeta } from '../interfaces/app-interfaces';
@@ -50,7 +51,7 @@ describe('NotificationsService', () => {
   let configSignal: WritableSignal<INotificationConfig>;
   let notificationMsg$: Subject<ISignalKDataValueUpdate>;
   let notificationMeta$: Subject<IMeta>;
-  let isReset$: Subject<boolean>;
+  let connectionState$: Subject<ConnectionState>;
   let putRequest: ReturnType<typeof vi.fn>;
   let service: NotificationsService;
 
@@ -58,7 +59,7 @@ describe('NotificationsService', () => {
     configSignal = signal<INotificationConfig>(initialConfig);
     notificationMsg$ = new Subject<ISignalKDataValueUpdate>();
     notificationMeta$ = new Subject<IMeta>();
-    isReset$ = new Subject<boolean>();
+    connectionState$ = new Subject<ConnectionState>();
     putRequest = vi.fn().mockReturnValue(null);
 
     const settingsStub: Partial<SettingsService> = {
@@ -68,7 +69,6 @@ describe('NotificationsService', () => {
     const dataStub: Partial<DataService> = {
       getNotificationMsgObservable: () => notificationMsg$.asObservable(),
       getNotificationMetaObservable: () => notificationMeta$.asObservable(),
-      isResetService: () => isReset$.asObservable(),
     };
     const requestsStub: Partial<SignalkRequestsService> = {
       putRequest: putRequest as SignalkRequestsService['putRequest'],
@@ -79,6 +79,7 @@ describe('NotificationsService', () => {
         { provide: SettingsService, useValue: settingsStub },
         { provide: DataService, useValue: dataStub },
         { provide: SignalkRequestsService, useValue: requestsStub },
+        { provide: ConnectionStateMachine, useValue: { state$: connectionState$.asObservable() } },
       ],
     });
     service = TestBed.inject(NotificationsService);
@@ -156,11 +157,11 @@ describe('NotificationsService', () => {
       expect(latestInfo().alarmCount).toBe(1);
     });
 
-    it('counts notifications with an unknown state at zero severity', () => {
+    it('excludes notifications with an unknown state from the alarm count', () => {
       setup();
       notificationMsg$.next(makeDelta('notifications.odd', makeValue('bogus' as TState, [Methods.Visual, Methods.Sound])));
 
-      expect(latestInfo()).toEqual({ audioSev: 0, visualSev: 0, alarmCount: 1, isMuted: false, isWarn: false, isAlarmEmergency: false });
+      expect(latestInfo()).toEqual({ audioSev: 0, visualSev: 0, alarmCount: 0, isMuted: false, isWarn: false, isAlarmEmergency: false });
     });
   });
 
@@ -384,17 +385,42 @@ describe('NotificationsService', () => {
     });
   });
 
-  describe('reset signal from DataService', () => {
-    // Pins current behavior: reset() only clears the list when notifications
-    // are disabled, so a data-service reset leaves enabled notifications intact.
-    it('keeps existing notifications on reset while notifications are enabled', () => {
+  describe('clear on connection reconnect', () => {
+    it('keeps alarms across a drop, clears them on reconnect, and repopulates from the fresh snapshot', () => {
       setup();
+      connectionState$.next(ConnectionState.Connected);
       notificationMsg$.next(makeDelta('notifications.a', makeValue(States.Alarm, [Methods.Visual, Methods.Sound])));
+      expect(latestNotifications()).toHaveLength(1);
+      expect(activeTrack()).toBe(1003);
 
-      isReset$.next(true);
-
+      // A drop alone must NOT clear: the last-known alarm stays visible (and sounding) during the outage.
+      connectionState$.next(ConnectionState.Disconnected);
       expect(latestNotifications()).toHaveLength(1);
       expect(latestInfo().alarmCount).toBe(1);
+      expect(activeTrack()).toBe(1003);
+
+      // Reconnect clears the carried-over list and silences its audio so nothing stale lingers...
+      connectionState$.next(ConnectionState.Connected);
+      expect(latestNotifications()).toHaveLength(0);
+      expect(latestInfo().alarmCount).toBe(0);
+      expect(activeTrack()).toBe(1000);
+
+      // ...then the fresh server snapshot re-delivers a still-active alarm, which reappears (#275).
+      notificationMsg$.next(makeDelta('notifications.a', makeValue(States.Alarm, [Methods.Visual, Methods.Sound])));
+      expect(latestNotifications()).toHaveLength(1);
+      expect(latestInfo().alarmCount).toBe(1);
+      expect(activeTrack()).toBe(1003);
+    });
+
+    it('does not clear notifications while the connection stays up', () => {
+      setup();
+      connectionState$.next(ConnectionState.Connected);
+      notificationMsg$.next(makeDelta('notifications.a', makeValue(States.Alarm, [Methods.Visual, Methods.Sound])));
+
+      // A repeated Connected emission without an intervening drop must not clear.
+      connectionState$.next(ConnectionState.Connected);
+
+      expect(latestNotifications()).toHaveLength(1);
     });
   });
 

--- a/src/app/core/services/notifications.service.ts
+++ b/src/app/core/services/notifications.service.ts
@@ -9,6 +9,7 @@ import { INotificationConfig } from '../interfaces/app-settings.interfaces';
 import { DefaultNotificationConfig } from '../../../default-config/config.blank.notification.const';
 import { SignalkRequestsService } from './signalk-requests.service';
 import { DataService } from './data.service';
+import { ConnectionState, ConnectionStateMachine } from './connection-state-machine.service';
 import { isEqual } from 'lodash-es';
 import { UUID } from '../utils/uuid.util';
 import { TMethod, ISignalKDataValueUpdate, ISkMetadata, ISignalKNotification, States, Methods } from '../interfaces/signalk-interfaces';
@@ -53,6 +54,7 @@ export class NotificationsService implements OnDestroy {
   private audioBlockedNotificationShown = false;
   private data = inject(DataService);
   private requests = inject(SignalkRequestsService);
+  private connectionStateMachine = inject(ConnectionStateMachine);
 
   private static readonly ALARM_SEVERITIES: IAlarmSeverities = {
     normal: { sound: 0, visual: 0 },
@@ -65,7 +67,8 @@ export class NotificationsService implements OnDestroy {
 
   private _notificationDataStreamSubscription: Subscription | null = null;
   private _notificationMetaStreamSubscription: Subscription | null = null;
-  private _resetServiceSubscription: Subscription;
+  private _connectionResetSubscription: Subscription;
+  private _wasConnected = false;
 
   private _notificationConfig: INotificationConfig;
   private _notificationConfig$ = new BehaviorSubject<INotificationConfig>(DefaultNotificationConfig);
@@ -88,8 +91,18 @@ export class NotificationsService implements OnDestroy {
     this.applyNotificationConfig(this.settings.notificationConfig());
     effect(() => this.applyNotificationConfig(this.settings.notificationConfig()));
 
-    this._resetServiceSubscription = this.data.isResetService().subscribe(reset => {
-      if (reset) this.reset();
+    this._connectionResetSubscription = this.connectionStateMachine.state$.subscribe(state => {
+      const connected = state === ConnectionState.Connected;
+      // On a (re)connection, drop notifications carried over from the previous session so stale
+      // alarms from a dropped or switched connection cannot linger. A drop alone does NOT clear —
+      // the last-known alarms stay visible through the outage. This is a blind clear that relies on
+      // the Signal K server re-delivering still-active notifications in its post-resubscribe snapshot
+      // (standard signalk-server behaviour) to repopulate them. Hardening the transient blank/audio
+      // restart into a reconcile (mark-stale + sweep) is tracked in #275.
+      if (connected && !this._wasConnected) {
+        this.clearNotifications();
+      }
+      this._wasConnected = connected;
     });
 
     // Pre-cache silent track player
@@ -132,10 +145,18 @@ export class NotificationsService implements OnDestroy {
   }
 
   private reset() {
+    // Clears the list ONLY when notifications are disabled (a #147-pinned behaviour); otherwise it
+    // just recomputes the aggregate. Distinct from clearNotifications(), which always clears.
     if (this._notificationConfig.disableNotifications) {
       this._notifications = [];
       this._notifications$.next([]);
     }
+    this.updateNotificationsState();
+  }
+
+  private clearNotifications(): void {
+    this._notifications = [];
+    this._notifications$.next([]);
     this.updateNotificationsState();
   }
 
@@ -198,6 +219,11 @@ export class NotificationsService implements OnDestroy {
 
       if ((alarm.value['state'] === States.Normal && !this._notificationConfig.devices.showNormalState) ||
           (alarm.value['state'] === States.Nominal && !this._notificationConfig.devices.showNominalState)) {
+        continue;
+      }
+
+      // An unrecognized state contributes no severity; it must not inflate the alarm count either.
+      if (!NotificationsService.ALARM_SEVERITIES[alarm.value['state']]) {
         continue;
       }
 
@@ -409,7 +435,7 @@ export class NotificationsService implements OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this._resetServiceSubscription?.unsubscribe();
+    this._connectionResetSubscription?.unsubscribe();
     this._notificationDataStreamSubscription?.unsubscribe();
     this._notificationMetaStreamSubscription?.unsubscribe();
 


### PR DESCRIPTION
## What & why
Packet B4 of the #257 backlog — two notifications defects from the #147 characterization pass (boat-safety: stale/phantom alarms erode trust in the alarm panel).

## Changes
- **Stale alarms survived a connection reset.** The old clear path subscribed to `DataService.isResetService()`, which is **dead** — `resetSignalKData()` has no caller, so it never fired (that's why `reset()`'s conditional clear never helped). Per the #257 Gate A decision, the dead subscription is removed and `NotificationsService` now clears its list on a **connection reconnect** (`ConnectionStateMachine.state$` transitioning back into `Connected`). Alarms from a dropped or switched connection can no longer linger; fresh deltas repopulate.
- **Unknown-state notifications inflated `alarmCount`.** `activeNotifications` was incremented *before* the state was validated. An unrecognized state (`!ALARM_SEVERITIES[state]`) now skips the count — it already contributed zero severity. Known zero-severity states (`normal`/`nominal`, when shown) still count, unchanged.

## Tests
Both #147 characterization tests flipped: unknown-state count `1 → 0`; the DataService-reset test replaced by reconnect-clear tests (drops stale on reconnect; no clear while the connection stays up).

## Verification
Local `npm run ci` green (lint · betterer 183 · full vitest suite · 7 plugin).

Closes #151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
