### PR TITLE
Standardize on 'Settings' terminology and add widget type to config dialog title

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -62,9 +62,6 @@ exports[`strictNullChecks`] = {
     "src/app/core/components/data-inspector/data-inspector.component.ts:2942185648": [
       [71, 4, 20, "Type \'Signal<BreakpointState | undefined>\' is not assignable to type \'Signal<BreakpointState>\'.\\n  Type \'Signal<BreakpointState | undefined>\' is not assignable to type \'() => BreakpointState\'.\\n    Type \'BreakpointState | undefined\' is not assignable to type \'BreakpointState\'.\\n      Type \'undefined\' is not assignable to type \'BreakpointState\'.", "1507091964"]
     ],
-    "src/app/core/components/group-widget/group-widget.component.ts:2421937404": [
-      [85, 8, 6, "Type \'IWidgetSvcConfig | undefined\' is not assignable to type \'object\'.\\n  Type \'undefined\' is not assignable to type \'object\'.", "1544266319"]
-    ],
     "src/app/core/components/options/notifications/notifications.component.ts:3253454142": [
       [41, 4, 20, "Type \'Signal<BreakpointState | undefined>\' is not assignable to type \'Signal<BreakpointState>\'.\\n  Type \'Signal<BreakpointState | undefined>\' is not assignable to type \'() => BreakpointState\'.\\n    Type \'BreakpointState | undefined\' is not assignable to type \'BreakpointState\'.\\n      Type \'undefined\' is not assignable to type \'BreakpointState\'.", "1507091964"],
       [47, 4, 24, "Object is possibly \'undefined\'.", "2222700196"],
@@ -87,7 +84,7 @@ exports[`strictNullChecks`] = {
     "src/app/core/components/widget-embedded/widget-embedded.component.ts:3928020917": [
       [114, 4, 13, "Type \'Type<WidgetViewComponentBase> | undefined\' is not assignable to type \'Type<WidgetViewComponentBase>\'.\\n  Type \'undefined\' is not assignable to type \'Type<WidgetViewComponentBase>\'.", "2689238020"]
     ],
-    "src/app/core/components/widget-host2/widget-host2.component.ts:4025766549": [
+    "src/app/core/components/widget-host2/widget-host2.component.ts:4255652117": [
       [134, 4, 13, "Type \'Type<WidgetViewComponentBase> | undefined\' is not assignable to type \'Type<WidgetViewComponentBase>\'.\\n  Type \'undefined\' is not assignable to type \'Type<WidgetViewComponentBase>\'.", "2689238020"],
       [250, 32, 9, "Type \'null\' cannot be used as an index type.", "2171020380"]
     ],
@@ -142,10 +139,10 @@ exports[`strictNullChecks`] = {
       [66, 26, 49, "Object is possibly \'null\'.", "3725617003"],
       [70, 26, 49, "Object is possibly \'null\'.", "3725617003"]
     ],
-    "src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.ts:513393189": [
-      [75, 4, 11, "Type \'{ label: string; value: string; }[]\' is not assignable to type \'never[]\'.\\n  Type \'{ label: string; value: string; }\' is not assignable to type \'never\'.", "3027418051"],
-      [210, 8, 4, "Type \'null\' is not assignable to type \'UntypedFormControl\'.", "2087777580"],
-      [231, 4, 9, "\'ctrlLabel\' is possibly \'null\'.", "2892925034"]
+    "src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.ts:104802355": [
+      [80, 4, 11, "Type \'{ label: string; value: string; }[]\' is not assignable to type \'never[]\'.\\n  Type \'{ label: string; value: string; }\' is not assignable to type \'never\'.", "3027418051"],
+      [215, 8, 4, "Type \'null\' is not assignable to type \'UntypedFormControl\'.", "2087777580"],
+      [236, 4, 9, "\'ctrlLabel\' is possibly \'null\'.", "2892925034"]
     ],
     "src/app/widget-config/solar-charger-setup/solar-charger-setup.component.ts:3993417046": [
       [47, 48, 28, "Object is possibly \'undefined\'.", "758680035"],

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -34,27 +34,27 @@ export const routes: Routes = [
   {
     path: 'options',
     loadComponent: () => import('./core/components/options/tabs/tabs.component').then(m => m.TabsComponent),
-    title: 'KIP - Options'
+    title: 'Skip - Settings'
   },
   {
     path: 'remote',
     loadComponent: () => import('./core/components/remote-control/remote-control.component').then(m => m.RemoteControlComponent),
-    title: 'KIP - Remote Control'
+    title: 'Skip - Remote Control'
   },
   {
     path: 'help/:page',
     loadComponent: () => import('./core/components/app-help/app-help.component').then(m => m.AppHelpComponent),
-    title: 'KIP - Help'
+    title: 'Skip - Help'
   },
   {
     path: 'help',
     loadComponent: () => import('./core/components/app-help/app-help.component').then(m => m.AppHelpComponent),
-    title: 'KIP - Help'
+    title: 'Skip - Help'
   },
   {
     path: 'data',
     loadComponent: () => import('./core/components/data-inspector/data-inspector.component').then(m => m.DataInspectorComponent),
-    title: 'KIP - Data Inspector'
+    title: 'Skip - Data Inspector'
   },
   {
     path: 'login',

--- a/src/app/core/components/group-widget/group-widget.component.ts
+++ b/src/app/core/components/group-widget/group-widget.component.ts
@@ -5,6 +5,7 @@ import { GestureDirective } from "../../directives/gesture.directive";
 import { IWidget, IWidgetSvcConfig } from '../../interfaces/widgets-interface';
 import { WidgetRuntimeDirective } from '../../directives/widget-runtime.directive';
 import { DialogService } from '../../services/dialog.service';
+import { WidgetService } from '../../services/widget.service';
 import { ActionMenuComponent } from '../action-menu/action-menu.component';
 import { WIDGET_ACTIONS } from '../action-menu/widget-actions';
 import { cloneDeep } from 'lodash-es';
@@ -25,6 +26,7 @@ export class GroupWidgetComponent extends BaseWidget implements OnInit {
   @Input({ required: true }) protected widgetProperties!: IWidget;
   protected readonly dashboard = inject(DashboardService);
   private readonly _dialog = inject(DialogService);
+  private readonly _widgetService = inject(WidgetService);
   protected readonly runtime = inject(WidgetRuntimeDirective);
   private readonly _actionMenu = viewChild.required(ActionMenuComponent);
   protected readonly widgetActions = WIDGET_ACTIONS;
@@ -81,9 +83,10 @@ export class GroupWidgetComponent extends BaseWidget implements OnInit {
 
       this._optionsOpen = true;
 
+      const widgetName = this._widgetService.getWidgetName(this.widgetProperties.type);
       this._dialog.openWidgetOptions({
-        title: 'Widget Options',
-        config: cloneDeep(this.runtime.options()),
+        title: 'Widget Settings',
+        config: { ...cloneDeep(this.runtime.options()), widgetName },
         confirmBtnText: 'Save',
         cancelBtnText: 'Cancel'
       }).afterClosed().subscribe(result => {

--- a/src/app/core/components/settings/settings.component.html
+++ b/src/app/core/components/settings/settings.component.html
@@ -2,7 +2,7 @@
   <div class="actions-header-container">
     <div class="actions-buttons-container">
       <tile-large-icon [class]="`${isPhonePortrait() ? 'no-label' : 'with-label'}`"
-        [iconOnly]="isPhonePortrait()" [compact]="true" svgIcon="settings" [iconSize]="48" label="Options"
+        [iconOnly]="isPhonePortrait()" [compact]="true" svgIcon="settings" [iconSize]="48" label="Settings"
         (click)="onActionItem('options')"
         (keydown.enter)="onActionItem('options')"
         (keydown.space)="onActionItem('options')" />

--- a/src/app/core/components/widget-host2/widget-host2.component.spec.ts
+++ b/src/app/core/components/widget-host2/widget-host2.component.spec.ts
@@ -74,7 +74,8 @@ describe('WidgetHost2Component', () => {
                 {
                     provide: WidgetService,
                     useValue: {
-                        getComponentType: vi.fn().mockReturnValue(undefined)
+                        getComponentType: vi.fn().mockReturnValue(undefined),
+                        getWidgetName: vi.fn().mockReturnValue(undefined)
                     }
                 },
                 {

--- a/src/app/core/components/widget-host2/widget-host2.component.ts
+++ b/src/app/core/components/widget-host2/widget-host2.component.ts
@@ -296,9 +296,10 @@ export class WidgetHost2Component extends BaseWidget implements OnInit, OnDestro
       }
 
       try {
+        const widgetName = this.widgetService.getWidgetName(this.widgetProperties.type);
         this.dialog.openWidgetOptions({
-          title: 'Widget Options',
-          config: this.widgetProperties.config,
+          title: 'Widget Settings',
+          config: { ...this.widgetProperties.config, widgetName },
           confirmBtnText: 'Save',
           cancelBtnText: 'Cancel'
         }).afterClosed().subscribe(result => {

--- a/src/app/core/services/widget.service.ts
+++ b/src/app/core/services/widget.service.ts
@@ -699,6 +699,17 @@ export class WidgetService {
   }
 
   /**
+   * Returns a widget type's human-readable name from the registry, or undefined when the
+   * type/selector is not a registered widget (e.g. structural containers like the group widget).
+   *
+   * @param selector Dashboard widget type / selector (e.g. `widget-numeric`).
+   * @returns The registered widget name (e.g. `Numeric`), or undefined if unknown.
+   */
+  public getWidgetName(selector: string): string | undefined {
+    return this._widgetDefinition.find(w => w.selector === selector)?.name;
+  }
+
+  /**
    * Returns the list of widget definitions, each enriched with plugin dependency status.
    *
    * For each widget, this method:

--- a/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.html
+++ b/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.html
@@ -82,7 +82,7 @@
                 >
                   Allow pointer events on embedded content. WARNING: this may
                   prevent swipe gestures over the Embed widget or keyboard events,
-                  while the focus is in the embed, from triggering normal KIP
+                  while the focus is in the embed, from triggering normal Skip
                   interactions.
                 </mat-checkbox>
               }

--- a/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.spec.ts
+++ b/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.spec.ts
@@ -126,3 +126,38 @@ describe('ModalWidgetComponent', () => {
     expect([f.courseOverGroundEnable.disabled, f.waypointEnable.disabled, f.driftEnable.disabled]).toEqual([true, true, true]);
   });
 });
+
+describe('ModalWidgetComponent title composition (#180)', () => {
+  const unitsServiceStub: Pick<UnitsService, 'getConversionsForPath'> = {
+    getConversionsForPath: (): IConversionPathList => ({ base: 'unitless', conversions: [] }),
+  };
+  const appServiceStub: Pick<AppService, 'configurableThemeColors'> = {
+    configurableThemeColors: []
+  };
+
+  beforeEach(() => TestBed.resetTestingModule());
+
+  function createComponentWithData(data: object): RootModalWidgetConfigComponent {
+    TestBed.configureTestingModule({
+      imports: [RootModalWidgetConfigComponent],
+      providers: [
+        { provide: UnitsService, useValue: unitsServiceStub },
+        { provide: AppService, useValue: appServiceStub },
+        { provide: MAT_DIALOG_DATA, useValue: data },
+        { provide: MatDialogRef, useValue: { close: vi.fn() } },
+      ],
+    });
+    ensureTestIconsReady();
+    return TestBed.createComponent(RootModalWidgetConfigComponent).componentInstance;
+  }
+
+  it('composes the widget name in front of the base dialog title', () => {
+    const component = createComponentWithData({ widgetName: 'Numeric' });
+    expect(component.titleDialog).toBe('Numeric — Widget Settings');
+  });
+
+  it('falls back to the base title when no widget name is provided', () => {
+    const component = createComponentWithData({});
+    expect(component.titleDialog).toBe('Widget Settings');
+  });
+});

--- a/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.ts
+++ b/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.ts
@@ -47,9 +47,11 @@ export class RootModalWidgetConfigComponent implements OnInit {
   private units = inject(UnitsService);
   private app = inject(AppService);
   private readonly destroyRef = inject(DestroyRef);
-  protected widgetConfig = inject<IWidgetSvcConfig>(MAT_DIALOG_DATA);
+  protected widgetConfig = inject<IWidgetSvcConfig & { widgetName?: string }>(MAT_DIALOG_DATA);
 
-  public titleDialog = "Widget Options";
+  public titleDialog = this.widgetConfig?.widgetName
+    ? `${this.widgetConfig.widgetName} — Widget Settings`
+    : "Widget Settings";
   public formMaster: UntypedFormGroup;
   public unitList: { default?: string, conversions?: IUnitGroup[] } = {};
   public isPathArray = false;
@@ -67,7 +69,10 @@ export class RootModalWidgetConfigComponent implements OnInit {
       return;
     }
     this.unitList = this.units.getConversionsForPath(''); // array of Group or Groups: "angle", "speed", etc...
-    this.formMaster = this.generateFormGroups(this.widgetConfig);
+    // widgetName is a dialog-title hint carried on the data payload, not a persisted config field.
+    const formConfig = { ...this.widgetConfig };
+    delete formConfig.widgetName;
+    this.formMaster = this.generateFormGroups(formConfig);
     this.setupWindsteerControlState();
     this.formMaster.statusChanges
       .pipe(takeUntilDestroyed(this.destroyRef))


### PR DESCRIPTION
Bundles #128, #179, #180 — all UX-consistency work around the "Settings" wording.

## What

**#128 — "Options" → "Settings":**
- The actions-overlay button that opens the config page: `label="Options"` → `label="Settings"` (the page already titles itself "Settings"; the icon is already `settings`).
- The `/options` route's browser title `'KIP - Options'` → `'Skip - Settings'`, and the other stale KIP browser titles de-KIP'd (`'Skip - Remote Control'`, `'Skip - Help'`, `'Skip - Data Inspector'`).

**#179 — "Widget Options" → "Widget Settings":** the config dialog's base title and the `title:` strings passed at both open sites. Also rebrands the Embed-widget warning prose "normal KIP" → "normal Skip".

**#180 — widget type in the dialog title:** the dialog now composes the widget's friendly registry name in front of the base title, e.g. **"Numeric — Widget Settings"**, falling back to plain "Widget Settings" for types without a registry entry (e.g. the group widget). Added `WidgetService.getWidgetName(selector)` next to the existing selector-keyed lookups.

## Deliberate decisions (please sanity-check)

1. **Route path `/options` → `/settings` is NOT done — deferred.** #128 proposed it, but `/settings` **already exists** (the actions/home overlay, `settings.component`). Renaming the path would collide, and resolving that requires the internal actions/settings naming swap that #128 itself defers (#38 friction). So the actions-overlay route (`/settings`, title left as `'KIP - Settings'`) is untouched — leaving that one stale "KIP" is intentional; de-KIPing it to "Skip - Settings" would duplicate the `/options` title. The path is invisible to users; the user-facing button label + tab title are fixed. Route-path rename tracked with the #38 swap.
2. **How `widgetName` reaches the dialog.** `DialogService.openWidgetOptions` only forwards `data.config`, and `DialogWidgetOptionsData.config` is typed `object`. Rather than widen the dialog-service data type (out of this packet's file scope), `widgetName` is carried **on** the config payload (spread into a fresh object — the live widget config is never mutated) and **stripped before form generation** (`delete formConfig.widgetName`), so it is never turned into a form control and never persisted: `submitConfig()` returns `formMaster.getRawValue()`, which is built from the stripped config. It is purely a title hint.

## Verification

Lint ✓, betterer:ci ✓ (183 → **182**, one issue incidentally fixed), and the new `root-modal-widget-config.component.spec.ts` title-composition tests pass locally (6/6). Pure user-facing string + title-composition change; no data-model or persistence change.

Fixes #179, #180. Addresses #128 (button label + browser title; route-path rename deferred to the #38 naming swap — see decision 1).