### PR TITLE
Deduplicate the IDimensions interface into a shared module (#263)

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -173,12 +173,12 @@ exports[`strictNullChecks`] = {
       [50, 57, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"],
       [51, 57, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"]
     ],
-    "src/app/widgets/svg-zone-states/svg-zone-states.component.ts:1762718998": [
-      [17, 41, 4, "No overload matches this call.\\n  Overload 1 of 5, \'(initialValue: IDynamicControl, opts?: InputOptionsWithoutTransform<IDynamicControl> | undefined): InputSignal<...>\', gave the following error.\\n    Argument of type \'null\' is not assignable to parameter of type \'IDynamicControl\'.\\n  Overload 2 of 5, \'(initialValue: undefined, opts: InputOptionsWithoutTransform<IDynamicControl>): InputSignal<IDynamicControl | undefined>\', gave the following error.\\n    Argument of type \'null\' is not assignable to parameter of type \'undefined\'.", "2087897566"],
-      [18, 33, 4, "Argument of type \'null\' is not assignable to parameter of type \'ITheme\'.", "2087897566"],
+    "src/app/widgets/svg-zone-states/svg-zone-states.component.ts:489168871": [
+      [16, 41, 4, "No overload matches this call.\\n  Overload 1 of 5, \'(initialValue: IDynamicControl, opts?: InputOptionsWithoutTransform<IDynamicControl> | undefined): InputSignal<...>\', gave the following error.\\n    Argument of type \'null\' is not assignable to parameter of type \'IDynamicControl\'.\\n  Overload 2 of 5, \'(initialValue: undefined, opts: InputOptionsWithoutTransform<IDynamicControl>): InputSignal<IDynamicControl | undefined>\', gave the following error.\\n    Argument of type \'null\' is not assignable to parameter of type \'undefined\'.", "2087897566"],
+      [17, 33, 4, "Argument of type \'null\' is not assignable to parameter of type \'ITheme\'.", "2087897566"],
+      [21, 41, 4, "Argument of type \'null\' is not assignable to parameter of type \'string\'.", "2087897566"],
       [22, 41, 4, "Argument of type \'null\' is not assignable to parameter of type \'string\'.", "2087897566"],
-      [23, 41, 4, "Argument of type \'null\' is not assignable to parameter of type \'string\'.", "2087897566"],
-      [24, 42, 4, "Argument of type \'null\' is not assignable to parameter of type \'string\'.", "2087897566"]
+      [23, 42, 4, "Argument of type \'null\' is not assignable to parameter of type \'string\'.", "2087897566"]
     ],
     "src/app/widgets/widget-ais-radar/dialog-ais-target/dialog-ais-target.component.ts:3744867362": [
       [49, 11, 38, "Object is possibly \'null\'.", "3959613788"],
@@ -199,9 +199,9 @@ exports[`strictNullChecks`] = {
       [1358, 21, 11, "\'b.longitude\' is possibly \'undefined\'.", "3370058570"],
       [1358, 35, 11, "\'a.longitude\' is possibly \'undefined\'.", "2985066057"]
     ],
-    "src/app/widgets/widget-boolean-switch/widget-boolean-switch.component.ts:46644229": [
-      [76, 38, 9, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "4119212820"],
-      [99, 10, 12, "Object is possibly \'null\'.", "4261782498"]
+    "src/app/widgets/widget-boolean-switch/widget-boolean-switch.component.ts:800795185": [
+      [71, 38, 9, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "4119212820"],
+      [94, 10, 12, "Object is possibly \'null\'.", "4261782498"]
     ],
     "src/app/widgets/widget-datetime/widget-datetime.component.ts:3033260432": [
       [60, 40, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'string\'.", "2620553983"],
@@ -272,8 +272,8 @@ exports[`strictNullChecks`] = {
       [212, 73, 9, "\'cfg.paths\' is possibly \'undefined\'.", "4139429943"],
       [213, 74, 9, "\'cfg.paths\' is possibly \'undefined\'.", "4139429943"]
     ],
-    "src/app/widgets/widget-zones-state-panel/widget-zones-state-panel.component.ts:2501103102": [
-      [78, 38, 9, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "4119212820"]
+    "src/app/widgets/widget-zones-state-panel/widget-zones-state-panel.component.ts:1602708938": [
+      [73, 38, 9, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "4119212820"]
     ],
     "src/default-config/config.blank.const.ts:2019243563": [
       [31, 2, 12, "Type \'null\' is not assignable to type \'string\'.", "3195809883"]

--- a/src/app/core/interfaces/widgets-interface.ts
+++ b/src/app/core/interfaces/widgets-interface.ts
@@ -19,6 +19,12 @@ export enum ControlType {
   indicator = 2,
 }
 
+/** Pixel dimensions of a widget's rendering area. */
+export interface IDimensions {
+  height: number;
+  width: number;
+}
+
 /**
  * Allowed path types for Signal K data paths.
  * - 'number'

--- a/src/app/widgets/svg-boolean-button/svg-boolean-button.component.spec.ts
+++ b/src/app/widgets/svg-boolean-button/svg-boolean-button.component.spec.ts
@@ -1,8 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SvgBooleanButtonComponent } from './svg-boolean-button.component';
-import type { IDynamicControl } from '../../core/interfaces/widgets-interface';
-import type { IDimensions } from '../widget-boolean-switch/widget-boolean-switch.component';
+import type { IDynamicControl, IDimensions } from '../../core/interfaces/widgets-interface';
 
 const controlMock: IDynamicControl = {
   ctrlLabel: 'Bilge Pump',

--- a/src/app/widgets/svg-boolean-button/svg-boolean-button.component.ts
+++ b/src/app/widgets/svg-boolean-button/svg-boolean-button.component.ts
@@ -1,8 +1,7 @@
 import { cloneDeep } from 'lodash-es';
 import { Component, DoCheck, OnDestroy, input, output, ChangeDetectionStrategy } from '@angular/core';
-import type { IDynamicControl } from '../../core/interfaces/widgets-interface';
+import type { IDynamicControl, IDimensions } from '../../core/interfaces/widgets-interface';
 import type { ITheme } from '../../core/services/app-service';
-import { IDimensions } from '../widget-boolean-switch/widget-boolean-switch.component';
 
 @Component({
   selector: 'app-svg-boolean-button',

--- a/src/app/widgets/svg-boolean-light/svg-boolean-light.component.ts
+++ b/src/app/widgets/svg-boolean-light/svg-boolean-light.component.ts
@@ -1,8 +1,7 @@
 import { Component, DoCheck, input, output } from '@angular/core';
 import { ChangeDetectionStrategy } from '@angular/core';
-import type { IDynamicControl } from '../../core/interfaces/widgets-interface';
+import type { IDynamicControl, IDimensions } from '../../core/interfaces/widgets-interface';
 import type { ITheme } from '../../core/services/app-service';
-import { IDimensions } from '../widget-boolean-switch/widget-boolean-switch.component';
 
 
 

--- a/src/app/widgets/svg-boolean-switch/svg-boolean-switch.component.ts
+++ b/src/app/widgets/svg-boolean-switch/svg-boolean-switch.component.ts
@@ -1,7 +1,6 @@
 import { Component, DoCheck, input, output, ChangeDetectionStrategy } from '@angular/core';
-import type { IDynamicControl } from '../../core/interfaces/widgets-interface';
+import type { IDynamicControl, IDimensions } from '../../core/interfaces/widgets-interface';
 import type { ITheme } from '../../core/services/app-service';
-import { IDimensions } from '../widget-boolean-switch/widget-boolean-switch.component';
 import { createSwipeGuard } from '../../core/utils/pointer-swipe-guard.util';
 
 @Component({

--- a/src/app/widgets/svg-zone-states/svg-zone-states.component.ts
+++ b/src/app/widgets/svg-zone-states/svg-zone-states.component.ts
@@ -1,8 +1,7 @@
 import { Component, computed, effect, input, output, signal, untracked } from '@angular/core';
 import { ChangeDetectionStrategy } from '@angular/core';
-import type { IDynamicControl } from '../../core/interfaces/widgets-interface';
+import type { IDynamicControl, IDimensions } from '../../core/interfaces/widgets-interface';
 import type { ITheme } from '../../core/services/app-service';
-import { IDimensions } from '../widget-zones-state-panel/widget-zones-state-panel.component';
 import { States } from '../../core/interfaces/signalk-interfaces';
 import { getColors } from "../../core/utils/themeColors.utils";
 

--- a/src/app/widgets/widget-boolean-switch/widget-boolean-switch.component.ts
+++ b/src/app/widgets/widget-boolean-switch/widget-boolean-switch.component.ts
@@ -3,7 +3,7 @@ import { Subscription } from 'rxjs';
 import { SignalkRequestsService } from '../../core/services/signalk-requests.service';
 import { ITheme } from '../../core/services/app-service';
 import { ToastService } from '../../core/services/toast.service';
-import { IWidgetSvcConfig, IDynamicControl, IWidgetPath } from '../../core/interfaces/widgets-interface';
+import { IWidgetSvcConfig, IDynamicControl, IWidgetPath, IDimensions } from '../../core/interfaces/widgets-interface';
 import { SvgBooleanLightComponent } from '../svg-boolean-light/svg-boolean-light.component';
 import { SvgBooleanButtonComponent } from '../svg-boolean-button/svg-boolean-button.component';
 import { SvgBooleanSwitchComponent } from '../svg-boolean-switch/svg-boolean-switch.component';
@@ -13,11 +13,6 @@ import { getColors } from '../../core/utils/themeColors.utils';
 import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
 import { WidgetStreamsDirective } from '../../core/directives/widget-streams.directive';
 import { KipResizeObserverDirective } from '../../core/directives/kip-resize-observer.directive';
-
-export interface IDimensions {
-  height: number,
-  width: number
-}
 
 @Component({
   selector: 'widget-boolean-switch',

--- a/src/app/widgets/widget-zones-state-panel/widget-zones-state-panel.component.ts
+++ b/src/app/widgets/widget-zones-state-panel/widget-zones-state-panel.component.ts
@@ -1,6 +1,6 @@
 import { Component, computed, effect, inject, input, signal, untracked, ChangeDetectionStrategy } from '@angular/core';
 import { ITheme } from '../../core/services/app-service';
-import { IWidgetSvcConfig, IDynamicControl, IWidgetPath } from '../../core/interfaces/widgets-interface';
+import { IWidgetSvcConfig, IDynamicControl, IWidgetPath, IDimensions } from '../../core/interfaces/widgets-interface';
 import { DashboardService } from '../../core/services/dashboard.service';
 import { WidgetTitleComponent } from '../../core/components/widget-title/widget-title.component';
 import { getColors } from '../../core/utils/themeColors.utils';
@@ -9,11 +9,6 @@ import { KipResizeObserverDirective } from '../../core/directives/kip-resize-obs
 import { SvgZoneStatesComponent } from '../svg-zone-states/svg-zone-states.component';
 import { INotification, NotificationsService } from '../../core/services/notifications.service';
 import { toSignal } from '@angular/core/rxjs-interop';
-
-export interface IDimensions {
-  height: number,
-  width: number
-}
 
 @Component({
   selector: 'widget-zones-state-panel',


### PR DESCRIPTION
## Motivation
`IDimensions` (`{ width, height }`) was defined **twice** — in `widget-boolean-switch.component.ts` and `widget-zones-state-panel.component.ts` — and imported cross-component (the `svg-*` widgets reached into a sibling **component** file for the type). Fixes #263.

## Approach
Moved a single `IDimensions` into `src/app/core/interfaces/widgets-interface.ts` (where every touched file already imports `IDynamicControl`, so it folds into an existing import line — no new import statements), deleted both duplicate definitions, and repointed all importers (the 4 `svg-*` components + the 2 panel components) and the one spec. Pure type move, no behavior change — zero `*.component.ts` `IDimensions` imports remain.

Betterer baseline regenerated: the deletions shifted line numbers of existing issues in the 3 touched files; count unchanged (183), no new strict-null issues.

Closes #263.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
