### PR TITLE
Reveal the toolbar by hovering the top peek band (#202)

### DIFF
--- a/src/app/core/components/toolbar/toolbar.component.spec.ts
+++ b/src/app/core/components/toolbar/toolbar.component.spec.ts
@@ -4,7 +4,7 @@ import { Router } from '@angular/router';
 import { of } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppService } from '../../services/app-service';
-import { ChromeVisibilityService } from '../../services/chrome-visibility.service';
+import { ChromeVisibilityService, CHROME_HOVER_DWELL_MS } from '../../services/chrome-visibility.service';
 import { DashboardService } from '../../services/dashboard.service';
 import { DialogService } from '../../services/dialog.service';
 import { NotificationsService } from '../../services/notifications.service';
@@ -126,6 +126,117 @@ describe('ToolbarComponent', () => {
     chrome.revealed.set(true);
     init();
     expect(el.querySelector('.toolbar-host')!.classList.contains('revealed')).toBe(true);
+  });
+
+  describe('hover-reveal (peek-band dwell)', () => {
+    // Drive the component's document-pointermove handler directly: dispatching on `document` would also
+    // fire the leaked listeners of prior test fixtures, breaking isolation.
+    interface HoverApi { onDocumentPointerMove: (e: PointerEvent) => void }
+    const move = (clientY: number, pointerType = 'mouse') => ({ clientY, pointerType }) as PointerEvent;
+
+    it('reveals the toolbar after the cursor dwells in the top peek band', () => {
+      vi.useFakeTimers();
+      try {
+        init();
+        const api = fixture.componentInstance as unknown as HoverApi;
+        api.onDocumentPointerMove(move(4)); // within the 8px band
+        expect(chrome.reveal).not.toHaveBeenCalled(); // not until the dwell elapses
+        vi.advanceTimersByTime(CHROME_HOVER_DWELL_MS);
+        expect(chrome.reveal).toHaveBeenCalledTimes(1);
+      } finally { vi.useRealTimers(); }
+    });
+
+    it('cancels the dwell when the cursor leaves the band before it elapses', () => {
+      vi.useFakeTimers();
+      try {
+        init();
+        const api = fixture.componentInstance as unknown as HoverApi;
+        api.onDocumentPointerMove(move(4));
+        vi.advanceTimersByTime(CHROME_HOVER_DWELL_MS - 50);
+        api.onDocumentPointerMove(move(200)); // leaves the band
+        vi.advanceTimersByTime(200);
+        expect(chrome.reveal).not.toHaveBeenCalled();
+      } finally { vi.useRealTimers(); }
+    });
+
+    it('ignores a touch pointer (tap-to-reveal stays the touch path)', () => {
+      vi.useFakeTimers();
+      try {
+        init();
+        const api = fixture.componentInstance as unknown as HoverApi;
+        api.onDocumentPointerMove(move(4, 'touch'));
+        vi.advanceTimersByTime(CHROME_HOVER_DWELL_MS);
+        expect(chrome.reveal).not.toHaveBeenCalled();
+      } finally { vi.useRealTimers(); }
+    });
+
+    it('does not arm a dwell while the toolbar is already revealed', () => {
+      vi.useFakeTimers();
+      try {
+        chrome.revealed.set(true);
+        init();
+        const api = fixture.componentInstance as unknown as HoverApi;
+        api.onDocumentPointerMove(move(4));
+        vi.advanceTimersByTime(CHROME_HOVER_DWELL_MS);
+        expect(chrome.reveal).not.toHaveBeenCalled();
+      } finally { vi.useRealTimers(); }
+    });
+
+    it('stops a pending dwell on destroy', () => {
+      vi.useFakeTimers();
+      try {
+        init();
+        const api = fixture.componentInstance as unknown as HoverApi;
+        api.onDocumentPointerMove(move(4));
+        fixture.destroy();
+        vi.advanceTimersByTime(CHROME_HOVER_DWELL_MS);
+        expect(chrome.reveal).not.toHaveBeenCalled();
+      } finally { vi.useRealTimers(); }
+    });
+
+    it('binds the passive document listener on construct and removes the same handler on destroy', () => {
+      const add = vi.spyOn(document, 'addEventListener');
+      init();
+      const registered = add.mock.calls.find((c) => c[0] === 'pointermove');
+      expect(registered).toBeTruthy();
+      expect(registered![2]).toEqual({ passive: true });
+
+      const remove = vi.spyOn(document, 'removeEventListener');
+      fixture.destroy();
+      expect(remove).toHaveBeenCalledWith('pointermove', registered![1]);
+
+      add.mockRestore();
+      remove.mockRestore();
+    });
+
+    it('keeps the original dwell running across small in-zone moves (dwell measures time in the band)', () => {
+      vi.useFakeTimers();
+      try {
+        init();
+        const api = fixture.componentInstance as unknown as HoverApi;
+        api.onDocumentPointerMove(move(4)); // enter → arm the dwell
+        vi.advanceTimersByTime(CHROME_HOVER_DWELL_MS - 50);
+        api.onDocumentPointerMove(move(3)); // a small move still inside the band must NOT reset the dwell
+        vi.advanceTimersByTime(50); // now CHROME_HOVER_DWELL_MS after the original entry
+        expect(chrome.reveal).toHaveBeenCalledTimes(1);
+      } finally { vi.useRealTimers(); }
+    });
+
+    it('arms a fresh dwell after leaving and re-entering the band', () => {
+      vi.useFakeTimers();
+      try {
+        init();
+        const api = fixture.componentInstance as unknown as HoverApi;
+        api.onDocumentPointerMove(move(4));
+        api.onDocumentPointerMove(move(200)); // leave → cancels
+        vi.advanceTimersByTime(CHROME_HOVER_DWELL_MS);
+        expect(chrome.reveal).not.toHaveBeenCalled();
+
+        api.onDocumentPointerMove(move(4)); // re-enter → fresh dwell
+        vi.advanceTimersByTime(CHROME_HOVER_DWELL_MS);
+        expect(chrome.reveal).toHaveBeenCalledTimes(1);
+      } finally { vi.useRealTimers(); }
+    });
   });
 
   it('hides the night toggle in auto-night mode and fullscreen when unsupported', () => {

--- a/src/app/core/components/toolbar/toolbar.component.ts
+++ b/src/app/core/components/toolbar/toolbar.component.ts
@@ -4,7 +4,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatBadgeModule } from '@angular/material/badge';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { ChromeVisibilityService } from '../../services/chrome-visibility.service';
+import { ChromeVisibilityService, CHROME_HOVER_DWELL_MS } from '../../services/chrome-visibility.service';
 import { DashboardService } from '../../services/dashboard.service';
 import { uiEventService } from '../../services/uiEvent.service';
 import { AppService } from '../../services/app-service';
@@ -13,12 +13,18 @@ import { DialogService } from '../../services/dialog.service';
 import { NotificationsService } from '../../services/notifications.service';
 import { PageNavControlComponent } from '../page-nav-control/page-nav-control.component';
 
+/** Top-edge band (px) whose cursor dwell exposes the toolbar; matches `--peek-height` in the SCSS. */
+const PEEK_HOTZONE_PX = 8;
+
 /**
  * The auto-hiding navigation toolbar. Overlays the top of the app (never
  * reflows the grid), is shown/hidden via {@link ChromeVisibilityService}, and
  * hosts the global controls migrated off the old sidenavs plus the page-icon
  * navigator. Hovering the bar suppresses auto-hide so it never disappears
- * mid-interaction; the transient peek strip re-reveals it on click.
+ * mid-interaction. It is re-exposed either by clicking the transient peek strip
+ * (also the keyboard/touch path) or, on a hover-capable pointer, by dwelling the
+ * cursor in the top peek band; both routes call the same {@link reveal}, so the
+ * existing idle-hide re-arms cleanly when the cursor leaves.
  */
 @Component({
   selector: 'app-toolbar',
@@ -44,6 +50,43 @@ export class ToolbarComponent implements OnDestroy {
 
   private readonly notificationsInfo = toSignal(this.notifications.observerNotificationsInfo());
   protected readonly alarmCount = computed(() => this.notificationsInfo()?.alarmCount ?? 0);
+
+  private dwellTimer: ReturnType<typeof setTimeout> | null = null;
+  private inPeekZone = false;
+
+  /** Reveals the toolbar once the cursor dwells in the top peek band, on a hover-capable pointer. */
+  private readonly onDocumentPointerMove = (event: PointerEvent): void => {
+    if (event.pointerType === 'touch') return; // touch has no hover; the tap-the-peek-strip path stays
+    const inZone = event.clientY <= PEEK_HOTZONE_PX;
+    if (inZone && !this.inPeekZone && !this.chrome.revealed()) {
+      this.armHoverDwell();
+    } else if (!inZone && this.inPeekZone) {
+      this.clearHoverDwell();
+    }
+    this.inPeekZone = inZone;
+  };
+
+  constructor() {
+    // Passive so it never blocks scrolling; a document listener sees moves over the peek band even
+    // though the strip is pointer-events:none until it peeks. Hover-reveal is gated per-event on a
+    // hover-capable pointer, leaving the tap-the-peek-strip path for touch.
+    document.addEventListener('pointermove', this.onDocumentPointerMove, { passive: true });
+  }
+
+  private armHoverDwell(): void {
+    this.clearHoverDwell();
+    this.dwellTimer = setTimeout(() => {
+      this.dwellTimer = null;
+      this.reveal();
+    }, CHROME_HOVER_DWELL_MS);
+  }
+
+  private clearHoverDwell(): void {
+    if (this.dwellTimer !== null) {
+      clearTimeout(this.dwellTimer);
+      this.dwellTimer = null;
+    }
+  }
 
   protected toggleFullScreen(): void {
     this.uiEvent.toggleFullScreen();
@@ -86,6 +129,8 @@ export class ToolbarComponent implements OnDestroy {
   // the ref-count on the singleton service would leak and pin the toolbar open.
   ngOnDestroy(): void {
     this.onPointerLeave();
+    document.removeEventListener('pointermove', this.onDocumentPointerMove);
+    this.clearHoverDwell();
   }
 
   private _hideSuppressed = false;

--- a/src/app/core/services/chrome-visibility.service.ts
+++ b/src/app/core/services/chrome-visibility.service.ts
@@ -7,6 +7,8 @@ import { Injectable, signal } from '@angular/core';
 export const CHROME_BOOT_DWELL_MS = 4000;
 export const CHROME_IDLE_HIDE_MS = 4000;
 export const CHROME_PEEK_MS = 1300;
+/** Cursor dwell in the top peek hotzone before a hover exposes the toolbar (debounces twitchy passes). */
+export const CHROME_HOVER_DWELL_MS = 200;
 
 /**
  * Owns the ephemeral visibility state of the top navigation toolbar.


### PR DESCRIPTION
## Motivation

The auto-hiding navigation toolbar could only be re-exposed by clicking the transient peek strip (or via keyboard/touch). On a mouse/desktop, moving the cursor to the top edge should expose it without a click (#202). The auto-close-after-leaving already exists (leaving the revealed toolbar re-arms the 4s idle-hide), so the genuinely new work is hover-to-expose.

## Approach

`ToolbarComponent` registers a **passive** `document` `pointermove` listener. On each move it:

- returns early for `pointerType === 'touch'` (touch has no hover — the tap-the-peek-strip path stays);
- computes `inZone = clientY <= PEEK_HOTZONE_PX` (8px, matching `--peek-height`);
- on entering the band (and only if not already revealed), arms a short dwell (`CHROME_HOVER_DWELL_MS = 200ms`) that debounces twitchy passes, then calls the existing `reveal()`;
- clears the dwell when the cursor leaves the band.

`reveal()` arms the existing 4s idle-hide, so leaving auto-closes on the same clock — **no second close timer**, per the issue's N-decision. `ngOnDestroy` removes the listener and clears the dwell timer. Using `clientY` off a document listener means the peek strip's `pointer-events` don't change (no click interception).

## Tests

Dwell reveals; leave cancels; touch is a no-op; already-revealed doesn't arm; destroy stops a pending dwell; the listener is bound on construct and the same handler removed on destroy; the dwell survives small in-zone moves (measures time in the band, not stillness); leaving and re-entering arms a fresh dwell.

## Verification

Local gate: lint ✓ · betterer 183 (unchanged) ✓ · full unit suite ✓ · plugin ✓. Reviewed via the standard multi-persona pass (correctness, reliability, testing, maintainability, project-standards) — no production defect; the listener/timer lifecycle and re-arm latch coverage were added on review feedback.

**Manual on-device check pending** (hover behavior on real hardware) before merge.

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)