### PR TITLE
feat(units): render consistent unit symbols everywhere via a central resolver (#245)

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -219,8 +219,8 @@ exports[`strictNullChecks`] = {
       [44, 9, 9, "Type \'null\' is not assignable to type \'string\'.", "2966443234"],
       [148, 40, 27, "Object is possibly \'undefined\'.", "3506675417"]
     ],
-    "src/app/widgets/widget-gauge-ng-compass/widget-gauge-ng-compass.component.ts:1976286112": [
-      [235, 30, 9, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "4119212820"]
+    "src/app/widgets/widget-gauge-ng-compass/widget-gauge-ng-compass.component.ts:3154966941": [
+      [237, 30, 9, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "4119212820"]
     ],
     "src/app/widgets/widget-iframe/widget-iframe.component.ts:2602616758": [
       [30, 4, 9, "Type \'null\' is not assignable to type \'string | undefined\'.", "2966443234"]
@@ -238,14 +238,14 @@ exports[`strictNullChecks`] = {
     "src/app/widgets/widget-race-timer/widget-race-timer.component.ts:602896548": [
       [66, 25, 9, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "4119212820"]
     ],
-    "src/app/widgets/widget-racer-line/widget-racer-line.component.ts:1502528665": [
-      [61, 4, 5, "Type \'{ dtsPath: { description: string; path: string; source: string; pathType: \\"number\\"; pathRequired: false; isPathConfigurable: false; convertUnitTo: string; showPathSkUnitsFilter: true; pathSkUnitsFilter: \\"m\\"; sampleTime: number; }; ... 5 more ...; ttbPath: { ...; }; }\' is not assignable to type \'IPathArray | IWidgetPath[] | undefined\'.\\n  The types of \'startLineNamePath.convertUnitTo\' are incompatible between these types.\\n    Type \'null\' is not assignable to type \'string | undefined\'.", "187670523"],
-      [174, 10, 13, "Type \'null\' is not assignable to type \'string\'.", "363509612"],
-      [187, 34, 9, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "4119212820"],
-      [338, 4, 6, "Type \'string | null\' is not assignable to type \'string\'.\\n  Type \'null\' is not assignable to type \'string\'.", "2123913871"],
-      [342, 4, 6, "Type \'string | null\' is not assignable to type \'string\'.\\n  Type \'null\' is not assignable to type \'string\'.", "2123913871"],
-      [486, 25, 13, "Argument of type \'number | null\' is not assignable to parameter of type \'number\'.\\n  Type \'null\' is not assignable to type \'number\'.", "2241094794"],
-      [490, 25, 13, "Argument of type \'number | null\' is not assignable to parameter of type \'number\'.\\n  Type \'null\' is not assignable to type \'number\'.", "2926687684"]
+    "src/app/widgets/widget-racer-line/widget-racer-line.component.ts:1630258628": [
+      [63, 4, 5, "Type \'{ dtsPath: { description: string; path: string; source: string; pathType: \\"number\\"; pathRequired: false; isPathConfigurable: false; convertUnitTo: string; showPathSkUnitsFilter: true; pathSkUnitsFilter: \\"m\\"; sampleTime: number; }; ... 5 more ...; ttbPath: { ...; }; }\' is not assignable to type \'IPathArray | IWidgetPath[] | undefined\'.\\n  The types of \'startLineNamePath.convertUnitTo\' are incompatible between these types.\\n    Type \'null\' is not assignable to type \'string | undefined\'.", "187670523"],
+      [176, 10, 13, "Type \'null\' is not assignable to type \'string\'.", "363509612"],
+      [189, 34, 9, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "4119212820"],
+      [340, 4, 6, "Type \'string | null\' is not assignable to type \'string\'.\\n  Type \'null\' is not assignable to type \'string\'.", "2123913871"],
+      [344, 4, 6, "Type \'string | null\' is not assignable to type \'string\'.\\n  Type \'null\' is not assignable to type \'string\'.", "2123913871"],
+      [488, 25, 13, "Argument of type \'number | null\' is not assignable to parameter of type \'number\'.\\n  Type \'null\' is not assignable to type \'number\'.", "2241094794"],
+      [492, 25, 13, "Argument of type \'number | null\' is not assignable to parameter of type \'number\'.\\n  Type \'null\' is not assignable to type \'number\'.", "2926687684"]
     ],
     "src/app/widgets/widget-racer-timer/widget-racer-timer.component.ts:3969781521": [
       [96, 34, 9, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "4119212820"],
@@ -268,9 +268,9 @@ exports[`strictNullChecks`] = {
       [148, 8, 15, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "4102914388"],
       [154, 29, 3, "\'cfg\' is possibly \'undefined\'.", "193415815"]
     ],
-    "src/app/widgets/widget-windsteer/widget-windsteer.component.ts:965751974": [
-      [210, 34, 9, "\'cfg.paths\' is possibly \'undefined\'.", "4139429943"],
-      [211, 35, 9, "\'cfg.paths\' is possibly \'undefined\'.", "4139429943"]
+    "src/app/widgets/widget-windsteer/widget-windsteer.component.ts:1696845112": [
+      [212, 73, 9, "\'cfg.paths\' is possibly \'undefined\'.", "4139429943"],
+      [213, 74, 9, "\'cfg.paths\' is possibly \'undefined\'.", "4139429943"]
     ],
     "src/app/widgets/widget-zones-state-panel/widget-zones-state-panel.component.ts:2501103102": [
       [78, 38, 9, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "4119212820"]

--- a/src/app/core/components/widget-history-chart-dialog/widget-history-chart-dialog.component.ts
+++ b/src/app/core/components/widget-history-chart-dialog/widget-history-chart-dialog.component.ts
@@ -621,7 +621,7 @@ export class WidgetHistoryChartDialogComponent implements OnInit, AfterViewInit,
   private getPrimaryAxisUnitLabel(): string {
     const convertUnitTo = this.resolveConvertUnitTo();
 
-    return this.getUnitsLabel(convertUnitTo);
+    return this.units.getUnitDisplaySymbol(convertUnitTo);
   }
 
   private resolveConvertUnitTo(rawPath?: string): string | null {
@@ -813,29 +813,5 @@ export class WidgetHistoryChartDialogComponent implements OnInit, AfterViewInit,
   private normalizeContext(context: string | null | undefined): string | undefined {
     const trimmed = typeof context === 'string' ? context.trim() : '';
     return trimmed.length ? trimmed : undefined;
-  }
-
-  /**
-   * Returns a display label for the y-axis unit, based on widget config.
-   * @param unit The convertUnitTo string
-   * @returns string label for axis
-   */
-  private getUnitsLabel(unit: string | null | undefined): string {
-    if (!unit) return '';
-    switch (unit) {
-      case 'percent':
-      case 'percentraw':
-        return '%';
-      case 'latitudeMin':
-        return 'latitude in minutes';
-      case 'latitudeSec':
-        return 'latitude in secondes';
-      case 'longitudeMin':
-        return 'longitude in minutes';
-      case 'longitudeSec':
-        return 'longitude in secondes';
-      default:
-        return unit;
-    }
   }
 }

--- a/src/app/core/services/units.service.spec.ts
+++ b/src/app/core/services/units.service.spec.ts
@@ -34,4 +34,29 @@ describe('UnitsService', () => {
 
     expect(service.getDefaults()).toEqual({ Speed: 'kph' });
   });
+
+  describe('getUnitDisplaySymbol', () => {
+    it('returns the dedicated display symbol for a measure', () => {
+      const service = setup({});
+      expect(service.getUnitDisplaySymbol('knots')).toBe('kn');
+      expect(service.getUnitDisplaySymbol('celsius')).toBe('°C');
+      expect(service.getUnitDisplaySymbol('kph')).toBe('km/h');
+      expect(service.getUnitDisplaySymbol('percent')).toBe('%');
+      expect(service.getUnitDisplaySymbol('latitudeMin')).toBe('lat ′');
+    });
+
+    it('falls back to the raw measure when it has no dedicated symbol', () => {
+      const service = setup({});
+      expect(service.getUnitDisplaySymbol('mph')).toBe('mph');
+      expect(service.getUnitDisplaySymbol('m/s')).toBe('m/s');
+    });
+
+    it('returns an unknown measure unchanged, and empty string for null/undefined/empty', () => {
+      const service = setup({});
+      expect(service.getUnitDisplaySymbol('not-a-unit')).toBe('not-a-unit');
+      expect(service.getUnitDisplaySymbol(null)).toBe('');
+      expect(service.getUnitDisplaySymbol(undefined)).toBe('');
+      expect(service.getUnitDisplaySymbol('')).toBe('');
+    });
+  });
 });

--- a/src/app/core/services/units.service.ts
+++ b/src/app/core/services/units.service.ts
@@ -67,6 +67,8 @@ export interface IUnitGroup {
 export interface IUnit {
   measure: string;
   description: string;
+  /** Display-only label rendered next to values; falls back to `measure` when absent. */
+  symbol?: string;
 }
 
 /**
@@ -114,22 +116,22 @@ export class UnitsService {
       { measure: ' ', description: "No unit label - As-Is numeric value" }
     ] },
     { group: 'Speed', units: [
-      { measure: 'knots', description: "Knots - Nautical miles per hour"},
-      { measure: 'kph', description: "kph - Kilometers per hour"},
+      { measure: 'knots', symbol: 'kn', description: "Knots - Nautical miles per hour"},
+      { measure: 'kph', symbol: 'km/h', description: "kph - Kilometers per hour"},
       { measure: 'mph', description: "mph - Miles per hour"},
       { measure: 'm/s', description: "m/s - Meters per second (base)"}
     ] },
     { group: 'Flow', units: [
-      { measure: 'm3/s', description: "Cubic meters per second (base)"},
+      { measure: 'm3/s', symbol: 'm³/s', description: "Cubic meters per second (base)"},
       { measure: 'l/min', description: "Liters per minute"},
       { measure: 'l/h', description: "Liters per hour"},
-      { measure: 'g/min', description: "Gallons per minute"},
-      { measure: 'g/h', description: "Gallons per hour"}
+      { measure: 'g/min', symbol: 'gal/min', description: "Gallons per minute"},
+      { measure: 'g/h', symbol: 'gal/h', description: "Gallons per hour"}
     ] },
     { group: 'Fuel Distance', units: [
-      { measure: 'm/m3', description: "Meters per cubic meter (base)"},
+      { measure: 'm/m3', symbol: 'm/m³', description: "Meters per cubic meter (base)"},
       { measure: 'nm/l', description: "Nautical Miles per liter"},
-      { measure: 'nm/g', description: "Nautical Miles per gallon"},
+      { measure: 'nm/g', symbol: 'nm/gal', description: "Nautical Miles per gallon"},
       { measure: 'km/l', description: "Kilometers per liter"},
       { measure: 'mpg', description: "Miles per Gallon"},
     ] },
@@ -142,23 +144,23 @@ export class UnitsService {
     ] },
     { group: 'Temperature', units: [
       { measure: 'K', description: "Kelvin (base)"},
-      { measure: 'celsius', description: "Celsius"},
-      { measure: 'fahrenheit', description: "Fahrenheit"}
+      { measure: 'celsius', symbol: '°C', description: "Celsius"},
+      { measure: 'fahrenheit', symbol: '°F', description: "Fahrenheit"}
      ] },
     { group: 'Length', units: [
       { measure: 'm', description: "Meters (base)"},
       { measure: 'mm', description: "Millimeters"},
-      { measure: 'fathom', description: "Fathoms"},
+      { measure: 'fathom', symbol: 'ftm', description: "Fathoms"},
       { measure: 'nm', description: "Nautical Miles"},
       { measure: 'km', description: "Kilometers"},
       { measure: 'mi', description: "Miles"},
-      { measure: 'feet', description: "Feet"},
-      { measure: 'inch', description: "Inches"},
+      { measure: 'feet', symbol: 'ft', description: "Feet"},
+      { measure: 'inch', symbol: 'in', description: "Inches"},
     ] },
     { group: 'Volume', units: [
-      { measure: 'liter', description: "Liters (base)"},
-      { measure: 'm3', description: "Cubic Meters"},
-      { measure: 'gallon', description: "Gallons"},
+      { measure: 'liter', symbol: 'L', description: "Liters (base)"},
+      { measure: 'm3', symbol: 'm³', description: "Cubic Meters"},
+      { measure: 'gallon', symbol: 'gal', description: "Gallons"},
      ] },
     { group: 'Current', units: [
       { measure: 'A', description: "Amperes (base)"},
@@ -181,8 +183,8 @@ export class UnitsService {
       { measure: 'kWh', description: "Kilowatt*Hours"},
     ] },
     { group: 'Resistance', units: [
-      { measure: 'ohm', description: "\u2126 (base)"},
-      { measure: 'kiloohm', description: "k\u2126"},
+      { measure: 'ohm', symbol: "\u2126", description: "\u2126 (base)"},
+      { measure: 'kiloohm', symbol: "k\u2126", description: "k\u2126"},
     ] },
     { group: 'Pressure', units: [
       { measure: 'Pa', description: "Pa (base)" },
@@ -197,9 +199,9 @@ export class UnitsService {
     { group: 'Density', units: [ { measure: 'kg/m3', description: "Air density - kg/cubic meter (base)"} ] },
     { group: 'Time', units: [
       { measure: 's', description: "Seconds (base)" },
-      { measure: 'Minutes', description: "Minutes" },
-      { measure: 'Hours', description: "Hours" },
-      { measure: 'Days', description: "Days" },
+      { measure: 'Minutes', symbol: 'min', description: "Minutes" },
+      { measure: 'Hours', symbol: 'h', description: "Hours" },
+      { measure: 'Days', symbol: 'd', description: "Days" },
       { measure: 'D HH:MM:SS', description: "Day Hour:Minute:sec"}
     ] },
     { group: 'Angular Velocity', units: [
@@ -220,16 +222,16 @@ export class UnitsService {
       { measure: 'GHz', description: "GHz - Gigahertz" },
     ] },
     { group: 'Ratio', units: [
-      { measure: 'percent', description: "As percentage value" },
-      { measure: 'percentraw', description: "As ratio 0-1 with % sign" },
+      { measure: 'percent', symbol: '%', description: "As percentage value" },
+      { measure: 'percentraw', symbol: '%', description: "As ratio 0-1 with % sign" },
       { measure: 'ratio', description: "Ratio 0-1 (base)" }
     ] },
     { group: 'Position', units: [
-      { measure: 'pdeg', description: "Position Degrees" },
-      { measure: 'latitudeMin', description: "Latitude in minutes" },
-      { measure: 'latitudeSec', description: "Latitude in seconds" },
-      { measure: 'longitudeMin', description: "Longitude in minutes" },
-      { measure: 'longitudeSec', description: "Longitude in seconds" },
+      { measure: 'pdeg', symbol: '°', description: "Position Degrees" },
+      { measure: 'latitudeMin', symbol: 'lat ′', description: "Latitude in minutes" },
+      { measure: 'latitudeSec', symbol: 'lat ″', description: "Latitude in seconds" },
+      { measure: 'longitudeMin', symbol: 'lon ′', description: "Longitude in minutes" },
+      { measure: 'longitudeSec', symbol: 'lon ″', description: "Longitude in seconds" },
     ] },
   ];
 
@@ -648,6 +650,24 @@ export class UnitsService {
    */
   public getDefaults(): IUnitDefaults {
     return this._defaultUnits;
+  }
+
+  /**
+   * Resolves the display-only label for a measure (the on-screen unit symbol), falling back to the
+   * measure key itself when no dedicated symbol is defined. This is the single seam every render site
+   * uses so units are labelled consistently (no spelled-out words), independent of the internal key.
+   */
+  public getUnitDisplaySymbol(measure: string | null | undefined): string {
+    if (!measure) {
+      return '';
+    }
+    for (const group of this._conversionList) {
+      const unit = group.units.find(u => u.measure === measure);
+      if (unit) {
+        return unit.symbol ?? unit.measure;
+      }
+    }
+    return measure;
   }
 
   /**

--- a/src/app/widgets/gauge-steel/gauge-steel.component.spec.ts
+++ b/src/app/widgets/gauge-steel/gauge-steel.component.spec.ts
@@ -16,6 +16,7 @@ describe('GaugeSteelComponent', () => {
           provide: UnitsService,
           useValue: {
             convertToUnit: (_unit: string, value: number) => value,
+            getUnitDisplaySymbol: (unit: string) => unit,
           },
         },
       ],

--- a/src/app/widgets/gauge-steel/gauge-steel.component.ts
+++ b/src/app/widgets/gauge-steel/gauge-steel.component.ts
@@ -109,7 +109,7 @@ export class GaugeSteelComponent implements OnInit, OnChanges, OnDestroy {
 
     //labels
     this.gaugeOptions['titleString'] = this.title();
-    this.gaugeOptions['unitString'] = this.units();
+    this.gaugeOptions['unitString'] = this.unitsService.getUnitDisplaySymbol(this.units());
 
     // Radial Arc size
     if (this.subType() == 'radial') {

--- a/src/app/widgets/widget-alternator/widget-alternator.component.ts
+++ b/src/app/widgets/widget-alternator/widget-alternator.component.ts
@@ -811,7 +811,7 @@ export class WidgetAlternatorComponent implements AfterViewInit, OnDestroy {
       return '-';
     }
 
-    return `${value.toFixed(1)} ${this.units.getDefaults().Temperature === 'celsius' ? '°C' : '°F'}`;
+    return `${value.toFixed(1)} ${this.units.getUnitDisplaySymbol(this.units.getDefaults().Temperature)}`;
   }
 
   private formatRevolutions(value: number | null | undefined): string {

--- a/src/app/widgets/widget-bms/widget-bms.component.ts
+++ b/src/app/widgets/widget-bms/widget-bms.component.ts
@@ -1231,7 +1231,7 @@ export class WidgetBmsComponent implements AfterViewInit, OnDestroy {
     const displayUnit = this.units.getDefaults().Temperature;
     const converted = this.units.convertToUnit(displayUnit, value);
     if (converted === null) return '';
-    return `${converted.toFixed(1)} ${displayUnit === 'celsius' ? '°C' : '°F'}`;
+    return `${converted.toFixed(1)} ${this.units.getUnitDisplaySymbol(displayUnit)}`;
   }
 
   private splitMetricText(rawText: string, unitSuffix: string): { valueText: string; unitText: string } {

--- a/src/app/widgets/widget-charger/widget-charger.component.spec.ts
+++ b/src/app/widgets/widget-charger/widget-charger.component.spec.ts
@@ -43,7 +43,8 @@ describe('WidgetChargerComponent', () => {
   const runtimeMock = { options: vi.fn() };
   const unitsMock = {
     convertToUnit: (_unit: string, value: unknown) => value,
-    getDefaults: () => ({ Temperature: 'celsius' })
+    getDefaults: () => ({ Temperature: 'celsius' }),
+    getUnitDisplaySymbol: (measure: string) => (measure === 'celsius' ? '°C' : measure === 'fahrenheit' ? '°F' : measure)
   };
 
   const setup = async (

--- a/src/app/widgets/widget-charger/widget-charger.component.ts
+++ b/src/app/widgets/widget-charger/widget-charger.component.ts
@@ -810,7 +810,7 @@ export class WidgetChargerComponent implements AfterViewInit, OnDestroy {
       .attr('dx', 1)
       .attr('font-size', 6)
       .attr('fill', 'var(--kip-contrast-dim-color)')
-      .text(`${this.units.getDefaults().Temperature === 'celsius' ? '°C' : '°F'}`);
+      .text(this.units.getUnitDisplaySymbol(this.units.getDefaults().Temperature));
 
     merged.select('text.charger-mode')
       .attr('x', 5)

--- a/src/app/widgets/widget-data-chart/widget-data-chart.component.spec.ts
+++ b/src/app/widgets/widget-data-chart/widget-data-chart.component.spec.ts
@@ -53,7 +53,7 @@ describe('WidgetDataChartComponent', () => {
 
   const runtimeMock = { options: vi.fn() };
   const historyMock = { getBackfillThenLive: vi.fn() };
-  const unitsMock = { convertToUnit: (_unit: string, value: number) => value };
+  const unitsMock = { convertToUnit: (_unit: string, value: number) => value, getUnitDisplaySymbol: (measure: string) => measure };
   const canvasMock = { releaseCanvas: vi.fn() };
 
   const setup = async (config: IWidgetSvcConfig): Promise<void> => {

--- a/src/app/widgets/widget-data-chart/widget-data-chart.component.ts
+++ b/src/app/widgets/widget-data-chart/widget-data-chart.component.ts
@@ -759,40 +759,6 @@ export class WidgetDataChartComponent implements OnDestroy {
     return colors;
   }
 
-  private getUnitsLabel(): string | null | undefined {
-    let label: string | null | undefined = null;
-    const unit = this.runtime.options()?.convertUnitTo;
-    switch (unit) {
-
-      case "percent":
-      case "percentraw":
-        label = "%";
-        break;
-
-      case "latitudeMin":
-        label = "latitude in minutes";
-        break;
-
-      case "latitudeSec":
-        label = "latitude in secondes";
-        break;
-
-      case "longitudeMin":
-        label = "longitude in minutes";
-        break;
-
-      case "longitudeSec":
-        label = "longitude in secondes";
-        break;
-
-      default:
-        label = unit;
-        break;
-    }
-
-    return label;
-  }
-
   private startStreaming(): void {
     const cfg = this.runtime.options();
     if (!cfg?.datachartPath) return;
@@ -855,7 +821,7 @@ export class WidgetDataChartComponent implements OnDestroy {
     if (convertedTrack !== null && Number.isFinite(convertedTrack)) {
       const titlePlugin = this.chart.options.plugins?.title;
       if (titlePlugin) {
-        titlePlugin.text = `${convertedTrack.toFixed(cfg.numDecimal)} ${this.getUnitsLabel()} `;
+        titlePlugin.text = `${convertedTrack.toFixed(cfg.numDecimal)} ${this.unitsService.getUnitDisplaySymbol(unit)} `;
       }
     }
 

--- a/src/app/widgets/widget-gauge-ng-compass/widget-gauge-ng-compass.component.ts
+++ b/src/app/widgets/widget-gauge-ng-compass/widget-gauge-ng-compass.component.ts
@@ -17,6 +17,7 @@ import { KipResizeObserverDirective } from '../../core/directives/kip-resize-obs
 import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
 import { WidgetStreamsDirective } from '../../core/directives/widget-streams.directive';
 import { ITheme } from '../../core/services/app-service';
+import { UnitsService } from '../../core/services/units.service';
 
 function rgbaToHex(rgba: string) {
   const match = rgba.match(/(\d+(\.\d+)?|\.\d+)/g);
@@ -57,6 +58,7 @@ export class WidgetGaugeNgCompassComponent implements AfterViewInit {
   // Inject directives/services
   private readonly runtime = inject(WidgetRuntimeDirective);
   private readonly streams = inject(WidgetStreamsDirective);
+  private readonly unitsService = inject(UnitsService);
 
   // Static DEFAULT_CONFIG for Host2
   public static readonly DEFAULT_CONFIG: IWidgetSvcConfig = {
@@ -210,7 +212,7 @@ export class WidgetGaugeNgCompassComponent implements AfterViewInit {
   private buildGaugeOptions(cfg: IWidgetSvcConfig, theme: ITheme) {
     const g = this.gaugeOptions = {} as RadialGaugeOptions;
     g.title = this.displayName();
-    g.minValue = 0; g.maxValue = 360; g.units = cfg.paths?.['gaugePath']?.convertUnitTo || '';
+    g.minValue = 0; g.maxValue = 360; g.units = this.unitsService.getUnitDisplaySymbol(cfg.paths?.['gaugePath']?.convertUnitTo);
     // Use configured integer/decimal digits (compass default: whole degrees)
     g.valueDec = cfg.numDecimal ?? 0; g.valueInt = cfg.numInt ?? 1;
     g.barProgress = false; g.barWidth = 0;

--- a/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.ts
+++ b/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.ts
@@ -272,7 +272,7 @@ export class WidgetGaugeNgLinearComponent implements AfterViewInit {
     opt.needleStart = enableNeedle ? (isVertical ? 200 : 155) : -45;
     opt.needleEnd = enableNeedle ? (isVertical ? 175 : 180) : 55;
     opt.needleShadow = true; opt.needleSide = 'both';
-    opt.units = cfg.paths?.['gaugePath']?.convertUnitTo; opt.fontUnits = 'Roboto'; opt.fontUnitsWeight = 'normal';
+    opt.units = this.unitsService.getUnitDisplaySymbol(cfg.paths?.['gaugePath']?.convertUnitTo); opt.fontUnits = 'Roboto'; opt.fontUnitsWeight = 'normal';
     opt.borders = false; opt.borderOuterWidth = 0; opt.borderMiddleWidth = 0; opt.borderInnerWidth = 0; opt.borderShadowWidth = 0; opt.borderRadius = 0;
     // Value box
     opt.valueBox = true; opt.valueBoxWidth = 35; opt.valueBoxStroke = 0; opt.valueBoxBorderRadius = 10;

--- a/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
+++ b/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
@@ -285,7 +285,7 @@ export class WidgetGaugeNgRadialComponent implements AfterViewInit {
     g.title = this.displayName();
     g.minValue = scale.min;
     g.maxValue = scale.max;
-    g.units = cfg.paths?.['gaugePath']?.convertUnitTo;
+    g.units = this.unitsService.getUnitDisplaySymbol(cfg.paths?.['gaugePath']?.convertUnitTo);
     g.highlights = [];
     // Include initial highlights if already available (after view init effect will re-apply).
     const initialHl = this.highlights();

--- a/src/app/widgets/widget-inverter/widget-inverter.component.ts
+++ b/src/app/widgets/widget-inverter/widget-inverter.component.ts
@@ -686,7 +686,7 @@ export class WidgetInverterComponent implements AfterViewInit, OnDestroy {
 
   private formatTemperature(value: number | null | undefined): string {
     if (value == null || Number.isNaN(value)) return '-';
-    return `${value.toFixed(1)} ${this.units.getDefaults().Temperature === 'celsius' ? '°C' : '°F'}`;
+    return `${value.toFixed(1)} ${this.units.getUnitDisplaySymbol(this.units.getDefaults().Temperature)}`;
   }
 
   private toStringValue(value: unknown): string | null {

--- a/src/app/widgets/widget-numeric/widget-numeric.component.ts
+++ b/src/app/widgets/widget-numeric/widget-numeric.component.ts
@@ -7,6 +7,7 @@ import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.dir
 import { WidgetStreamsDirective } from '../../core/directives/widget-streams.directive';
 import { IPathUpdate } from '../../core/services/data.service';
 import { CanvasService } from '../../core/services/canvas.service';
+import { UnitsService } from '../../core/services/units.service';
 import { ITheme } from '../../core/services/app-service';
 import { getColors } from '../../core/utils/themeColors.utils';
 import { States } from '../../core/interfaces/signalk-interfaces';
@@ -57,6 +58,7 @@ export class WidgetNumericComponent implements OnInit, AfterViewInit, OnDestroy 
   private readonly stream = inject(WidgetStreamsDirective);
 
   private readonly canvas = inject(CanvasService);
+  private readonly unitsService = inject(UnitsService);
   protected miniChart = viewChild(MinichartComponent);
   private canvasMainRef = viewChild.required<ElementRef<HTMLCanvasElement>>('canvasMainRef');
 
@@ -284,10 +286,10 @@ export class WidgetNumericComponent implements OnInit, AfterViewInit, OnDestroy 
             this.cssHeight,
             0.1
           );
-          if (unit !== undefined && !['unitless', 'percent', 'ratio', 'latitudeSec', 'latitudeMin', 'longitudeSec', 'longitudeMin'].includes(unit)) {
+          if (unit !== undefined && !['unitless', 'percent', 'percentraw', 'ratio', 'latitudeSec', 'latitudeMin', 'longitudeSec', 'longitudeMin'].includes(unit)) {
             this.canvas.drawText(
               bitmapCtx,
-              unit,
+              this.unitsService.getUnitDisplaySymbol(unit),
               this.cssWidth - marginX,
               this.cssHeight - marginY,
               Math.floor(this.cssWidth * 0.25),

--- a/src/app/widgets/widget-racer-line/widget-racer-line.component.ts
+++ b/src/app/widgets/widget-racer-line/widget-racer-line.component.ts
@@ -19,6 +19,7 @@ import {CanvasService} from '../../core/services/canvas.service';
 import {getColors} from '../../core/utils/themeColors.utils';
 import {DashboardService} from '../../core/services/dashboard.service';
 import {SignalkRequestsService} from '../../core/services/signalk-requests.service';
+import {UnitsService} from '../../core/services/units.service';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {MatButtonModule} from '@angular/material/button';
 import {MatIconModule} from '@angular/material/icon';
@@ -44,6 +45,7 @@ export class WidgetRacerLineComponent implements AfterViewInit, OnDestroy {
   private readonly canvas = inject(CanvasService);
   protected readonly dashboard = inject(DashboardService);
   private readonly signalk = inject(SignalkRequestsService);
+  private readonly unitsService = inject(UnitsService);
   private readonly destroyRef = inject(DestroyRef);
 
   // Static config from legacy defaultConfig
@@ -398,7 +400,7 @@ export class WidgetRacerLineComponent implements AfterViewInit, OnDestroy {
 
     this.canvas.drawText(
       this.ctx,
-      (this.runtime.options()?.paths as IPathArray | undefined)?.['dtsPath']?.convertUnitTo || 'm',
+      this.unitsService.getUnitDisplaySymbol((this.runtime.options()?.paths as IPathArray | undefined)?.['dtsPath']?.convertUnitTo || 'm'),
       Math.floor(this.cssWidth * 0.975),
       Math.floor(this.cssHeight * 0.60),
       Math.floor(this.cssWidth * 0.95),
@@ -493,13 +495,13 @@ export class WidgetRacerLineComponent implements AfterViewInit, OnDestroy {
   private setLenBias(): void {
     const cfg = this.runtime.options(); if (!cfg) return;
     if ((cfg.paths as IPathArray)['lineLengthPath'].path && this.lengthValue != null) {
-      let unit = (cfg.paths as IPathArray)['lineLengthPath'].convertUnitTo;
-      if (unit === 'feet') unit = '′';
+      const rawUnit = (cfg.paths as IPathArray)['lineLengthPath'].convertUnitTo;
+      const unit = rawUnit === 'feet' ? '′' : this.unitsService.getUnitDisplaySymbol(rawUnit);
       this.lineLengthValue.set(`―${this.applyDecorations(this.lengthValue.toFixed(cfg.numDecimal))}${unit}―`);
     }
     if ((cfg.paths as IPathArray)['lineBiasPath'].path && this.biasValue != null) {
-      let unit = (cfg.paths as IPathArray)['lineBiasPath'].convertUnitTo;
-      if (unit === 'feet') unit = '′';
+      const rawUnit = (cfg.paths as IPathArray)['lineBiasPath'].convertUnitTo;
+      const unit = rawUnit === 'feet' ? '′' : this.unitsService.getUnitDisplaySymbol(rawUnit);
       if (this.biasValue < 0) {
         this.portBiasValue.set('+' + (-this.biasValue).toFixed(cfg.numDecimal) + unit);
         this.stbBiasValue.set(this.biasValue.toFixed(cfg.numDecimal) + unit);

--- a/src/app/widgets/widget-simple-linear/widget-simple-linear.component.ts
+++ b/src/app/widgets/widget-simple-linear/widget-simple-linear.component.ts
@@ -118,8 +118,10 @@ export class WidgetSimpleLinearComponent {
         });
 
         // Unit label (abr|full)
-        const unit = cfg.paths?.['gaugePath'].convertUnitTo;
-        this.unitsLabel.set(cfg.gauge?.unitLabelFormat === 'abr' ? unit?.substring(0,1) : unit);
+        const unit = this.unitsService.getUnitDisplaySymbol(cfg.paths?.['gaugePath'].convertUnitTo);
+        // Symbols are already compact; only truncate longer ones in 'abr' mode so short symbols that
+        // share a first character (°C/°F, kn) stay distinct.
+        this.unitsLabel.set(cfg.gauge?.unitLabelFormat === 'abr' && unit.length > 2 ? unit.substring(0,1) : unit);
       });
     });
 

--- a/src/app/widgets/widget-solar-charger/widget-solar-charger.component.spec.ts
+++ b/src/app/widgets/widget-solar-charger/widget-solar-charger.component.spec.ts
@@ -33,7 +33,8 @@ describe('WidgetSolarChargerComponent', () => {
 
   const unitsMock = {
     convertToUnit: (_unit: string, value: unknown) => value,
-    getDefaults: () => ({ Temperature: 'celsius' })
+    getDefaults: () => ({ Temperature: 'celsius' }),
+    getUnitDisplaySymbol: (measure: string) => (measure === 'celsius' ? '°C' : measure === 'fahrenheit' ? '°F' : measure)
   };
 
   const themeMock = {

--- a/src/app/widgets/widget-solar-charger/widget-solar-charger.component.ts
+++ b/src/app/widgets/widget-solar-charger/widget-solar-charger.component.ts
@@ -1025,7 +1025,7 @@ export class WidgetSolarChargerComponent implements AfterViewInit, OnDestroy {
   private formatTemperature(value: number | null | undefined): string {
     if (value === null) return '--';
     if (value === undefined) return '';
-    return `${value.toFixed(1)} ${this.units.getDefaults().Temperature === 'celsius' ? '°C' : '°F'}`;
+    return `${value.toFixed(1)} ${this.units.getUnitDisplaySymbol(this.units.getDefaults().Temperature)}`;
   }
 
   private formatRelayState(value: string | number | boolean | null | undefined): string {

--- a/src/app/widgets/widget-windsteer/widget-windsteer.component.spec.ts
+++ b/src/app/widgets/widget-windsteer/widget-windsteer.component.spec.ts
@@ -4,8 +4,11 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { WidgetWindComponent, computeTrueWindBaseAngle } from './widget-windsteer.component';
 import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
 import { WidgetStreamsDirective } from '../../core/directives/widget-streams.directive';
+import { UnitsService } from '../../core/services/units.service';
 import { IPathUpdate } from '../../core/services/data.service';
 import { IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
+
+const unitsServiceStub = { getUnitDisplaySymbol: (measure: string | null | undefined) => measure ?? '' };
 
 /**
  * Regression tests for #1066 / #1063.
@@ -76,7 +79,8 @@ describe('WidgetWindComponent live compass-mode toggle (#73)', () => {
     TestBed.configureTestingModule({
       providers: [
         { provide: WidgetRuntimeDirective, useValue: { options } },
-        { provide: WidgetStreamsDirective, useValue: streamsMock }
+        { provide: WidgetStreamsDirective, useValue: streamsMock },
+        { provide: UnitsService, useValue: unitsServiceStub }
       ]
     });
 
@@ -124,7 +128,8 @@ describe('WidgetWindComponent true-wind sector source', () => {
     TestBed.configureTestingModule({
       providers: [
         { provide: WidgetRuntimeDirective, useValue: { options } },
-        { provide: WidgetStreamsDirective, useValue: streamsMock }
+        { provide: WidgetStreamsDirective, useValue: streamsMock },
+        { provide: UnitsService, useValue: unitsServiceStub }
       ]
     });
     component = TestBed.runInInjectionContext(() => new WidgetWindComponent());

--- a/src/app/widgets/widget-windsteer/widget-windsteer.component.ts
+++ b/src/app/widgets/widget-windsteer/widget-windsteer.component.ts
@@ -6,6 +6,7 @@ import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.dir
 import { WidgetStreamsDirective } from '../../core/directives/widget-streams.directive';
 import { IPathUpdate } from '../../core/services/data.service';
 import { ITheme } from '../../core/services/app-service';
+import { UnitsService } from '../../core/services/units.service';
 
 // Default rolling window (seconds) for the wind-sector history; the single
 // source of truth for both the default config and the missing-value fallback.
@@ -159,6 +160,7 @@ export class WidgetWindComponent implements OnDestroy {
 
   public readonly runtime = inject(WidgetRuntimeDirective); // accessed in template
   private readonly stream = inject(WidgetStreamsDirective);
+  private readonly unitsService = inject(UnitsService);
 
   // Removed local registeredPaths guard; rely on WidgetStreamsDirective diff + idempotent observe() with stable callbacks
 
@@ -208,8 +210,8 @@ export class WidgetWindComponent implements OnDestroy {
       const cfg = this.runtime.options();
       if (!cfg) return;
       untracked(() => {
-        this.appWindSpeedUnit.set(cfg.paths['appWindSpeed'].convertUnitTo);
-        this.trueWindSpeedUnit.set(cfg.paths['trueWindSpeed'].convertUnitTo);
+        this.appWindSpeedUnit.set(this.unitsService.getUnitDisplaySymbol(cfg.paths['appWindSpeed'].convertUnitTo));
+        this.trueWindSpeedUnit.set(this.unitsService.getUnitDisplaySymbol(cfg.paths['trueWindSpeed'].convertUnitTo));
         this.registerStreams();
         this.stopWindSectors();
         this.startWindSectors();


### PR DESCRIPTION
## What & why
Packet G3 of the #257 backlog. Widget unit labels were inconsistent — some symbols, some spelled-out words (`knots`, `celsius`, `liter`, `feet`, `Minutes`), some invalid (`kph`). The `measure` string did double duty as both the conversion lookup key and the on-screen label.

## Changes
- **`IUnit` gains an optional display `symbol`** (measure stays the internal key → **no config migration**) and a central **`UnitsService.getUnitDisplaySymbol(measure)`** resolver. Symbols added for the offenders (`knots→kn`, `kph→km/h`, `celsius→°C`, `fahrenheit→°F`, `liter→L`, `m3→m³`, `gallon→gal`, `fathom→ftm`, `feet→ft`, `inch→in`, `Minutes→min`/`Hours→h`/`Days→d`, the `g`-for-gallons collisions → `gal/*`, `ohm→Ω`, `percent→%`, and the lat/lon minute/second marks `lat ′` / `lon ″`).
- **Every on-screen unit label routes through the resolver.** The two ad-hoc `getUnitsLabel` switches (data-chart, history dialog) and the 5 celsius ternaries (alternator/bms/inverter/solar-charger/charger) are deleted; the gauge / simple-linear / windsteer / racer-line / numeric render sites resolve symbols.
- **Conversion-*key* usages are left untouched** — `convertToUnit`, `getHighlights`, cache signatures, and the latitude / `feet` comparisons still use the raw measure. Saved dashboards keep their configured units.

This is also the seam #246-P1 (S2-2) swaps server unit-preference sources into.

## Verification
Local `npm run ci` green (lint · betterer 183 regenerated · 1177 vitest · 7 plugin).
**Boat-verify:** rendered unit-label spot-check across widgets — batched into the Stage-1 session.

Closes #245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
