### PR TITLE
Rename time-series "charts" to "plots" + fix stale sampling copy (#126, #247)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Skip is designed for sailors and boaters who want:
 - A **modern, polished interface** optimized for marine displays.
 - **Touch-optimized design**: touch-first, intuitive design for tablets, phones, and other touch-enabled devices.
 - **Cross-platform support**: runs on phones, tablets, laptops, Raspberry Pi, Web Enabled TV or other fixed displays - anywhere you can run a web browser.
-- **Instant access to all Signal K data**: displays gauges, charts, switches, and other widgets right out of the box.
+- **Instant access to all Signal K data**: displays gauges, plots, switches, and other widgets right out of the box.
 - **Flexible dashboards**: customize layouts, drag-and-drop widgets, night/day mode, kiosk/fullscreen and remote control support.
 
 With Skip, you get the **familiar feel of professional Multi-Function Displays** combined with the flexibility of Signal K. It’s simple, reliable, and highly usable — a modern, touch-first Multi-Function Display for [Signal K](https://signalk.org) vessels.
@@ -115,7 +115,7 @@ All Skip widgets are visual presentation controls that are very versatile, with 
 - **AC/DC Charger**- Monitor charging performance at a glance with a compact AC/DC Charger Widget. View single or multiple chargers with charge mode, voltage, current, power and temperature. Chargers are discovered automatically.
 - **Freeboard-SK** – Adds the Freeboard-SK chart plotter as a widget with automatic sign-in.
 - **Autopilot Head** – Typical autopilot controls for compatible Signal K Autopilot devices.
-- **Realtime Data Chart** – Visualizes data on a real-time chart with actuals, averages, and min/max.
+- **Realtime Data Plot** – Visualizes data on a real-time plot with actuals, averages, and min/max.
 - **AIS Radar**: Display AIS targets with range rings, interactive target details, and quick zoom and filtering controls.
 - **Embed Webpage Viewer** – Embeds external web apps (Grafana, Node-RED, etc.) into your dashboard.
 - **Racesteer** – Race steering display fusing polar performance data with live conditions for optimal tactics.
@@ -139,7 +139,7 @@ Grafana integration with other widgets
 ![Embedded Webpage Concept Image](./images/KipGaugeSample3-1024x508.png)
 
 ## Historical Data
-Skip charts recent history for your numeric data by reading it from an external Signal K History API provider (such as `signalk-to-influxdb2` or `signalk-parquet`). Press and hold (long-press) a widget to open its history dialog, or use a Realtime Data Chart or Wind Trends widget to see recent trends. Skip does **not** record or store data itself — the detail and time span available depend on whatever provider your Signal K server runs, and charts show live data only when no provider is present. See the [History-API Provider](src/assets/help-docs/history-api.md) help file for setup.
+Skip plots recent history for your numeric data by reading it from an external Signal K History API provider (such as `signalk-to-influxdb2` or `signalk-parquet`). Press and hold (long-press) a widget to open its history dialog, or use a Realtime Data Plot or Wind Trends widget to see recent trends. Skip does **not** record or store data itself — the detail and time span available depend on whatever provider your Signal K server runs, and plots show live data only when no provider is present. See the [History-API Provider](src/assets/help-docs/history-api.md) help file for setup.
 
 ## Night Modes
 Keep your night vision with automatic or manual day and night switching to a color preserving dim mode or an all Red theme. The images below look very dark, but at night... they are perfect!
@@ -175,7 +175,7 @@ Typical complementary components you may install (most are often bundled with Si
 - **Node‑RED** – Low‑code, flow‑based wiring of devices, APIs, online services, and custom logic (alert escalation, device control automation, data enrichment, protocol bridging).
 
 **Data Storage & Analytics**
-- **InfluxDB / other TSDB** – High‑resolution historical storage of sensor & performance metrics beyond what lightweight widget charts should retain.
+- **InfluxDB / other TSDB** – High‑resolution historical storage of sensor & performance metrics beyond what lightweight widget plots should retain.
 - **Grafana** – Rich exploratory / comparative dashboards, ad‑hoc queries, alert rules on stored metrics, correlation across heterogeneous data sources.
 
 ## Harness the Power of Data State Notifications
@@ -191,7 +191,7 @@ Please ensure you submit an issue (bug/feature) before submitting a pull request
 What Skip IS about:
 - Real‑time presentation of vessel & environment data (navigation, performance, systems) pulled from Signal K.
 - Fast, legible, touchscreen‑friendly dashboards for underway decision making.
-- Configurable widgets (gauges, charts, timers, controls) tuned for sailing operations.
+- Configurable widgets (gauges, plots, timers, controls) tuned for sailing operations.
 
 What Skip deliberately IS NOT trying to become:
 - A full data lake / long‑term time‑series historian.

--- a/src/app/core/components/widget-history-chart-dialog/widget-history-chart-dialog.component.html
+++ b/src/app/core/components/widget-history-chart-dialog/widget-history-chart-dialog.component.html
@@ -6,7 +6,7 @@
 </div>
 <mat-dialog-content class="history-dialog-content">
   <div class="time-select">
-    <mat-button-toggle-group [(ngModel)]="selectedPeriod" hideSingleSelectionIndicator="true" aria-label="Chart Time Span Selection">
+    <mat-button-toggle-group [(ngModel)]="selectedPeriod" hideSingleSelectionIndicator="true" aria-label="Plot Time Span Selection">
       <mat-button-toggle value="PT15M" (click)="setPeriod('PT15M')">15 Minutes</mat-button-toggle>
       <mat-button-toggle value="PT1H" (click)="setPeriod('PT1H')">1 Hour</mat-button-toggle>
       <mat-button-toggle value="PT8H" (click)="setPeriod('PT8H')">8 Hours</mat-button-toggle>

--- a/src/app/core/services/widget.service.ts
+++ b/src/app/core/services/widget.service.ts
@@ -156,7 +156,7 @@ export class WidgetService {
   private readonly _widgetDefinition: readonly WidgetDescription[] = [
     {
       name: 'Numeric',
-      description: 'Displays numeric data in a clear and concise format, with options to show minimum and/or maximum recorded values. Includes an optional background minichart for quick visual trend insights.',
+      description: 'Displays numeric data in a clear and concise format, with options to show minimum and/or maximum recorded values. Includes an optional background mini plot for quick visual trend insights.',
       icon: 'numericWidget',
       minWidth: 1,
       minHeight: 2,
@@ -481,8 +481,8 @@ export class WidgetService {
       componentClassName: 'WidgetAutopilotComponent'
     },
     {
-      name: 'Realtime Data Chart',
-      description: 'Visualizes data on a real-time chart with multiple preconfigured series including actuals, SMA and period overall averages and Min/Max. Requires the KIP Dataset to be configured.',
+      name: 'Realtime Data Plot',
+      description: 'Visualizes data on a real-time plot with multiple preconfigured series including actuals, SMA and period overall averages and Min/Max. Requires the KIP Dataset to be configured.',
       icon: 'datachartWidget',
       minWidth: 2,
       minHeight: 3,

--- a/src/app/widget-config/dataset-chart-options/dataset-chart-options.component.html
+++ b/src/app/widget-config/dataset-chart-options/dataset-chart-options.component.html
@@ -96,7 +96,7 @@
   }
   <br />
   <p style="margin-top: 10px;">
-    Time scale and duration set how much history the chart shows (the chart window). Data is sampled to keep roughly 120 points across the window; very short windows may show fewer points for performance.
+    Time scale and duration set how far back the plot shows — the plot window. Shorter windows show finer detail.
   </p>
   <div class="flex-container" style="margin-top: 10px;">
     <div class="flex-field-50">
@@ -125,8 +125,8 @@
       </mat-form-field>
     </div>
     <div style="grid-column: 1 / -1; font-size: 0.9em; color: var(--mat-sys-outline);">
-      <strong>History API:</strong> When the time scale is minutes or longer, the Data Chart can be pre-filled with historical data.
-      <a routerLink="/help/history-data-charts" style="color: var(--kip-blue-color); cursor: pointer; text-decoration: underline;">Learn more</a>
+      <strong>History API:</strong> When the time scale is minutes or longer, the Data Plot can be pre-filled with historical data.
+      <a routerLink="/help/history-api" style="color: var(--kip-blue-color); cursor: pointer; text-decoration: underline;">Learn more</a>
     </div>
   </div>
 </div>

--- a/src/assets/help-docs/dashboards.md
+++ b/src/assets/help-docs/dashboards.md
@@ -41,9 +41,9 @@ In edit mode, widgets show dashed outlines.
 >**Tip:** If you can’t add a widget, free up space by resizing or moving existing ones first.
 
 ## Viewing Widget History on a Locked Page
-When a page is locked (normal viewing mode), you can open a history chart for a widget without entering edit mode: **press and hold (long-press)** the widget.
+When a page is locked (normal viewing mode), you can open a history plot for a widget without entering edit mode: **press and hold (long-press)** the widget.
 
-Skip opens a history chart dialog and loads historical series data for that widget using the History API. Only widgets bound to numeric data have a history — long-pressing anything else does nothing.
+Skip opens a history plot dialog and loads historical series data for that widget using the History API. Only widgets bound to numeric data have a history — long-pressing anything else does nothing.
 
 
 ## Workflow: From Idea to Page
@@ -58,7 +58,7 @@ Skip opens a history chart dialog and loads historical series data for that widg
 ## Widget Gallery (Overview)
 Skip widgets turn Signal K data into readable visuals and controls. Available widget types:
 
-- **Numeric** – Displays numeric data in a clear and concise format, with options to show min/max values and a background minichart for trends.
+- **Numeric** – Displays numeric data in a clear and concise format, with options to show min/max values and a background mini plot for trends.
 - **Text** – Displays text data with customizable color formatting.
 - **Date & Time** – Shows date and time with custom formatting and timezone correction.
 - **Position** – Displays latitude and longitude for location tracking and navigation.
@@ -81,7 +81,7 @@ Skip widgets turn Signal K data into readable visuals and controls. Available wi
 - **AC/DC Charger**- Monitor charging performance at a glance with a compact AC/DC Charger Widget. View single or multiple chargers with charge mode, voltage, current, power and temperature. Chargers are discovered automatically.
 - **Freeboard-SK** – Adds the Freeboard-SK chart plotter as a widget with automatic sign-in.
 - **Autopilot Head** – Typical autopilot controls for compatible Signal K Autopilot devices.
-- **Realtime Data Chart** – Visualizes data on a real-time chart with actuals, averages, and min/max.
+- **Realtime Data Plot** – Visualizes data on a real-time plot with actuals, averages, and min/max.
 - **AIS Radar**: Display AIS targets with range rings, interactive target details, and quick zoom and filtering controls. See [AIS Radar Widget](#/help/ais-radar.md).
 - **Embed Webpage Viewer** – Embeds external web apps (Grafana, Node-RED, etc.) into your dashboard.
 - **Racesteer** – Race steering display fusing polar performance data with live conditions for optimal tactics.

--- a/src/assets/help-docs/history-api.md
+++ b/src/assets/help-docs/history-api.md
@@ -1,10 +1,10 @@
 ## Using a History API Provider
 
 Skip reads historical data from an external Signal K History API provider plugin. With a compatible provider installed, Skip can:
-1. Pre-seed Data Chart and Wind Trends so they show recent trends immediately.
+1. Pre-seed Data Plot and Wind Trends so they show recent trends immediately.
 2. Populate historical views for widgets on your pages that use numeric value paths.
 
-You must configure the provider plugin to capture the paths you want to chart, and it must have enough recorded data to cover your chart time span. This is not automatic.
+You must configure the provider plugin to capture the paths you want to plot, and it must have enough recorded data to cover your plot time span. This is not automatic.
 
 Running a provider gives you full control, including:
 - Long-term record keeping.
@@ -13,7 +13,7 @@ Running a provider gives you full control, including:
 
 ## Which Widgets Support History?
 
-Most widgets that use numeric paths support history, including Horizon, Battery Monitor, Solar, and similar numeric-based widgets. Your provider plugin must be configured to capture the paths you want to chart.
+Most widgets that use numeric paths support history, including Horizon, Battery Monitor, Solar, and similar numeric-based widgets. Your provider plugin must be configured to capture the paths you want to plot.
 
 ## Required Plugins and Signal K Version
 
@@ -27,7 +27,7 @@ Currently, two plugins support History API v2:
 - **Purpose:** Records Signal K data to an InfluxDB v2 time-series database (requires InfluxDB v2).
 - **Link:** [signalk-to-influxdb2](https://www.npmjs.com/package/signalk-to-influxdb2)
 - **Setup:** Follow the plugin documentation for installation and configuration.
-- **Path Configuration:** By default, records all paths. Configure filters, resolution, and related settings for the paths you want available in Skip charts.
+- **Path Configuration:** By default, records all paths. Configure filters, resolution, and related settings for the paths you want available in Skip plots.
 
 ### 2. signalk-parquet
 - **Purpose:** Records Signal K data to Parquet files for efficient storage and querying (no external database required).
@@ -38,31 +38,33 @@ Currently, two plugins support History API v2:
 ## How History Data Works in Skip
 
 ### History Seeding
-When you open a chart widget with a larger time scale (minutes/hours):
+When you open a plot widget with a larger time scale (minutes/hours):
 1. Skip checks whether history data is available through the History API.
 2. If available and the time window allows it (resolution >= 1000 ms), Skip requests historical data points.
-3. The chart displays the historical trend immediately.
+3. The plot displays the historical trend immediately.
 
 ### Live Updates
 After history data loads:
 - New data points continue to arrive through Signal K's live WebSocket connection.
-- The chart transitions smoothly from history to live updates.
+- The plot transitions smoothly from history to live updates.
 - Old points are removed to maintain a rolling window based on the configured time scale.
 
 ### When History Is Not Available
 - If no History API plugin is installed, or the provider reports that a path is not recorded, history requests are skipped silently.
-- The chart shows live data only, starting from when it was opened.
+- The plot shows live data only, starting from when it was opened.
 - This is expected behavior and does not indicate an error.
 
 ## Provider Plugin Configuration
 
-For performance reasons, Skip charts display a maximum of 120 datapoints. Skip uses the chart's configured time window and asks the provider to return data for that window as up to 120 datapoints.
+Skip does not impose a fixed datapoint limit. For each request it derives a resolution (sample interval) from the time window being shown and asks the provider to return data at that resolution:
+- The Realtime Data Plot targets roughly 500 points across its window (with a floor for very short windows), so finer sampling produces more detail rather than a capped number of points.
+- The pop-up history plot dialog targets a lighter density (about 120 points) across its fixed windows.
 
-When configuring provider sampling rates, ensure your rules support this behavior:
-- Slower sampling rates produce fewer datapoints (lower visual resolution).
-- Faster sampling rates do not produce more than 120 datapoints in Skip charts.
+A plot can only show detail the provider recorded. When configuring provider sampling rates:
+- If the provider stored data at a coarser interval than Skip requests, the plot shows that coarser detail (lower visual resolution), whatever the window.
+- Recording at a finer interval than Skip requests is fine — Skip asks for the resolution it needs and the provider returns data at that resolution.
 
-### Widget Historical Charts
+### Widget Historical Plots
 
 For the smallest fixed window (**last 15 minutes**), collect enough samples to provide useful resolution. A sampling interval around 7.5 seconds is ideal; 15 seconds is also usable.
 
@@ -74,11 +76,11 @@ The Wind Trends widget uses two fixed Signal K paths:
 
 To display Wind Trends history, both paths **must be captured by your selected History API plugin**.
 
-Choose a sampling rate that supports chart durations of 5 and 30 minutes.
+Choose a sampling rate that supports plot durations of 5 and 30 minutes.
 
 ## Limitations
 
-To seed charts with historical data, you must configure your provider to collect the required paths. This is not automatic.
+To seed plots with historical data, you must configure your provider to collect the required paths. This is not automatic.
 
 ## Troubleshooting
 
@@ -93,16 +95,16 @@ To seed charts with historical data, you must configure your provider to collect
 
 **Check 3: Are paths configured in the plugin?**
 - Open plugin configuration.
-- Confirm the paths you are charting (for example, `navigation.speedThroughWater`) are included in the capture list.
+- Confirm the paths you are plotting (for example, `navigation.speedThroughWater`) are included in the capture list.
 
 **Check 4: Is there historical data available?**
 - If the plugin was installed recently, data is only available from that point onward.
-- Charts cannot display history for periods before the plugin was enabled or before the path was configured.
+- Plots cannot display history for periods before the plugin was enabled or before the path was configured.
 - Allow time for data to accumulate before expecting deeper history.
 
-**Check 5: Is the chart time scale eligible?**
+**Check 5: Is the plot time scale eligible?**
 - Very short time scales (seconds) skip history seeding for performance.
-- Use chart time scales of **minutes or longer** for history seeding.
+- Use plot time scales of **minutes or longer** for history seeding.
 
 **Check 6: Are there network or permission issues?**
 - Confirm Skip can reach the Signal K server History API endpoint.
@@ -112,10 +114,10 @@ To seed charts with historical data, you must configure your provider to collect
 ## Next Steps
 
 1. Verify that a History API plugin is installed on your Signal K server.
-2. Configure the plugin to capture the paths you want to chart.
-3. Wait for the plugin to collect enough data to fill your chart time span.
-4. Open a Data Chart or Wind Trends widget with a time scale of minutes or longer.
-5. Let the chart load; history appears when available.
+2. Configure the plugin to capture the paths you want to plot.
+3. Wait for the plugin to collect enough data to fill your plot time span.
+4. Open a Data Plot or Wind Trends widget with a time scale of minutes or longer.
+5. Let the plot load; history appears when available.
 6. For more details, consult plugin documentation and Signal K community resources.
 
 ## Questions or Issues?

--- a/src/assets/help-docs/time-series.md
+++ b/src/assets/help-docs/time-series.md
@@ -1,26 +1,26 @@
 ## Historical Widget Data
 
-Skip is primarily designed for live sailing data, but most numeric widgets can also show recent history — both as a pop-up history chart you open from a widget and as startup seeding for chart widgets, so they show recent trends immediately instead of starting empty.
+Skip is primarily designed for live sailing data, but most numeric widgets can also show recent history — both as a pop-up history plot you open from a widget and as startup seeding for plot widgets, so they show recent trends immediately instead of starting empty.
 
 History is served by an external **Signal K History API provider** — a server plugin such as `signalk-to-influxdb2` or `signalk-parquet`. Skip does not record or store data itself; it reads history from whatever provider your Signal K server runs. When no provider is available, Skip shows live data only, starting from when a widget was opened.
 
 See [History-API Provider](#/help/history-api.md) in the Integrations help menu for how to install and configure a provider.
 
 ## What Skip Does With History
-- Pre-seeds Data Chart and Wind Trends so they show recent trends immediately on open.
+- Pre-seeds Data Plot and Wind Trends so they show recent trends immediately on open.
 - Provides a pop-up historical view for numeric-value widgets on your pages.
 
 The detail and time span available depend entirely on what your provider has recorded and how it is configured.
 
-## Accessing the History Chart
-On a **locked page** (normal viewing mode), **press and hold (long-press)** a numeric value widget to open its pop-up history chart directly — no edit mode, no menu. This is the only way to open it; interactive widgets keep single-tap for their own control, so long-press is the history gesture there too.
+## Accessing the History Plot
+On a **locked page** (normal viewing mode), **press and hold (long-press)** a numeric value widget to open its pop-up history plot directly — no edit mode, no menu. This is the only way to open it; interactive widgets keep single-tap for their own control, so long-press is the history gesture there too.
 
-The pop-up chart displays recorded data only (no live-stream overlay), across a fixed set of time windows: the last 15 minutes, 1 hour, 8 hours, or 24 hours. For more flexible analytics, use a purpose-built platform such as Grafana.
+The pop-up plot displays recorded data only (no live-stream overlay), across a fixed set of time windows: the last 15 minutes, 1 hour, 8 hours, or 24 hours. For more flexible analytics, use a purpose-built platform such as Grafana.
 
 ## Supported Widgets
-Most widgets that use numeric paths support history, including Horizon, Battery Monitor, Solar, and similar numeric-based widgets. Chart widgets seed from history according to their configuration:
+Most widgets that use numeric paths support history, including Horizon, Battery Monitor, Solar, and similar numeric-based widgets. Plot widgets seed from history according to their configuration:
 
-#### Data Chart Widget
+#### Data Plot Widget
 - **Supported:** Yes, seeded with history data.
 - **Requirements:** Time scale must be minutes or longer.
 
@@ -28,9 +28,9 @@ Most widgets that use numeric paths support history, including Horizon, Battery 
 - **Supported:** Yes, seeded with history data.
 - **Requirements:** Time span of `5 minutes` or `30 minutes`.
 
-#### Numeric Widget's Mini Chart
-- **Supported:** No. Mini charts use very short time windows (12 seconds) and skip history seeding.
-- Mini charts start live-only for performance reasons.
+#### Numeric Widget's Mini Plot
+- **Supported:** No. Mini plots use very short time windows (12 seconds) and skip history seeding.
+- Mini plots start live-only for performance reasons.
 
 ## Requirements
 - Signal K v2.22.1+: the history query service uses History API v2, introduced in Signal K v2.22.1.


### PR DESCRIPTION
## Motivation
In a marine app "chart" means a **nautical chart**, so the time-series widgets should read as **plots** in user-facing wording (#126). Separately, the Realtime Data Chart's config still cited a removed "~120 sample" limit — factually wrong and exposing internal sampling mechanics (#247). Fixes #126, #247.

## Approach
Per-context "chart" → "plot" rename of **user-facing wording** across `widget.service.ts` (widget names/descriptions), the config + history-dialog templates, and the help docs + README. **Deliberately kept** (verified per occurrence): nautical "chartplotter" / "nautical chart", code identifiers & component selectors, persisted config keys (`datachartPath`, `showMiniChart`, `verticalChart`, … — renaming would break saved dashboards), CSS class names, and chart.js types.

**#247:** replaced the stale "~120 sample" copy with the real model — point count is **window-derived and uncapped** (the Realtime Data Plot targets ~500 points, 100ms floor). Nuance preserved: the pop-up history **dialog** still targets ~120 points (`widget-history-chart-dialog.component.ts:815`), so both densities are described and the still-valid 7.5s/15-min guidance kept; only the *universal* 120 claim was removed.

## Note — schema not regenerated (blocked by #293)
`widget.service.ts` drives `src/assets/kip-dashboard-schema.json`, but `gen:mcp-schema` is **broken on `main`** (can't resolve `WidgetAcComponent`'s import — pre-existing, filed as #293). So the schema artifact stays stale for the plot rename and will update once #293 lands. `test:mcp-schema` is not in the `npm run ci` gate, so this doesn't block CI.

## Known residual
The widget-config panel still labels the mini-plot toggles "Graph" (a third term) — outside the chart→plot mandate here; flag if the whole time-series UI should converge on "plot".

Fixes #126, #247.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
