### PR TITLE
Hydrate all app-config holders before persist-on-missing writes (#170)

### DIFF
--- a/src/app/core/services/settings.service.spec.ts
+++ b/src/app/core/services/settings.service.spec.ts
@@ -391,11 +391,12 @@ describe('SettingsService — hydration (pushSettings) characterization', () => 
   });
 
   // The persist-on-missing bootstrap fields: exactly these three (widgetHistoryDisabled was
-  // removed by #157). Each missing field fires its own whole-app patch during startup.
-  const persistOnMissing: { field: string; bootstrapDefault: unknown; read: (s: SettingsService) => unknown }[] = [
-    { field: 'autoNightMode', bootstrapDefault: false, read: (s) => s.getAutoNightMode() },
-    { field: 'redNightMode', bootstrapDefault: false, read: (s) => s.getRedNightMode() },
-    { field: 'nightModeBrightness', bootstrapDefault: 0.2, read: (s) => s.getNightModeBrightness() }
+  // removed by #157). A single missing field fires one whole-app patch built from fully-hydrated state;
+  // `loaded` is that field's value in the DEFAULT_LOADED fixture, used to pin sibling preservation.
+  const persistOnMissing: { field: string; bootstrapDefault: unknown; loaded: unknown; read: (s: SettingsService) => unknown }[] = [
+    { field: 'autoNightMode', bootstrapDefault: false, loaded: true, read: (s) => s.getAutoNightMode() },
+    { field: 'redNightMode', bootstrapDefault: false, loaded: true, read: (s) => s.getRedNightMode() },
+    { field: 'nightModeBrightness', bootstrapDefault: 0.2, loaded: 0.65, read: (s) => s.getNightModeBrightness() }
   ];
 
   for (const { field, bootstrapDefault, read } of persistOnMissing) {
@@ -413,17 +414,28 @@ describe('SettingsService — hydration (pushSettings) characterization', () => 
       expect(blob.unitDefaults).toEqual({ Speed: 'knots' });
       expect(blob.notificationConfig).toEqual(fullNotificationConfig());
       expect(read(service)).toBe(bootstrapDefault);
+      // The write for THIS absent field must not revert a sibling (#170, symmetric across all three): every
+      // other app-blob field rides along at its loaded value, not a pre-hydration default.
+      for (const other of persistOnMissing) {
+        if (other.field !== field) expect(blob[other.field]).toBe(other.loaded);
+      }
+      expect(blob.browserTabTitle).toBe('My Boat');
     });
   }
 
