### PR TITLE
Momentary boolean button: emit on press for low control latency (#241a)

### DIFF
--- a/src/app/widgets/svg-boolean-button/svg-boolean-button.component.spec.ts
+++ b/src/app/widgets/svg-boolean-button/svg-boolean-button.component.spec.ts
@@ -43,41 +43,57 @@ describe('SvgBooleanButtonComponent momentary emit', () => {
     vi.clearAllMocks();
   });
 
-  it('actuates after the short hold, not before', () => {
+  it('emits immediately on press, with no hold delay', () => {
     setup();
     vi.useFakeTimers();
 
+    // The hold-timeout path is gone: the emit fires synchronously on press-down,
+    // before any timer can advance.
     component.handleClickDown(pointerAt(10, 10));
-    expect(emitted).toHaveLength(0);
-    vi.advanceTimersByTime(74);
-    expect(emitted).toHaveLength(0);
 
-    vi.advanceTimersByTime(1);
     expect(emitted).toHaveLength(1);
     expect(emitted[0].value).toBe(true);
   });
 
-  it('does not actuate when a swipe cancels within the hold window', () => {
+  it('stops emitting once a swipe is detected', () => {
     setup();
     vi.useFakeTimers();
 
     component.handleClickDown(pointerAt(10, 10));
-    // A scroll/swipe crossing the threshold before the hold elapses must suppress actuation entirely.
+    expect(emitted).toHaveLength(1);
+
+    // A scroll/swipe crossing the threshold cancels the repeat, so no further emits arrive.
     component.handlePointerMove(pointerAt(60, 12));
     vi.advanceTimersByTime(500);
 
-    expect(emitted).toHaveLength(0);
+    expect(emitted).toHaveLength(1);
   });
 
-  it('does not actuate on a quick tap released within the hold window', () => {
+  it('stops emitting once a vertical swipe is detected', () => {
     setup();
     vi.useFakeTimers();
 
     component.handleClickDown(pointerAt(10, 10));
-    component.handleClickUp();
+    expect(emitted).toHaveLength(1);
+
+    // Vertical scroll: deltaX=2 stays under threshold, deltaY=50 crosses it and cancels the repeat.
+    component.handlePointerMove(pointerAt(12, 60));
     vi.advanceTimersByTime(500);
 
-    expect(emitted).toHaveLength(0);
+    expect(emitted).toHaveLength(1);
+  });
+
+  it('keeps repeating when movement stays below the swipe threshold', () => {
+    setup();
+    vi.useFakeTimers();
+
+    component.handleClickDown(pointerAt(10, 10));
+    // 25px/5px move — under the 30px threshold, so it must not cancel.
+    component.handlePointerMove(pointerAt(35, 15));
+
+    vi.advanceTimersByTime(100);
+    expect(emitted).toHaveLength(2);
+    expect(emitted[1].value).toBe(true);
   });
 
   it('repeats every 100ms while held', () => {
@@ -85,7 +101,6 @@ describe('SvgBooleanButtonComponent momentary emit', () => {
     vi.useFakeTimers();
 
     component.handleClickDown(pointerAt(10, 10));
-    vi.advanceTimersByTime(75);
     expect(emitted).toHaveLength(1);
 
     vi.advanceTimersByTime(100);
@@ -94,25 +109,11 @@ describe('SvgBooleanButtonComponent momentary emit', () => {
     expect(emitted).toHaveLength(3);
   });
 
-  it('keeps the press when movement stays below the swipe threshold', () => {
-    setup();
-    vi.useFakeTimers();
-
-    component.handleClickDown(pointerAt(10, 10));
-    // 25px/5px move — under the 30px threshold, so it must not cancel.
-    component.handlePointerMove(pointerAt(35, 15));
-    vi.advanceTimersByTime(75);
-
-    expect(emitted).toHaveLength(1);
-    expect(emitted[0].value).toBe(true);
-  });
-
   it('stops repeating once the pointer is released', () => {
     setup();
     vi.useFakeTimers();
 
     component.handleClickDown(pointerAt(10, 10));
-    vi.advanceTimersByTime(75);
     expect(emitted).toHaveLength(1);
 
     // A lifted finger clears the repeat interval, so actuation stops.

--- a/src/app/widgets/svg-boolean-button/svg-boolean-button.component.ts
+++ b/src/app/widgets/svg-boolean-button/svg-boolean-button.component.ts
@@ -21,8 +21,6 @@ export class SvgBooleanButtonComponent implements DoCheck, OnDestroy {
   private toggleOn = "0 0 180 35";
   private oldTheme: ITheme | null = null;
 
-  private static readonly HOLD_DELAY_MS = 75;
-  private holdTimeoutId: ReturnType<typeof setTimeout> | null = null; // brief hold before actuating; a swipe cancels it
   private emitIntervalId: ReturnType<typeof setInterval> | null = null; // repeating emit while pressed
   private pressed = false;
   private isSwiping = false;
@@ -61,18 +59,14 @@ export class SvgBooleanButtonComponent implements DoCheck, OnDestroy {
     const data = this.data();
     if (!data) return;
 
-    // Brief hold before actuating so a swipe/scroll starting on the button cancels before any emit.
-    this.holdTimeoutId = setTimeout(() => {
-      this.holdTimeoutId = null;
-      if (this.isSwiping) return;
-      this.pressed = true;
-      const state: IDynamicControl = cloneDeep(data);
-      state.value = this.pressed;
+    // Emit on press for low control latency; a swipe later resets pressed and clears the repeat.
+    this.pressed = true;
+    const state: IDynamicControl = cloneDeep(data);
+    state.value = this.pressed;
+    this.toggleClick.emit(state);
+    this.emitIntervalId = setInterval(() => {
       this.toggleClick.emit(state);
-      this.emitIntervalId = setInterval(() => {
-        this.toggleClick.emit(state);
-      }, 100);
-    }, SvgBooleanButtonComponent.HOLD_DELAY_MS);
+    }, 100);
   }
 
   public handlePointerMove(event: PointerEvent): void {
@@ -151,10 +145,6 @@ export class SvgBooleanButtonComponent implements DoCheck, OnDestroy {
   }
 
   private clearTimers(): void {
-    if (this.holdTimeoutId) {
-      clearTimeout(this.holdTimeoutId);
-      this.holdTimeoutId = null;
-    }
     if (this.emitIntervalId) {
       clearInterval(this.emitIntervalId);
       this.emitIntervalId = null;


### PR DESCRIPTION
## Motivation
The momentary boolean button waited a hold delay before actuating — added latency to a boat control. Fixes the momentary-button half of #241.

## Approach
Emit synchronously on `pointerdown` (no hold timer), then repeat every 100ms while held; a swipe (>30px in x **or** y) sets `pressed=false` and clears the repeat so a scroll gesture starting on the button stops firing. Matches upstream `f9d657cf`'s post-PR semantics. The `data()` null-guard is preserved (file stays strict-clean).

## Review
Multi-persona + adversarial verify. One P3 coverage gap fixed: the vertical-swipe (`deltaY>30`) cancel branch is now tested. Emit-on-press means a swipe that begins with a press necessarily fires one emit (the Gate-A latency-first decision), so the test asserts the swipe stops the *repeat*, not zero emits.

The OFF-state visual half of #241 (packet G4 / #240, boat-verify) is intentionally **not** in this PR — sanctioned carve-out.

Part of #257. Refs #241.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
