### PR TITLE
History-engine trend charts: re-backfill the gap after a WebSocket reconnect (#85)

### DIFF
--- a/src/app/core/services/history-chart-stream.service.spec.ts
+++ b/src/app/core/services/history-chart-stream.service.spec.ts
@@ -1,10 +1,11 @@
 import { TestBed } from '@angular/core/testing';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { Subject, firstValueFrom } from 'rxjs';
+import { BehaviorSubject, Subject, firstValueFrom } from 'rxjs';
 import { HistoryChartStreamService, IHistoryChartStreamParams, isHistoryUnavailable } from './history-chart-stream.service';
 import { HistoryApiClientService, HistoryRequestError } from './history-api-client.service';
 import { HistoryToChartMapperService } from './history-to-chart-mapper.service';
 import { DataService, IPathUpdate } from './data.service';
+import { ConnectionState, ConnectionStateMachine } from './connection-state-machine.service';
 import { IDatasetServiceDatapoint } from '../interfaces/dataset.interfaces';
 
 const PARAMS: IHistoryChartStreamParams = {
@@ -18,6 +19,7 @@ const PARAMS: IHistoryChartStreamParams = {
 
 describe('HistoryChartStreamService', () => {
   let path$: Subject<IPathUpdate>;
+  let state$: BehaviorSubject<ConnectionState>;
   const history = { getValues: vi.fn() };
   const mapper = { mapValuesToChartDatapoints: vi.fn() };
   const data = { subscribePath: vi.fn(), getPathUnitType: vi.fn() };
@@ -28,7 +30,8 @@ describe('HistoryChartStreamService', () => {
         HistoryChartStreamService,
         { provide: HistoryApiClientService, useValue: history },
         { provide: HistoryToChartMapperService, useValue: mapper },
-        { provide: DataService, useValue: data }
+        { provide: DataService, useValue: data },
+        { provide: ConnectionStateMachine, useValue: { state$ } }
       ]
     });
     return TestBed.inject(HistoryChartStreamService);
@@ -36,6 +39,9 @@ describe('HistoryChartStreamService', () => {
 
   beforeEach(() => {
     path$ = new Subject<IPathUpdate>();
+    // Charts mount while already connected; the reconnect re-backfill fires only on LATER Connected
+    // transitions, so a stuck-Connected stream leaves the existing live-tail behavior unchanged.
+    state$ = new BehaviorSubject<ConnectionState>(ConnectionState.Connected);
     history.getValues.mockReset();
     mapper.mapValuesToChartDatapoints.mockReset().mockReturnValue([]);
     data.subscribePath.mockReset().mockReturnValue(path$);
@@ -385,5 +391,550 @@ describe('HistoryChartStreamService', () => {
     // Circular mean of 350° and 10° is ~0° in the direction domain, NOT the ~180° a linear mean gives.
     // Pre-#133 this path resolved to 'scalar' and lastAverage would be ~π.
     expect(Math.min(avg, 2 * Math.PI - avg)).toBeLessThan(0.02);
+  });
+
+  describe('reconnect re-backfill (#85)', () => {
+    it('does not re-backfill on the initial connect — only the constructor backfill runs', async () => {
+      history.getValues.mockResolvedValue({ context: 'vessels.self', range: {}, values: [], data: [] });
+      mapper.mapValuesToChartDatapoints.mockReturnValue([]);
+      make().getBackfillThenLive(PARAMS).subscribe();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // state$ replays its seeded Connected once during wiring; that first Connected must not trigger a
+      // second History request on top of the constructor's backfill.
+      expect(history.getValues).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-fetches only the missed interval on reconnect and appends it as a batch', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(1_000_000);
+      try {
+        history.getValues.mockResolvedValue({ context: 'vessels.self', range: { to: new Date(1_000_000).toISOString() }, values: [], data: [] });
+        mapper.mapValuesToChartDatapoints.mockReturnValue([]); // empty initial backfill
+        const emissions: (IDatasetServiceDatapoint | IDatasetServiceDatapoint[] | { unavailable: true })[] = [];
+        make().getBackfillThenLive(PARAMS).subscribe(e => emissions.push(e));
+        await vi.advanceTimersByTimeAsync(0); // settle initial backfill → live subscribes
+
+        // A live sample fixes lastLiveTs at the client clock (1_000_000).
+        path$.next({ data: { value: 5, timestamp: new Date(1_000_000) }, state: 'normal' });
+
+        // The WS drops; 20s pass; the re-backfill will return one gap sample at 1_010_000.
+        state$.next(ConnectionState.Disconnected);
+        vi.setSystemTime(1_020_000);
+        history.getValues.mockResolvedValue({ context: 'vessels.self', range: { to: new Date(1_020_000).toISOString() }, values: [], data: [] });
+        mapper.mapValuesToChartDatapoints.mockReturnValue([
+          { timestamp: 990_000, data: { value: 1 } },   // at/behind the seam → dropped
+          { timestamp: 1_010_000, data: { value: 9 } }   // inside the gap → kept
+        ]);
+        const callsBefore = history.getValues.mock.calls.length;
+
+        state$.next(ConnectionState.Connected);
+        await vi.advanceTimersByTimeAsync(0); // settle the re-backfill
+
+        // Exactly one extra request, scoped to the gap: biased earlier than the seam by the skew margin
+        // but still within the window. The stale-side point it re-admits is dropped by the > seam de-dup.
+        expect(history.getValues.mock.calls.length).toBe(callsBefore + 1);
+        const reQuery = history.getValues.mock.calls[history.getValues.mock.calls.length - 1][0];
+        expect(Date.parse(reQuery.from)).toBeLessThanOrEqual(1_000_000);
+        expect(Date.parse(reQuery.from)).toBeGreaterThanOrEqual(1_020_000 - PARAMS.windowMs);
+
+        // The batch carries only the point newer than the seam; the stale-side point is de-duped.
+        const batch = emissions.filter(e => Array.isArray(e)).pop() as IDatasetServiceDatapoint[];
+        expect(batch.map(p => p.data.value)).toEqual([9]);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('holds the live tail while disconnected so no gap is drawn mid-drop', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(1_000_000);
+      try {
+        history.getValues.mockResolvedValue({ context: 'vessels.self', range: { to: new Date(1_000_000).toISOString() }, values: [], data: [] });
+        mapper.mapValuesToChartDatapoints.mockReturnValue([]);
+        const emissions: (IDatasetServiceDatapoint | IDatasetServiceDatapoint[] | { unavailable: true })[] = [];
+        make().getBackfillThenLive(PARAMS).subscribe(e => emissions.push(e));
+        await vi.advanceTimersByTimeAsync(0);
+
+        path$.next({ data: { value: 5, timestamp: new Date(1_000_000) }, state: 'normal' });
+        state$.next(ConnectionState.Disconnected);
+
+        // Well past the staleness window: a CONNECTED silent source would gap here (see the #131 test),
+        // but a disconnect must not — the reconnect re-backfill fills it instead.
+        await vi.advanceTimersByTimeAsync(31_000);
+        const gaps = emissions.filter(
+          e => !Array.isArray(e) && !('unavailable' in e) && Number.isNaN((e as IDatasetServiceDatapoint).data.value)
+        );
+        expect(gaps.length).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not re-backfill after the stream is torn down', async () => {
+      history.getValues.mockResolvedValue({ context: 'vessels.self', range: {}, values: [], data: [] });
+      mapper.mapValuesToChartDatapoints.mockReturnValue([]);
+      const sub = make().getBackfillThenLive(PARAMS).subscribe();
+      await Promise.resolve();
+      await Promise.resolve();
+      const callsAfterInit = history.getValues.mock.calls.length;
+
+      sub.unsubscribe();
+      state$.next(ConnectionState.Disconnected);
+      state$.next(ConnectionState.Connected);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(history.getValues.mock.calls.length).toBe(callsAfterInit);
+    });
+
+    it('breaks the trace with a gap when the re-backfill fails over a long outage (no interpolation)', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(1_000_000);
+      try {
+        history.getValues.mockResolvedValue({ context: 'vessels.self', range: { to: new Date(1_000_000).toISOString() }, values: [], data: [] });
+        mapper.mapValuesToChartDatapoints.mockReturnValue([]);
+        const emissions: (IDatasetServiceDatapoint | IDatasetServiceDatapoint[] | { unavailable: true })[] = [];
+        make().getBackfillThenLive(PARAMS).subscribe(e => emissions.push(e));
+        await vi.advanceTimersByTimeAsync(0);
+        path$.next({ data: { value: 5, timestamp: new Date(1_000_000) }, state: 'normal' });
+
+        state$.next(ConnectionState.Disconnected);
+        vi.setSystemTime(1_040_000); // 40s outage — past the 30s bootstrap staleness threshold
+        history.getValues.mockRejectedValue(new HistoryRequestError(503)); // provider down at reconnect
+        state$.next(ConnectionState.Connected);
+        await vi.advanceTimersByTimeAsync(0);
+
+        // No batch (fetch failed); a NaN gap breaks the trace so the live tail cannot interpolate a
+        // straight line across the outage.
+        const last = emissions[emissions.length - 1];
+        expect(Array.isArray(last)).toBe(false);
+        expect(Number.isNaN((last as IDatasetServiceDatapoint).data.value)).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('breaks the trace with a gap when the re-backfill returns no rows over a long outage', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(1_000_000);
+      try {
+        history.getValues.mockResolvedValue({ context: 'vessels.self', range: { to: new Date(1_000_000).toISOString() }, values: [], data: [] });
+        mapper.mapValuesToChartDatapoints.mockReturnValue([]);
+        const emissions: (IDatasetServiceDatapoint | IDatasetServiceDatapoint[] | { unavailable: true })[] = [];
+        make().getBackfillThenLive(PARAMS).subscribe(e => emissions.push(e));
+        await vi.advanceTimersByTimeAsync(0);
+        path$.next({ data: { value: 5, timestamp: new Date(1_000_000) }, state: 'normal' });
+
+        state$.next(ConnectionState.Disconnected);
+        vi.setSystemTime(1_040_000); // 40s outage — past the 30s bootstrap staleness threshold
+        // Provider up but no rows for the window (e.g. a non-recorded path).
+        history.getValues.mockResolvedValue({ context: 'vessels.self', range: { to: new Date(1_040_000).toISOString() }, values: [], data: [] });
+        mapper.mapValuesToChartDatapoints.mockReturnValue([]);
+        state$.next(ConnectionState.Connected);
+        await vi.advanceTimersByTimeAsync(0);
+
+        const last = emissions[emissions.length - 1];
+        expect(Number.isNaN((last as IDatasetServiceDatapoint).data.value)).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not gap a brief blip the re-backfill cannot fill', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(1_000_000);
+      try {
+        history.getValues.mockResolvedValue({ context: 'vessels.self', range: { to: new Date(1_000_000).toISOString() }, values: [], data: [] });
+        mapper.mapValuesToChartDatapoints.mockReturnValue([]);
+        const emissions: (IDatasetServiceDatapoint | IDatasetServiceDatapoint[] | { unavailable: true })[] = [];
+        make().getBackfillThenLive(PARAMS).subscribe(e => emissions.push(e));
+        await vi.advanceTimersByTimeAsync(0);
+        path$.next({ data: { value: 5, timestamp: new Date(1_000_000) }, state: 'normal' });
+
+        state$.next(ConnectionState.Disconnected);
+        vi.setSystemTime(1_001_000); // 1s blip — well under the staleness threshold
+        history.getValues.mockResolvedValue({ context: 'vessels.self', range: { to: new Date(1_001_000).toISOString() }, values: [], data: [] });
+        mapper.mapValuesToChartDatapoints.mockReturnValue([]);
+        state$.next(ConnectionState.Connected);
+        await vi.advanceTimersByTimeAsync(0);
+
+        // A sub-threshold blip is indistinguishable from normal live cadence — no marker.
+        const gaps = emissions.filter(
+          e => !Array.isArray(e) && !('unavailable' in e) && Number.isNaN((e as IDatasetServiceDatapoint).data.value)
+        );
+        expect(gaps.length).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('recovers a failed initial backfill on the first connect, without waiting for a WS drop', async () => {
+      // The constructor backfill fails transiently, so ctx.seeded stays false; the replayed first
+      // Connected must then drive a recovery re-backfill rather than being skipped.
+      history.getValues.mockReset();
+      history.getValues
+        .mockRejectedValueOnce(new HistoryRequestError(503))
+        .mockResolvedValue({ context: 'vessels.self', range: {}, values: [], data: [] });
+      mapper.mapValuesToChartDatapoints.mockReturnValue([]);
+
+      const emissions: (IDatasetServiceDatapoint | IDatasetServiceDatapoint[] | { unavailable: true })[] = [];
+      make().getBackfillThenLive(PARAMS).subscribe(e => emissions.push(e));
+      await new Promise(resolve => setTimeout(resolve));
+      await new Promise(resolve => setTimeout(resolve));
+
+      // The transient failure did not disable the chart, and the seeded=false first Connected drove a
+      // second (recovery) fetch on top of the constructor's failed one.
+      expect(emissions.some(e => !Array.isArray(e) && 'unavailable' in e)).toBe(false);
+      expect(history.getValues.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('coalesces a reconnect that lands mid-fetch and re-runs from the advanced seam', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(1_000_000);
+      try {
+        history.getValues.mockResolvedValue({ context: 'vessels.self', range: { to: new Date(1_000_000).toISOString() }, values: [], data: [] });
+        mapper.mapValuesToChartDatapoints.mockReturnValue([]);
+        const emissions: (IDatasetServiceDatapoint | IDatasetServiceDatapoint[] | { unavailable: true })[] = [];
+        make().getBackfillThenLive(PARAMS).subscribe(e => emissions.push(e));
+        await vi.advanceTimersByTimeAsync(0);
+        path$.next({ data: { value: 5, timestamp: new Date(1_000_000) }, state: 'normal' });
+
+        // Hold the first reconnect's re-backfill fetch open with a manual promise.
+        let releaseFirst: (v: unknown) => void = () => { /* set below */ };
+        const firstFetch = new Promise(res => { releaseFirst = res; });
+        history.getValues.mockReturnValueOnce(firstFetch);
+        state$.next(ConnectionState.Disconnected);
+        vi.setSystemTime(1_010_000);
+        state$.next(ConnectionState.Connected); // reBackfill #1 issues its fetch, then awaits
+        await vi.advanceTimersByTimeAsync(0);
+        const callsAfterFirst = history.getValues.mock.calls.length;
+        const runAFrom = Date.parse(history.getValues.mock.calls[callsAfterFirst - 1][0].from);
+
+        // A second drop/reconnect lands WHILE #1 is in flight: coalesced, no second fetch yet.
+        state$.next(ConnectionState.Disconnected);
+        state$.next(ConnectionState.Connected);
+        await vi.advanceTimersByTimeAsync(0);
+        expect(history.getValues.mock.calls.length).toBe(callsAfterFirst);
+
+        // Run A delivers a point at 1_005_000 → the seam advances; the coalesced re-run (run B) must then
+        // re-fetch from the ADVANCED seam, not the original one. Run B's fetch returns the same point,
+        // which its > seam de-dup now drops (proving the seam advanced).
+        mapper.mapValuesToChartDatapoints.mockReturnValue([{ timestamp: 1_005_000, data: { value: 8 } }]);
+        history.getValues.mockResolvedValue({ context: 'vessels.self', range: { to: new Date(1_010_000).toISOString() }, values: [], data: [] });
+        releaseFirst({ context: 'vessels.self', range: { to: new Date(1_010_000).toISOString() }, values: [], data: [] });
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(history.getValues.mock.calls.length).toBe(callsAfterFirst + 1);
+        const runBFrom = Date.parse(history.getValues.mock.calls[callsAfterFirst][0].from);
+        expect(runBFrom).toBeGreaterThan(runAFrom); // re-run starts from the advanced seam
+
+        // Run A's batch landed and no NaN gap was drawn out of order (the seam advanced, so run B's
+        // > seam de-dup keeps the trace monotonic).
+        const batch = emissions.filter(e => Array.isArray(e)).pop() as IDatasetServiceDatapoint[];
+        expect(batch.map(p => p.data.value)).toEqual([8]);
+        const anyGap = emissions.some(
+          e => !Array.isArray(e) && !('unavailable' in e) && Number.isNaN((e as IDatasetServiceDatapoint).data.value)
+        );
+        expect(anyGap).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('holds a live sample tick that arrives while a re-backfill fetch is in flight', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(1_000_000);
+      try {
+        history.getValues.mockResolvedValue({ context: 'vessels.self', range: { to: new Date(1_000_000).toISOString() }, values: [], data: [] });
+        mapper.mapValuesToChartDatapoints.mockReturnValue([]);
+        const emissions: (IDatasetServiceDatapoint | IDatasetServiceDatapoint[] | { unavailable: true })[] = [];
+        make().getBackfillThenLive(PARAMS).subscribe(e => emissions.push(e));
+        await vi.advanceTimersByTimeAsync(0);
+        path$.next({ data: { value: 5, timestamp: new Date(1_000_000) }, state: 'normal' });
+
+        // Hold the reconnect re-backfill fetch open so backfillInFlight stays true.
+        let releaseFetch: (v: unknown) => void = () => { /* set below */ };
+        const heldFetch = new Promise(res => { releaseFetch = res; });
+        history.getValues.mockReturnValueOnce(heldFetch);
+        state$.next(ConnectionState.Disconnected);
+        vi.setSystemTime(1_005_000);
+        state$.next(ConnectionState.Connected); // backfillInFlight = true, awaiting heldFetch
+        await vi.advanceTimersByTimeAsync(0);
+
+        // A sampled tick fires WHILE the fetch is in flight: the gate must suppress the replayed value so
+        // it cannot append ahead of the pending batch.
+        const countMidFetch = emissions.length;
+        await vi.advanceTimersByTimeAsync(PARAMS.sampleTime);
+        expect(emissions.length).toBe(countMidFetch);
+
+        // Once the batch lands the gate reopens and the batch is emitted.
+        mapper.mapValuesToChartDatapoints.mockReturnValue([{ timestamp: 1_004_000, data: { value: 7 } }]);
+        releaseFetch({ context: 'vessels.self', range: { to: new Date(1_005_000).toISOString() }, values: [], data: [] });
+        await vi.advanceTimersByTimeAsync(0);
+        const batch = emissions.filter(e => Array.isArray(e)).pop() as IDatasetServiceDatapoint[];
+        expect(batch.map(p => p.data.value)).toEqual([7]);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not gap a slow-cadence source on a reconnect shorter than its update interval', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(1_000_000);
+      try {
+        history.getValues.mockResolvedValue({ context: 'vessels.self', range: { to: new Date(1_000_000).toISOString() }, values: [], data: [] });
+        mapper.mapValuesToChartDatapoints.mockReturnValue([]);
+        const emissions: (IDatasetServiceDatapoint | IDatasetServiceDatapoint[] | { unavailable: true })[] = [];
+        make().getBackfillThenLive(PARAMS).subscribe(e => emissions.push(e));
+        await vi.advanceTimersByTimeAsync(0);
+
+        // Establish a ~10s source cadence (two samples 10s apart).
+        path$.next({ data: { value: 1, timestamp: new Date(1_000_000) }, state: 'normal' });
+        vi.setSystemTime(1_010_000);
+        path$.next({ data: { value: 2, timestamp: new Date(1_010_000) }, state: 'normal' });
+
+        // A 12s drop — well past the flat 3s floor but under the 3× cadence threshold, so the source
+        // could not have produced data during it and no gap should be drawn.
+        state$.next(ConnectionState.Disconnected);
+        vi.setSystemTime(1_022_000);
+        history.getValues.mockResolvedValue({ context: 'vessels.self', range: { to: new Date(1_022_000).toISOString() }, values: [], data: [] });
+        mapper.mapValuesToChartDatapoints.mockReturnValue([]);
+        state$.next(ConnectionState.Connected);
+        await vi.advanceTimersByTimeAsync(0);
+
+        const gaps = emissions.filter(
+          e => !Array.isArray(e) && !('unavailable' in e) && Number.isNaN((e as IDatasetServiceDatapoint).data.value)
+        );
+        expect(gaps.length).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('gaps a known-cadence source when the reconnect outage exceeds its interval', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(1_000_000);
+      try {
+        history.getValues.mockResolvedValue({ context: 'vessels.self', range: { to: new Date(1_000_000).toISOString() }, values: [], data: [] });
+        mapper.mapValuesToChartDatapoints.mockReturnValue([]);
+        const emissions: (IDatasetServiceDatapoint | IDatasetServiceDatapoint[] | { unavailable: true })[] = [];
+        make().getBackfillThenLive(PARAMS).subscribe(e => emissions.push(e));
+        await vi.advanceTimersByTimeAsync(0);
+
+        // Learn a ~5s cadence → gap threshold = max(3s, 3×5s) = 15s.
+        path$.next({ data: { value: 1, timestamp: new Date(1_000_000) }, state: 'normal' });
+        vi.setSystemTime(1_005_000);
+        path$.next({ data: { value: 2, timestamp: new Date(1_005_000) }, state: 'normal' });
+
+        // A 25s outage — past the 15s threshold → a real gap must be drawn (locks the gap-drawing side of
+        // the cadence branch; a regression inflating the known-cadence threshold would suppress it).
+        state$.next(ConnectionState.Disconnected);
+        vi.setSystemTime(1_025_000);
+        history.getValues.mockResolvedValue({ context: 'vessels.self', range: { to: new Date(1_025_000).toISOString() }, values: [], data: [] });
+        mapper.mapValuesToChartDatapoints.mockReturnValue([]);
+        state$.next(ConnectionState.Connected);
+        await vi.advanceTimersByTimeAsync(0);
+
+        const gaps = emissions.filter(
+          e => !Array.isArray(e) && !('unavailable' in e) && Number.isNaN((e as IDatasetServiceDatapoint).data.value)
+        );
+        expect(gaps.length).toBe(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not fold the outage into the cadence when a delta arrives during the re-backfill', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(1_000_000);
+      try {
+        history.getValues.mockResolvedValue({ context: 'vessels.self', range: { to: new Date(1_000_000).toISOString() }, values: [], data: [] });
+        mapper.mapValuesToChartDatapoints.mockReturnValue([]);
+        const emissions: (IDatasetServiceDatapoint | IDatasetServiceDatapoint[] | { unavailable: true })[] = [];
+        make().getBackfillThenLive(PARAMS).subscribe(e => emissions.push(e));
+        await vi.advanceTimersByTimeAsync(0);
+
+        // Learn a ~5s cadence → threshold 15s.
+        path$.next({ data: { value: 1, timestamp: new Date(1_000_000) }, state: 'normal' });
+        vi.setSystemTime(1_005_000);
+        path$.next({ data: { value: 2, timestamp: new Date(1_005_000) }, state: 'normal' });
+
+        // Long outage; hold the re-backfill fetch open across it.
+        let releaseFetch: (v: unknown) => void = () => { /* set below */ };
+        const heldFetch = new Promise(res => { releaseFetch = res; });
+        history.getValues.mockReturnValueOnce(heldFetch);
+        state$.next(ConnectionState.Disconnected);
+        vi.setSystemTime(1_040_000); // 40s outage
+        state$.next(ConnectionState.Connected); // reBackfill awaits heldFetch
+        await vi.advanceTimersByTimeAsync(0);
+
+        // The resumed WS delivers a fresh delta DURING the fetch, ~40s after the pre-drop sample. Folding
+        // that gap into the EWMA cadence would inflate the threshold past 40s and suppress the gap below.
+        path$.next({ data: { value: 9, timestamp: new Date(1_040_000) }, state: 'normal' });
+
+        history.getValues.mockResolvedValue({ context: 'vessels.self', range: { to: new Date(1_040_000).toISOString() }, values: [], data: [] });
+        mapper.mapValuesToChartDatapoints.mockReturnValue([]);
+        releaseFetch({ context: 'vessels.self', range: { to: new Date(1_040_000).toISOString() }, values: [], data: [] });
+        await vi.advanceTimersByTimeAsync(0);
+
+        // The cadence stayed ~5s (threshold ~15s), so the 40s outage still draws its honest gap.
+        const gaps = emissions.filter(
+          e => !Array.isArray(e) && !('unavailable' in e) && Number.isNaN((e as IDatasetServiceDatapoint).data.value)
+        );
+        expect(gaps.length).toBe(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('caps the live-tail hold on a slow provider — draws the gap and resumes live instead of freezing', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(1_000_000);
+      try {
+        history.getValues.mockResolvedValue({ context: 'vessels.self', range: { to: new Date(1_000_000).toISOString() }, values: [], data: [] });
+        mapper.mapValuesToChartDatapoints.mockReturnValue([]);
+        const emissions: (IDatasetServiceDatapoint | IDatasetServiceDatapoint[] | { unavailable: true })[] = [];
+        make().getBackfillThenLive(PARAMS).subscribe(e => emissions.push(e));
+        await vi.advanceTimersByTimeAsync(0);
+        path$.next({ data: { value: 5, timestamp: new Date(1_000_000) }, state: 'normal' });
+
+        // Reconnect while the history provider hangs (never resolves) — the freeze scenario.
+        history.getValues.mockReturnValueOnce(new Promise<never>(() => { /* hangs */ }));
+        state$.next(ConnectionState.Disconnected);
+        vi.setSystemTime(1_030_000);
+        state$.next(ConnectionState.Connected);
+        await vi.advanceTimersByTimeAsync(0);
+
+        // Just before the hold cap (RECONNECT_HOLD_MS = 3000ms) elapses: still held, no gap yet.
+        await vi.advanceTimersByTimeAsync(2_900);
+        expect(emissions.some(e => !Array.isArray(e) && !('unavailable' in e) && Number.isNaN((e as IDatasetServiceDatapoint).data.value))).toBe(false);
+
+        // Past the cap: the hold releases and the honest gap is drawn even though the fetch is still hung.
+        await vi.advanceTimersByTimeAsync(200);
+        const gaps = emissions.filter(
+          e => !Array.isArray(e) && !('unavailable' in e) && Number.isNaN((e as IDatasetServiceDatapoint).data.value)
+        );
+        expect(gaps.length).toBe(1);
+
+        // And the gate is released: a fresh live delta renders again instead of being dropped.
+        vi.setSystemTime(1_034_000);
+        path$.next({ data: { value: 7, timestamp: new Date(1_034_000) }, state: 'normal' });
+        await vi.advanceTimersByTimeAsync(PARAMS.sampleTime);
+        const rendered = emissions.some(
+          e => !Array.isArray(e) && !('unavailable' in e) && (e as IDatasetServiceDatapoint).data.value === 7
+        );
+        expect(rendered).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('advances the seam past a drawn gap so a lagging provider cannot backfill behind it', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(1_000_000);
+      try {
+        history.getValues.mockResolvedValue({ context: 'vessels.self', range: { to: new Date(1_000_000).toISOString() }, values: [], data: [] });
+        mapper.mapValuesToChartDatapoints.mockReturnValue([]);
+        const emissions: (IDatasetServiceDatapoint | IDatasetServiceDatapoint[] | { unavailable: true })[] = [];
+        make().getBackfillThenLive(PARAMS).subscribe(e => emissions.push(e));
+        await vi.advanceTimersByTimeAsync(0);
+        path$.next({ data: { value: 5, timestamp: new Date(1_000_000) }, state: 'normal' }); // seam 1_000_000
+
+        // Reconnect #1: the provider is still ingesting and returns no rows → a gap is drawn at ~1_040_000.
+        state$.next(ConnectionState.Disconnected);
+        vi.setSystemTime(1_040_000);
+        history.getValues.mockResolvedValue({ context: 'vessels.self', range: { to: new Date(1_040_000).toISOString() }, values: [], data: [] });
+        mapper.mapValuesToChartDatapoints.mockReturnValue([]);
+        state$.next(ConnectionState.Connected);
+        await vi.advanceTimersByTimeAsync(0);
+        expect(emissions.filter(e => !Array.isArray(e) && !('unavailable' in e) && Number.isNaN((e as IDatasetServiceDatapoint).data.value)).length).toBe(1);
+
+        // Reconnect #2: the provider has now ingested the backdated outage samples (all older than the gap).
+        state$.next(ConnectionState.Disconnected);
+        state$.next(ConnectionState.Connected);
+        mapper.mapValuesToChartDatapoints.mockReturnValue([
+          { timestamp: 1_005_000, data: { value: 1 } },
+          { timestamp: 1_038_000, data: { value: 2 } }
+        ]);
+        history.getValues.mockResolvedValue({ context: 'vessels.self', range: { to: new Date(1_040_000).toISOString() }, values: [], data: [] });
+        await vi.advanceTimersByTimeAsync(0);
+
+        // The seam advanced to the gap timestamp, so those backdated points are de-duped — never drawn
+        // behind the break.
+        const drewBackdated = emissions.some(
+          e => Array.isArray(e) && (e as IDatasetServiceDatapoint[]).some(p => p.data.value === 1)
+        );
+        expect(drewBackdated).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('survives an unexpected (non-request) error during the reconnect re-backfill', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(1_000_000);
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      try {
+        history.getValues.mockResolvedValue({ context: 'vessels.self', range: { to: new Date(1_000_000).toISOString() }, values: [], data: [] });
+        mapper.mapValuesToChartDatapoints.mockReturnValue([]);
+        const emissions: (IDatasetServiceDatapoint | IDatasetServiceDatapoint[] | { unavailable: true })[] = [];
+        make().getBackfillThenLive(PARAMS).subscribe(e => emissions.push(e));
+        await vi.advanceTimersByTimeAsync(0);
+        path$.next({ data: { value: 5, timestamp: new Date(1_000_000) }, state: 'normal' });
+
+        state$.next(ConnectionState.Disconnected);
+        vi.setSystemTime(1_040_000); // 40s outage
+        history.getValues.mockRejectedValue(new Error('mapper boom')); // unexpected, not a HistoryRequestError
+        state$.next(ConnectionState.Connected);
+        await vi.advanceTimersByTimeAsync(0);
+
+        // The unexpected error is logged, the stream is not disabled (no HISTORY_UNAVAILABLE), and the
+        // trace still breaks honestly rather than throwing out of the async handler.
+        expect(errorSpy).toHaveBeenCalled();
+        expect(emissions.some(e => !Array.isArray(e) && 'unavailable' in e)).toBe(false);
+        const last = emissions[emissions.length - 1];
+        expect(Number.isNaN((last as IDatasetServiceDatapoint).data.value)).toBe(true);
+      } finally {
+        errorSpy.mockRestore();
+        vi.useRealTimers();
+      }
+    });
+
+    it('re-backfills the first connect when mounted during an outage — the seed is not contemporaneous (#85)', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(1_000_000);
+      try {
+        // Mount while the WS is already down (HTTP still up, so the constructor backfill succeeds). The
+        // seeded window and the first Connected land minutes apart, so that Connected is a real reconnect
+        // whose elapsed interval must be re-fetched — not the free skip a contemporaneous seed would earn.
+        state$.next(ConnectionState.Disconnected);
+        history.getValues.mockResolvedValue({ context: 'vessels.self', range: { to: new Date(1_000_000).toISOString() }, values: [], data: [] });
+        mapper.mapValuesToChartDatapoints.mockReturnValue([{ timestamp: 1_000_000, data: { value: 5 } }]);
+        const emissions: (IDatasetServiceDatapoint | IDatasetServiceDatapoint[] | { unavailable: true })[] = [];
+        make().getBackfillThenLive(PARAMS).subscribe(e => emissions.push(e));
+        await vi.advanceTimersByTimeAsync(0); // settle the mount backfill → beginLive replays Disconnected
+
+        // 20s of outage elapse, then the WS reconnects.
+        vi.setSystemTime(1_020_000);
+        history.getValues.mockResolvedValue({ context: 'vessels.self', range: { to: new Date(1_020_000).toISOString() }, values: [], data: [] });
+        mapper.mapValuesToChartDatapoints.mockReturnValue([
+          { timestamp: 990_000, data: { value: 1 } },   // at/behind the seam → dropped
+          { timestamp: 1_010_000, data: { value: 9 } }   // inside the gap → kept
+        ]);
+        const callsBefore = history.getValues.mock.calls.length; // the single mount backfill
+
+        state$.next(ConnectionState.Connected);
+        await vi.advanceTimersByTimeAsync(0); // settle the re-backfill
+
+        // Exactly one re-backfill fires, scoped to the gap; without it the outage would draw a silent line.
+        expect(history.getValues.mock.calls.length).toBe(callsBefore + 1);
+        const batch = emissions.filter(e => Array.isArray(e)).pop() as IDatasetServiceDatapoint[];
+        expect(batch.map(p => p.data.value)).toEqual([9]);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 });

--- a/src/app/core/services/history-chart-stream.service.ts
+++ b/src/app/core/services/history-chart-stream.service.ts
@@ -1,8 +1,9 @@
 import { Injectable, inject } from '@angular/core';
-import { Observable, Subscription, filter, merge, shareReplay, take, timer, withLatestFrom } from 'rxjs';
+import { Observable, Subscription, distinctUntilChanged, filter, merge, shareReplay, take, timer, withLatestFrom } from 'rxjs';
 import { DataService, IPathUpdate } from './data.service';
 import { HistoryApiClientService, HistoryRequestError } from './history-api-client.service';
 import { HistoryToChartMapperService } from './history-to-chart-mapper.service';
+import { ConnectionState, ConnectionStateMachine } from './connection-state-machine.service';
 import { resolveAngleDomain } from '../utils/angle-domain.util';
 import { IDatasetServiceDatapoint } from '../interfaces/dataset.interfaces';
 import { computeWindowStats, windowSma, ChartStatsDomain } from '../utils/chart-stats.util';
@@ -24,8 +25,34 @@ const MIN_STALE_MS = 3_000;
 /** Staleness threshold used before the source's update interval has been observed. */
 const BOOTSTRAP_STALE_MS = 30_000;
 
+/**
+ * How long the source may be silent before its trace should break, keyed to the observed update
+ * interval (not the chart cadence) so a slow-but-alive source is not gapped. Shared by the live tail
+ * and the reconnect gap so a reconnect breaks the trace on exactly the same silence the live tail would.
+ */
+function staleThresholdMs(intervalMs: number | null): number {
+  return intervalMs === null ? BOOTSTRAP_STALE_MS : Math.max(MIN_STALE_MS, STALE_INTERVAL_FACTOR * intervalMs);
+}
+
 /** Emitted once to break the trace when the source goes silent, so a dropout reads as a gap. */
 const GAP_POINT = { value: NaN, sma: NaN, lastAverage: NaN, lastMinimum: NaN, lastMaximum: NaN } as const;
+
+/**
+ * The re-backfill seam is a client-clock timestamp but the History API filters in server time, so
+ * under server-behind-client skew the exact seam would drop real buckets. Bias `from` earlier by this
+ * margin; the `> seam` de-dup drops the resulting overlap harmlessly, so over-fetching is free.
+ */
+const RECONNECT_FROM_SKEW_MARGIN_MS = 10_000;
+
+/**
+ * Cap on how long the live tail is held while a reconnect re-backfill fetch is in flight. Past this the
+ * live tail resumes and the gap is drawn honestly, rather than letting a slow/overloaded history provider
+ * (bounded only by the 30s History-API HTTP timeout) freeze the chart and drop healthy live deltas.
+ */
+const RECONNECT_HOLD_MS = 3_000;
+
+/** Sentinel: the re-backfill hold cap elapsed before the fetch resolved. */
+const HOLD_TIMEOUT = Symbol('reconnect-hold-timeout');
 
 /** Inputs for one chart's History-API-backed data stream. */
 export interface IHistoryChartStreamParams {
@@ -41,6 +68,31 @@ export interface IHistoryChartStreamParams {
 
 type StreamEmission = IDatasetServiceDatapoint[] | IDatasetServiceDatapoint | IHistoryUnavailable;
 
+/** Per-stream mutable state shared between the live tail and the reconnect re-backfill (#85). */
+interface IStreamCtx {
+  /** Client-clock timestamp of the newest emitted point (backfill, live, or re-backfill) — the seam the
+   * next re-backfill de-dups against. */
+  lastEmittedTs: number | null;
+  /** Whether the delta stream is connected; the live tail is gated while it is not. */
+  connected: boolean;
+  /** True while a reconnect re-backfill is fetching, so live emissions do not interleave the seam. */
+  backfillInFlight: boolean;
+  /** A reconnect arrived while a re-backfill was in flight; re-run once the current one finishes so the
+   * newly-missed interval is not lost to the coalescing guard. */
+  reconnectPending: boolean;
+  /** The live tail's observed source update interval, so the reconnect gap uses the same cadence-aware
+   * staleness threshold the live tail does (null until an interval has been observed). */
+  sourceIntervalMs: number | null;
+  /** Set on disconnect so the first sample after a reconnect re-seeds the cadence baseline instead of
+   * learning the outage duration as a spurious (inflated) interval. */
+  resetCadenceBaseline: boolean;
+  /** Whether the constructor backfill completed (even if empty). When it did not, the first Connected is
+   * treated as a reconnect so the window is still fetched without waiting for a later WS drop. */
+  seeded: boolean;
+  /** Set on teardown so an in-flight async re-backfill does not emit after disposal. */
+  disposed: boolean;
+}
+
 /**
  * Trend-chart data path: History-API backfill for the initial window, then a thin SK delta-stream
  * live tail with a minimal rolling buffer and the shared stats util. When no history provider is
@@ -52,6 +104,7 @@ export class HistoryChartStreamService {
   private readonly history = inject(HistoryApiClientService);
   private readonly mapper = inject(HistoryToChartMapperService);
   private readonly data = inject(DataService);
+  private readonly connection = inject(ConnectionStateMachine);
 
   /**
    * Backfill (History API, one-shot) then a live delta tail. Emits the backfill as a single array,
@@ -62,13 +115,37 @@ export class HistoryChartStreamService {
   public getBackfillThenLive(params: IHistoryChartStreamParams): Observable<StreamEmission> {
     return new Observable<StreamEmission>(subscriber => {
       const domain = resolveAngleDomain(params.path, this.data.getPathUnitType(params.path), params.angleDomainOverride);
-      let disposed = false;
-      let liveSub: Subscription | null = null;
+      const ctx: IStreamCtx = { lastEmittedTs: null, connected: true, backfillInFlight: false, reconnectPending: false, sourceIntervalMs: null, resetCadenceBaseline: false, seeded: false, disposed: false };
       const buffer: number[] = [];
+      let liveSub: Subscription | null = null;
+      let reconnectSub: Subscription | null = null;
+
+      // Track the delta stream's connection and re-backfill on reconnect (#85). A WS drop/reconnect
+      // resumes the live tail but never re-fetches the interval that elapsed during the drop, leaving a
+      // silent gap. Skip the FIRST Connected only while the seed is still contemporaneous — the stream
+      // has stayed connected since the constructor backfill (no disconnect seen yet). If a disconnect
+      // was seen first (mounted mid-outage, so the seed and this connect are minutes apart) or the
+      // window was never seeded (transient backfill failure / cold boot), treat the first Connected as a
+      // reconnect and fetch the elapsed interval. Every later reconnect is preceded by a disconnect.
+      const beginLive = (offsetMs: number | null, newestBackfillTs: number | null) => {
+        ctx.lastEmittedTs = newestBackfillTs;
+        let sawDisconnected = false;
+        reconnectSub = this.connection.state$.pipe(distinctUntilChanged()).subscribe(state => {
+          ctx.connected = state === ConnectionState.Connected;
+          if (!ctx.connected) {
+            // Drop the cadence baseline so the outage is not learned as an interval on reconnect.
+            ctx.resetCadenceBaseline = true;
+            sawDisconnected = true;
+            return;
+          }
+          if (!ctx.seeded || sawDisconnected) void this.reBackfill(params, domain, buffer, subscriber, ctx);
+        });
+        liveSub = this.startLive(params, domain, buffer, offsetMs, newestBackfillTs, subscriber, ctx);
+      };
 
       this.fetchBackfill(params, domain)
         .then(result => {
-          if (disposed) return;
+          if (ctx.disposed) return;
           if (result === null) {
             subscriber.next(HISTORY_UNAVAILABLE);
             subscriber.complete();
@@ -81,16 +158,18 @@ export class HistoryChartStreamService {
           }
           this.trim(buffer, params.maxDataPoints);
           const newestBackfillTs = points.length ? points[points.length - 1].timestamp : null;
-          liveSub = this.startLive(params, domain, buffer, offsetMs, newestBackfillTs, subscriber);
+          ctx.seeded = true;
+          beginLive(offsetMs, newestBackfillTs);
         })
         .catch(err => {
-          if (disposed) return;
+          if (ctx.disposed) return;
           if (err instanceof HistoryRequestError) {
             // Transient backfill failure (network blip, 5xx, timeout): don't disable the chart. Ride
-            // the live delta tail with no seed so live data still renders; a reconnect re-backfill
-            // (#85) fills the gap. Only a genuine no-provider (null result above) degrades to empty.
+            // the live delta tail with no seed so live data still renders; the first Connected then
+            // drives a re-backfill (ctx.seeded is false) so the window is filled without waiting for a
+            // WS drop. Only a genuine no-provider (null result above) degrades to empty.
             // offsetMs is null (no backfill anchor) → startLive derives it from the first live sample.
-            liveSub = this.startLive(params, domain, buffer, null, null, subscriber);
+            beginLive(null, null);
             return;
           }
           // An unexpected error (e.g. a mapper/logic bug), not a known request failure: degrade to
@@ -101,8 +180,9 @@ export class HistoryChartStreamService {
         });
 
       return () => {
-        disposed = true;
+        ctx.disposed = true;
         liveSub?.unsubscribe();
+        reconnectSub?.unsubscribe();
       };
     });
   }
@@ -113,7 +193,8 @@ export class HistoryChartStreamService {
     buffer: number[],
     offsetMs: number | null,
     newestBackfillTs: number | null,
-    subscriber: { next: (v: StreamEmission) => void }
+    subscriber: { next: (v: StreamEmission) => void },
+    ctx: IStreamCtx
   ): Subscription {
     // One shared upstream so the freshness tracker, the immediate first value and the resampler all
     // draw from a single path subscription.
@@ -140,19 +221,27 @@ export class HistoryChartStreamService {
     // Staleness is keyed to the SOURCE's observed update interval, not the chart's render cadence, so a
     // slow-but-alive sensor holds while a genuinely dead one (or a stale value replayed on subscribe)
     // gaps. Until an interval is observed, only a long silence counts as a dropout.
-    const staleAfterMs = (): number =>
-      intervalMs === null ? BOOTSTRAP_STALE_MS : Math.max(MIN_STALE_MS, STALE_INTERVAL_FACTOR * intervalMs);
+    const staleAfterMs = (): number => staleThresholdMs(intervalMs);
 
     const sub = new Subscription();
     // Learn the source interval from the spacing of consecutive delta timestamps.
     sub.add(path$.subscribe(u => {
       const ts = sourceTsOf(u);
       if (!Number.isFinite(ts)) return;
+      if (ctx.resetCadenceBaseline) {
+        // First sample after a disconnect: re-seed the baseline (do not measure the outage as an
+        // interval, which would inflate the cadence and suppress the reconnect gap).
+        ctx.resetCadenceBaseline = false;
+        prevSourceTs = ts;
+        return;
+      }
       if (prevSourceTs !== null) {
         const gap = ts - prevSourceTs;
         if (gap > 0) intervalMs = intervalMs === null ? gap : 0.3 * gap + 0.7 * intervalMs;
       }
       prevSourceTs = ts;
+      // Publish the learned cadence so the reconnect gap uses the same staleness threshold.
+      ctx.sourceIntervalMs = intervalMs;
     }));
 
     // Backfill ended well before now (a dropout captured in history): break the trace at the seam so it
@@ -169,6 +258,10 @@ export class HistoryChartStreamService {
     sub.add(merge(path$.pipe(take(1)), sampled$).subscribe(u => {
       const value = Number(u.data.value);
       if (!Number.isFinite(value)) return;
+      // While the stream is disconnected (all sources silent) or a reconnect re-backfill is filling the
+      // seam, hold the live tail: otherwise the sampled$ replay of the last stale value would fire a gap
+      // marker mid-drop that the later re-backfill batch cannot order cleanly against.
+      if (!ctx.connected || ctx.backfillInFlight) return;
       // Stamp with the client clock so points sit on the chart's realtime axis;
       // server timestamps would drift the whole series under clock skew.
       const now = Date.now();
@@ -186,13 +279,14 @@ export class HistoryChartStreamService {
       gapMarked = false;
       buffer.push(value);
       this.trim(buffer, params.maxDataPoints);
+      ctx.lastEmittedTs = now;
       const stats = computeWindowStats(buffer, params.smoothingPeriod, domain);
       subscriber.next({ timestamp: now, data: { ...stats } });
     }));
     return sub;
   }
 
-  private async fetchBackfill(params: IHistoryChartStreamParams, domain: ChartStatsDomain): Promise<{ points: IDatasetServiceDatapoint[]; offsetMs: number } | null> {
+  private async fetchBackfill(params: IHistoryChartStreamParams, domain: ChartStatsDomain, fromMs: number = Date.now() - params.windowMs): Promise<{ points: IDatasetServiceDatapoint[]; offsetMs: number } | null> {
     const normalizedPath = params.path.replace(/^(vessels\.)?self\./, '');
     // Only the raw per-bucket value is fetched; the SMA overlay is derived client-side below so it
     // uses the same circular-aware smoothing as the live tail (#162).
@@ -201,7 +295,7 @@ export class HistoryChartStreamService {
 
     const response = await this.history.getValues({
       paths,
-      from: new Date(Date.now() - params.windowMs).toISOString(),
+      from: new Date(fromMs).toISOString(),
       resolution: resolutionSeconds
     });
     if (!response) {
@@ -234,6 +328,96 @@ export class HistoryChartStreamService {
       }
     }));
     return { points, offsetMs };
+  }
+
+  /**
+   * Re-fetch the interval missed during a WS drop and emit it as a batch so the live tail's gap is
+   * filled (#85). Covers only [max(seam - skew margin, now - windowMs), now] and drops points at or
+   * before the seam, so the batch appends cleanly and in order against the buffered/live points. The
+   * live tail is held only until the fetch resolves or {@link RECONNECT_HOLD_MS} elapses (whichever comes
+   * first), so a slow provider cannot freeze the chart; if the re-backfill delivers nothing (empty, error,
+   * or hold-timeout), {@link emitReconnectGap} breaks the trace so the live tail does not interpolate.
+   */
+  private async reBackfill(
+    params: IHistoryChartStreamParams,
+    domain: ChartStatsDomain,
+    buffer: number[],
+    subscriber: { next: (v: StreamEmission) => void },
+    ctx: IStreamCtx
+  ): Promise<void> {
+    // A reconnect that arrives while a re-backfill is in flight is coalesced: mark it pending so the
+    // in-flight run re-runs from the (advanced) seam afterwards, rather than dropping the newly-missed
+    // interval silently.
+    if (ctx.backfillInFlight || ctx.disposed) {
+      if (ctx.backfillInFlight && !ctx.disposed) ctx.reconnectPending = true;
+      return;
+    }
+    ctx.backfillInFlight = true;
+    ctx.reconnectPending = false;
+    const seam = ctx.lastEmittedTs;
+    let delivered = false;
+    let holdTimer: ReturnType<typeof setTimeout> | null = null;
+    try {
+      const earliest = Date.now() - params.windowMs;
+      const fromMs = seam !== null ? Math.max(seam - RECONNECT_FROM_SKEW_MARGIN_MS, earliest) : earliest;
+      const fetchPromise = this.fetchBackfill(params, domain, fromMs);
+      // If the hold cap wins the race we abandon this fetch; swallow its late rejection so it does not
+      // surface as an unhandled rejection.
+      fetchPromise.catch(() => undefined);
+      const outcome = await Promise.race([
+        fetchPromise,
+        new Promise<typeof HOLD_TIMEOUT>(resolve => { holdTimer = setTimeout(() => resolve(HOLD_TIMEOUT), RECONNECT_HOLD_MS); })
+      ]);
+      if (ctx.disposed) return;
+      // outcome === HOLD_TIMEOUT: the provider is too slow — stop holding the live tail and fall through
+      // to the honest gap below rather than freeze the chart for up to the 30s HTTP timeout.
+      if (outcome !== HOLD_TIMEOUT) {
+        const fresh = outcome === null ? [] : (seam !== null ? outcome.points.filter(p => p.timestamp > seam) : outcome.points);
+        if (fresh.length > 0) {
+          for (const p of fresh) {
+            if (Number.isFinite(p.data.value)) buffer.push(p.data.value);
+          }
+          this.trim(buffer, params.maxDataPoints);
+          ctx.lastEmittedTs = fresh[fresh.length - 1].timestamp;
+          subscriber.next(fresh);
+          delivered = true;
+        }
+      }
+    } catch (err) {
+      if (ctx.disposed) return;
+      // A transient error/timeout is expected when the history provider is down or slow; only an
+      // unexpected error is worth surfacing. Either path falls through to the honest-gap decision below.
+      if (!(err instanceof HistoryRequestError)) {
+        console.error('[HistoryChartStreamService] Unexpected re-backfill error:', err);
+      }
+    } finally {
+      if (holdTimer !== null) clearTimeout(holdTimer);
+      ctx.backfillInFlight = false;
+      if (!ctx.disposed) {
+        if (ctx.reconnectPending && ctx.connected) {
+          // A reconnect landed mid-fetch; run it now from the current seam and defer the gap decision to it.
+          void this.reBackfill(params, domain, buffer, subscriber, ctx);
+        } else if (!delivered) {
+          this.emitReconnectGap(subscriber, ctx);
+        }
+      }
+    }
+  }
+
+  /**
+   * Break the trace at the seam when a reconnect re-backfill could not fill the gap — but only if the
+   * outage exceeds what the source's own update cadence would explain, so a drop shorter than the live
+   * tail's own staleness threshold (a slow source that simply had no new sample) draws no marker.
+   */
+  private emitReconnectGap(subscriber: { next: (v: StreamEmission) => void }, ctx: IStreamCtx): void {
+    if (ctx.lastEmittedTs !== null && Date.now() - ctx.lastEmittedTs > staleThresholdMs(ctx.sourceIntervalMs)) {
+      const now = Date.now();
+      subscriber.next({ timestamp: now, data: { ...GAP_POINT } });
+      // Advance the seam to the gap so a later re-backfill de-dups (> seam) any backdated points a
+      // lagging provider ingests after the fact, keeping emissions monotonic rather than drawing behind
+      // the break.
+      ctx.lastEmittedTs = now;
+    }
   }
 
   private trim(buffer: number[], maxDataPoints: number): void {


### PR DESCRIPTION
## Motivation

When the Signal K WebSocket drops and reconnects, the History-engine trend charts resumed their live delta tail but **never re-fetched the interval that elapsed during the outage**. The chart drew a straight interpolated line across the gap — silently hiding a data dropout on a marine display, exactly what a trend chart must not do. Fixes #85.

## Approach

`HistoryChartStreamService` now watches the connection lifecycle and, on a transition back into `Connected`, re-backfills the window and splices the missed interval in as a batch:

- **Reconnect re-backfill.** On reconnect it re-fetches the window from the History API and appends only the points newer than the current seam (`> lastEmittedTs`, with a skew margin on `from`), so the gap is filled without duplicating the tail.
- **First-connect handling.** The initial `Connected` is skipped only while the constructor backfill is *contemporaneous* with it (the stream stayed connected since seeding). If a disconnect was seen first (chart mounted mid-outage) or the initial backfill failed (cold boot), the first `Connected` is treated as a reconnect and the elapsed interval is fetched.
- **Cadence-aware gaps.** The staleness threshold scales with the learned source interval, so a legitimately slow source is not false-gapped; the outage duration itself is not folded into the learned cadence.
- **Bounded live-tail hold.** The live tail is briefly held during the re-backfill fetch to keep the append-only chart chronological. That hold is capped at `RECONNECT_HOLD_MS` (3s) via `Promise.race` so a slow/hung history provider cannot freeze the chart — on cap it draws an honest gap and resumes live, letting the superseded fetch's late result be ignored.

Scoped to the non-default History engine flag. The delta-stream tail itself is unchanged; this is additive reconnect recovery on top of it.

## Testing

`history-chart-stream.service.spec.ts` gains 17 reconnect specs (fake-timer driven): no-double-backfill, missed-interval re-fetch, hold-while-disconnected, teardown safety, gap-on-error / gap-on-empty, no-gap-blip, cold-boot recovery, coalesced-seam advance, slow-cadence no-gap, known-cadence gap, cadence-race, hold-cap release, seam-advance ordering, mount-mid-outage re-backfill. Full gate green locally (lint + betterer:ci + 1183 unit + 7 plugin).

## Review

Five rounds of multi-persona + adversarial review, each surfacing a real defect (design flaws, cadence threshold, cadence-pollution race, freeze/data-loss, ordering, and the mount-mid-outage miss). Residual bounded items (coalesced-chain hold budget, abandoned-fetch cancellation, seam offset-jitter) are tracked in #281.

Closes #85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
