### PR TITLE
Register the minimal Chart.js union, drop chart.js/auto (#267)

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -71,11 +71,11 @@ exports[`strictNullChecks`] = {
       [54, 6, 17, "Object is possibly \'undefined\'.", "2944426029"],
       [55, 6, 17, "Object is possibly \'undefined\'.", "27783321"]
     ],
-    "src/app/core/components/options/signalk/signalk.component.ts:3082783318": [
-      [101, 10, 6, "Type \'null\' is not assignable to type \'Chart<keyof ChartTypeRegistry, (number | [number, number] | Point | BubbleDataPoint | null)[], unknown>\'.", "3491622934"],
-      [110, 45, 20, "Object is possibly \'undefined\'.", "235433357"],
-      [171, 28, 20, "Object is possibly \'undefined\'.", "235433357"],
-      [171, 28, 51, "Argument of type \'CanvasRenderingContext2D | null\' is not assignable to parameter of type \'ChartItem\'.\\n  Type \'null\' is not assignable to type \'ChartItem\'.", "38422540"]
+    "src/app/core/components/options/signalk/signalk.component.ts:2801402843": [
+      [102, 10, 6, "Type \'null\' is not assignable to type \'Chart<keyof ChartTypeRegistry, (number | [number, number] | Point | BubbleDataPoint | null)[], unknown>\'.", "3491622934"],
+      [111, 45, 20, "Object is possibly \'undefined\'.", "235433357"],
+      [172, 28, 20, "Object is possibly \'undefined\'.", "235433357"],
+      [172, 28, 51, "Argument of type \'CanvasRenderingContext2D | null\' is not assignable to parameter of type \'ChartItem\'.\\n  Type \'null\' is not assignable to type \'ChartItem\'.", "38422540"]
     ],
     "src/app/core/components/options/units/units.component.ts:2220224509": [
       [36, 19, 4, "Argument of type \'IUnit\' is not assignable to parameter of type \'never\'.", "2087995779"]

--- a/src/app/core/components/options/signalk/signalk.component.ts
+++ b/src/app/core/components/options/signalk/signalk.component.ts
@@ -15,12 +15,13 @@ import { MatButton } from '@angular/material/button';
 import { MatInput } from '@angular/material/input';
 import { MatFormField, MatLabel, MatError } from '@angular/material/form-field';
 import { FormsModule } from '@angular/forms';
-import Chart from 'chart.js/auto';
+import { Chart } from 'chart.js';
 import 'chartjs-adapter-date-fns';
 import { CanvasService } from '../../../services/canvas.service';
 import { InternetReachabilityService } from '../../../services/internet-reachability.service';
+import { registerChartComponents } from '../../../utils/chart-registration.util';
 
-
+registerChartComponents();
 
 /**
  * Signal K settings component for managing server connection configuration.

--- a/src/app/core/utils/chart-registration.util.spec.ts
+++ b/src/app/core/utils/chart-registration.util.spec.ts
@@ -1,15 +1,28 @@
 import { describe, it, expect, vi } from 'vitest';
 
-// Chart.js cannot instantiate under jsdom; the only behaviour under test is the module-level
-// register-once guard. The suite shares module state, so other chart specs may have already
-// imported (and tripped) the util — reset the module registry inside the test and re-import
-// fresh so the guard starts clean regardless of run order.
-vi.mock('chart.js', () => ({ Chart: { register: vi.fn() }, registerables: [] }));
-vi.mock('chartjs-plugin-annotation', () => ({ default: {} }));
-vi.mock('@aziham/chartjs-plugin-streaming', () => ({ default: {} }));
+// Chart.js cannot instantiate under jsdom; the behaviour under test is the module-level
+// register-once guard and the exact minimal component union it registers. The suite shares module
+// state, so other chart specs may have already imported (and tripped) the util — reset the module
+// registry inside the test and re-import fresh so the guard starts clean regardless of run order.
+// Each mocked component is a distinct sentinel string so the assertion can name the exact set.
+vi.mock('chart.js', () => ({
+  Chart: { register: vi.fn() },
+  LineController: 'LineController',
+  LineElement: 'LineElement',
+  PointElement: 'PointElement',
+  LinearScale: 'LinearScale',
+  TimeScale: 'TimeScale',
+  Filler: 'Filler',
+  Legend: 'Legend',
+  Tooltip: 'Tooltip',
+  Title: 'Title',
+  SubTitle: 'SubTitle'
+}));
+vi.mock('chartjs-plugin-annotation', () => ({ default: 'annotationPlugin' }));
+vi.mock('@aziham/chartjs-plugin-streaming', () => ({ default: 'ChartStreaming' }));
 
 describe('registerChartComponents', () => {
-  it('registers the Chart.js components only once across repeated calls', async () => {
+  it('registers the minimal line/time chart component union exactly once', async () => {
     vi.resetModules();
     const { Chart } = await import('chart.js');
     const { registerChartComponents } = await import('./chart-registration.util');
@@ -17,6 +30,21 @@ describe('registerChartComponents', () => {
     registerChartComponents();
     registerChartComponents();
 
-    expect(vi.mocked(Chart.register)).toHaveBeenCalledTimes(1);
+    const register = vi.mocked(Chart.register);
+    expect(register).toHaveBeenCalledTimes(1);
+    expect(register).toHaveBeenCalledWith(
+      'LineController',
+      'LineElement',
+      'PointElement',
+      'LinearScale',
+      'TimeScale',
+      'Filler',
+      'Legend',
+      'Tooltip',
+      'Title',
+      'SubTitle',
+      'annotationPlugin',
+      'ChartStreaming'
+    );
   });
 });

--- a/src/app/core/utils/chart-registration.util.ts
+++ b/src/app/core/utils/chart-registration.util.ts
@@ -1,19 +1,47 @@
-import { Chart, registerables } from 'chart.js';
+import {
+  Chart,
+  LineController,
+  LineElement,
+  PointElement,
+  LinearScale,
+  TimeScale,
+  Filler,
+  Legend,
+  Tooltip,
+  Title,
+  SubTitle
+} from 'chart.js';
 import annotationPlugin from 'chartjs-plugin-annotation';
 import ChartStreaming from '@aziham/chartjs-plugin-streaming';
 
 let registered = false;
 
 /**
- * Registers every Chart.js building block plus the annotation and streaming
- * plugins exactly once for the whole app. Chart consumers call this at module
- * load instead of each running their own `Chart.register`, so a chart is never
- * created before its controller/scale/plugin set is present.
+ * Registers only the Chart.js building blocks Skip actually renders — line charts on
+ * linear and time scales — plus the annotation and streaming plugins, exactly once for
+ * the whole app. Chart consumers call this at module load instead of each running their
+ * own `Chart.register`, so a chart is never created before its controller/scale/plugin
+ * set is present. Registering the explicit union rather than every registerable lets the
+ * bundler drop the unused controllers/scales on this Pi-class target. The `realtime`
+ * scale used by the live-tail charts is contributed by the streaming plugin registration.
  */
 export function registerChartComponents(): void {
   if (registered) {
     return;
   }
   registered = true;
-  Chart.register(...registerables, annotationPlugin, ChartStreaming);
+  Chart.register(
+    LineController,
+    LineElement,
+    PointElement,
+    LinearScale,
+    TimeScale,
+    Filler,
+    Legend,
+    Tooltip,
+    Title,
+    SubTitle,
+    annotationPlugin,
+    ChartStreaming
+  );
 }

--- a/src/app/widgets/minichart/minichart.component.spec.ts
+++ b/src/app/widgets/minichart/minichart.component.spec.ts
@@ -20,7 +20,7 @@ vi.mock('chart.js', () => {
     Chart: MockChart,
     registerables: [],
     TimeScale: {}, LinearScale: {}, LineController: {}, PointElement: {},
-    LineElement: {}, Filler: {}, CategoryScale: {}
+    LineElement: {}, Filler: {}, Legend: {}, Tooltip: {}, Title: {}, SubTitle: {}, CategoryScale: {}
   };
 });
 vi.mock('chartjs-adapter-date-fns', () => ({}));

--- a/src/app/widgets/widget-data-chart/widget-data-chart.component.spec.ts
+++ b/src/app/widgets/widget-data-chart/widget-data-chart.component.spec.ts
@@ -20,7 +20,7 @@ vi.mock('chart.js', () => {
     Chart: MockChart,
     registerables: [],
     TimeScale: {}, LinearScale: {}, LineController: {}, PointElement: {},
-    LineElement: {}, Filler: {}, Title: {}, SubTitle: {}
+    LineElement: {}, Filler: {}, Legend: {}, Tooltip: {}, Title: {}, SubTitle: {}
   };
 });
 vi.mock('chartjs-plugin-annotation', () => ({ default: {} }));

--- a/src/app/widgets/widget-windtrends-chart/widget-windtrends-chart.component.spec.ts
+++ b/src/app/widgets/widget-windtrends-chart/widget-windtrends-chart.component.spec.ts
@@ -19,7 +19,7 @@ vi.mock('chart.js', () => {
     Chart: MockChart,
     registerables: [],
     TimeScale: {}, LinearScale: {}, LineController: {}, PointElement: {},
-    LineElement: {}, Filler: {}, Title: {}, SubTitle: {}
+    LineElement: {}, Filler: {}, Legend: {}, Tooltip: {}, Title: {}, SubTitle: {}
   };
 });
 vi.mock('chartjs-adapter-date-fns', () => ({}));


### PR DESCRIPTION
## Motivation
`chart-registration.util.ts` registered `...registerables` — **every** Chart.js controller/scale/element (bar, pie, radar, financial, …) — but Skip only renders line/time charts. And `signalk.component` imported `chart.js/auto`, which self-registers everything at module load. Both pull the full Chart.js surface into the bundle on a Pi-class target. Fixes #267.

## Approach
Register the explicit **minimal union** the five chart consumers actually use — `LineController, LineElement, PointElement, LinearScale, TimeScale, Filler, Legend, Tooltip, Title, SubTitle` plus the annotation and streaming plugins (the streaming plugin also contributes the `realtime` scale) — once, idempotently. Migrate `signalk.component` off `chart.js/auto` onto the shared `registerChartComponents()` util so nothing self-registers the full set; its needs are a strict subset of the union.

## Verification
jsdom mocks `<canvas>`, so unit tests cannot catch a missing registration. Verified two ways: (a) exhaustive static enumeration of all five consumers (minichart, data-chart, windtrends, history-dialog, signalk) with file:line evidence, independently re-audited under adversarial review; and (b) an on-device deploy + render check of every chart surface. Betterer regenerated for `signalk.component`'s hash (stayed 183 — no new strict-null issues).

Closes #267.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
