### PR TITLE
Notifications: reconcile on reconnect instead of blind-clearing (#275)

### DIFF
--- a/src/app/core/services/notifications.service.spec.ts
+++ b/src/app/core/services/notifications.service.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { signal, WritableSignal } from '@angular/core';
 import { Subject } from 'rxjs';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { INotification, INotificationInfo, NotificationsService } from './notifications.service';
 import { DataService } from './data.service';
 import { SettingsService } from './settings.service';
@@ -99,6 +99,10 @@ describe('NotificationsService', () => {
 
   function activeTrack(): number | null {
     return (service as unknown as { _activeAlarmSoundtrack: number | null })._activeAlarmSoundtrack;
+  }
+
+  function alarmPlayer(track: number): HTMLAudioElement {
+    return (service as unknown as { _players: Map<number, HTMLAudioElement> })._players.get(track)!;
   }
 
   describe('alarm state aggregation from deltas', () => {
@@ -385,34 +389,129 @@ describe('NotificationsService', () => {
     });
   });
 
-  describe('clear on connection reconnect', () => {
-    it('keeps alarms across a drop, clears them on reconnect, and repopulates from the fresh snapshot', () => {
-      setup();
-      connectionState$.next(ConnectionState.Connected);
-      notificationMsg$.next(makeDelta('notifications.a', makeValue(States.Alarm, [Methods.Visual, Methods.Sound])));
-      expect(latestNotifications()).toHaveLength(1);
-      expect(activeTrack()).toBe(1003);
-
-      // A drop alone must NOT clear: the last-known alarm stays visible (and sounding) during the outage.
-      connectionState$.next(ConnectionState.Disconnected);
-      expect(latestNotifications()).toHaveLength(1);
-      expect(latestInfo().alarmCount).toBe(1);
-      expect(activeTrack()).toBe(1003);
-
-      // Reconnect clears the carried-over list and silences its audio so nothing stale lingers...
-      connectionState$.next(ConnectionState.Connected);
-      expect(latestNotifications()).toHaveLength(0);
-      expect(latestInfo().alarmCount).toBe(0);
-      expect(activeTrack()).toBe(1000);
-
-      // ...then the fresh server snapshot re-delivers a still-active alarm, which reappears (#275).
-      notificationMsg$.next(makeDelta('notifications.a', makeValue(States.Alarm, [Methods.Visual, Methods.Sound])));
-      expect(latestNotifications()).toHaveLength(1);
-      expect(latestInfo().alarmCount).toBe(1);
-      expect(activeTrack()).toBe(1003);
+  describe('reconcile on connection reconnect', () => {
+    afterEach(() => {
+      vi.useRealTimers();
     });
 
-    it('does not clear notifications while the connection stays up', () => {
+    it('keeps an active alarm across a reconnect without clearing it or restarting its tone', () => {
+      setup();
+      connectionState$.next(ConnectionState.Connected);
+      notificationMsg$.next(makeDelta('notifications.bilge', makeValue(States.Alarm, [Methods.Visual, Methods.Sound])));
+      expect(latestNotifications()).toHaveLength(1);
+      expect(activeTrack()).toBe(1003);
+
+      const player = alarmPlayer(1003);
+      const playSpy = vi.spyOn(player, 'play');
+      const pauseSpy = vi.spyOn(player, 'pause');
+
+      vi.useFakeTimers();
+      // A drop must not clear; the reconnect that follows must not blank or silence the alarm.
+      connectionState$.next(ConnectionState.Disconnected);
+      connectionState$.next(ConnectionState.Connected);
+      expect(latestNotifications()).toHaveLength(1);
+      expect(latestInfo().alarmCount).toBe(1);
+      expect(activeTrack()).toBe(1003);
+
+      // The snapshot re-delivers the same still-active alarm: recognised as the existing entry, not
+      // cleared-and-re-added, so the looping player is never paused/restarted.
+      notificationMsg$.next(makeDelta('notifications.bilge', makeValue(States.Alarm, [Methods.Visual, Methods.Sound])));
+      vi.runOnlyPendingTimers();
+
+      expect(latestNotifications()).toHaveLength(1);
+      expect(latestInfo().alarmCount).toBe(1);
+      expect(activeTrack()).toBe(1003);
+      expect(playSpy).not.toHaveBeenCalled();
+      expect(pauseSpy).not.toHaveBeenCalled();
+    });
+
+    it('sweeps a notification the server no longer reports once the snapshot settles', () => {
+      setup();
+      connectionState$.next(ConnectionState.Connected);
+      notificationMsg$.next(makeDelta('notifications.engine', makeValue(States.Alarm, [Methods.Visual, Methods.Sound])));
+      notificationMsg$.next(makeDelta('notifications.bilge', makeValue(States.Warn, [Methods.Visual, Methods.Sound])));
+      expect(latestNotifications()).toHaveLength(2);
+
+      vi.useFakeTimers();
+      connectionState$.next(ConnectionState.Disconnected);
+      connectionState$.next(ConnectionState.Connected);
+
+      // The snapshot re-delivers only the engine alarm; the bilge warning resolved during the outage.
+      notificationMsg$.next(makeDelta('notifications.engine', makeValue(States.Alarm, [Methods.Visual, Methods.Sound])));
+
+      // Nothing is removed until the grace window elapses.
+      expect(latestNotifications()).toHaveLength(2);
+
+      vi.runOnlyPendingTimers();
+
+      expect(latestNotifications().map(n => n.path)).toEqual(['notifications.engine']);
+      expect(latestInfo().alarmCount).toBe(1);
+    });
+
+    it('adds notifications that first appear after a reconnect', () => {
+      setup();
+      connectionState$.next(ConnectionState.Connected);
+      notificationMsg$.next(makeDelta('notifications.engine', makeValue(States.Alarm, [Methods.Visual, Methods.Sound])));
+
+      vi.useFakeTimers();
+      connectionState$.next(ConnectionState.Disconnected);
+      connectionState$.next(ConnectionState.Connected);
+
+      // The snapshot re-confirms the existing alarm and introduces a brand-new one.
+      notificationMsg$.next(makeDelta('notifications.engine', makeValue(States.Alarm, [Methods.Visual, Methods.Sound])));
+      notificationMsg$.next(makeDelta('notifications.mob', makeValue(States.Emergency, [Methods.Visual, Methods.Sound])));
+      expect(latestNotifications().map(n => n.path)).toContain('notifications.mob');
+
+      vi.runOnlyPendingTimers();
+
+      expect(latestNotifications().map(n => n.path).sort()).toEqual(['notifications.engine', 'notifications.mob']);
+      expect(latestInfo().alarmCount).toBe(2);
+    });
+
+    it('keeps an unconfirmed alarm when the server re-delivers no snapshot on reconnect', () => {
+      setup();
+      connectionState$.next(ConnectionState.Connected);
+      notificationMsg$.next(makeDelta('notifications.mob', makeValue(States.Emergency, [Methods.Visual, Methods.Sound])));
+      expect(latestNotifications()).toHaveLength(1);
+      expect(activeTrack()).toBe(1004);
+
+      vi.useFakeTimers();
+      connectionState$.next(ConnectionState.Disconnected);
+      connectionState$.next(ConnectionState.Connected);
+      // No delta arrives after reconnect (a server that emits only on change, not on subscribe).
+      vi.runOnlyPendingTimers();
+
+      // The still-active alarm must not be silently dropped for lack of a snapshot.
+      expect(latestNotifications()).toHaveLength(1);
+      expect(latestInfo().alarmCount).toBe(1);
+      expect(activeTrack()).toBe(1004);
+    });
+
+    it('does not sweep a carried alarm when only an unrelated new path arrives after reconnect', () => {
+      setup();
+      connectionState$.next(ConnectionState.Connected);
+      notificationMsg$.next(makeDelta('notifications.bilge', makeValue(States.Alarm, [Methods.Visual, Methods.Sound])));
+      expect(latestNotifications()).toHaveLength(1);
+      expect(activeTrack()).toBe(1003);
+
+      const pauseSpy = vi.spyOn(alarmPlayer(1003), 'pause');
+
+      vi.useFakeTimers();
+      connectionState$.next(ConnectionState.Disconnected);
+      connectionState$.next(ConnectionState.Connected);
+
+      // A change-only server never re-delivers bilge; only an unrelated new path updates in the
+      // window. That is not evidence the carried alarm was re-streamed, so it must not arm the sweep.
+      notificationMsg$.next(makeDelta('notifications.other', makeValue(States.Normal, [Methods.Visual])));
+      vi.runOnlyPendingTimers();
+
+      expect(latestNotifications().map(n => n.path)).toContain('notifications.bilge');
+      expect(latestInfo().alarmCount).toBe(1);
+      expect(activeTrack()).toBe(1003);
+      expect(pauseSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not reconcile or clear notifications while the connection stays up', () => {
       setup();
       connectionState$.next(ConnectionState.Connected);
       notificationMsg$.next(makeDelta('notifications.a', makeValue(States.Alarm, [Methods.Visual, Methods.Sound])));

--- a/src/app/core/services/notifications.service.ts
+++ b/src/app/core/services/notifications.service.ts
@@ -65,10 +65,16 @@ export class NotificationsService implements OnDestroy {
     emergency: { sound: 4, visual: 2 },
   };
 
+  // Window to let the server's post-resubscribe snapshot arrive before sweeping unconfirmed entries.
+  private static readonly RECONCILE_GRACE_MS = 3000;
+
   private _notificationDataStreamSubscription: Subscription | null = null;
   private _notificationMetaStreamSubscription: Subscription | null = null;
   private _connectionResetSubscription: Subscription;
   private _wasConnected = false;
+  private _reconcilePendingPaths: Set<string> | null = null;
+  private _reconcileSawSnapshot = false;
+  private _reconcileTimer: ReturnType<typeof setTimeout> | null = null;
 
   private _notificationConfig: INotificationConfig;
   private _notificationConfig$ = new BehaviorSubject<INotificationConfig>(DefaultNotificationConfig);
@@ -93,14 +99,12 @@ export class NotificationsService implements OnDestroy {
 
     this._connectionResetSubscription = this.connectionStateMachine.state$.subscribe(state => {
       const connected = state === ConnectionState.Connected;
-      // On a (re)connection, drop notifications carried over from the previous session so stale
-      // alarms from a dropped or switched connection cannot linger. A drop alone does NOT clear —
-      // the last-known alarms stay visible through the outage. This is a blind clear that relies on
-      // the Signal K server re-delivering still-active notifications in its post-resubscribe snapshot
-      // (standard signalk-server behaviour) to repopulate them. Hardening the transient blank/audio
-      // restart into a reconcile (mark-stale + sweep) is tracked in #275.
+      // A drop alone does NOT clear — the last-known alarms stay visible (and sounding) through the
+      // outage. On (re)connection we reconcile the carried-over list against the server's fresh
+      // snapshot rather than blind-clearing, so an active alarm never transiently blanks or restarts
+      // its audio while the reconnect settles.
       if (connected && !this._wasConnected) {
-        this.clearNotifications();
+        this.beginReconnectReconcile();
       }
       this._wasConnected = connected;
     });
@@ -146,7 +150,7 @@ export class NotificationsService implements OnDestroy {
 
   private reset() {
     // Clears the list ONLY when notifications are disabled (a #147-pinned behaviour); otherwise it
-    // just recomputes the aggregate. Distinct from clearNotifications(), which always clears.
+    // just recomputes the aggregate.
     if (this._notificationConfig.disableNotifications) {
       this._notifications = [];
       this._notifications$.next([]);
@@ -154,10 +158,42 @@ export class NotificationsService implements OnDestroy {
     this.updateNotificationsState();
   }
 
-  private clearNotifications(): void {
-    this._notifications = [];
-    this._notifications$.next([]);
+  /**
+   * Reconcile carried-over notifications against the server's post-resubscribe snapshot instead of
+   * blind-clearing. Every current entry is marked pending; each delta that arrives during the grace
+   * window confirms its path. After the window, only still-unconfirmed entries are swept — and only
+   * when the server actually re-delivered a snapshot, so a server that emits notifications only on
+   * change (not on subscribe) leaves an active alarm in place rather than silently dropping it.
+   */
+  private beginReconnectReconcile(): void {
+    const pendingPaths = this._notifications.filter(n => n.value).map(n => n.path);
+    if (pendingPaths.length === 0) return;
+
+    this._reconcilePendingPaths = new Set(pendingPaths);
+    this._reconcileSawSnapshot = false;
+    this.clearReconcileTimer();
+    this._reconcileTimer = setTimeout(
+      () => this.sweepUnconfirmedNotifications(),
+      NotificationsService.RECONCILE_GRACE_MS
+    );
+  }
+
+  private sweepUnconfirmedNotifications(): void {
+    const pending = this._reconcilePendingPaths;
+    this._reconcileTimer = null;
+    this._reconcilePendingPaths = null;
+    if (!pending || !this._reconcileSawSnapshot || pending.size === 0) return;
+
+    this._notifications = this._notifications.filter(n => !pending.has(n.path));
     this.updateNotificationsState();
+    this.emitNotifications();
+  }
+
+  private clearReconcileTimer(): void {
+    if (this._reconcileTimer !== null) {
+      clearTimeout(this._reconcileTimer);
+      this._reconcileTimer = null;
+    }
   }
 
   private emitNotifications(): void {
@@ -252,6 +288,14 @@ export class NotificationsService implements OnDestroy {
 
   private processNotificationDeltaMsg(delta: ISignalKDataValueUpdate) {
     if (delta.path.startsWith("notifications.security")) return;
+
+    if (this._reconcilePendingPaths?.has(delta.path)) {
+      // Only re-delivery of a carried path is evidence the server sent a snapshot, and it confirms
+      // that path. An unrelated/new-path delta must NOT arm the sweep, or a change-only server's
+      // incidental update would let the sweep drop still-active carried alarms.
+      this._reconcileSawSnapshot = true;
+      this._reconcilePendingPaths.delete(delta.path);
+    }
 
     if (delta.value === null) {
       this.deleteValue(delta.path);
@@ -435,6 +479,7 @@ export class NotificationsService implements OnDestroy {
   }
 
   ngOnDestroy(): void {
+    this.clearReconcileTimer();
     this._connectionResetSubscription?.unsubscribe();
     this._notificationDataStreamSubscription?.unsubscribe();
     this._notificationMetaStreamSubscription?.unsubscribe();


### PR DESCRIPTION
## Motivation
On a WebSocket reconnect, `NotificationsService` blind-cleared its entire list and relied on the server re-delivering a full snapshot. On a marine display that transiently blanked an active alarm (bilge/engine/MOB) and **restarted its tone from zero on every WiFi flap**, and if the server never volunteered a snapshot the alarm never returned. Fixes #275.

## Approach
On reconnect, keep the list intact and mark all value-bearing paths *pending*; arm a 3s grace window. A delta that re-delivers a **pending (carried-over)** path removes it from pending and records that a snapshot was seen. At timeout, still-pending paths are swept **only if** a carried path was re-delivered (evidence the server actually re-streamed). On a change-only server (no re-delivery) nothing is swept — active alarms are retained and their tone is never interrupted.

## Review
Multi-persona + adversarial verify found a **P1/P2 hole** in the first cut: the snapshot-seen flag was armed by *any* delta, so an unrelated notification could authorize the sweep to drop still-active alarms on a change-only server — the exact failure this packet exists to prevent. Fixed with **per-path gating** (flag set only when a *carried* path is re-delivered) plus a survival test (unrelated-delta → carried alarm retained). The reviewer's "never sweep active alarms" alternative was rejected: on a snapshot server a resolved alarm is simply *absent*, so that would leave a resolved alarm sounding forever.

Design note: the cleanest signal would be an explicit "resubscribe snapshot complete" event from the connection layer; the packet deliberately avoids that coupling — per-path gating is correct for realistic servers.

Part of #257. Refs #151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
