### PR TITLE
Replace connection-status magic-number operation codes with typed per-layer enums

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -5,7 +5,7 @@
 //
 exports[`strictNullChecks`] = {
   value: `{
-    "src/app/app.component.ts:2963952310": [
+    "src/app/app.component.ts:281943337": [
       [111, 19, 25, "Object is possibly \'undefined\'.", "255143637"]
     ],
     "src/app/core/components/dashboard/dashboard.component.ts:3995263170": [

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { BehaviorSubject, Subject } from 'rxjs';
 import { signal } from '@angular/core';
 import { AppComponent } from './app.component';
+import { ConnectionState, IConnectionStatus } from './core/services/connection-state-machine.service';
 import { AppNetworkInitService } from './core/services/app-initNetwork.service';
 import { DashboardService } from './core/services/dashboard.service';
 import { uiEventService } from './core/services/uiEvent.service';
@@ -16,6 +17,10 @@ interface AppComponentHotkeyApi {
   dashboardVisible: { set: (v: boolean) => void };
   handleKeyDown: (key: string, event: { shiftKey: boolean }) => void;
   onShellPointerDown: (event: { target: { closest: (sel: string) => unknown } }) => void;
+}
+
+interface AppComponentNotifyApi {
+  displayConnectionsStatusNotification: (status: IConnectionStatus) => void;
 }
 
 describe('AppComponent', () => {
@@ -68,6 +73,7 @@ describe('AppComponent', () => {
     chrome = { revealed: signal(false), reveal: vi.fn(), hide: vi.fn(), pulsePeek: vi.fn() };
     toast = { show: vi.fn().mockReturnValue({ onAction: () => new Subject() }) };
     appNetworkInitServiceStub.bootstrapIssue$.next({ reason: 'none' });
+    appNetworkInitServiceStub.bootstrapStatus$.next('ready');
 
     await TestBed.configureTestingModule({
       imports: [AppComponent],
@@ -128,6 +134,62 @@ describe('AppComponent', () => {
       action$.next();
 
       expect(reloadSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('connection status notifications', () => {
+    // Exercised through the private handler directly: mapping IConnectionStatus.state to the right
+    // toast is the behavior under test, and driving it through the real root ConnectionStateMachine
+    // would hinge on its retry timers and debounce. bootstrapStatus is 'ready', so
+    // silentDuringBootstrap is false.
+    function notify(state: ConnectionState, message = 'status message'): void {
+      const app = create() as unknown as AppComponentNotifyApi;
+      toast.show.mockClear();
+      app.displayConnectionsStatusNotification({ state, message, timestamp: new Date() });
+    }
+
+    it('shows a transient toast when disconnected', () => {
+      notify(ConnectionState.Disconnected, 'Not connected');
+      expect(toast.show).toHaveBeenCalledWith('Not connected', 5000, true);
+    });
+
+    it('warns while retrying the connection', () => {
+      notify(ConnectionState.WebSocketRetrying, 'Retrying');
+      expect(toast.show).toHaveBeenCalledWith('Retrying', 3000, false, 'warn');
+    });
+
+    it('shows a persistent toast on permanent failure', () => {
+      notify(ConnectionState.PermanentFailure, 'Gave up');
+      expect(toast.show).toHaveBeenCalledWith('Gave up', 0, false);
+    });
+
+    it('stays silent while connecting or connected', () => {
+      notify(ConnectionState.Connected, 'Connected');
+      expect(toast.show).not.toHaveBeenCalled();
+    });
+
+    it('silences the warn and permanent-failure toasts while the app is still bootstrapping', () => {
+      appNetworkInitServiceStub.bootstrapStatus$.next('starting');
+      const app = create() as unknown as AppComponentNotifyApi;
+      TestBed.tick();
+      toast.show.mockClear();
+
+      app.displayConnectionsStatusNotification({ state: ConnectionState.WebSocketRetrying, message: 'Retrying', timestamp: new Date() });
+      expect(toast.show).toHaveBeenCalledWith('Retrying', 3000, true, 'warn');
+
+      toast.show.mockClear();
+      app.displayConnectionsStatusNotification({ state: ConnectionState.PermanentFailure, message: 'Gave up', timestamp: new Date() });
+      expect(toast.show).toHaveBeenCalledWith('Gave up', 0, true);
+    });
+
+    it('reports an unrecognized state as an error toast', () => {
+      const app = create() as unknown as AppComponentNotifyApi;
+      toast.show.mockClear();
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      app.displayConnectionsStatusNotification({ state: 'Bogus' as ConnectionState, message: 'weird', timestamp: new Date() });
+      expect(toast.show).toHaveBeenCalledWith(expect.stringContaining('Unknown connection status'), 0, false, 'error');
+      expect(errorSpy).toHaveBeenCalled();
+      errorSpy.mockRestore();
     });
   });
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -9,7 +9,7 @@ import { Title } from '@angular/platform-browser';
 import { AuthenticationService } from './core/services/authentication.service';
 import { SettingsService } from './core/services/settings.service';
 import { SignalKDeltaService } from './core/services/signalk-delta.service';
-import { ConnectionStateMachine, IConnectionStatus } from './core/services/connection-state-machine.service';
+import { ConnectionState, ConnectionStateMachine, IConnectionStatus } from './core/services/connection-state-machine.service';
 import { GestureDirective } from './core/directives/gesture.directive';
 import { ChromeIntent, PageNavDirection, ScrollNavDirective } from './core/directives/scroll-nav.directive';
 import { ToolbarComponent } from './core/components/toolbar/toolbar.component';
@@ -279,24 +279,27 @@ export class AppComponent implements AfterViewInit, OnDestroy {
   private displayConnectionsStatusNotification(connectionStatus: IConnectionStatus) {
     const message = connectionStatus.message;
     const silentDuringBootstrap = this.bootstrapStatus() !== 'ready';
-    switch (connectionStatus.operation) {
-      case 0:
+    switch (connectionStatus.state) {
+      case ConnectionState.Disconnected:
         this.toast.show(message, 5000, true);
         break;
-      case 1:
-      case 2:
+      case ConnectionState.HTTPDiscovering:
+      case ConnectionState.WebSocketConnecting:
+      case ConnectionState.HTTPConnected:
+      case ConnectionState.Connected:
+        // Transient/steady connecting states — no user-facing toast.
         break;
-      case 3:
+      case ConnectionState.HTTPError:
+      case ConnectionState.WebSocketError:
+      case ConnectionState.HTTPRetrying:
+      case ConnectionState.WebSocketRetrying:
         this.toast.show(message, 3000, silentDuringBootstrap, 'warn');
         break;
-      case 4:
-        this.toast.show(message, 3000, true, 'info');
-        break;
-      case 5:
+      case ConnectionState.PermanentFailure:
         this.toast.show(message, 0, silentDuringBootstrap);
         break;
       default:
-        console.error('[AppComponent] Unknown operation code:', connectionStatus.operation);
+        console.error('[AppComponent] Unknown connection state:', connectionStatus.state);
         this.toast.show(`Unknown connection status: ${connectionStatus.state}`, 0, silentDuringBootstrap, 'error');
     }
   }

--- a/src/app/core/components/options/signalk/signalk.component.spec.ts
+++ b/src/app/core/components/options/signalk/signalk.component.spec.ts
@@ -1,8 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { SettingsSignalkComponent } from './signalk.component';
-import { SignalKConnectionService } from '../../../services/signalk-connection.service';
-import { SignalKDeltaService } from '../../../services/signalk-delta.service';
+import { EndpointStatus, SignalKConnectionService } from '../../../services/signalk-connection.service';
+import { SignalKDeltaService, StreamStatus } from '../../../services/signalk-delta.service';
 
 describe('SettingsSignalkComponent', () => {
   let component: SettingsSignalkComponent;
@@ -34,7 +34,7 @@ describe('SettingsSignalkComponent', () => {
   it('updates the endpoint line on a same-reference status re-emit', () => {
     const connection = TestBed.inject(SignalKConnectionService);
     const status = {
-      operation: 2,
+      state: EndpointStatus.Connected,
       message: 'Connected',
       serverDescription: 'signalk-server 2.5.0',
       httpServiceUrl: 'http://localhost:3000',
@@ -52,7 +52,7 @@ describe('SettingsSignalkComponent', () => {
 
   it('updates the stream line on a same-reference status re-emit', () => {
     const delta = TestBed.inject(SignalKDeltaService);
-    const status = { operation: 2, message: 'Connected' };
+    const status = { state: StreamStatus.Connected, message: 'Connected' };
     delta.streamEndpoint$.next(status);
     fixture.detectChanges();
     expect(statusText()).toContain('Connected');

--- a/src/app/core/services/connection-state-machine.service.ts
+++ b/src/app/core/services/connection-state-machine.service.ts
@@ -22,7 +22,6 @@ export enum ConnectionState {
  */
 export interface IConnectionStatus {
   state: ConnectionState;
-  operation: number; // Legacy operation codes for compatibility
   message: string;
   retryCount?: number;
   maxRetries?: number;
@@ -308,35 +307,11 @@ export class ConnectionStateMachine implements OnDestroy {
   private createStatus(state: ConnectionState, message: string, retryCount?: number, maxRetries?: number): IConnectionStatus {
     return {
       state,
-      operation: this.stateToOperationCode(state),
       message,
       retryCount: retryCount || 0,
       maxRetries: maxRetries || 0,
       timestamp: new Date()
     };
-  }
-
-  private stateToOperationCode(state: ConnectionState): number {
-    switch (state) {
-      case ConnectionState.Disconnected:
-        return 0;
-      case ConnectionState.HTTPDiscovering:
-      case ConnectionState.WebSocketConnecting:
-        return 1; // Connecting
-      case ConnectionState.Connected:
-        return 2; // Connected
-      case ConnectionState.HTTPError:
-      case ConnectionState.WebSocketError:
-      case ConnectionState.HTTPRetrying:
-      case ConnectionState.WebSocketRetrying:
-        return 3; // Error/Retrying
-      case ConnectionState.HTTPConnected:
-        return 2; // Connected (HTTP level)
-      case ConnectionState.PermanentFailure:
-        return 5; // Permanent failure
-      default:
-        return 0;
-    }
   }
 
   private scheduleHTTPRetry(): void {

--- a/src/app/core/services/history-api-client.service.spec.ts
+++ b/src/app/core/services/history-api-client.service.spec.ts
@@ -2,11 +2,11 @@ import { TestBed } from '@angular/core/testing';
 import { beforeEach, describe, expect, it, afterEach } from 'vitest';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { BehaviorSubject } from 'rxjs';
-import { SignalKConnectionService, IEndpointStatus } from './signalk-connection.service';
+import { EndpointStatus, SignalKConnectionService, IEndpointStatus } from './signalk-connection.service';
 import { HistoryApiClientService, HistoryRequestError } from './history-api-client.service';
 
 const CONNECTED_ENDPOINT: IEndpointStatus = {
-  operation: 2,
+  state: EndpointStatus.Connected,
   message: 'Connected',
   serverDescription: 'Signal K',
   httpServiceUrl: 'http://localhost:3000/signalk/v1/api/',
@@ -16,7 +16,7 @@ const VALUES_URL = 'http://localhost:3000/signalk/v2/api/history/values';
 
 class SignalKConnectionServiceStub {
   public serverServiceEndpoint$ = new BehaviorSubject<IEndpointStatus>({
-    operation: 0,
+    state: EndpointStatus.Disconnected,
     message: 'Not connected',
     serverDescription: null,
     httpServiceUrl: null,
@@ -60,7 +60,7 @@ describe('HistoryApiClientService', () => {
 
   it('should pass duration to history values endpoint', async () => {
     connectionStub.serverServiceEndpoint$.next({
-      operation: 2,
+      state: EndpointStatus.Connected,
       message: 'Connected',
       serverDescription: 'Signal K',
       httpServiceUrl: 'http://localhost:3000/signalk/v1/api/',
@@ -96,7 +96,7 @@ describe('HistoryApiClientService', () => {
 
   it('should fetch values from v2 history endpoint with resolution in seconds', async () => {
     connectionStub.serverServiceEndpoint$.next({
-      operation: 2,
+      state: EndpointStatus.Connected,
       message: 'Connected',
       serverDescription: 'Signal K',
       httpServiceUrl: 'http://localhost:3000/signalk/v1/api/',
@@ -132,7 +132,7 @@ describe('HistoryApiClientService', () => {
 
   it('should pass through string resolution without restriction', async () => {
     connectionStub.serverServiceEndpoint$.next({
-      operation: 2,
+      state: EndpointStatus.Connected,
       message: 'Connected',
       serverDescription: 'Signal K',
       httpServiceUrl: 'http://localhost:3000/signalk/v1/api/',
@@ -163,7 +163,7 @@ describe('HistoryApiClientService', () => {
 
   it('should pass duration query to history paths endpoint', async () => {
     connectionStub.serverServiceEndpoint$.next({
-      operation: 2,
+      state: EndpointStatus.Connected,
       message: 'Connected',
       serverDescription: 'Signal K',
       httpServiceUrl: 'http://localhost:3000/signalk/v1/api/',
@@ -187,7 +187,7 @@ describe('HistoryApiClientService', () => {
 
   it('should pass from/to query to history contexts endpoint', async () => {
     connectionStub.serverServiceEndpoint$.next({
-      operation: 2,
+      state: EndpointStatus.Connected,
       message: 'Connected',
       serverDescription: 'Signal K',
       httpServiceUrl: 'http://localhost:3000/signalk/v1/api/',
@@ -215,7 +215,7 @@ describe('HistoryApiClientService', () => {
 
   it('should pass numeric zero resolution when provided', async () => {
     connectionStub.serverServiceEndpoint$.next({
-      operation: 2,
+      state: EndpointStatus.Connected,
       message: 'Connected',
       serverDescription: 'Signal K',
       httpServiceUrl: 'http://localhost:3000/signalk/v1/api/',
@@ -246,7 +246,7 @@ describe('HistoryApiClientService', () => {
 
   it('should return null when history values endpoint returns 404 (plugin/API missing)', async () => {
     connectionStub.serverServiceEndpoint$.next({
-      operation: 2,
+      state: EndpointStatus.Connected,
       message: 'Connected',
       serverDescription: 'Signal K',
       httpServiceUrl: 'http://localhost:3000/signalk/v1/api/',
@@ -307,7 +307,7 @@ describe('HistoryApiClientService', () => {
 
   it('should return null when history paths endpoint returns 500', async () => {
     connectionStub.serverServiceEndpoint$.next({
-      operation: 2,
+      state: EndpointStatus.Connected,
       message: 'Connected',
       serverDescription: 'Signal K',
       httpServiceUrl: 'http://localhost:3000/signalk/v1/api/',
@@ -332,7 +332,7 @@ describe('HistoryApiClientService', () => {
 
   it('should return null when history contexts endpoint returns 500', async () => {
     connectionStub.serverServiceEndpoint$.next({
-      operation: 2,
+      state: EndpointStatus.Connected,
       message: 'Connected',
       serverDescription: 'Signal K',
       httpServiceUrl: 'http://localhost:3000/signalk/v1/api/',
@@ -354,7 +354,7 @@ describe('HistoryApiClientService', () => {
 
   it('should still preload history when endpoint is available', async () => {
     connectionStub.serverServiceEndpoint$.next({
-      operation: 2,
+      state: EndpointStatus.Connected,
       message: 'Connected',
       serverDescription: 'Signal K',
       httpServiceUrl: 'http://localhost:3000/signalk/v1/api/',

--- a/src/app/core/services/signalk-connection.service.spec.ts
+++ b/src/app/core/services/signalk-connection.service.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpClient, HttpResponse } from '@angular/common/http';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { SignalKConnectionService } from './signalk-connection.service';
+import { EndpointStatus, SignalKConnectionService } from './signalk-connection.service';
 import { ConnectionStateMachine } from './connection-state-machine.service';
 
 describe('SignalKConnectionService', () => {
@@ -24,7 +24,7 @@ describe('SignalKConnectionService', () => {
   // contract, including the fail-loud behavior for a malformed discovery response.
   const parseEndpoint = (body: unknown, proxyEnabled = false) =>
     (service as unknown as {
-      processEndpointResponse: (r: unknown, p?: boolean, s?: boolean) => { operation: number; httpServiceUrl: string | null };
+      processEndpointResponse: (r: unknown, p?: boolean, s?: boolean) => { state: EndpointStatus; httpServiceUrl: string | null };
     }).processEndpointResponse(new HttpResponse({ body, status: 200 }), proxyEnabled);
 
   const wellFormedBody = {
@@ -33,9 +33,9 @@ describe('SignalKConnectionService', () => {
   };
 
   describe('processEndpointResponse', () => {
-    it('returns a connected (operation 2) endpoint for a well-formed v1 response', () => {
+    it('returns a connected endpoint for a well-formed v1 response', () => {
       const status = parseEndpoint(wellFormedBody);
-      expect(status.operation).toBe(2);
+      expect(status.state).toBe(EndpointStatus.Connected);
       expect(status.httpServiceUrl).toBe('http://host:3000/signalk/v1/api/');
     });
 

--- a/src/app/core/services/signalk-connection.service.ts
+++ b/src/app/core/services/signalk-connection.service.ts
@@ -26,17 +26,21 @@ interface ISignalKEndpointResponse {
 }
 
 /**
- * Operation value represent connection statuses.
- * @usageNotes `operation` field describes the type of operation being
- * performed on the connections.
- * `0 = Stopped
- * `1 = Connecting (connection being set up/under execution)
- * `2 = Connected
- * `3 = Error connecting
- * `4 = Resetting
+ * HTTP endpoint discovery status for the Signal K server connection.
+ */
+export enum EndpointStatus {
+  Disconnected = 'Disconnected',
+  Connecting = 'Connecting',
+  Connected = 'Connected',
+  Error = 'Error'
+}
+
+/**
+ * Signal K server HTTP endpoint discovery result: connection status plus the
+ * discovered service URLs.
  */
 export interface IEndpointStatus {
-  operation: number;
+  state: EndpointStatus;
   message: string;
   serverDescription: string | null;
   httpServiceUrl: string | null;     // v1 API endpoint
@@ -62,7 +66,7 @@ export class SignalKConnectionService {
   }
 
   public serverServiceEndpoint$: BehaviorSubject<IEndpointStatus> = new BehaviorSubject<IEndpointStatus>({
-    operation: 0,
+    state: EndpointStatus.Disconnected,
     message: "Not connected",
     serverDescription: null,
     httpServiceUrl: null,
@@ -171,7 +175,7 @@ export class SignalKConnectionService {
     this.currentSubscribeAll = subscribeAll;
 
     const serverServiceEndpoints: IEndpointStatus = {
-      operation: 1,
+      state: EndpointStatus.Connecting,
       message: "Connecting...",
       serverDescription: null,
       httpServiceUrl: null,
@@ -210,7 +214,7 @@ export class SignalKConnectionService {
       this.connectionStateMachine.onHTTPDiscoverySuccess();
 
     } catch (error) {
-      serverServiceEndpoints.operation = 3;
+      serverServiceEndpoints.state = EndpointStatus.Error;
       serverServiceEndpoints.message = error.message;
 
       // Notify ConnectionStateMachine of HTTP failure
@@ -275,7 +279,7 @@ export class SignalKConnectionService {
 
     } catch (error) {
       const serverServiceEndpoints: IEndpointStatus = {
-        operation: 3,
+        state: EndpointStatus.Error,
         message: error.message,
         serverDescription: null,
         httpServiceUrl: null,
@@ -318,7 +322,7 @@ export class SignalKConnectionService {
     }
 
     const serverServiceEndpoints: IEndpointStatus = {
-      operation: 2,
+      state: EndpointStatus.Connected,
       message: endpointResponse.status?.toString() || "Connected",
       serverDescription: `${endpointResponse.body.server.id} ${endpointResponse.body.server.version}`,
       httpServiceUrl: null,

--- a/src/app/core/services/signalk-delta.service.spec.ts
+++ b/src/app/core/services/signalk-delta.service.spec.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { BehaviorSubject } from 'rxjs';
 import { SignalKDeltaService } from './signalk-delta.service';
 import { AuthenticationService } from './authentication.service';
-import { SignalKConnectionService } from './signalk-connection.service';
+import { EndpointStatus, SignalKConnectionService } from './signalk-connection.service';
 import { ConnectionStateMachine } from './connection-state-machine.service';
 import { ISignalKDeltaMessage, ISignalKUpdateMessage, ISignalKDataValueUpdate, ISignalKMeta, ISkMetadata } from '../interfaces/signalk-interfaces';
 import { IPathValueData, IMeta } from '../interfaces/app-interfaces';
@@ -14,7 +14,7 @@ class AuthStub {
 }
 
 class ConnStub {
-  serverServiceEndpoint$ = new BehaviorSubject<{ operation: number; WsServiceUrl?: string; subscribeAll?: boolean }>({ operation: 0 });
+  serverServiceEndpoint$ = new BehaviorSubject<{ state: EndpointStatus; WsServiceUrl?: string; subscribeAll?: boolean }>({ state: EndpointStatus.Disconnected });
   setServerInfo(): void { /* noop */ }
 }
 
@@ -63,7 +63,7 @@ describe('SignalKDeltaService', () => {
   describe('WebSocket URL', () => {
     it('never appends an auth token (the same-origin session cookie authenticates the upgrade)', () => {
       const { service, conn } = setup();
-      conn.serverServiceEndpoint$.next({ operation: 2, WsServiceUrl: 'wss://host/signalk/v1/stream', subscribeAll: false });
+      conn.serverServiceEndpoint$.next({ state: EndpointStatus.Connected, WsServiceUrl: 'wss://host/signalk/v1/stream', subscribeAll: false });
 
       const url = (service as unknown as DeltaInternals).buildWebSocketUrl();
       expect(url).not.toContain('token=');

--- a/src/app/core/services/signalk-delta.service.ts
+++ b/src/app/core/services/signalk-delta.service.ts
@@ -5,24 +5,25 @@ import { webSocket, WebSocketSubject } from 'rxjs/webSocket';
 
 import { ISignalKDataValueUpdate, ISignalKDeltaMessage, ISignalKMeta, ISignalKUpdateMessage } from '../interfaces/signalk-interfaces';
 import { IMeta, IPathValueData } from "../interfaces/app-interfaces";
-import { SignalKConnectionService, IEndpointStatus } from './signalk-connection.service'
+import { SignalKConnectionService, IEndpointStatus, EndpointStatus } from './signalk-connection.service'
 import { AuthenticationService } from './authentication.service';
 import { ConnectionStateMachine, ConnectionState } from './connection-state-machine.service';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 
 /**
- * Operation value represent connection statuses.
- * @usageNotes `operation` field describes the type of operation being
- * performed on the connections.
- * `0 = Stopped
- * `1 = Connecting (connection being set up/under execution)
- * `2 = Connected
- * `3 = Error connecting
- * `4 = Resetting
+ * WebSocket delta-stream connection status.
  */
+export enum StreamStatus {
+  Disconnected = 'Disconnected',
+  Connecting = 'Connecting',
+  Connected = 'Connected',
+  Error = 'Error',
+  Closing = 'Closing'
+}
+
 export interface IStreamStatus {
-  operation: number;
+  state: StreamStatus;
   message: string;
 }
 
@@ -63,7 +64,7 @@ export class SignalKDeltaService implements OnDestroy {
 
   // Delta Service Endpoint status publishing
   public streamEndpoint: IStreamStatus = {
-    operation: 0,
+    state: StreamStatus.Disconnected,
     message: "Not connected",
   }
   public streamEndpoint$: BehaviorSubject<IStreamStatus> = new BehaviorSubject<IStreamStatus>(this.streamEndpoint);
@@ -106,7 +107,7 @@ export class SignalKDeltaService implements OnDestroy {
     this.server.serverServiceEndpoint$
       .pipe(takeUntilDestroyed(this._destroyRef))
       .subscribe((endpointStatus: IEndpointStatus) => {
-        if (endpointStatus.operation === 2) {
+        if (endpointStatus.state === EndpointStatus.Connected) {
           this.endpointWS = endpointStatus.WsServiceUrl;
 
           // Set subscription type
@@ -153,7 +154,7 @@ export class SignalKDeltaService implements OnDestroy {
       .pipe(takeUntilDestroyed(this._destroyRef))
       .subscribe(() => {
         this.streamEndpoint.message = "Connected";
-        this.streamEndpoint.operation = 2;
+        this.streamEndpoint.state = StreamStatus.Connected;
         console.log("[Delta Service] WebSocket connected");
         this.streamEndpoint$.next(this.streamEndpoint);
 
@@ -172,11 +173,11 @@ export class SignalKDeltaService implements OnDestroy {
         if (event.wasClean) {
           console.log('[Delta Service] WebSocket closed cleanly');
           this.streamEndpoint.message = "WebSocket closed";
-          this.streamEndpoint.operation = 0;
+          this.streamEndpoint.state = StreamStatus.Disconnected;
         } else {
           console.log('[Delta Service] WebSocket terminated due to socket error');
           this.streamEndpoint.message = "WebSocket error";
-          this.streamEndpoint.operation = 3;
+          this.streamEndpoint.state = StreamStatus.Error;
 
           // Notify ConnectionStateMachine of WebSocket error
           this.connectionStateMachine.onWebSocketError('WebSocket connection lost');
@@ -209,7 +210,7 @@ export class SignalKDeltaService implements OnDestroy {
    */
   public connectWS(reason: string): void {
     this.streamEndpoint.message = "Connecting";
-    this.streamEndpoint.operation = 1;
+    this.streamEndpoint.state = StreamStatus.Connecting;
     console.log(`[Delta Service] ${reason}: WebSocket opening...`);
     this.streamEndpoint$.next(this.streamEndpoint);
 
@@ -271,7 +272,7 @@ export class SignalKDeltaService implements OnDestroy {
     }
 
     this.streamEndpoint.message = "Not connected";
-    this.streamEndpoint.operation = 0;
+    this.streamEndpoint.state = StreamStatus.Disconnected;
     this.streamEndpoint$.next(this.streamEndpoint);
   }
 
@@ -303,7 +304,7 @@ export class SignalKDeltaService implements OnDestroy {
   */
   public closeWS(reason: string) {
     if (this.socketWS$) {
-      this.streamEndpoint.operation = 4; // closing status. Internal - no need to push to Observers
+      this.streamEndpoint.state = StreamStatus.Closing; // internal - no need to push to Observers
       console.log("[Delta Service] " + reason + ": WebSocket closing...");
       this.socketWS$.complete();
     }

--- a/src/app/core/services/storage.service.spec.ts
+++ b/src/app/core/services/storage.service.spec.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { BehaviorSubject } from 'rxjs';
 import { StorageService, IPatchFailure } from './storage.service';
 import { IConfig } from '../interfaces/app-settings.interfaces';
-import { SignalKConnectionService, IEndpointStatus } from './signalk-connection.service';
+import { EndpointStatus, SignalKConnectionService, IEndpointStatus } from './signalk-connection.service';
 import { AuthenticationService } from './authentication.service';
 import { ensureLocalStorage } from '../../../test-helpers/local-storage.test-helper';
 
@@ -276,12 +276,12 @@ class AuthStub {
   isLoggedIn$ = new BehaviorSubject<boolean>(false);
 }
 class ConnStub {
-  serverServiceEndpoint$ = new BehaviorSubject<IEndpointStatus>({ operation: 0 } as IEndpointStatus);
+  serverServiceEndpoint$ = new BehaviorSubject<IEndpointStatus>({ state: EndpointStatus.Disconnected } as IEndpointStatus);
   serverVersion$ = new BehaviorSubject<string | null>(null);
 }
 
-function endpoint(httpServiceUrl: string, operation = 2): IEndpointStatus {
-  return { operation, message: '', serverDescription: '', httpServiceUrl, WsServiceUrl: '' };
+function endpoint(httpServiceUrl: string, state: EndpointStatus = EndpointStatus.Connected): IEndpointStatus {
+  return { state, message: '', serverDescription: '', httpServiceUrl, WsServiceUrl: '' };
 }
 
 const tick = () => new Promise(resolve => setTimeout(resolve, 0));

--- a/src/app/core/services/storage.service.ts
+++ b/src/app/core/services/storage.service.ts
@@ -1,5 +1,5 @@
 import { cloneDeep } from 'lodash-es';
-import { IEndpointStatus, SignalKConnectionService } from './signalk-connection.service';
+import { EndpointStatus, IEndpointStatus, SignalKConnectionService } from './signalk-connection.service';
 import { Injectable, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { IConfig } from "../interfaces/app-settings.interfaces";
@@ -154,7 +154,7 @@ export class StorageService {
       this.serverEndpoint = this._networkStatus.httpServiceUrl.substring(0, this._networkStatus.httpServiceUrl.length - 4) + "applicationData/"; // this removes 'api/' from the end;
     }
 
-    if (this._networkStatus?.operation === 2 && this._isLoggedIn && this.serverEndpoint) {
+    if (this._networkStatus?.state === EndpointStatus.Connected && this._isLoggedIn && this.serverEndpoint) {
       this.storageServiceReady$.next(true);
       console.log(`[Remote Storage Service] Authenticated ${this._isLoggedIn}, AppData API: ${this.serverEndpoint}`);
     } else {


### PR DESCRIPTION
## Motivation

The three connection-status interfaces — `IConnectionStatus`, `IEndpointStatus`, `IStreamStatus` — each carried an untyped `operation: number` field whose meaning lived only in a stale `0–4` doc comment. Consumers compared against bare magic numbers (`operation === 2`), and the app's connection-status toast switch dispatched on those codes. This is packet **E3** of the #257 backlog (issue #9): give each connection layer a typed vocabulary.

## Approach

Per-layer typed enums, because the three fields describe **different** layers:

- **`IConnectionStatus`** (overall lifecycle): the `operation` field and the `stateToOperationCode()` mapping are **deleted**. `AppComponent.displayConnectionsStatusNotification` now switches on `connectionStatus.state` (the existing `ConnectionState` enum) directly.
- **`IEndpointStatus`** (HTTP discovery): `operation: number` → `state: EndpointStatus` (`Disconnected` / `Connecting` / `Connected` / `Error`).
- **`IStreamStatus`** (WebSocket delta stream): `operation: number` → `state: StreamStatus` (adds `Closing` for the internal `closeWS` state).
- Consumers in `signalk-delta.service` and `storage.service` now key off `EndpointStatus.Connected` instead of `=== 2`.

## Behavior preservation

This is a typing/consistency refactor. Every toast (message, duration, silent flag, level), the delta `WsServiceUrl` gating, and the storage-readiness gate map to the **same observable outcomes** as the numeric codes. The two intentional deltas:

1. The dead `case 4` (a "Resetting" info toast) is removed — `stateToOperationCode` never produced code 4 for `IConnectionStatus`, so it was unreachable.
2. `PermanentFailure` now has an explicit named branch (was numeric code 5).

Note: `operation === 2` was **not** dead — `processEndpointResponse` sets `operation: 2` on HTTP-discovery success, so the `EndpointStatus.Connected` mapping preserves the live delta `WsServiceUrl` capture.

## Tests

Adds `AppComponent` notification-switch coverage (the state→toast mapping was previously untested), including the bootstrap-silent path, and repoints the endpoint/stream status fixtures across the affected specs.

## Verification

Local `npm run ci` equivalent: lint ✓ · betterer 183 (unchanged, baseline regenerated for content hashes) ✓ · 1171 unit tests ✓ · 7 plugin tests ✓.

Reviewed via the standard multi-persona pass (correctness, testing, maintainability, project-standards, reliability, adversarial): 5/6 lenses clean; one confirmed P3 (bootstrap-silent coverage) addressed; one P2 refuted as a nitpick (100% switch-branch coverage already).

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)