### PR TITLE
Fix false history-provider claim and rebrand user-facing KIP prose in templates

### DIFF
--- a/src/app/core/components/options/configuration/config.component.html
+++ b/src/app/core/components/options/configuration/config.component.html
@@ -71,7 +71,7 @@
         </div>
 
         <div class="upload-txt">
-          Import a KIP configuration file as a <strong>new profile</strong>. This never overwrites an
+          Import a Skip configuration file as a <strong>new profile</strong>. This never overwrites an
           existing profile.
         </div>
         <div class="upload-btn btn-div">

--- a/src/app/core/components/options/display/display.component.html
+++ b/src/app/core/components/options/display/display.component.html
@@ -82,14 +82,14 @@
           </mat-panel-title>
           @if (!isPhonePortrait().matches) {
             <mat-panel-description>
-              Configure remote dashboard operations between KIP instances.
+              Configure remote dashboard operations between Skip instances.
             </mat-panel-description>
           }
         </mat-expansion-panel-header>
         <mat-slide-toggle #isRemoteControlCb class="full-width"
           [(ngModel)]="isRemoteControl"
           name="isRemoteControl">
-            Allow remote KIP instances to view and control this dashboard.
+            Allow remote Skip instances to view and control this dashboard.
         </mat-slide-toggle>
         <mat-form-field class="optional-field">
           <mat-label>Name of this instance</mat-label>

--- a/src/app/core/components/options/signalk/signalk.component.html
+++ b/src/app/core/components/options/signalk/signalk.component.html
@@ -53,7 +53,7 @@
       <canvas class="activity-graph" #activityGraph></canvas>
     </div>
     <div class="info-container">
-      <pre>KIP: {{ app.appVersion() }}
+      <pre>Skip: {{ app.appVersion() }}
 {{ app.browserVersion() }}, {{ app.osVersion() }}<br />
 {{ endpointServiceStatus().serverDescription }}
 {{ streamStatus().message }}, {{ isUserSession() ? 'Signed in' : 'Not signed in' }}

--- a/src/app/core/components/remote-control/remote-control.component.html
+++ b/src/app/core/components/remote-control/remote-control.component.html
@@ -37,8 +37,8 @@
       <div class="empty-state-msg" role="status" aria-live="polite">
         <mat-icon class="empty-state-icon" aria-hidden="true" color="primary">cast</mat-icon>
         <div class="copy">
-          <p>Select an available remote KIP in the menu.</p>
-          <p>To allow remote control of a dashboard, on that KIP device open Options → Display → Remote Control and enable it.</p>
+          <p>Select an available remote Skip in the menu.</p>
+          <p>To allow remote control of a dashboard, on that Skip device open Settings, then enable Remote Control on the Display tab.</p>
         </div>
       </div>
     }

--- a/src/app/core/components/upgrade-config/upgrade-config.component.html
+++ b/src/app/core/components/upgrade-config/upgrade-config.component.html
@@ -1,7 +1,7 @@
 <h2>All New Touch, Mouse, and Keyboard Navigation</h2>
 <p class="warning"><strong>Heads up:</strong> The new version introduces a completely
   redesigned fullscreen interface with no navigation bar. Please review the input modes table below to get an understanding
-  of the new ways to operate KIP before upgrading. After the upgrade, give yourself time to get comfortable with the
+  of the new ways to operate Skip before upgrading. After the upgrade, give yourself time to get comfortable with the
   changes.</p>
 <table class="nav-table">
   <thead>
@@ -49,7 +49,7 @@
   <span class="warning">Important:</span> The new widget layout engine is <strong>completely different</strong> from the previous version. When you upgrade, your configuration will be migrated, but <strong>the way pages and widgets are arranged will change significantly</strong>.
 </p>
 <ul>
-  <li>All KIP configuration settings will be migrated.</li>
+  <li>All Skip configuration settings will be migrated.</li>
   <li>Each v2 Page layout becomes its own v3 page.</li>
   <li>All widgets and their settings will appear in their new pages.</li>
   <li>
@@ -67,13 +67,13 @@
     </ul>
   </li>
   <li>Click the <strong>Upgrade</strong> button below.</li>
-  <li>Once the upgrade is complete, KIP will restart and display the migrated pages.</li>
+  <li>Once the upgrade is complete, Skip will restart and display the migrated pages.</li>
   <li>Reposition and resize your widgets as needed.</li>
   <li>Once satisfied, delete the <code>9.0.0.json</code> configuration files located in the previously mentioned folders. They are not needed any more.</li>
 </ol>
 
 <p>
-  For tips and guidance, consult KIP’s in-app <strong>Help</strong> section. Most common questions are answered there.
+  For tips and guidance, consult Skip’s in-app <strong>Help</strong> section. Most common questions are answered there.
   If you need support, join the <a href="https://discord.gg/AMDYT2DQga" target="_blank">Signal K #kip Discord channel</a>.
 </p>
 

--- a/src/app/core/components/widget-history-chart-dialog/widget-history-chart-dialog.component.html
+++ b/src/app/core/components/widget-history-chart-dialog/widget-history-chart-dialog.component.html
@@ -19,7 +19,7 @@
     } @else if (error()) {
       <p class="history-message error">503: {{ error() }}</p>
     } @else if (hasNoData()) {
-      <p class="history-message">No historical data is available for this widget. If you are not using the built-in KIP History API provider, validate your plugin configuration supports the widget's path and try again.</p>
+      <p class="history-message">No historical data is available for this widget. Historical data comes from an external Signal K history provider (such as signalk-to-influxdb2 or signalk-parquet) — make sure one is installed and configured to support the widget's path, then try again.</p>
     } @else {
       <div class="chart-wrapper">
         <canvas #historyCanvas></canvas>


### PR DESCRIPTION
## Why

Two related issues in user-facing Angular template prose:

1. **A false claim (priority).** The history-chart dialog's empty state told users about *"the built-in KIP History API provider"* — but Skip ships **no** server-side history provider. It is a pure History-API *reader*; trend data comes from an **external** Signal K provider (`signalk-to-influxdb2` or `signalk-parquet`). The old wording misled users about where their data comes from and what to fix when a chart is empty.
2. **Stale "KIP" product prose.** F3 (#198) rebranded the help docs + README but deliberately scoped app-template strings out. Several templates still say "KIP" in user-visible sentences.

## What

- **Corrected the empty-state message** (`widget-history-chart-dialog.component.html`) to accurately point users at an external Signal K history provider they must install/configure to support the widget's path.
- **Rebranded user-facing "KIP" → "Skip"** across `signalk`, `configuration`, `display`, `remote-control`, and `upgrade-config` templates (version label, prose sentences).
- In `remote-control`, also updated the instruction path "Options → Display" → "**Settings → Display**" to stay consistent with the sibling Options→Settings rename (#128).

## Deliberately preserved

- The external **Signal K `#kip` Discord channel** link (a real upstream community channel — there is no `#skip` channel to point to).
- The persisted on-disk config dir names `.../users/(username)/kip/` and `.../global/kip/` (storage identifiers, not prose).
- All `--kip-*` CSS variables, TypeScript identifiers (`IKipDisplayInfo`, `KipUUID`, `self.kip.remote.*`), selectors, and config keys.

Pure prose in `.html` templates — no behavior change, no `.ts` touched (betterer baseline unaffected). Lint passes.

Fixes #285.