### PR TITLE
Rebrand user-facing docs KIP → Skip (#198)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,17 @@
 
 > **Skip** is an experimental [HaLOS](https://halos.fi) fork of [Kip](https://github.com/mxtommy/Kip) by Thomas St.Pierre and David Godin. It adds standard Signal K session/SSO authentication and account-independent named profiles, and may diverge from upstream as it evolves. The webapp is served at `/@halos-org/skip/`. Licensed under MIT (see [LICENSE](LICENSE)).
 
-*Original Kip readme follows.*
-
 ---
 
 [![Help Docs](https://img.shields.io/badge/Help-Docs-blue)](src/assets/help-docs/welcome.md)
 [![Community Videos](https://img.shields.io/badge/Community-Videos-purple)](src/assets/help-docs/community.md)
 [![Contact](https://img.shields.io/badge/Contact-Get_in_touch-success)](src/assets/help-docs/contact-us.md)
 
-**KIP is the most popular Signal K MFD and marine instrument panel: plug-and-play, touch-optimized, pre-installed, and ready-to-use across all devices.**
+**Skip is a Signal K MFD and marine instrument panel: touch-optimized and ready-to-use across all your devices.**
 
-Unlike many instrument panels, KIP offers full MFD functionality and is **automatically included with Signal K distributions**, so there’s nothing extra to install or configure. Simply start your [Signal K](https://signalk.org) server, open KIP in a browser, and it’s ready to go. A single instance works everywhere — no per‑device deployment is needed.
+Skip offers full MFD functionality as a Signal K webapp. Install it from the Signal K app store, then open Skip in a browser and it’s ready to go. A single instance works everywhere — no per‑device deployment is needed.
 
-KIP is designed for sailors and boaters who want:
+Skip is designed for sailors and boaters who want:
 
 - A **ready-to-use, classic marine app experience** with minimal setup.
 - A **modern, polished interface** optimized for marine displays.
@@ -27,9 +25,9 @@ KIP is designed for sailors and boaters who want:
 - **Instant access to all Signal K data**: displays gauges, charts, switches, and other widgets right out of the box.
 - **Flexible dashboards**: customize layouts, drag-and-drop widgets, night/day mode, kiosk/fullscreen and remote control support.
 
-With KIP, you get the **familiar feel of professional Multi-Function Displays** combined with the flexibility of Signal K. It’s simple, reliable, and highly usable — the ultimate ready-to-go, modern, touch-first, Multi-Function Display for [Signal K](https://signalk.org) vessels.
+With Skip, you get the **familiar feel of professional Multi-Function Displays** combined with the flexibility of Signal K. It’s simple, reliable, and highly usable — a modern, touch-first Multi-Function Display for [Signal K](https://signalk.org) vessels.
 
-![KIP](./images/KIPDemo.png)
+![Skip](./images/KIPDemo.png)
 
 ## Table of Content
 - [Installations Showcase](#installations-showcase)
@@ -37,19 +35,19 @@ With KIP, you get the **familiar feel of professional Multi-Function Displays** 
 - [User Experience](#user-experience)
 - [Dashboards and Configuration](#dashboards-and-configuration), [Widget Library](#widget-library) & [Historical Data](#historycal-data)
 - [Night Modes](#night-modes)
-- [Remote Control](#remote-control-other-kip-displays)
+- [Remote Control](#remote-control-other-skip-displays)
 - [Kiosk Mode](#dedicated-fullscreen-instrument-display-kiosk-mode)
 - [Progressive Web App (PWA)](#progressive-web-app-pwa)
 - [Multiple User Configurations](#multiple-user-configurations)
-- [How To Contribute](#how-to-contribute) & [Creating Your Own Widgets](#kip-widgets)
+- [How To Contribute](#how-to-contribute) & [Creating Your Own Widgets](#skip-widgets)
 - [Connect, Share, and Support](#connect-share-and-support) & [Features, Ideas, Bugs](#features-ideas-bugs)
 
 ## Installations Showcase
 ![Form factor support](./images/exterior_user_installs.png)
-In addition to the obvious navstation, wall mounted instrument panel and autopilot remote control usecases using PCs, tablets and phones, users have taken KIP into the elements using Raspberry Pi, Pi Zero, rugged tablets and all kinds of low cost AliExpress screens and industry leading, high quality, sunlight readable marine touch screens. KIP's native remote control feature opens up all kinds of possibilities.
+In addition to the obvious navstation, wall mounted instrument panel and autopilot remote control usecases using PCs, tablets and phones, users have taken Skip into the elements using Raspberry Pi, Pi Zero, rugged tablets and all kinds of low cost AliExpress screens and industry leading, high quality, sunlight readable marine touch screens. Skip's native remote control feature opens up all kinds of possibilities.
 
 ## Read the Help Introduction How-To
-You just installed KIP and you're stuck; read the [Introduction](https://github.com/mxtommy/Kip/blob/master/src/assets/help-docs/welcome.md) help file.
+You just installed Skip and you're stuck; read the [Introduction](src/assets/help-docs/welcome.md) help file.
 
 # Design Goal
 The goal is to replicate and enhance the functionality of modern marine instrumentation displays while providing unmatched customization and flexibility. The design principles include:
@@ -95,14 +93,14 @@ Intuitive widget configuration.
 See what Signal K has to offer that you can leverage with widgets. Select it and tweak the display options to suit your purpose.
 ![Paths Configuration Image](./images/KipWidgetConfig-paths-1024x488.png)
 
-Many units are supported. Choose your preferred app defaults, then tweak them widget-by-widget as necessary. KIP will automatically convert the units for you.
+Many units are supported. Choose your preferred app defaults, then tweak them widget-by-widget as necessary. Skip will automatically convert the units for you.
 ![Units Configuration Image](./images/KipConfig-Units-1024.png)
 
 Organize your dashboards and access tools.
 ![Options and Dashboards](./images/Options.png)
 
 ## Widget Library
-All KIP widgets are visual presentation controls that are very versatile, with multiple advanced configuration options available to suit your needs:
+All Skip widgets are visual presentation controls that are very versatile, with multiple advanced configuration options available to suit your needs:
 - **Compact Linear** – Simple horizontal linear gauge with a large value label and modern look.
 - **Linear** – Horizontal or vertical linear gauge with zone highlighting.
 - **Radial** – Radial gauge with configurable dials and zone highlighting.
@@ -125,7 +123,7 @@ All KIP widgets are visual presentation controls that are very versatile, with m
 - **Racer - Start Timer** – Advanced racing countdown timer with OCS status and auto dashboard switching.
 - **Countdown Timer** – Simple race start countdown timer with start, pause, sync, and reset options.
 
-Get the latest version of KIP to see what's new!
+Get the latest version of Skip to see what's new!
 
 ### Widget Samples
 Gauges sample
@@ -141,7 +139,7 @@ Grafana integration with other widgets
 ![Embedded Webpage Concept Image](./images/KipGaugeSample3-1024x508.png)
 
 ## Historical Data
-Experience effortless insight into your vessel’s past with KIP’s Widget Historical Charts—automatically track, store, and visualize key data, unlocking instant access charts showing up to the last full day of performance. Whether you’re sailing or docked, simply two-finger tap or right-click widgets to reveal a seamless history dialog—no setup, no clutter, just the trends you need. When combining data visualisation using Data Driven widgets, live-to-history transitions, KIP puts your boat’s story at your fingertips—so you can make smarter decisions, spot patterns, and sail with confidence.
+Skip charts recent history for your numeric data by reading it from an external Signal K History API provider (such as `signalk-to-influxdb2` or `signalk-parquet`). Press and hold (long-press) a widget to open its history dialog, or use a Realtime Data Chart or Wind Trends widget to see recent trends. Skip does **not** record or store data itself — the detail and time span available depend on whatever provider your Signal K server runs, and charts show live data only when no provider is present. See the [History-API Provider](src/assets/help-docs/history-api.md) help file for setup.
 
 ## Night Modes
 Keep your night vision with automatic or manual day and night switching to a color preserving dim mode or an all Red theme. The images below look very dark, but at night... they are perfect!
@@ -150,8 +148,8 @@ Keep your night vision with automatic or manual day and night switching to a col
 
 ![Night mode - Brightness](./images/KipBrightness-1024.png)
 
-## Remote Control Other KIP Displays
-Control which dashboard is shown on another KIP instance (e.g., a mast display, hard-to-reach screen, or a non‑touch device) from any KIP, including your phone.
+## Remote Control Other Skip Displays
+Control which dashboard is shown on another Skip instance (e.g., a mast display, hard-to-reach screen, or a non‑touch device) from any Skip, including your phone.
 
 Use cases
 - Mast display: change dashboards from the cockpit.
@@ -159,13 +157,13 @@ Use cases
 - Non‑touch/no input: select dashboards when no keyboard/mouse is connected or touch is not supported/disabled.
 
 ## Dedicated Fullscreen instrument display (Kiosk Mode)
-Runs KIP on Raspberry Pi as a single full-screen application, suppresses the desktop UI and stays on screen like a dedicated chartplotter or marine instrument panel at a fraction of the cost. Read the [Kiosk Mode](https://github.com/mxtommy/Kip/blob/master/src/assets/help-docs/kiosk.md) help file.
+Runs Skip on Raspberry Pi as a single full-screen application, suppresses the desktop UI and stays on screen like a dedicated chartplotter or marine instrument panel at a fraction of the cost. Read the [Kiosk Mode](src/assets/help-docs/kiosk.md) help file.
 
 ## Progressive Web App PWA
-Run KIP without browser controls, just like a native computer, tablet or phone app. This feature is supported on most mobile operating systems and desktop browser. It freezes up screen real estate and offers a native Android and iOS app experience with single icon launch. Follow your browser's instructions to install Progressiver Web Apps. It's usually just a few clicks, such as "Add to Home Screen".
+Run Skip without browser controls, just like a native computer, tablet or phone app. This feature is supported on most mobile operating systems and desktop browser. It freezes up screen real estate and offers a native Android and iOS app experience with single icon launch. Follow your browser's instructions to install Progressiver Web Apps. It's usually just a few clicks, such as "Add to Home Screen".
 
 ## Multiple User Configurations
-If you have different roles on board: captain, skipper, tactician, navigator, engineer—or simply different people with different needs, each can tailor KIP as they wish. The use of profiles also allows you to tie specific configuration arrangements to use cases or device form factors.
+If you have different roles on board: captain, skipper, tactician, navigator, engineer—or simply different people with different needs, each can tailor Skip as they wish. The use of profiles also allows you to tie specific configuration arrangements to use cases or device form factors.
 
 ## Complementary Components
 Typical complementary components you may install (most are often bundled with Signal K distributions):
@@ -182,73 +180,73 @@ Typical complementary components you may install (most are often bundled with Si
 
 ## Harness the Power of Data State Notifications
 Stay informed with notifications about the state of the data you are interested in.
-For example, Signal K will notify KIP when a water depth or temperature sensor reaches certain levels. In addition to KIP's centralized notification menu, individual widgets offer tailored visual representations appropriate to their design objectives, providing an optimal user experience.
+For example, Signal K will notify Skip when a water depth or temperature sensor reaches certain levels. In addition to Skip's centralized notification menu, individual widgets offer tailored visual representations appropriate to their design objectives, providing an optimal user experience.
 
 # How To Contribute
-KIP is under the MIT license and is built with Node and Angular using various open-source assets. All free! The project want's to insure your time is well invested by favouring discussion before submitting bug fixes and new features.
+Skip is under the MIT license and is built with Node and Angular using various open-source assets. All free! The project want's to insure your time is well invested by favouring discussion before submitting bug fixes and new features.
 
 Please ensure you submit an issue (bug/feature) before submitting a pull request.
 
 ## Project Scope
-What KIP IS about:
+What Skip IS about:
 - Real‑time presentation of vessel & environment data (navigation, performance, systems) pulled from Signal K.
 - Fast, legible, touchscreen‑friendly dashboards for underway decision making.
 - Configurable widgets (gauges, charts, timers, controls) tuned for sailing operations.
 
-What KIP deliberately IS NOT trying to become:
+What Skip deliberately IS NOT trying to become:
 - A full data lake / long‑term time‑series historian.
 - A general purpose automation / rules / orchestration engine.
 - A universal external web‑app embedding or mash‑up framework.
 - A low‑code integration hub for arbitrarily wiring protocols and services.
 
-Those domains already have excellent, specialized open‑source tools. Instead of re‑implementing them, KIP plays nicely alongside them within a Signal K based onboard stack.
+Those domains already have excellent, specialized open‑source tools. Instead of re‑implementing them, Skip plays nicely alongside them within a Signal K based onboard stack.
 
 ### Processing, Extensions and Widgets
 
 #### Signal K Plugins
-Domain‑specific enrichment (polars, performance calculations, derived environmental data, routing aids) published directly into the Signal K data model that KIP can then display.
+Domain‑specific enrichment (polars, performance calculations, derived environmental data, routing aids) published directly into the Signal K data model that Skip can then display.
 
-#### KIP Widgets
-Visual data representation component that use Signal K path data and API V2 features. Scaffolding a new widgets only takes a few moments and is backed by KIP AI agent instructions providing willed creative minds a personal assistant programmer.
+#### Skip Widgets
+Visual data representation component that use Signal K path data and API V2 features. Scaffolding a new widgets only takes a few moments and is backed by Skip AI agent instructions providing willed creative minds a personal assistant programmer.
 
 Run one simple command (example):
 ```
 npm run generate:widget
 ```
-or ask your AI to create a widget using the KIP project AI instructions.
+or ask your AI to create a widget using the Skip project AI instructions.
 
 For deeper details you can still look at `COPILOT.md`, but you don’t need to in order to get started.
 
 ### Why this separation matters
 
-Keeping KIP focused preserves responsiveness (lower CPU / memory), reduces UI clutter, and accelerates core sailing user experience development. Heavy analytics, complex workflow logic, and broad third‑party embedding stay where they are strongest—outside—but still feed KIP through the common Signal K data fabric.
+Keeping Skip focused preserves responsiveness (lower CPU / memory), reduces UI clutter, and accelerates core sailing user experience development. Heavy analytics, complex workflow logic, and broad third‑party embedding stay where they are strongest—outside—but still feed Skip through the common Signal K data fabric.
 
-In short: use KIP to see & act on live sailing information; use the complementary tools to store it long‑term, analyze it deeply, automate decisions, or build advanced integrations.
+In short: use Skip to see & act on live sailing information; use the complementary tools to store it long‑term, analyze it deeply, automate decisions, or build advanced integrations.
 
 ## Getting Started
 
 **Linux, Mac, RPi, or Windows dev platform supported**
 1. Download your favorite coding IDE (we use the free Visual Studio Code)
-2. Create your own GitHub KIP fork.
-3. Configure your IDE's source control to point it to your forked KIP instance (Visual Studio Code, GitHub support is built-in) and get the fork's master branch locally.
+2. Create your own GitHub Skip fork.
+3. Configure your IDE's source control to point it to your forked Skip instance (Visual Studio Code, GitHub support is built-in) and get the fork's main branch locally.
 4. Install `npm` and `node`. On macOS, you can use `brew install node` if you have Homebrew. See https://nodejs.org/en/download for more options.
 5. Install the Angular CLI using `npm install -g @angular/cli`
 
 **Project Setup**
-1. From your fork's master branch, create a working branch with a name such as: `new-widget-abc` or `fix-issue-abc`, etc.
+1. From your fork's main branch, create a working branch with a name such as: `new-widget-abc` or `fix-issue-abc`, etc.
 2. Check out this new branch.
 3. In a command shell (or in the Visual Studio Code Terminal window), go to the root of your local project folder, if not done automatically by your IDE.
-4. Install project dependencies using the NPM package and dependency manager: run `npm install`. NPM will read the KIP project dependencies, download, and install everything automatically for you.
-5. Build the app locally using Angular CLI: from that same project root folder, run `npm run build:prod`. The CLI tool will build KIP.
+4. Install project dependencies using the NPM package and dependency manager: run `npm install`. NPM will read the Skip project dependencies, download, and install everything automatically for you.
+5. Build the app locally using Angular CLI: from that same project root folder, run `npm run build:prod`. The CLI tool will build Skip.
 
 **Code and Test**
-1. Fire up your local KIP development instance with `npm run dev`.
+1. Fire up your local Skip development instance with `npm run dev`.
 2. Hit Run/Start Debugging in Visual Studio Code or manually point your favorite browser to `http://localhost:4200/@halos-org/skip`. Alternatively, to start the development server and allow remote devices connections, such as with your phone or RPi (blocked for security reasons by default):  
    `ng serve --configuration=dev --serve-path=/@halos-org/skip/ --host=<your computer's IP> --port=4200`
 3. Voila!
 
 *As you work on source code and save files, the app will automatically reload in the browser with your latest changes.*  
-*You will also need a running Signal K server for KIP to connect to and receive data. You could also use https://demo.signalk.org but without authentication enabled, your actions, features and test coverage will be limited.*
+*You will also need a running Signal K server for Skip to connect to and receive data. You could also use https://demo.signalk.org but without authentication enabled, your actions, features and test coverage will be limited.*
 
 **Apple PWA Icon Generation**
 
@@ -264,13 +262,13 @@ Once done with your work, from your fork's working branch, make a GitHub pull re
 For comprehensive development guidance, please refer to these instruction files:
 
 ### Primary Instructions
-- **[Project Instructions](./.github/instructions/project.instructions.md)**: KIP policy owner for architecture/domain rules, including widget creation and Host2 contracts.
+- **[Project Instructions](./.github/instructions/project.instructions.md)**: Skip policy owner for architecture/domain rules, including widget creation and Host2 contracts.
 - **[COPILOT.md](./COPILOT.md)**: Architecture context, rationale, and evolution notes (non-policy).
 - **[Angular Instructions](./.github/instructions/angular.instructions.md)**: Modern Angular v21+ coding standards, component patterns, and framework best practices.
 - **[Copilot Agent Instructions](./.github/copilot-instructions.md)**: Architecture details and coding-agent guardrails for this repository.
 
 ### Development Workflow
-1. **Start Here**: Read `.github/instructions/project.instructions.md` for KIP policy contracts.
+1. **Start Here**: Read `.github/instructions/project.instructions.md` for Skip policy contracts.
 2. **Angular Standards**: Follow `.github/instructions/angular.instructions.md` for modern Angular development.
 3. **Architecture Context**: Use `COPILOT.md` for rationale and dated architecture notes.
 4. **Setup & Build**: Use this README for project setup and build commands.
@@ -285,17 +283,16 @@ For comprehensive development guidance, please refer to these instruction files:
 ### Key Priorities
 - **Widget Development**: Use Host2 patterns and scaffold with the `create-host2-widget` schematic (see `docs/widget-schematic.md`).
 - **Angular Patterns**: Use signals, standalone components, and modern control flow.
-- **Theming**: Follow KIP's theme system for consistent UI.
+- **Theming**: Follow Skip's theme system for consistent UI.
 - **Code Quality**: Run `npm run lint` before commits.
 
-KIP is open-source under the MIT license, built by the community and 100% free. [Join the community](https://discord.gg/AMDYT2DQga) on Discord or contribute to the project on GitHub!
+Skip is open-source under the MIT license, built by the community and 100% free. Contribute to the project on [GitHub](https://github.com/halos-org/skip)!
 
 # Connect, Share, and Support
-KIP has its own Discord Signal K channel for getting in touch. Join us at https://discord.gg/AMDYT2DQga
+Report issues and request features on [Skip's GitHub project](https://github.com/halos-org/skip/issues). Skip is a fork of [Kip](https://github.com/mxtommy/Kip); the upstream Kip community chats on [Discord](https://discord.gg/AMDYT2DQga).
 
 # Features, Ideas, Bugs
-See KIP's GitHub project for the latest feature requests:
-https://github.com/mxtommy/Kip/issues
+See [Skip's GitHub project](https://github.com/halos-org/skip/issues) for the latest feature requests and bug reports.
 
 This repository may not be used to train machine learning or AI models
 without explicit permission from the author.

--- a/src/assets/help-docs/ais-radar.md
+++ b/src/assets/help-docs/ais-radar.md
@@ -17,7 +17,7 @@ This page explains:
 
 > AIS data must be available in the Signal K server for the widget to function correctly. This usually means using compatible AIS hardware receiver or connecting to a Virtual AIS service over the internet with a Server Connection of type WebSocket.
 
-If the KIP Connection option does not include `Subscribe to remote source message such as AIS and DSC targets.`, the widget warns that AIS data is disabled and asks you to enable remote source subscription in Settings / Options.
+If the Skip Connection option does not include `Subscribe to remote source message such as AIS and DSC targets.`, the widget warns that AIS data is disabled and asks you to enable remote source subscription in Settings / Options.
 
 The Derived Data plugin must be installed, enabled and it's Traffic section options must be configured with attention to provide collision risk information.
 

--- a/src/assets/help-docs/community.md
+++ b/src/assets/help-docs/community.md
@@ -1,8 +1,8 @@
 # Online Community Content
 
-> Want to contribute a video or resource? Share your links by [submitting a PR to this page](https://github.com/mxtommy/Kip/blob/master/src/assets/help-docs/community.md), use the [KIP Discord channel](https://discord.gg/AMDYT2DQga) or open a [GitHub issue](https://github.com/mxtommy/Kip/issues)**!
+> Want to contribute a video or resource? Share your links by [submitting a PR to this page](https://github.com/halos-org/skip/blob/main/src/assets/help-docs/community.md), use the upstream [Kip Discord channel](https://discord.gg/AMDYT2DQga) or open a [GitHub issue](https://github.com/halos-org/skip/issues)**!
 
-Explore KIP in action and learn from the community. Below are curated videos, creator channels, and related ecosystem resources.
+Explore Skip in action and learn from the community. Below are curated videos, creator channels, and related ecosystem resources.
 
 ## Community Video Library
 Curated videos created by community members. Ordered to highlight broad onboarding value first.
@@ -19,7 +19,7 @@ Improve or add entries: PR or Discord #showcase.
 
 
 ## Authors & Channels
-Creator channels producing helpful KIP or Signal K related content.
+Creator channels producing helpful Kip or Signal K related content.
 
 ### Boating with the Baileys
 - Channel: https://www.youtube.com/@BoatingwiththeBaileys
@@ -55,7 +55,7 @@ Open a PR or post in Discord #showcase with:
 
 ## More Community Resources
 
-- [Signal K Home page](https://signalk.org/) — The open marine data standard powering KIP
+- [Signal K Home page](https://signalk.org/) — The open marine data standard powering Skip
 - [Signal K Discord](https://discord.com/invite/uuZrwz4dCS) — Live chat server: questions, support, contribute and collaborate
 - [Signal K GitHub Project](https://github.com/SignalK) — Feature requests, bug reports, and feedback
 - [SensESP](https://signalk.org/SensESP/) — A Signal K sensor development toolkit for the ESP32 platform

--- a/src/assets/help-docs/configuration.md
+++ b/src/assets/help-docs/configuration.md
@@ -1,57 +1,61 @@
 ## Configuration Management
 
-KIP provides a "Login to Server" option that determines where your configuration is stored. It is **strongly recommended** to enable server login in the **Settings** under the **Connectivity** tab. This ensures your configurations are stored remotely on the Signal K server and allows automatic loading of configuration from any device. See the "Creating a Signal K user" section below for information on how to create a user.
+Skip keeps your setup in two separate places:
 
-- **Login to Server Enabled** (recommended setting): Configuration is stored remotely on the Signal K server. This mode allow automatic loading of your configuration from any device (also known as configuration sharing).
-- **Login to Server Disabled** (default value): Configuration is saved on your computer/device, in the browser's private storage. In this mode, the configuration is per browser.
+- **Connection settings** (Signal K server URL and connection options) are always stored **on this device**, in the browser. They are never shared between devices.
+- **Application configuration** (pages, widgets, layouts, and theme) is stored **on the Signal K server**, tied to your Signal K user account, so it follows you to any device where you sign in as the same user.
 
-You can manage your configurations using the **Configurations** page, accessible from the right menu. Depending on your login mode, different management options are available.
+## Signing In
+
+Skip signs in through your Signal K server's session (single sign-on). It **never asks you for a Signal K username or password directly** and never stores credentials — the sign-in happens on the server, and Skip only holds the resulting session.
+
+Open **Settings > Connectivity**:
+
+- If the server requires sign-in and you are not signed in yet, a **Sign in** button appears. It sends you to the Signal K server's login and returns you to Skip once you are authenticated.
+- When signed in, the Connectivity tab shows the account you are signed in as.
+- If your account has read-only access, Skip shows a **Read-only access** notice and configuration changes are disabled.
+- If your Signal K server does not require authentication, Skip connects without signing in.
+
+Application configuration is stored on the server under a Signal K user account. Without a signed-in user account, profile management and server-stored configuration are unavailable, and Skip runs with connection settings only.
 
 ## Creating a Signal K User
 
-To log in to Signal K, you must first create a user. Follow these steps to create a Signal K user:
+To sign in, your Signal K server needs a user account. To create one:
 
-1. Navigate to the Signal K server's **Security > Users** menu.
+1. In the Signal K server admin, open the **Security > Users** menu.
 2. Click **Add** to create a new user.
-3. Provide a **User ID** and **Password** for the user.
-4. Assign **Read/Write** permissions at a minimum. To allow access to the Global storage scope, assign **Admin** permissions as well.
+3. Provide a **User ID** and **Password**.
+4. Assign **Read/Write** permissions so the account can store configuration. A **Read-only** account can view configuration but not change it.
 5. Click **Apply** to save the new user.
 
-## Login to Server Mode
+Then sign in to that account from Skip via **Settings > Connectivity > Sign in**.
 
->In this mode, your configuration is shared across all devices **as long as you authenticate to Signal K using the same User ID**. It's that simple!
+## Profiles
 
-On the **Configurations** page, you can perform the following actions:
+A **profile** is a named set of pages, layouts, and theme, stored under your Signal K user account. Profiles let a single account keep several independent setups — for example one per station, role, or device form factor. Each device remembers which profile it is showing, so different displays signed in as the same user can each show a different profile.
 
-- **Backup**: Save the currently active configuration. Backups can be created in different scopes (see below for details).
-- **Delete**: Permanently delete a backup configuration. This action is irreversible.
-- **Restore**: Replace the active configuration with a selected backup and reload the app. It is recommended to back up your active configuration before restoring, to avoid losing it.
+Manage profiles in **Settings > Configurations**:
 
-### Storage Scopes
+- **New** — create a new profile.
+- **Switch** — show a different profile on this device.
+- **Rename** / **Duplicate** — rename a profile or copy it (including its configuration).
+- **Delete** — remove a profile. You cannot delete the active profile or the `default` profile.
 
-When using "Login to Server" mode, you can save and retrieve configuration backups from different storage scopes. Think of storage scopes as separate folders:
+Profile changes require a read/write session; they are disabled when you are signed in with a read-only account.
 
-- **User Scope**: Each user has their own private storage space. Users cannot access or view each other's storage.
-- **Global Scope**: Accessible only to users with Signal K "Admin" permissions. This shared storage space allows configuration backups to be shared between users. To share configurations, both users must, at least temporarily, have admin permissions.
+## Sharing Configuration Between Devices
 
-## Planning Configurations
+Because application configuration lives on the server under your Signal K user account, signing in as the **same** user on another device gives you the same profiles automatically — this is how configuration is shared across devices.
 
-If you log in with the same user credentials, your configuration will be consistent across all devices and browsers. 
+To keep devices independent, either sign in with **different** Signal K users, or switch each device to a different profile.
 
-To manage configurations for different devices, stations, or roles, you can create separate Signal K users, each with their own configurations. This approach allows you to tailor configurations to specific use cases. Plan carefully to take full advantage of KIP's flexible configuration management.
+## Backup, Import, and Reset
 
-## Local Storage
+The **Advanced** section of **Settings > Configurations** provides:
 
-If you do not log in to the server, KIP saves and retrieves configuration changes using your browser's local storage. In this mode:
+- **Download** — save the active profile's configuration to a file, for backup or to move it to another Signal K server.
+- **Import** — load a configuration file as a **new profile**. This never overwrites an existing profile.
+- **Default** — reset the active profile to a single Getting Started widget. Your connection settings are kept.
+- **Connection** — clear the Connectivity settings only; this does not affect your profiles.
 
-- Each browser instance has its own independent configuration.
-- Configurations **cannot be shared** between different devices or browsers.
-- Configuration management is limited to downloading and uploading configuration files.
-
-## Advanced Operations
-
-Use advanced operations with caution. All changes affect your active configuration in real time and are irreversible.
-
-KIP separates configuration into two parts:
-1. **Server Connection**: This configuration is always stored locally in your browser and is never shared. It is used in the **Connectivity** tab of the **Settings** page.
-2. **Application Settings**: This includes the configuration settings you can back up, delete, and restore with the **Configurations** page. It contains all pages, widgets and other configuration settings.
+Use these operations with care: they change your active configuration in real time and cannot be undone.

--- a/src/assets/help-docs/contact-us.md
+++ b/src/assets/help-docs/contact-us.md
@@ -1,10 +1,10 @@
 ## Get in Touch
 
-We’d love to hear from you. The KIP community is active and friendly—whether you are just getting started, troubleshooting an installation, or brainstorming a new idea.
+We’d love to hear from you. The Skip community is active and friendly—whether you are just getting started, troubleshooting an installation, or brainstorming a new idea.
 
-👉 **Chat with the community in the [KIP Discord channel](https://discord.gg/AMDYT2DQga).**
+👉 **Chat with the community in the upstream [Kip Discord channel](https://discord.gg/AMDYT2DQga).**
 
-Use Discord for quick questions, sharing dashboards, comparing hardware setups, and learning how others integrate KIP with Signal K.
+Use Discord for quick questions, sharing dashboards, comparing hardware setups, and learning how others integrate Skip with Signal K.
 
 
 ## When to Use GitHub Issues
@@ -15,7 +15,7 @@ Please open a GitHub issue anytime you:
 - Notice incorrect documentation
 - Have a reproducible performance or stability problem
 
-🔗 **Create or review issues here: [KIP GitHub Issues](https://github.com/mxtommy/Kip/issues)**
+🔗 **Create or review issues here: [Skip GitHub Issues](https://github.com/halos-org/skip/issues)**
 
 Before creating a new issue:
 1. Use the search box to see if it already exists (add keywords like the widget name, setting, or error text).
@@ -25,7 +25,7 @@ Before creating a new issue:
 Provide clear, specific details so we can reproduce and fix the problem faster:
 - What you expected vs. what happened
 - Steps to reproduce (numbered list if possible)
-- KIP version (see About / build info) and deployment method (e.g. Signal K app store, manual build)
+- Skip version (see About / build info) and deployment method (e.g. Signal K app store, manual build)
 - Signal K server version
 - Browser + version (e.g. Firefox 128, Chrome 129, Safari 18)
 - Relevant widget(s) or data paths (e.g. `navigation.speedOverGround`)
@@ -57,6 +57,6 @@ If something critical slips through, feel free to politely bump the issue after 
 
 
 ## Thank You
-Your feedback, curiosity, and ideas directly shape KIP. Whether it’s a tiny typo fix or a major feature concept—every contribution moves the project forward.
+Your feedback, curiosity, and ideas directly shape Skip. Whether it’s a tiny typo fix or a major feature concept—every contribution moves the project forward.
 
 Fair winds, and happy hacking.

--- a/src/assets/help-docs/contributing-widgets.md
+++ b/src/assets/help-docs/contributing-widgets.md
@@ -1,6 +1,6 @@
 ## Contributing Widgets
 
-KIP widgets are community-powered. If you need a widget that does not exist yet, you can request one from the community or build and contribute it.
+Skip widgets are community-powered. If you need a widget that does not exist yet, you can request one from the community or build and contribute it.
 
 ## For End Users
 
@@ -29,7 +29,7 @@ Developer references:
 2. Generate and implement the widget.
 3. Generate and implement the widget test when necessary.
 4. Add an svg icon
-5. Update README.md and KIP documentation with your plugin information.
+5. Update README.md and Skip documentation with your plugin information.
 6. Validate with lint/tests (ng lint/ng test).
 7. Submit a pull request with screenshots and a short behavior summary.
 

--- a/src/assets/help-docs/dashboards.md
+++ b/src/assets/help-docs/dashboards.md
@@ -43,7 +43,7 @@ In edit mode, widgets show dashed outlines.
 ## Viewing Widget History on a Locked Page
 When a page is locked (normal viewing mode), you can open a history chart for a widget without entering edit mode: **press and hold (long-press)** the widget.
 
-KIP opens a history chart dialog and loads historical series data for that widget using the History API. Only widgets bound to numeric data have a history — long-pressing anything else does nothing.
+Skip opens a history chart dialog and loads historical series data for that widget using the History API. Only widgets bound to numeric data have a history — long-pressing anything else does nothing.
 
 
 ## Workflow: From Idea to Page
@@ -56,7 +56,7 @@ KIP opens a history chart dialog and loads historical series data for that widge
 
 
 ## Widget Gallery (Overview)
-KIP widgets turn Signal K data into readable visuals and controls. Available widget types:
+Skip widgets turn Signal K data into readable visuals and controls. Available widget types:
 
 - **Numeric** – Displays numeric data in a clear and concise format, with options to show min/max values and a background minichart for trends.
 - **Text** – Displays text data with customizable color formatting.

--- a/src/assets/help-docs/datainspector.md
+++ b/src/assets/help-docs/datainspector.md
@@ -1,6 +1,6 @@
 ## Data Inspector
 
-The Data Inspector is a powerful tool in KIP that allows you to view all Signal K paths and the data received from the server in real time. It provides detailed insights into the data being transmitted, including metadata, sources, and supported operations. This guide explains how to use the Data Inspector effectively.
+The Data Inspector is a powerful tool in Skip that allows you to view all Signal K paths and the data received from the server in real time. It provides detailed insights into the data being transmitted, including metadata, sources, and supported operations. This guide explains how to use the Data Inspector effectively.
 
 The Data Inspector is a good way to validate raw data and available paths without the constraints that each widget can impose. It provides a clear and unrestricted view of the data, making it an essential tool for understanding the underlying Signal K data structure.
 
@@ -33,7 +33,7 @@ The Data Inspector is a good way to validate raw data and available paths withou
 4. **Unit Conversion**:
    - If a path supports unit conversion, you can change the data format to your preferred unit (e.g., converting speed from knots to kilometers per hour).
    - This feature is especially useful to quickly display data in a format that matches your preferences.
-   - Changing the units in the Data Inspector does not change KIP's default units or any widget's format settings. It is only for quick consultation.
+   - Changing the units in the Data Inspector does not change Skip's default units or any widget's format settings. It is only for quick consultation.
 
 ## Practical Use Cases
 
@@ -43,11 +43,11 @@ The Data Inspector is a good way to validate raw data and available paths withou
 - **Verify PUT Support**:
    - Check if a path supports PUT operations. It is required to configure widgets like Switch Panel, Slider, or Multi State Switch.
    - For more details on PUT support and how to use it, refer to the [Updating Signal K Data](#/help/putcontrols.md) help documentation.
-   - If you are learning Node-RED flows and want your flow to work with KIP digital switching widgets, continue with [Node-RED Control Flows for KIP Widgets (Beginner Guide)](#/help/nodered-control-flows.md).
+   - If you are learning Node-RED flows and want your flow to work with Skip digital switching widgets, continue with [Node-RED Control Flows for Skip Widgets (Beginner Guide)](#/help/nodered-control-flows.md).
 
 - **Troubleshoot Data Issues**:
    - The Data Inspector is a good troubleshooting tool, but it should be used with the Signal K Data Browser when trying to understand raw data and behavior. The combination of these tools provides a more complete picture of the data, its processing, and its behavior.
 
 ## Summary
 
-The Data Inspector is an essential tool for managing and understanding the data KIP receives from your Signal K server. With its real-time updates, filtering, and unit conversion capabilities, it provides a comprehensive view of your vessel's data whether you're monitoring performance, configuring widgets, or troubleshooting issues. For deeper analysis and understanding of raw data, pair it with the Signal K Data Browser.
+The Data Inspector is an essential tool for managing and understanding the data Skip receives from your Signal K server. With its real-time updates, filtering, and unit conversion capabilities, it provides a comprehensive view of your vessel's data whether you're monitoring performance, configuring widgets, or troubleshooting issues. For deeper analysis and understanding of raw data, pair it with the Signal K Data Browser.

--- a/src/assets/help-docs/embedwidget.md
+++ b/src/assets/help-docs/embedwidget.md
@@ -8,47 +8,47 @@ While this embedding feature is powerful, it comes with certain limitations due 
 
 CORS (Cross-Origin Resource Sharing) is a security feature built into web browsers. It prevents one website from accessing resources (like web pages or data) from another website unless the other website explicitly allows it. This is done to protect users from malicious websites trying to steal data or perform unauthorized actions.
 
-When you use the Embed Page Viewer widget, it tries to load the content of the URL you provide into an iframe. However, if the website you are trying to embed does not allow its content to be displayed in an iframe on another website (like embeding their app in your KIP dashboard), the browser will block it. This is not something the widget or Signal K can control—it is a restriction set by the website you are trying to embed.
+When you use the Embed Page Viewer widget, it tries to load the content of the URL you provide into an iframe. However, if the website you are trying to embed does not allow its content to be displayed in an iframe on another website (like embeding their app in your Skip dashboard), the browser will block it. This is not something the widget or Signal K can control—it is a restriction set by the website you are trying to embed.
 
 ## Understanding CORS and Hostname/Port Behavior
 
-It is important to clarify that CORS (Cross-Origin Resource Sharing) restrictions are not enforced when the hostname and port of the embedded content match the hostname and port of the KIP dashboard. This is because CORS only applies to requests made across different origins. An origin is defined as a combination of the protocol (e.g., `http` or `https`), hostname (e.g., `localhost` or `example.com`), and optional port (e.g., `80`, `443`, or a custom port). If all those are the same as the ones used by KIP, irrespective of the paths that can be present after the port, it is a same-origin path and CORS restrictions do not apply.
+It is important to clarify that CORS (Cross-Origin Resource Sharing) restrictions are not enforced when the hostname and port of the embedded content match the hostname and port of the Skip dashboard. This is because CORS only applies to requests made across different origins. An origin is defined as a combination of the protocol (e.g., `http` or `https`), hostname (e.g., `localhost` or `example.com`), and optional port (e.g., `80`, `443`, or a custom port). If all those are the same as the ones used by Skip, irrespective of the paths that can be present after the port, it is a same-origin path and CORS restrictions do not apply.
 
 ### When CORS Does Not Apply
 
-If the URL you are embedding in the Embed Page Viewer widget uses the same hostname and port as your KIP dashboard (e.g., all Signal K app store applications), the browser considers it to be the same origin. In this case, CORS restrictions do not apply, and the content can be embedded without issues.
+If the URL you are embedding in the Embed Page Viewer widget uses the same hostname and port as your Skip dashboard (e.g., all Signal K app store applications), the browser considers it to be the same origin. In this case, CORS restrictions do not apply, and the content can be embedded without issues.
 
 #### Examples:
 
 1. **Same Origin (No CORS Restrictions)**:
-   - KIP Dashboard URL: `http://localhost:3000/@halos-org/skip/`
+   - Skip Dashboard URL: `http://localhost:3000/@halos-org/skip/`
    - Embedded Content URL: `http://localhost:3000/some-page/`
-   - Since both KIP and the embedded URL share the same protocol (`http`), hostname (`localhost`), and port (`3000`), CORS does not apply.
+   - Since both Skip and the embedded URL share the same protocol (`http`), hostname (`localhost`), and port (`3000`), CORS does not apply.
 
 2. **Different Origin (CORS Restrictions Apply)**:
-   - KIP Dashboard URL: `http://localhost:3000/@halos-org/skip/`
+   - Skip Dashboard URL: `http://localhost:3000/@halos-org/skip/`
    - Embedded Content URL: `http://localhost:4000/some-page/`
    - In this case, the ports are different (`3000` vs. `4000`), so the browser considers them to be different origins, and CORS restrictions will apply.
 
 3. **Different Hostname (CORS Restrictions Apply)**:
-   - KIP Dashboard URL: `http://dashboard.local/@halos-org/skip/`
+   - Skip Dashboard URL: `http://dashboard.local/@halos-org/skip/`
    - Embedded Content URL: `http://example.com/some-page`
    - Even if the ports are the same, the hostnames are different (`dashboard.local` vs. `example.com`), so CORS restrictions will apply.
 
 4. **Different Protocol (CORS Restrictions Apply)**:
-   - KIP Dashboard URL: `http://localhost:3000/@halos-org/skip/`
+   - Skip Dashboard URL: `http://localhost:3000/@halos-org/skip/`
    - Embedded Content URL: `https://localhost:3000/some-page/`
    - Even though the hostname and port are the same, the protocols are different (`http` vs. `https`), so CORS restrictions will apply.
 
-### IMPORTANT:  Practical Implications for KIP Users
+### IMPORTANT:  Practical Implications for Skip Users
 
-- Embedding webapp and websites is far from perfect. Their are tradeoffs and limitations. If you find yourself unhappy with the result, keep your smile and give back to the community by build a dedicated KIP widget. We will help and many have done so.
+- Embedding webapp and websites is far from perfect. Their are tradeoffs and limitations. If you find yourself unhappy with the result, keep your smile and give back to the community by build a dedicated Skip widget. We will help and many have done so.
 - By default you cannot interact with the Embed content. Activate the **Enable Input** widget option if you need to interact with the content.
-- If you are hosting custom web pages or applications on the same server as your KIP dashboard, ideally you've created a Signal K webapp and shared it with the community, ensure they use the same hostname and port. Use a relative URL path in the Embed configuration. For example, if your KIP dashboard is running on `http://localhost:3000/@halos-org/skip/` and your custom content is under the same origin, such as `http://localhost:3000/signalk-anchoralarm-plugin/` simply enter a relative URL in the widget options, like `/signalk-anchoralarm-plugin/`. KIP will automatically add the proper protocol, hostname, port and load the content. This will prevent issues loading the embedded content when launching KIP from different devices such as: the server, on your phone, tablet, laptop, etc.
+- If you are hosting custom web pages or applications on the same server as your Skip dashboard, ideally you've created a Signal K webapp and shared it with the community, ensure they use the same hostname and port. Use a relative URL path in the Embed configuration. For example, if your Skip dashboard is running on `http://localhost:3000/@halos-org/skip/` and your custom content is under the same origin, such as `http://localhost:3000/signalk-anchoralarm-plugin/` simply enter a relative URL in the widget options, like `/signalk-anchoralarm-plugin/`. Skip will automatically add the proper protocol, hostname, port and load the content. This will prevent issues loading the embedded content when launching Skip from different devices such as: the server, on your phone, tablet, laptop, etc.
 
 ### Summary
 
-CORS restrictions only apply when the protocol, hostname, or port of the embedded content differs from the KIP dashboard. By ensuring that your embedded content shares the same origin as the dashboard, you can avoid CORS-related issues and seamlessly use the Embed Page Viewer widget.
+CORS restrictions only apply when the protocol, hostname, or port of the embedded content differs from the Skip dashboard. By ensuring that your embedded content shares the same origin as the dashboard, you can avoid CORS-related issues and seamlessly use the Embed Page Viewer widget.
 
 ## How Does This Affect the Embed Widget?
 
@@ -59,8 +59,8 @@ CORS restrictions only apply when the protocol, hostname, or port of the embedde
    - Many popular websites (e.g., banking sites, social media platforms, or secure portals) block iframe embedding for security reasons.
    - Some websites may allow embedding only for specific trusted domains, which most probably, do not include your Signal K installation.
 
-3. **Consequences of Blocked Content in KIP**:
-   - When you enable the "Allow Input" Embed widget option, KIP needs to inject gestures within the embedded application to trigger page navigation, reveal the auto-hiding toolbar, or use KIP's keyboard hotkeys while the focus is inside the iframe. To achieve this, KIP dynamically injects scripts into the iframe application. If CORS restrictions apply, this will be prohibited by the browser. This means that gestures and hotkeys will not work over the Embed widget. If you have a full-screen Embed widget, you could get stuck with no way to change pages or reveal the toolbar.
+3. **Consequences of Blocked Content in Skip**:
+   - When you enable the "Allow Input" Embed widget option, Skip needs to inject gestures within the embedded application to trigger page navigation, reveal the auto-hiding toolbar, or use Skip's keyboard hotkeys while the focus is inside the iframe. To achieve this, Skip dynamically injects scripts into the iframe application. If CORS restrictions apply, this will be prohibited by the browser. This means that gestures and hotkeys will not work over the Embed widget. If you have a full-screen Embed widget, you could get stuck with no way to change pages or reveal the toolbar.
 
 4. **No Workaround for Restricted Websites**:
    - If the application does not allow iframe embedding, there is no way to bypass this restriction without the application owner's adding some kind of authorization for you. This is a browser-enforced security feature.
@@ -73,7 +73,7 @@ CORS restrictions only apply when the protocol, hostname, or port of the embedde
 2. **Check with the Application Owner**:
    - If you need to embed a specific app, contact the app owner see if they provide a mechanism to add allowed host URL to their app.
 
-## Authorizing KIP to Load Embedded Content
+## Authorizing Skip to Load Embedded Content
 
 When using the Embed Page Viewer widget, it is important to understand that the ability to display a website or app inside the widget depends on the website or app itself. Specifically, the website being embedded must explicitly allow YOUR PERSONAL SIGNAL K SERVER to load its app or content in an iframe. This can be configured by the embedded app's security settings, which are typically configured using HTTP headers in configuration files.
 
@@ -86,7 +86,7 @@ When using the Embed Page Viewer widget, it is important to understand that the 
        ```http
        Content-Security-Policy: frame-ancestors *
        ```
-     - To allow embedding only from the KIP dashboard (replace `your-signalk-domain.com` with your actual domain):
+     - To allow embedding only from the Skip dashboard (replace `your-signalk-domain.com` with your actual domain):
        ```http
        Content-Security-Policy: frame-ancestors http://your-signalk-domain.com:3000
        ```

--- a/src/assets/help-docs/history-api.md
+++ b/src/assets/help-docs/history-api.md
@@ -1,6 +1,6 @@
 ## Using a History API Provider
 
-KIP reads historical data from an external Signal K History API provider plugin. With a compatible provider installed, KIP can:
+Skip reads historical data from an external Signal K History API provider plugin. With a compatible provider installed, Skip can:
 1. Pre-seed Data Chart and Wind Trends so they show recent trends immediately.
 2. Populate historical views for widgets on your pages that use numeric value paths.
 
@@ -27,7 +27,7 @@ Currently, two plugins support History API v2:
 - **Purpose:** Records Signal K data to an InfluxDB v2 time-series database (requires InfluxDB v2).
 - **Link:** [signalk-to-influxdb2](https://www.npmjs.com/package/signalk-to-influxdb2)
 - **Setup:** Follow the plugin documentation for installation and configuration.
-- **Path Configuration:** By default, records all paths. Configure filters, resolution, and related settings for the paths you want available in KIP charts.
+- **Path Configuration:** By default, records all paths. Configure filters, resolution, and related settings for the paths you want available in Skip charts.
 
 ### 2. signalk-parquet
 - **Purpose:** Records Signal K data to Parquet files for efficient storage and querying (no external database required).
@@ -35,12 +35,12 @@ Currently, two plugins support History API v2:
 - **Setup:** Follow the plugin documentation for installation and configuration.
 - **Path Configuration:** You must specify which paths to record; none are recorded by default.
 
-## How History Data Works in KIP
+## How History Data Works in Skip
 
 ### History Seeding
 When you open a chart widget with a larger time scale (minutes/hours):
-1. KIP checks whether history data is available through the History API.
-2. If available and the time window allows it (resolution >= 1000 ms), KIP requests historical data points.
+1. Skip checks whether history data is available through the History API.
+2. If available and the time window allows it (resolution >= 1000 ms), Skip requests historical data points.
 3. The chart displays the historical trend immediately.
 
 ### Live Updates
@@ -56,11 +56,11 @@ After history data loads:
 
 ## Provider Plugin Configuration
 
-For performance reasons, KIP charts display a maximum of 120 datapoints. KIP uses the chart's configured time window and asks the provider to return data for that window as up to 120 datapoints.
+For performance reasons, Skip charts display a maximum of 120 datapoints. Skip uses the chart's configured time window and asks the provider to return data for that window as up to 120 datapoints.
 
 When configuring provider sampling rates, ensure your rules support this behavior:
 - Slower sampling rates produce fewer datapoints (lower visual resolution).
-- Faster sampling rates do not produce more than 120 datapoints in KIP charts.
+- Faster sampling rates do not produce more than 120 datapoints in Skip charts.
 
 ### Widget Historical Charts
 
@@ -105,7 +105,7 @@ To seed charts with historical data, you must configure your provider to collect
 - Use chart time scales of **minutes or longer** for history seeding.
 
 **Check 6: Are there network or permission issues?**
-- Confirm KIP can reach the Signal K server History API endpoint.
+- Confirm Skip can reach the Signal K server History API endpoint.
 - Use the OpenAPI link in Signal K Server Admin pages to test endpoint availability.
 - Check browser console logs (F12) for HTTP errors from history requests.
 

--- a/src/assets/help-docs/kiosk.md
+++ b/src/assets/help-docs/kiosk.md
@@ -1,12 +1,12 @@
 ## Raspberry Pi Kiosk Mode (Chromium)
 
-This guide launches Chromium in kiosk mode to display KIP at:
+This guide launches Chromium in kiosk mode to display Skip at:
 http://<sk_server_IP>:3000/@halos-org/skip/#/page/0
 
 It supports Raspberry Pi OS Bullseye (X11/LXDE) and Bookworm (Wayland).
 
 ## What is “kiosk mode”?
-Kiosk mode runs a single application full-screen and suppresses most desktop UI. In this guide, Chromium loads KIP and stays on screen like a dedicated instrument display.
+Kiosk mode runs a single application full-screen and suppresses most desktop UI. In this guide, Chromium loads Skip and stays on screen like a dedicated instrument display.
 
 - What it does:
   - Launches Chromium full-screen without toolbars (“chrome”).
@@ -53,7 +53,7 @@ Paste:
 #!/usr/bin/env bash
 set -euo pipefail
 
-# URL for KIP (adjust as needed)
+# URL for Skip (adjust as needed)
 URL="${URL:-http://<sk_server_IP>:3000/@halos-org/skip/#/page/0}"
 
 # Pick Chromium binary
@@ -140,7 +140,7 @@ Paste:
 ```ini
 [Desktop Entry]
 Type=Application
-Name=KIP Kiosk
+Name=Skip Kiosk
 Exec=/home/pi/kiosk.sh
 Terminal=false
 X-GNOME-Autostart-enabled=true
@@ -161,7 +161,7 @@ Paste:
 
 ```ini
 [Unit]
-Description=KIP Chromium Kiosk
+Description=Skip Chromium Kiosk
 After=graphical-session.target network-online.target
 Wants=network-online.target
 
@@ -203,6 +203,6 @@ http://<sk_server_IP>:3000/@halos-org/skip/#/page/0
 
 - Blank screen on Bookworm: confirm Screen Blanking is disabled in raspi-config (Wayland ignores xset).
 - Chromium not found: install package `chromium-browser` or `chromium` (varies by OS version).
-- Wrong URL: KIP is served under /@halos-org/skip/. Ensure the full path is used.
+- Wrong URL: Skip is served under /@halos-org/skip/. Ensure the full path is used.
 - Certificates: prefer HTTP or trusted TLS. Avoid `--ignore-certificate-errors` in kiosk.
 - systemd service not starting: check `journalctl --user -u kiosk.service -f

--- a/src/assets/help-docs/nodered-control-flows.md
+++ b/src/assets/help-docs/nodered-control-flows.md
@@ -1,6 +1,6 @@
-## Node-RED Control Flows for KIP Widgets (Beginner Guide)
+## Node-RED Control Flows for Skip Widgets (Beginner Guide)
 
-This guide is for first-time Node-RED users who want KIP control widgets to trigger real actions (like GPIO or relay switching) through Signal K. It is not a full Node-RED product guide or a complete flow-programming course. It focuses on the Signal K and KIP-specific parts you need for digital switching.
+This guide is for first-time Node-RED users who want Skip control widgets to trigger real actions (like GPIO or relay switching) through Signal K. It is not a full Node-RED product guide or a complete flow-programming course. It focuses on the Signal K and Skip-specific parts you need for digital switching.
 
 Before you start building flows, read **[Digital Switching and PUT Path Setup](#/help/putcontrols.md)** so you understand the core concepts, data flow, and control logic.
 
@@ -8,11 +8,11 @@ Before you start building flows, read **[Digital Switching and PUT Path Setup](#
 
 Use this sequence as your basic mental model:
 
-KIP widget → Signal K path (PUT) → Node-RED **put handler** → action node (GPIO/relay/driver/Web Service/etc.)
+Skip widget → Signal K path (PUT) → Node-RED **put handler** → action node (GPIO/relay/driver/Web Service/etc.)
 
 This is the basic flow:
 
-1. A KIP widget sends a value to a Signal K path (PUT).
+1. A Skip widget sends a value to a Signal K path (PUT).
 2. Node-RED receives that path value through a **put handler** node.
 3. Your flow converts or uses that value to perform the final action.
 
@@ -20,10 +20,10 @@ Think of Signal K as the shared data bus and Node-RED as the automation logic.
 
 ### Why You Need a PUT Handler in the Flow
 
-To receive commands sent by KIP widgets, your flow needs a Signal K node named `put handler`.
+To receive commands sent by Skip widgets, your flow needs a Signal K node named `put handler`.
 
 Why it is needed:
-- KIP writes values to Signal K paths using PUT.
+- Skip writes values to Signal K paths using PUT.
 - The `put handler` listens for PUT updates on those paths.
 - Without it, your flow will not receive widget commands, so no action will run.
 
@@ -35,7 +35,7 @@ Where to find it:
 
 Check these basics first:
 
-1. KIP is connected and authenticated to Signal K.
+1. Skip is connected and authenticated to Signal K.
 2. You can see your target path in Data Inspector, unless you plan to create a new path with your flow.
 3. The path type matches your widget type.
 4. Your Node-RED environment can access target hardware (GPIO, relay board, Web Service, etc.).
@@ -50,23 +50,23 @@ Always test with non-critical outputs first.
 
 ## 5-Minute First Success
 
-Goal: prove the full command path works end-to-end (KIP → Signal K PUT → Node-RED `put handler` → value update).
+Goal: prove the full command path works end-to-end (Skip → Signal K PUT → Node-RED `put handler` → value update).
 
 1. In Node-RED, open **Import** (`Cmd+I` on Mac).
 2. In **Examples**, go to: `flows -> @signalk/node-red-embedded -> put-handler`, then click **Import**.
 3. Open the imported **put handler** node and note the path it listens to (default example: `self.red.autoLights.state`).  
    Leave defaults unchanged for this first test.
 4. Click **Deploy**.
-5. In KIP **Data Inspector**, search for `self.red.autoLights.state`.
+5. In Skip **Data Inspector**, search for `self.red.autoLights.state`.
    - Confirm the path exists.
    - Confirm **PUT Support** is enabled.
-6. In KIP, add a **Switch Panel** widget:
+6. In Skip, add a **Switch Panel** widget:
    - Add a **Toggle** control.
    - Set the control path to `self.red.autoLights.state`.
    - Save/apply widget settings.
-7. Toggle ON/OFF in KIP and verify:
+7. Toggle ON/OFF in Skip and verify:
    - The widget changes state without error notifications.
-   - The value updates in both Signal K Admin Data Browser and KIP Data Inspector.
+   - The value updates in both Signal K Admin Data Browser and Skip Data Inspector.
    - The updated value is visible in Node-RED under the **send autoLights** node (green status dot, e.g. **State: 1**).
 
 Note that this example flow uses numeric `1/0` path values. For ON/OFF control, the preferred value type is `boolean` (`true/false`).

--- a/src/assets/help-docs/putcontrols.md
+++ b/src/assets/help-docs/putcontrols.md
@@ -1,10 +1,10 @@
 ## Digital Switching, Node-RED, and PUT
 
-Use KIP digital switching controls when you want to do real actions from your dashboard, like turning devices on/off, changing levels, or selecting operating modes. This guide helps you choose the right Signal K path for Switch Panel, Slider, and Multi State Switch controls so they work reliably in daily use.
+Use Skip digital switching controls when you want to do real actions from your dashboard, like turning devices on/off, changing levels, or selecting operating modes. This guide helps you choose the right Signal K path for Switch Panel, Slider, and Multi State Switch controls so they work reliably in daily use.
 
-The focus here is practical KIP setup: what path type to use, what PUT support is needed, and how to avoid common configuration mistakes. This guide supports built-in server handlers, custom plugins, and Node-RED flows.
+The focus here is practical Skip setup: what path type to use, what PUT support is needed, and how to avoid common configuration mistakes. This guide supports built-in server handlers, custom plugins, and Node-RED flows.
 
-If you are new to Node-RED, start with this guide, then continue with **[Node-RED Control Flows for KIP Widgets (Beginner Guide)](#/help/nodered-control-flows.md)** for beginner flow examples.
+If you are new to Node-RED, start with this guide, then continue with **[Node-RED Control Flows for Skip Widgets (Beginner Guide)](#/help/nodered-control-flows.md)** for beginner flow examples.
 
 ## What PUT Does (and Does Not Do)
 
@@ -15,13 +15,13 @@ PUT writes a value to a Signal K path. By itself, that write does not trigger ha
 Examples of server-side handlers:
 - A built-in server handler
 - A Signal K plugin (see Popular Digital Switching Plugins)
-- A Node-RED flow (see Node-RED Control Flows for KIP Widgets - Beginner Guide)
+- A Node-RED flow (see Node-RED Control Flows for Skip Widgets - Beginner Guide)
 
 ## Basic Requirements
 
 Check these basics first:
 
-1. For security reasons, KIP must be authenticated against Signal K for the server to accept PUTs.
+1. For security reasons, Skip must be authenticated against Signal K for the server to accept PUTs.
 2. The target path must exist in Signal K and have metadata matching the digital switching widget type.
 3. For control widgets that send commands, the path metadata must report that PUT Support is enabled.
 4. The appropriate server-side handler must be present to react to value changes and control the targeted hardware.
@@ -56,7 +56,7 @@ Follow these steps in order:
 3. If using Node-RED, include a Signal K **put handler** node in your flow so widget commands are received.
 4. Confirm path exists in Data Inspector.
 5. Confirm type and PUT support are compatible with widget/control type.
-6. Configure the widget in KIP.
+6. Configure the widget in Skip.
 7. Trigger the control and verify the value changes in Data Inspector.
 8. Validate the server-side handler executes the expected real-world action.
 
@@ -96,6 +96,6 @@ If something does not work, check these first.
 
 Use these guides next as needed.
 
-- **Node-RED beginners:** [Node-RED Control Flows for KIP Widgets (Beginner Guide)](#/help/nodered-control-flows.md)
+- **Node-RED beginners:** [Node-RED Control Flows for Skip Widgets (Beginner Guide)](#/help/nodered-control-flows.md)
 - **Path discovery and validation:** [Data Inspector](#/help/datainspector.md)
 - **Widget overview and placement:** [Pages and Layout](#/help/dashboards.md)

--- a/src/assets/help-docs/time-series.md
+++ b/src/assets/help-docs/time-series.md
@@ -1,12 +1,12 @@
 ## Historical Widget Data
 
-KIP is primarily designed for live sailing data, but most numeric widgets can also show recent history — both as a pop-up history chart you open from a widget and as startup seeding for chart widgets, so they show recent trends immediately instead of starting empty.
+Skip is primarily designed for live sailing data, but most numeric widgets can also show recent history — both as a pop-up history chart you open from a widget and as startup seeding for chart widgets, so they show recent trends immediately instead of starting empty.
 
-History is served by an external **Signal K History API provider** — a server plugin such as `signalk-to-influxdb2` or `signalk-parquet`. KIP does not record or store data itself; it reads history from whatever provider your Signal K server runs. When no provider is available, KIP shows live data only, starting from when a widget was opened.
+History is served by an external **Signal K History API provider** — a server plugin such as `signalk-to-influxdb2` or `signalk-parquet`. Skip does not record or store data itself; it reads history from whatever provider your Signal K server runs. When no provider is available, Skip shows live data only, starting from when a widget was opened.
 
 See [History-API Provider](#/help/history-api.md) in the Integrations help menu for how to install and configure a provider.
 
-## What KIP Does With History
+## What Skip Does With History
 - Pre-seeds Data Chart and Wind Trends so they show recent trends immediately on open.
 - Provides a pop-up historical view for numeric-value widgets on your pages.
 
@@ -38,4 +38,4 @@ Most widgets that use numeric paths support history, including Horizon, Battery 
 
 ## Questions or Issues?
 - Refer to [History-API Provider](#/help/history-api.md) to install and configure a provider.
-- For general questions or issues, see the Contact-Us help page. The KIP community is active on Discord and GitHub.
+- For general questions or issues, see the Contact-Us help page. The Signal K community is active on Discord and GitHub.

--- a/src/assets/help-docs/video-widget.md
+++ b/src/assets/help-docs/video-widget.md
@@ -4,7 +4,7 @@ The Video widget puts live cameras and saved video clips right on your page. Use
 eye on the water while docking, watch the foredeck under sail, check the engine room, or look back at
 a clip you saved earlier.
 
-<img src="assets/help-docs/img/video/widget-playing.png" alt="A Video widget playing a live camera on a KIP page" title="A live camera on the page" width="100%">
+<img src="assets/help-docs/img/video/widget-playing.png" alt="A Video widget playing a live camera on a Skip page" title="A live camera on the page" width="100%">
 
 There are three kinds of video you can show:
 
@@ -43,7 +43,7 @@ doesn't appear, pick the type by hand — MJPEG and WebRTC can't be detected fro
 ## Cameras (RTSP / IP cameras)
 
 Most onboard cameras speak **RTSP**, which browsers can't play directly. The **SK Video** add-on for
-your Signal K server does the translating for you, so KIP can show the picture. Once it's installed,
+your Signal K server does the translating for you, so Skip can show the picture. Once it's installed,
 choose **Camera** under **Source**.
 
 <img src="assets/help-docs/img/video/camera-setup.png" alt="Camera setup showing the saved-camera list, a Scan button, and the Add a camera form" title="Set up a camera" width="100%">
@@ -53,7 +53,7 @@ You have three ways to set up a camera:
 **1. Pick a saved camera.** Cameras you've already added show up in the **Camera** list. Choose one and
 you're done — its login and settings are remembered, so you never type them twice.
 
-**2. Scan for cameras.** Tap **Scan network** and KIP asks your boat's network for cameras that
+**2. Scan for cameras.** Tap **Scan network** and Skip asks your boat's network for cameras that
 announce themselves. Found cameras appear in a list; tap one to fill in its details for you.
 
 <img src="assets/help-docs/img/video/scan.png" alt="A list of cameras found on the network after scanning" title="Cameras found on the network" width="100%">

--- a/src/assets/help-docs/welcome.md
+++ b/src/assets/help-docs/welcome.md
@@ -1,5 +1,5 @@
 ## Touch, Mouse, and Keyboard Navigation
-KIP supports touch, mouse, and keyboard input across devices.
+Skip supports touch, mouse, and keyboard input across devices.
 
 | Action               | Touch                        | Mouse / wheel                         | Keyboard                                          |
 |----------------------|------------------------------|---------------------------------------|---------------------------------------------------|
@@ -14,7 +14,7 @@ KIP supports touch, mouse, and keyboard input across devices.
 > Note that the words Touch and Tap are synonymous with mouse click.
 
 ## The Toolbar
-KIP has no permanent navigation bar. A toolbar sits hidden at the top of the page and slides down when you need it — swipe down from the top, scroll up, or tap the thin strip that peeks at the top edge. It hides again when you scroll back, tap elsewhere, or leave it idle.
+Skip has no permanent navigation bar. A toolbar sits hidden at the top of the page and slides down when you need it — swipe down from the top, scroll up, or tap the thin strip that peeks at the top edge. It hides again when you scroll back, tap elsewhere, or leave it idle.
 
 The toolbar holds:
 1. Settings
@@ -30,35 +30,35 @@ When an alarm is active, a notification badge also appears in the lower-left cor
 
 **Only visible if automatic day and night is not enabled. See <Home / Settings / Display>.
 
-## Loading KIP on Phones, Tablets, Raspberry Pi, and Computers
-Simply navigate to `http://<Signal K Server URL>:<port>/@halos-org/skip/` to load KIP and enjoy its features remotely on any device.
+## Loading Skip on Phones, Tablets, Raspberry Pi, and Computers
+Simply navigate to `http://<Signal K Server URL>:<port>/@halos-org/skip/` to load Skip and enjoy its features remotely on any device.
 
 ## Mobile App
-Run KIP in full screen, without browser controls, just like a regular mobile app. This feature is supported on most mobile operating systems. Each browser has its own way of handling Progressive Web App (PWA) installations.
+Run Skip in full screen, without browser controls, just like a regular mobile app. This feature is supported on most mobile operating systems. Each browser has its own way of handling Progressive Web App (PWA) installations.
 
 **iOS**
 1. Press the "Share" button.
 2. Select "Add to Home Screen" from the action popup list.
 3. Tap "Add" in the top right corner to finish installation.
-KIP is now installed and available on your home screen.
+Skip is now installed and available on your home screen.
 
 **Android**
 1. Press the "three dot" icon in the upper right to open the menu.
 2. Select "Add to Home screen."
 3. Press the "Add" button in the popup.
-KIP is now installed and available on your home screen.
+Skip is now installed and available on your home screen.
 
 ## Fullscreen
 You can toggle fullscreen mode on and off, and disable the screen saver and computer sleep mode (if supported by the device/browser), by tapping the Expand/Reduce button on the toolbar or using the keyboard hotkey. This button is not available on mobile devices.
 
 ## Night Mode
-Save your night vision by automatically switching KIP to day or night mode based on sunrise and sunset hours (the Signal K Derived Data plugin is required for automatic switching). This feature can be enabled in the **Settings > Display** page. You can also manually set the mode by tapping the Moon/Sun button on the toolbar. Note that if automatic switching is enabled, brightness will reset to the Signal K mode value.
+Save your night vision by automatically switching Skip to day or night mode based on sunrise and sunset hours (the Signal K Derived Data plugin is required for automatic switching). This feature can be enabled in the **Settings > Display** page. You can also manually set the mode by tapping the Moon/Sun button on the toolbar. Note that if automatic switching is enabled, brightness will reset to the Signal K mode value.
 
 ## Multiple User Profiles and Configuration Sharing
-KIP supports multiple user profiles, allowing different roles on board—such as captain, skipper, tactician, navigator, or engineer—to tailor the interface to their needs. Profiles can also be used to tie specific configuration arrangements to use cases or device form factors. See the Login & Configurations help sections for mode details.
+Skip supports multiple user profiles, allowing different roles on board—such as captain, skipper, tactician, navigator, or engineer—to tailor the interface to their needs. Profiles can also be used to tie specific configuration arrangements to use cases or device form factors. See the Login & Configurations help sections for mode details.
 
-## Remote Control Other KIP Displays
-Control which page is shown on another KIP instance (for example: a mast display, a TV or pilot‑house screen that is hard to reach, or a device with no local input hardware).
+## Remote Control Other Skip Displays
+Control which page is shown on another Skip instance (for example: a mast display, a TV or pilot‑house screen that is hard to reach, or a device with no local input hardware).
 
 ### Typical Use Cases
 - Mast display: change pages from the cockpit without going forward.
@@ -67,16 +67,16 @@ Control which page is shown on another KIP instance (for example: a mast display
 
 ### Requirements
 - Both devices must be connected to the same Signal K server.
-- You must be logged in (authenticated) on both devices (Connectivity tab → Login to Server enabled).
+- You must be signed in (authenticated) to the Signal K server on both devices (Connectivity tab → Sign in).
 - The target device must explicitly allow remote control (Display tab → Remote Control option group).
 
 ### Good Naming Practice
 If multiple devices log in with the same Signal K user to share configuration, they inevitably share the same Instance Name. Whilst being confusing, it will still work. To fix this, you must use different Signal K users and set a descriptive name on each configuration (e.g. Mast Display, Helm Port, Nav Station) so you can identify them quickly.
 
 ### Setup
-1. On the device you want to control (Target KIP)
+1. On the device you want to control (Target Skip)
   - Open: Options → Display → Remote Control.
-  - Enable: Allow this KIP dashboard to be managed remotely.
+  - Enable: Allow this Skip dashboard to be managed remotely.
   - Set: Instance Name (this is what will appear in the controller list).
 2. On the controlling device
   - Open: reveal the toolbar → Settings → Remote Control.
@@ -103,4 +103,4 @@ If multiple devices log in with the same Signal K user to share configuration, t
 >- Use different Signal K users if you want fully isolated configurations.
 
 ### Privacy / Safety Note
-Anyone with access to a logged‑in controlling KIP instance can switch pages on enabled targets. Only enable remote management on displays where that is acceptable.
+Anyone with access to a logged‑in controlling Skip instance can switch pages on enabled targets. Only enable remote management on displays where that is acceptable.

--- a/src/assets/help-docs/zones.md
+++ b/src/assets/help-docs/zones.md
@@ -1,6 +1,6 @@
 ## Harness the Power of Data State Notifications
 
-Stay informed about your vessel’s data with Signal K’s state notifications. For example, Signal K can flag certain sensor readings—such as depth or temperature—when they reach critical levels. KIP can then visually or audibly alert you. For instance, if the depth drops to 3 meters or less, KIP can highlight this with a warning sound or visual cue. This powerful feature combines **Zones Configuration** and **Notification Methods** in Signal K.
+Stay informed about your vessel’s data with Signal K’s state notifications. For example, Signal K can flag certain sensor readings—such as depth or temperature—when they reach critical levels. Skip can then visually or audibly alert you. For instance, if the depth drops to 3 meters or less, Skip can highlight this with a warning sound or visual cue. This powerful feature combines **Zones Configuration** and **Notification Methods** in Signal K.
 
 
 ## Zones & Notification Configuration
@@ -8,21 +8,21 @@ Stay informed about your vessel’s data with Signal K’s state notifications. 
 **Zones** are value ranges defined as metadata for each data path. Learn more at the [Signal K Metadata documentation](https://signalk.org/specification/1.7.0/doc/data_model_metadata.html).  
 To configure metadata in Signal K, visit the [Data Browser server page](/../../admin/#/databrowser) and enable the **Meta Data** switch. Here, you can add or edit **methods** and **zones** for any path you want to monitor.
 
-> **Note:** Zone values use base units (e.g., wind speed in meters per second). Define your zone ranges using the base unit for each path. KIP will automatically convert and display these values according to your widget’s unit settings.
+> **Note:** Zone values use base units (e.g., wind speed in meters per second). Define your zone ranges using the base unit for each path. Skip will automatically convert and display these values according to your widget’s unit settings.
 
 For more details on path units, see the [Keys Reference (Vessel)](https://signalk.org/specification/1.7.0/doc/vesselsBranch.html) and [Keys Reference (Other)](https://signalk.org/specification/1.7.0/doc/otherBranches.html).
 
-As path values move between zone ranges, Signal K generates a notification sent to KIP. Each notification includes a state (severity), optional presentation methods (visual and/or sound), and an optional message.
+As path values move between zone ranges, Signal K generates a notification sent to Skip. Each notification includes a state (severity), optional presentation methods (visual and/or sound), and an optional message.
 
 
 ### Zone State and Method Guidance
 
 - The **Nominal** and **Emergency** zones are special-purpose zones and should not be used.
 - You do **not** need to configure a **Normal** zone; it is the default when no other zone matches.
-- KIP displays a notification in the Notifications menu for all zone states that include the **visual** method, except for the **Normal** and **Nominal** zones. Excluding the **visual** method for a zone does not prevent supporting widgets from displaying zones. This can be achieved by configuring individual widgets to ignore zones settings.
-- KIP emits audio prompts for all zone states that include the **sound** method, except for the **Normal** and **Nominal** zones.
-- KIP uses predefined, state specific sound files.
-- You can configure KIP to globally ignore audio prompts in **Settings > Notifications**; this applies globally to all notifications and paths.
+- Skip displays a notification in the Notifications menu for all zone states that include the **visual** method, except for the **Normal** and **Nominal** zones. Excluding the **visual** method for a zone does not prevent supporting widgets from displaying zones. This can be achieved by configuring individual widgets to ignore zones settings.
+- Skip emits audio prompts for all zone states that include the **sound** method, except for the **Normal** and **Nominal** zones.
+- Skip uses predefined, state specific sound files.
+- You can configure Skip to globally ignore audio prompts in **Settings > Notifications**; this applies globally to all notifications and paths.
 
 >**Tips:**
 >1. You don’t need zones for every path.
@@ -39,7 +39,7 @@ You can **Silence** or **Resolve** notifications.
 - Manually resolving a notification tells Signal K to treat the current value as **Normal** until a new value is received. **Normal** zones method have no visual and sound methods defined.
 
 **Important:**  
-- Signal K and KIP do **not** persist data through power cycles. If a device is off when Signal K starts, no value or notification will be present until then device is powered on and it sends data.
+- Signal K and Skip do **not** persist data through power cycles. If a device is off when Signal K starts, no value or notification will be present until then device is powered on and it sends data.
 - If you turn off a device, then resolve its last notification, it will remain resolved until the device is powered back on and sends new data.
 - Different devices send data at different intervals—some multiple times per second, others as infrequently as once per day. Check your device or plugin documentation for details. Once a notification is silenced or resolved, it will stay in this state until a new value is received and evaluated.
 
@@ -68,7 +68,7 @@ You can **Silence** or **Resolve** notifications.
 
   #### Quick setup
   1. In Signal K **Data Browser**, enable **Meta Data** and add **zones** (and optional **methods/messages**) for the paths you care about.
-  2. In KIP, add a **Zones State Panel** widget to a systems page.
+  2. In Skip, add a **Zones State Panel** widget to a systems page.
   3. Configure each panel/control with the paths you want to monitor.
   4. Optionally hide the widget label (useful for compact “status strip” pages).
 
@@ -78,8 +78,8 @@ You can **Silence** or **Resolve** notifications.
   Widgets such as **Numeric**, **Simple Linear**, **Linear**, **Radial**, and **Steel Style** visually highlight relevant data ranges according to their configured zones and integrate notification states into their display. You can configure each widget to ignore zones if desired.
 
 
-## KIP Notification Configuration Override
+## Skip Notification Configuration Override
 
 In **Settings > Notifications**, you can customize which notification states are displayed and enable or disable audio prompts to suit your preferences.
 
-> **Note:** Muting all notifications will also mute other KIP system sounds, such as those played when KIP connects to or disconnects from Signal K, not just zone-related alerts.
+> **Note:** Muting all notifications will also mute other Skip system sounds, such as those played when Skip connects to or disconnects from Signal K, not just zone-related alerts.


### PR DESCRIPTION
## Motivation
User-facing docs (README + help docs) still carried Kip branding and, in places, claims that are false for Skip. Fixes #198.

## Approach
A **per-claim verified rebrand — a review, not a blind find-replace** — of the README body and ~16 help docs. Corrected real inaccuracies against the source: Kip credential-login → Skip session-SSO + server-stored profiles (`configuration.md`); "automatically stores history" → Skip reads from an **external** History-API provider and stores nothing itself; removed false "most popular / pre-installed" marketing; fixed the open-history gesture to long-press. Deliberately left untouched: the hotkey/gesture tables (owned by the keymap packet), upstream Kip provenance, genuine external Kip community video titles, and nautical "chart"/"chartplotter".

## Review
Multi-persona + adversarial verify. One P2 fixed: the README told users the wrong gesture — "two-finger tap or right-click" — to open a widget's history dialog; corrected to **long-press**, matching the `(press)` binding and the packet's own sibling docs. App-template user-facing KIP prose (including a false "built-in KIP History API provider" line) is outside this packet's docs scope → filed as **#285**. The tracker's "sidenav-hint" item found no user-facing KIP prose in the notifications templates (only `--kip-*` CSS identifiers, owned by #192).

Part of #257.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
