### PR TITLE
Type the paths-options form group, removing the widget-config `any` (#25 Phase 0)

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -131,13 +131,13 @@ exports[`strictNullChecks`] = {
       [119, 4, 20, "Object is possibly \'undefined\'.", "2522653710"],
       [120, 4, 20, "Object is possibly \'undefined\'.", "2522653710"]
     ],
-    "src/app/widget-config/paths-options/paths-options.component.ts:3600643100": [
+    "src/app/widget-config/paths-options/paths-options.component.ts:3797853945": [
       [31, 51, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'IAddNewPathObject\'.", "2620553983"],
       [32, 40, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'string\'.", "2620553983"],
       [33, 54, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'IDynamicControl[]\'.", "2620553983"],
-      [42, 28, 49, "Object is possibly \'null\'.", "3725617003"],
-      [66, 26, 49, "Object is possibly \'null\'.", "3725617003"],
-      [70, 26, 49, "Object is possibly \'null\'.", "3725617003"]
+      [58, 28, 49, "Object is possibly \'null\'.", "3725617003"],
+      [85, 26, 49, "Object is possibly \'null\'.", "3725617003"],
+      [89, 26, 49, "Object is possibly \'null\'.", "3725617003"]
     ],
     "src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.ts:104802355": [
       [80, 4, 11, "Type \'{ label: string; value: string; }[]\' is not assignable to type \'never[]\'.\\n  Type \'{ label: string; value: string; }\' is not assignable to type \'never\'.", "3027418051"],

--- a/src/app/widget-config/paths-options/paths-options.component.html
+++ b/src/app/widget-config/paths-options/paths-options.component.html
@@ -14,9 +14,9 @@
     <span matTextSuffix>Seconds</span>
   </mat-form-field>
 </div>
-<ng-container [formGroup]="pathsFormGroup">
+<ng-container [formGroup]="pathsGroup">
   @if(isArray()) {
-    @for (group of pathsFormGroup.controls; track $index) {
+    @for (group of pathControlGroups; track $index) {
       <path-control-config style="display: block;"
         [pathFormGroup]="group"
         [filterSelfPaths]="filterSelfPaths().value"
@@ -24,9 +24,9 @@
       </path-control-config>
     }
   } @else {
-    @for (group of pathsFormGroup.controls | objectKeys; track $index) {
+    @for (key of pathsGroup.controls | objectKeys; track $index) {
       <path-control-config style="display: block;"
-        [pathFormGroup]="pathsFormGroup.get(group)"
+        [pathFormGroup]="pathGroupByKey(key)"
         [filterSelfPaths]="filterSelfPaths().value"
         [multiCTRLArray]="multiCTRLArray">
       </path-control-config>

--- a/src/app/widget-config/paths-options/paths-options.component.ts
+++ b/src/app/widget-config/paths-options/paths-options.component.ts
@@ -33,9 +33,25 @@ export class PathsOptionsComponent implements OnInit, OnChanges {
   readonly delPathEvent = input<string>(undefined);
   readonly updatePathEvent = input<IDynamicControl[]>(undefined);
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  protected pathsFormGroup!: any;
+  protected pathsFormGroup!: UntypedFormArray | UntypedFormGroup;
   protected multiCTRLArray: IDynamicControl[] = [];
+
+  /** The paths group typed as a FormGroup for the `[formGroup]` container binding and the
+   * Record-shaped (single-path) branch. In the array branch the runtime value is a FormArray;
+   * the cast is compile-time only and leaves the bound value unchanged. */
+  protected get pathsGroup(): UntypedFormGroup {
+    return this.pathsFormGroup as UntypedFormGroup;
+  }
+
+  /** The per-path child FormGroups in the array (multi-control) branch. */
+  protected get pathControlGroups(): UntypedFormGroup[] {
+    return (this.pathsFormGroup as UntypedFormArray).controls as UntypedFormGroup[];
+  }
+
+  /** The child FormGroup for a given control key in the Record (single-path) branch. */
+  protected pathGroupByKey(key: string): UntypedFormGroup {
+    return this.pathsGroup.get(key) as UntypedFormGroup;
+  }
 
   ngOnInit(): void {
     if (this.isArray()) {
@@ -47,6 +63,9 @@ export class PathsOptionsComponent implements OnInit, OnChanges {
   }
 
   public addPath(newPath: IAddNewPathObject): void {
+    if (!(this.pathsFormGroup instanceof UntypedFormArray)) {
+      return;
+    }
     this.pathsFormGroup.push(
       this.fb.group({
         description: [newPath.path.description],


### PR DESCRIPTION
First slice of the #25 typed-forms migration (**Phase 0 — quick win**). See the [plan](https://github.com/halos-org/skip/issues/25#issuecomment-4977756811).

## Why

`paths-options.component.ts` held `protected pathsFormGroup!: any` — the **sole** `@typescript-eslint/no-explicit-any` suppression in the widget-config layer, and a latent crash path (`.push()` is FormArray-only but the field can be a FormGroup). The `any` existed because the same field is a `FormArray` for multi-control widgets and a `FormGroup` otherwise, and the template binds it four ways that a naive union breaks under `strictTemplates`.

## What

- Field retyped to a discriminated `UntypedFormArray | UntypedFormGroup`.
- Typed accessors so `strictTemplates` is satisfied with **zero runtime change** (casts are compile-time only; the bound values are identical): `pathsGroup` (FormGroup view for the `[formGroup]` container + the Record/single-path branch), `pathControlGroups` (the per-path element groups for the array branch), `pathGroupByKey(key)` (the Record branch's element lookup).
- `addPath()`'s FormArray-only `.push()` is now guarded by an `instanceof UntypedFormArray` check (defends the FormGroup case that previously would have thrown).

## Premise correction (from the #25 analysis)

The issue lists `path-control-config.component.ts` as also carrying an `any` — it does **not** (already `input.required<UntypedFormGroup>()`). There is exactly one `any` in the named pair, and it's the one removed here. A genuine typed conversion of `path-control-config` is hard (runtime-added `sampleTime`, numeric-only `convertUnitTo`, `parent.parent` sibling access) and is out of scope for #25.

## Verification

Lint clears (no-explicit-any gone), **`build:dev` passes** (the real strictTemplates gate), the paths-options spec passes, and `.betterer.results` regenerated (182 held; content-hash re-anchored). No behavior change — the discriminant (`isArray()`) provably tracks the runtime shape the parent builder produces.

Part of #25 (Phase 0). Does not close the issue.