### PR TITLE
refactor(windsteer): fix swapped layline ids; extract dialPoint helper (#220)

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -163,7 +163,7 @@ exports[`strictNullChecks`] = {
       [42, 57, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"],
       [43, 57, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"]
     ],
-    "src/app/widgets/svg-windsteer/svg-windsteer.component.ts:3559272095": [
+    "src/app/widgets/svg-windsteer/svg-windsteer.component.ts:2551054731": [
       [28, 59, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"],
       [40, 50, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"],
       [45, 46, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"],

--- a/src/app/widgets/svg-windsteer/svg-windsteer.component.svg
+++ b/src/app/widgets/svg-windsteer/svg-windsteer.component.svg
@@ -555,11 +555,11 @@
       </g>
       <!-- Moved inside rotating dial so they rotate passively with the boat -->
       <g id="LayerLayline" [style.display]="closeHauledLineEnabled() && trueWindActive() ? 'inline' : 'none'">
-        <path id="PortLayline"
+        <path id="StbdLayline"
           [attr.d]="closeHauledLineStbdPath()"
           style="fill:none;stroke-width:5;stroke-dasharray:40, 20;stroke-dashoffset:0;stroke-opacity:0.6"
           class="laylines" />
-        <path id="StbdLayline"
+        <path id="PortLayline"
           [attr.d]="closeHauledLinePortPath()"
           class="laylines"
           style="fill:none;stroke-width:5;stroke-dasharray:40, 20;stroke-dashoffset:0;stroke-opacity:0.6" />

--- a/src/app/widgets/svg-windsteer/svg-windsteer.component.ts
+++ b/src/app/widgets/svg-windsteer/svg-windsteer.component.ts
@@ -362,10 +362,19 @@ export class SvgWindsteerComponent implements OnDestroy {
     if (isPort) this.portLaylineAnimId = id; else this.stbdLaylineAnimId = id;
   }
 
-  private drawLayline(angleDeg: number, isPort: boolean) {
+  /** Project a dial angle (degrees, 0 = up) onto the dial circle. Unrounded; callers round if needed. */
+  private dialPoint(angleDeg: number): [number, number] {
     const radian = (angleDeg * Math.PI) / 180;
-    const x = Math.floor(this.RADIUS * Math.sin(radian) + this.CENTER);
-    const y = Math.floor((this.RADIUS * Math.cos(radian) * -1) + this.CENTER);
+    return [
+      this.RADIUS * Math.sin(radian) + this.CENTER,
+      (this.RADIUS * Math.cos(radian) * -1) + this.CENTER,
+    ];
+  }
+
+  private drawLayline(angleDeg: number, isPort: boolean) {
+    const [px, py] = this.dialPoint(angleDeg);
+    const x = Math.floor(px);
+    const y = Math.floor(py);
     if (isPort) {
       this.closeHauledLinePortPath.set(`M ${this.CENTER},${this.CENTER} L ${x},${y}`);
     } else {
@@ -530,12 +539,9 @@ export class SvgWindsteerComponent implements OnDestroy {
     const midAngle = this.toDialLocal(this.addHeading(this.addHeading(state.mid, -heading), offset));
     const maxAngle = this.toDialLocal(this.addHeading(this.addHeading(state.max, -heading), offset));
 
-    const minX = this.RADIUS * Math.sin((minAngle * Math.PI) / 180) + this.CENTER;
-    const minY = (this.RADIUS * Math.cos((minAngle * Math.PI) / 180) * -1) + this.CENTER;
-    const midX = this.RADIUS * Math.sin((midAngle * Math.PI) / 180) + this.CENTER;
-    const midY = (this.RADIUS * Math.cos((midAngle * Math.PI) / 180) * -1) + this.CENTER;
-    const maxX = this.RADIUS * Math.sin((maxAngle * Math.PI) / 180) + this.CENTER;
-    const maxY = (this.RADIUS * Math.cos((maxAngle * Math.PI) / 180) * -1) + this.CENTER;
+    const [minX, minY] = this.dialPoint(minAngle);
+    const [midX, midY] = this.dialPoint(midAngle);
+    const [maxX, maxY] = this.dialPoint(maxAngle);
 
     const largeArcFlag = Math.abs(angle([minX, minY], [midX, midY], [maxX, maxY])) > Math.PI / 2 ? 0 : 1;
     const sweepFlag = angle([maxX, maxY], [minX, minY], [midX, midY]) > 0 ? 0 : 1;


### PR DESCRIPTION
## What & why
Packet H5 of the #257 backlog — two pre-existing P3 maintainability items in `svg-windsteer.component`, surfaced during the #219 review. No behavior change intended (the geometry spec pins the projection values; layline render is boat-verify).

## Changes
- **Swapped layline ids:** `id="PortLayline"` bound `closeHauledLineStbdPath()` and `id="StbdLayline"` bound `closeHauledLinePortPath()` — each id named the opposite side from the path it renders (a debugging trap; rendering was already correct on-device). Renamed the ids to match their bound paths; the `[attr.d]` bindings are unchanged. No SCSS/TS references these ids (they style via `class="laylines"`).
- **Deduplicated dial projection:** the polar→cartesian `RADIUS·sin / ·cos + CENTER` projection was written four times (once in `drawLayline`, three inline in `computeSectorPath`). Extracted a single `dialPoint(angleDeg): [number, number]` returning unrounded coordinates; `drawLayline` keeps its `Math.floor` at the call site, `computeSectorPath` uses the raw values exactly as before.

## Verification
Local `npm run ci` green (lint · betterer 183, regenerated · full vitest incl. 11 windsteer geometry tests · 7 plugin). Layline render batched into the Stage-1 boat-verify session.

Closes #220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