-  it('all three persist-on-missing fields absent fire one bootstrap patch each', () => {
+  it('all three persist-on-missing fields absent fire a single coalesced bootstrap patch', () => {
     const { patchSpy } = setupHydrated({
       app: loadedAppConfig(['autoNightMode', 'redNightMode', 'nightModeBrightness']),
       theme: null,
       dashboards: []
     });
-    expect(patchSpy).toHaveBeenCalledTimes(3);
-    expect(patchSpy.mock.calls.map((c) => c[0])).toEqual(['IAppConfig', 'IAppConfig', 'IAppConfig']);
+    expect(patchSpy).toHaveBeenCalledTimes(1);
+    const [objType, blob] = patchSpy.mock.calls[0];
+    expect(objType).toBe('IAppConfig');
+    expect(blob.autoNightMode).toBe(false);
+    expect(blob.redNightMode).toBe(false);
+    expect(blob.nightModeBrightness).toBe(0.2);
+    expect(blob.browserTabTitle).toBe('My Boat');
   });
 
   it('a missing browserTabTitle defaults to "Skip" in memory WITHOUT a bootstrap write', () => {

--- a/src/app/core/services/settings.service.ts
+++ b/src/app/core/services/settings.service.ts
@@ -228,34 +228,20 @@ export class SettingsService {
     this.applyUnitDefaults(app.unitDefaults);
     this.applyNotificationConfig(app.notificationConfig);
 
-    if (app.autoNightMode === undefined) {
-      this.setAutoNightMode(false);
-    } else {
-      this._autoNightMode.set(app.autoNightMode);
-    }
+    // Hydrate every app-config holder from stored state (defaults for absent fields) BEFORE any persist.
+    // A persist-on-missing bootstrap write serializes the full IAppConfig from the holders it reads (the
+    // night-mode fields + browserTabTitle), so any of those still at its pre-hydration default when a
+    // write fires is captured wrong and reverted on the server (#170) — including one night-mode field
+    // reverting the others. Hydrate them all, then persist once. (dashboards is hydrated here too but is
+    // not part of the app blob.)
+    this._dashboards = this.activeConfig.dashboards === undefined ? [] : this.activeConfig.dashboards;
+    this._browserTabTitle.set(app.browserTabTitle === undefined ? 'Skip' : app.browserTabTitle);
+    this._autoNightMode.set(app.autoNightMode === undefined ? false : app.autoNightMode);
+    this._redNightMode.set(app.redNightMode === undefined ? false : app.redNightMode);
+    this._nightModeBrightness.set(app.nightModeBrightness === undefined ? 0.2 : app.nightModeBrightness);
 
-    if (app.redNightMode === undefined) {
-      this.setRedNightMode(false);
-    } else {
-      this._redNightMode.set(app.redNightMode);
-    }
-
-    if (app.nightModeBrightness === undefined) {
-      this.setNightModeBrightness(0.2);
-    } else {
-      this._nightModeBrightness.set(app.nightModeBrightness);
-    }
-
-    if (this.activeConfig.dashboards === undefined) {
-      this._dashboards = [];
-    } else {
-      this._dashboards = this.activeConfig.dashboards;
-    }
-
-    if (app.browserTabTitle === undefined) {
-      this._browserTabTitle.set('Skip');
-    } else {
-      this._browserTabTitle.set(app.browserTabTitle);
+    if (app.autoNightMode === undefined || app.redNightMode === undefined || app.nightModeBrightness === undefined) {
+      this.saveAppConfig();
     }
   }
 


### PR DESCRIPTION
## Motivation

`SettingsService.pushSettings()` fired its persist-on-missing bootstrap writes (for an absent `autoNightMode` / `redNightMode` / `nightModeBrightness`) **mid-hydration**, interleaved with field hydration. Each write serializes the full `IAppConfig` from the reactive holders, so any holder not yet hydrated was captured at its default and **reverted on the server** (#170):

- a stored profile missing `autoNightMode` but with a custom `browserTabTitle` had the title silently reverted to `'Skip'` on the next reload; and
- the same defect one field over — a missing `autoNightMode` also reverted a stored `redNightMode` / `nightModeBrightness` to their init defaults, because those blocks ran *after* the write.

Only sparse configs are affected (persist-on-missing fires only when a night-mode field is absent), which is why it went unnoticed.

## Approach

Hydrate **every** app-config holder (`browserTabTitle` + the three night-mode fields; `dashboards` too, though it isn't part of the app blob) from stored-or-default state **first**, then persist **once** from the fully-hydrated blob if any night-mode field was absent — coalescing what were up to three separate mid-hydration writes into one correct write. This closes the revert class for every field rather than just `browserTabTitle`.

## Tests

The parametrized persist-on-missing loop now asserts, for each single-absent permutation, that every *other* app-blob field (the sibling night-mode fields + `browserTabTitle`) rides along at its loaded value — locking the whole revert class symmetrically. The all-three-absent test asserts the single coalesced write carries every default.

## Verification

Local gate: lint ✓ · betterer 183 (unchanged) ✓ · full unit suite ✓ · plugin ✓.

Reviewed via the standard multi-persona pass. The first review caught that an initial reorder-only fix left the night-mode fields reverting each other; this revision (hydrate-all-then-coalesce) closes that, and a re-review confirmed the code correct with the test coverage extended symmetrically.

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)