### PR TITLE
History dialog: enumerate template concretes over a retention window (#278)

### DIFF
--- a/src/app/core/components/widget-history-chart-dialog/widget-history-chart-dialog.component.spec.ts
+++ b/src/app/core/components/widget-history-chart-dialog/widget-history-chart-dialog.component.spec.ts
@@ -765,4 +765,154 @@ describe('WidgetHistoryChartDialogComponent', () => {
     expect((scales['yCurrent'] as { position?: string }).position).toBe('right');
     expect((scales['yFrequency'] as { position?: string }).position).toBe('left');
   });
+
+  it('enumerates a template concrete visible only in the retention window, not the short display window', async () => {
+    (component as unknown as {
+      data: {
+        title: string;
+        widget: IWidget;
+        seriesDefinitions: IKipSeriesDefinition[];
+      };
+    }).data = {
+      title: 'Solar History',
+      widget: {
+        uuid: 'widget-solar-1',
+        type: 'widget-solar-charger',
+        config: {
+          displayName: 'Solar Charger'
+        }
+      } as IWidget,
+      seriesDefinitions: [
+        {
+          seriesId: 'widget-solar-1:solar-template',
+          datasetUuid: 'widget-solar-1:solar-template',
+          ownerWidgetUuid: 'widget-solar-1',
+          ownerWidgetSelector: 'widget-solar-charger',
+          path: 'self.electrical.solar.*',
+          expansionMode: 'solar-tree',
+          familyKey: 'solar',
+          allowedIds: ['charger-1'],
+          retentionDurationMs: 24 * 60 * 60 * 1000,
+          enabled: true
+        }
+      ]
+    };
+
+    // The briefly-quiet device only shows up when paths are enumerated over the 24h retention window;
+    // the short 1h display window would omit it.
+    historyApiClientMock.getPaths.mockImplementation(({ duration }: { duration: string }) =>
+      Promise.resolve(duration === 'PT86400S'
+        ? ['electrical.solar.charger-1.panelPower', 'electrical.solar.charger-1.current']
+        : []));
+
+    await component.loadHistoryDatasets();
+
+    expect(historyApiClientMock.getPaths).toHaveBeenCalledWith(expect.objectContaining({ duration: 'PT86400S' }));
+    expect(historyApiClientMock.getPaths).not.toHaveBeenCalledWith(expect.objectContaining({ duration: 'PT1H' }));
+    expect(historyApiClientMock.getValues).toHaveBeenCalledWith(expect.objectContaining({
+      paths: 'electrical.solar.charger-1.panelPower:avg'
+    }));
+  });
+
+  it('widens only the enumeration window while leaving the chart data window at the display window', async () => {
+    (component as unknown as {
+      data: {
+        title: string;
+        widget: IWidget;
+        seriesDefinitions: IKipSeriesDefinition[];
+      };
+    }).data = {
+      title: 'Solar History',
+      widget: {
+        uuid: 'widget-solar-1',
+        type: 'widget-solar-charger',
+        config: {
+          displayName: 'Solar Charger'
+        }
+      } as IWidget,
+      seriesDefinitions: [
+        {
+          seriesId: 'widget-solar-1:solar-template',
+          datasetUuid: 'widget-solar-1:solar-template',
+          ownerWidgetUuid: 'widget-solar-1',
+          ownerWidgetSelector: 'widget-solar-charger',
+          path: 'self.electrical.solar.*',
+          expansionMode: 'solar-tree',
+          familyKey: 'solar',
+          allowedIds: ['charger-1'],
+          retentionDurationMs: 48 * 60 * 60 * 1000,
+          enabled: true
+        }
+      ]
+    };
+
+    historyApiClientMock.getPaths.mockResolvedValue([
+      'electrical.solar.charger-1.panelPower',
+      'electrical.solar.charger-1.current'
+    ]);
+
+    await component.loadHistoryDatasets();
+
+    // Enumeration follows the series' 48h retention window, decoupled from the display window.
+    expect(historyApiClientMock.getPaths).toHaveBeenCalledWith(expect.objectContaining({ duration: 'PT172800S' }));
+
+    // The chart data fetch still uses the 1-hour display window for every concrete.
+    const valueDurations = historyApiClientMock.getValues.mock.calls.map((call: [{ duration: string }]) => call[0].duration);
+    expect(valueDurations.length).toBeGreaterThan(0);
+    expect(valueDurations.every((duration: string) => duration === 'PT1H')).toBe(true);
+    expect(historyApiClientMock.getValues).not.toHaveBeenCalledWith(expect.objectContaining({ duration: 'PT172800S' }));
+  });
+
+  it('falls back to the 24h default enumeration window when the series carries no usable retention', async () => {
+    const baseTemplate = {
+      seriesId: 'widget-solar-1:solar-template',
+      datasetUuid: 'widget-solar-1:solar-template',
+      ownerWidgetUuid: 'widget-solar-1',
+      ownerWidgetSelector: 'widget-solar-charger' as const,
+      path: 'self.electrical.solar.*',
+      expansionMode: 'solar-tree' as const,
+      familyKey: 'solar' as const,
+      allowedIds: ['charger-1'],
+      enabled: true
+    };
+
+    const solarWidget = {
+      uuid: 'widget-solar-1',
+      type: 'widget-solar-charger',
+      config: {
+        displayName: 'Solar Charger'
+      }
+    } as IWidget;
+
+    historyApiClientMock.getPaths.mockResolvedValue([
+      'electrical.solar.charger-1.panelPower',
+      'electrical.solar.charger-1.current'
+    ]);
+
+    // Absent retention, plus every guard-falsy value, must collapse to the 24h default window.
+    const unusableRetentions: (number | null | undefined)[] = [undefined, null, 0, -1, Number.NaN];
+
+    for (const retentionDurationMs of unusableRetentions) {
+      historyApiClientMock.getPaths.mockClear();
+      (component as unknown as {
+        data: {
+          title: string;
+          widget: IWidget;
+          seriesDefinitions: IKipSeriesDefinition[];
+        };
+      }).data = {
+        title: 'Solar History',
+        widget: solarWidget,
+        seriesDefinitions: [
+          retentionDurationMs === undefined
+            ? { ...baseTemplate }
+            : { ...baseTemplate, retentionDurationMs }
+        ]
+      };
+
+      await component.loadHistoryDatasets();
+
+      expect(historyApiClientMock.getPaths).toHaveBeenCalledWith(expect.objectContaining({ duration: 'PT86400S' }));
+    }
+  });
 });

--- a/src/app/core/components/widget-history-chart-dialog/widget-history-chart-dialog.component.ts
+++ b/src/app/core/components/widget-history-chart-dialog/widget-history-chart-dialog.component.ts
@@ -74,6 +74,13 @@ export class WidgetHistoryChartDialogComponent implements OnInit, AfterViewInit,
   private pendingDatasets: HistoryChartDataset[] = [];
   private dualAxisDescriptorCache = new Map<string, IDualAxisSeriesDescriptor | null>();
 
+  /**
+   * Fallback retention-scale window for enumerating template concretes when a series carries no
+   * explicit retentionDurationMs. Matches the auto-retention the series are stamped with (24h) and is
+   * decoupled from the chart display window so a briefly-quiet device is not dropped from enumeration.
+   */
+  private readonly DEFAULT_ENUMERATION_WINDOW_MS = 24 * 60 * 60 * 1000;
+
   constructor() {
     effect(() => {
       const canvas = this.chartCanvas();
@@ -412,8 +419,12 @@ export class WidgetHistoryChartDialogComponent implements OnInit, AfterViewInit,
       return [series];
     }
 
-    const duration = this.resolveDuration(series);
-    const availablePaths = await this.historyApiClient.getPaths({ duration });
+    // Enumerate concretes over the retention window, not the (possibly short) chart display window:
+    // getPaths only lists paths with a sample inside the window, so a briefly-quiet device would be
+    // dropped if enumerated over the display window alone. The chart data itself is still fetched over
+    // the display window in buildDatasetForSeries.
+    const enumerationDuration = this.resolveEnumerationDuration(series);
+    const availablePaths = await this.historyApiClient.getPaths({ duration: enumerationDuration });
     if (!availablePaths?.length) {
       return [series];
     }
@@ -757,6 +768,15 @@ export class WidgetHistoryChartDialogComponent implements OnInit, AfterViewInit,
     }
 
     return this.selectedPeriod();
+  }
+
+  private resolveEnumerationDuration(series: IKipSeriesDefinition): string {
+    const retentionMs = series.retentionDurationMs;
+    const windowMs = typeof retentionMs === 'number' && Number.isFinite(retentionMs) && retentionMs > 0
+      ? retentionMs
+      : this.DEFAULT_ENUMERATION_WINDOW_MS;
+    const seconds = Math.max(1, Math.round(windowMs / 1000));
+    return `PT${seconds}S`;
   }
 
   private durationFromScaleAndPeriod(scaleRaw: string, periodRaw: number): string {


### PR DESCRIPTION
## Motivation
Since the kip-series reconcile was removed (#106), template/electrical widget history is enumerated via the History API's `getPaths`. It used the chart **display** window, so a configured device that hadn't logged a sample within that (possibly short) window was silently dropped from the template chart. Fixes #278.

## Approach
`expandTemplateSeries` now derives the `getPaths` enumeration window from the series' `retentionDurationMs` (~24h), falling back to a named 24h constant when it's absent/invalid. The chart **data** fetch window (`resolveDuration` / `getValues`) is unchanged — only the enumeration widens, so a briefly-quiet device is still listed while the chart still renders over the display window.

## Review
Multi-persona + adversarial verify. One P3 test gap fixed: the fallback-window branch is now covered (absent / 0 / negative / NaN retention all collapse to the 24h default).

Part of #257.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
