### PR TITLE
Type the leaf chart/datetime config inputs to FormControl<T> (#25 Phase 1)

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -113,15 +113,15 @@ exports[`strictNullChecks`] = {
       [37, 10, 26, "Type \'null\' is not assignable to type \'Subscription\'.", "273497119"],
       [79, 8, 13, "Type \'null\' is not assignable to type \'string | undefined\'.", "2466344431"]
     ],
-    "src/app/widget-config/dataset-chart-options/dataset-chart-options.component.ts:2604195000": [
-      [82, 26, 10, "Argument of type \'ISkPathData | null\' is not assignable to parameter of type \'ISkPathData\'.\\n  Type \'null\' is not assignable to type \'ISkPathData\'.", "384538813"]
+    "src/app/widget-config/dataset-chart-options/dataset-chart-options.component.ts:155376543": [
+      [83, 26, 10, "Argument of type \'ISkPathData | null\' is not assignable to parameter of type \'ISkPathData\'.\\n  Type \'null\' is not assignable to type \'ISkPathData\'.", "384538813"]
     ],
-    "src/app/widget-config/display-chart-options/display-chart-options.component.ts:333710162": [
+    "src/app/widget-config/display-chart-options/display-chart-options.component.ts:2641875525": [
       [48, 4, 11, "Type \'{ label: string; value: string; }[]\' is not assignable to type \'never[]\'.\\n  Type \'{ label: string; value: string; }\' is not assignable to type \'never\'.", "3027418051"]
     ],
-    "src/app/widget-config/display-datetime/display-datetime.component.ts:1505324315": [
-      [45, 50, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'UntypedFormControl\'.", "2620553983"],
-      [46, 52, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'UntypedFormControl\'.", "2620553983"],
+    "src/app/widget-config/display-datetime/display-datetime.component.ts:2719976956": [
+      [45, 51, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'FormControl<string>\'.", "2620553983"],
+      [46, 53, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'FormControl<string>\'.", "2620553983"],
       [49, 10, 22, "Type \'null\' is not assignable to type \'Subscription\'.", "29842089"]
     ],
     "src/app/widget-config/electrical-family-setup/electrical-family-setup.component.ts:4115844403": [
@@ -139,7 +139,7 @@ exports[`strictNullChecks`] = {
       [85, 26, 49, "Object is possibly \'null\'.", "3725617003"],
       [89, 26, 49, "Object is possibly \'null\'.", "3725617003"]
     ],
-    "src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.ts:104802355": [
+    "src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.ts:1740588238": [
       [80, 4, 11, "Type \'{ label: string; value: string; }[]\' is not assignable to type \'never[]\'.\\n  Type \'{ label: string; value: string; }\' is not assignable to type \'never\'.", "3027418051"],
       [215, 8, 4, "Type \'null\' is not assignable to type \'UntypedFormControl\'.", "2087777580"],
       [236, 4, 9, "\'ctrlLabel\' is possibly \'null\'.", "2892925034"]

--- a/src/app/widget-config/dataset-chart-options/dataset-chart-options.component.ts
+++ b/src/app/widget-config/dataset-chart-options/dataset-chart-options.component.ts
@@ -4,7 +4,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatAutocompleteModule, MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
 import { UnitsService } from './../../core/services/units.service';
 import { Component, OnInit, input, inject, signal, computed, DestroyRef } from '@angular/core';
-import { AbstractControl, ReactiveFormsModule, UntypedFormControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+import { AbstractControl, FormControl, ReactiveFormsModule, ValidationErrors, ValidatorFn } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
 import { DataService } from '../../core/services/data.service';
@@ -46,13 +46,13 @@ function pathRequiredOrValidMatch(getPaths: () => IPathMetaData[]): ValidatorFn 
   styleUrl: './dataset-chart-options.component.scss'
 })
 export class DatasetChartOptionsComponent implements OnInit {
-  public convertUnitTo = input.required<UntypedFormControl>();
-  public datachartAngleRange = input<UntypedFormControl | undefined>(undefined);
-  public filterSelfPaths = input.required<UntypedFormControl>()
-  public datachartPath = input.required<UntypedFormControl>()
-  public datachartSource = input.required<UntypedFormControl>()
-  public timeScale = input.required<UntypedFormControl>();
-  public period = input.required<UntypedFormControl>()
+  public convertUnitTo = input.required<FormControl<string | null>>();
+  public datachartAngleRange = input<FormControl<'signed' | 'direction' | null> | undefined>(undefined);
+  public filterSelfPaths = input.required<FormControl<boolean>>()
+  public datachartPath = input.required<FormControl<string | null>>()
+  public datachartSource = input.required<FormControl<string | null>>()
+  public timeScale = input.required<FormControl<string>>();
+  public period = input.required<FormControl<number>>()
 
   private readonly data = inject(DataService);
   private readonly units = inject(UnitsService);
@@ -78,10 +78,11 @@ export class DatasetChartOptionsComponent implements OnInit {
     });
 
     this.datachartPath().setValidators([pathRequiredOrValidMatch(() => this.getPaths())]);
-    if (this.datachartPath()?.value) {
-      const pathObject = this.data.getPathObject(this.datachartPath().value);
+    const currentPath = this.datachartPath()?.value;
+    if (currentPath) {
+      const pathObject = this.data.getPathObject(currentPath);
       this.setPathSources(pathObject);
-      this.unitList.set(this.units.getConversionsForPath(this.datachartPath().value));
+      this.unitList.set(this.units.getConversionsForPath(currentPath));
     }
     this.setInitFormState();
   }

--- a/src/app/widget-config/display-chart-options/display-chart-options.component.ts
+++ b/src/app/widget-config/display-chart-options/display-chart-options.component.ts
@@ -4,7 +4,7 @@ import { MatCardModule } from '@angular/material/card';
 import { MatOptionModule } from '@angular/material/core';
 import { MatSelectModule } from '@angular/material/select';
 import { MatFormFieldModule, MatLabel } from '@angular/material/form-field';
-import { ReactiveFormsModule, UntypedFormControl } from '@angular/forms';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { MatInputModule } from '@angular/material/input';
 import { MatCheckboxChange, MatCheckboxModule } from '@angular/material/checkbox';
 import { MatRadioChange, MatRadioModule } from '@angular/material/radio';
@@ -19,30 +19,30 @@ import { MatRadioChange, MatRadioModule } from '@angular/material/radio';
 export class DisplayChartOptionsComponent implements OnInit {
   private app = inject(AppService);
 
-  readonly convertUnitTo = input.required<UntypedFormControl>();
-  readonly datasetAverageArray = input.required<UntypedFormControl>();
-  readonly showAverageData = input.required<UntypedFormControl>();
-  readonly showDataPoints = input.required<UntypedFormControl>();
-  readonly trackAgainstAverage = input.required<UntypedFormControl>();
-  readonly showDatasetMinimumValueLine = input.required<UntypedFormControl>();
-  readonly showDatasetMaximumValueLine = input.required<UntypedFormControl>();
-  readonly showDatasetAverageValueLine = input.required<UntypedFormControl>();
-  readonly showDatasetAngleAverageValueLine = input.required<UntypedFormControl>();
-  readonly verticalChart = input.required<UntypedFormControl>();
-  readonly inverseYAxis = input.required<UntypedFormControl>();
-  readonly showTimeScale = input.required<UntypedFormControl>();
+  readonly convertUnitTo = input.required<FormControl<string | null>>();
+  readonly datasetAverageArray = input.required<FormControl<string>>();
+  readonly showAverageData = input.required<FormControl<boolean>>();
+  readonly showDataPoints = input.required<FormControl<boolean>>();
+  readonly trackAgainstAverage = input.required<FormControl<boolean>>();
+  readonly showDatasetMinimumValueLine = input.required<FormControl<boolean>>();
+  readonly showDatasetMaximumValueLine = input.required<FormControl<boolean>>();
+  readonly showDatasetAverageValueLine = input.required<FormControl<boolean>>();
+  readonly showDatasetAngleAverageValueLine = input.required<FormControl<boolean>>();
+  readonly verticalChart = input.required<FormControl<boolean>>();
+  readonly inverseYAxis = input.required<FormControl<boolean>>();
+  readonly showTimeScale = input.required<FormControl<boolean>>();
 
-  readonly showYScale = input.required<UntypedFormControl>();
-  readonly startScaleAtZero = input.required<UntypedFormControl>();
-  readonly yScaleSuggestedMin = input.required<UntypedFormControl>();
-  readonly yScaleSuggestedMax = input.required<UntypedFormControl>();
+  readonly showYScale = input.required<FormControl<boolean>>();
+  readonly startScaleAtZero = input.required<FormControl<boolean>>();
+  readonly yScaleSuggestedMin = input.required<FormControl<number>>();
+  readonly yScaleSuggestedMax = input.required<FormControl<number>>();
 
-  readonly enableMinMaxScaleLimit = input.required<UntypedFormControl>();
-  readonly yScaleMin = input.required<UntypedFormControl>();
-  readonly yScaleMax = input.required<UntypedFormControl>();
+  readonly enableMinMaxScaleLimit = input.required<FormControl<boolean>>();
+  readonly yScaleMin = input.required<FormControl<number>>();
+  readonly yScaleMax = input.required<FormControl<number>>();
 
-  readonly numDecimal = input.required<UntypedFormControl>();
-  readonly color = input.required<UntypedFormControl>();
+  readonly numDecimal = input.required<FormControl<number>>();
+  readonly color = input.required<FormControl<string>>();
   protected colors = [];
 
   ngOnInit(): void {

--- a/src/app/widget-config/display-datetime/display-datetime.component.ts
+++ b/src/app/widget-config/display-datetime/display-datetime.component.ts
@@ -1,5 +1,5 @@
 import { Component, DestroyRef, OnInit, inject, input } from '@angular/core';
-import { AbstractControl, UntypedFormControl, ValidationErrors, ValidatorFn, Validators, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { AbstractControl, FormControl, ValidationErrors, ValidatorFn, Validators, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { Observable, Subscription, debounceTime, map, startWith } from 'rxjs';
 import { MatOption } from '@angular/material/core';
 import { MatIconButton } from '@angular/material/button';
@@ -43,8 +43,8 @@ export const getDynamicTimeZones = (): ITzDefinition[] => {
 })
 export class DisplayDatetimeComponent implements OnInit {
   private readonly _destroyRef = inject(DestroyRef);
-  readonly dateFormat = input<UntypedFormControl>(undefined);
-  readonly dateTimezone = input<UntypedFormControl>(undefined);
+  readonly dateFormat = input<FormControl<string>>(undefined);
+  readonly dateTimezone = input<FormControl<string>>(undefined);
   private tz: ITzDefinition[] = [];
   public filteredTZ: Observable<ITzDefinition[]>;
   private filteredTZSubscription: Subscription = null;

--- a/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.ts
+++ b/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, inject, signal, DestroyRef } from '@angular/core';
-import { UntypedFormGroup, UntypedFormControl, Validators, UntypedFormBuilder, UntypedFormArray, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { UntypedFormGroup, UntypedFormControl, FormControl, Validators, UntypedFormBuilder, UntypedFormArray, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatDialogRef, MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
@@ -278,32 +278,32 @@ export class RootModalWidgetConfigComponent implements OnInit {
     this.formMaster.updateValueAndValidity();
   }
 
-  get datachartPathControl(): UntypedFormControl {
-    return this.formMaster.get('datachartPath') as UntypedFormControl;
+  get datachartPathControl(): FormControl<string | null> {
+    return this.formMaster.get('datachartPath') as FormControl<string | null>;
   }
 
-  get datachartSourceControl(): UntypedFormControl {
-    return this.formMaster.get('datachartSource') as UntypedFormControl;
+  get datachartSourceControl(): FormControl<string | null> {
+    return this.formMaster.get('datachartSource') as FormControl<string | null>;
   }
 
-  get convertUnitToControl(): UntypedFormControl {
-    return this.formMaster.get('convertUnitTo') as UntypedFormControl;
+  get convertUnitToControl(): FormControl<string | null> {
+    return this.formMaster.get('convertUnitTo') as FormControl<string | null>;
   }
 
-  get datachartAngleRangeControl(): UntypedFormControl {
-    return this.formMaster.get('datachartAngleRange') as UntypedFormControl;
+  get datachartAngleRangeControl(): FormControl<'signed' | 'direction' | null> {
+    return this.formMaster.get('datachartAngleRange') as FormControl<'signed' | 'direction' | null>;
   }
 
-  get timeScaleControl(): UntypedFormControl {
-    return this.formMaster.get('timeScale') as UntypedFormControl;
+  get timeScaleControl(): FormControl<string> {
+    return this.formMaster.get('timeScale') as FormControl<string>;
   }
 
-  get periodControl(): UntypedFormControl {
-    return this.formMaster.get('period') as UntypedFormControl;
+  get periodControl(): FormControl<number> {
+    return this.formMaster.get('period') as FormControl<number>;
   }
 
-  get filterSelfPathsToControl(): UntypedFormControl {
-    return this.formMaster.get('filterSelfPaths') as UntypedFormControl;
+  get filterSelfPathsToControl(): FormControl<boolean> {
+    return this.formMaster.get('filterSelfPaths') as FormControl<boolean>;
   }
 
   get dataTimeoutToControl(): UntypedFormControl {
@@ -314,92 +314,92 @@ export class RootModalWidgetConfigComponent implements OnInit {
     return this.formMaster.get('enableTimeout') as UntypedFormControl;
   }
 
-  get dateTimezoneToControl(): UntypedFormControl {
-    return this.formMaster.get('dateTimezone') as UntypedFormControl;
+  get dateTimezoneToControl(): FormControl<string> {
+    return this.formMaster.get('dateTimezone') as FormControl<string>;
   }
 
-  get yScaleSuggestedMaxToControl(): UntypedFormControl {
-    return this.formMaster.get('yScaleSuggestedMax') as UntypedFormControl;
+  get yScaleSuggestedMaxToControl(): FormControl<number> {
+    return this.formMaster.get('yScaleSuggestedMax') as FormControl<number>;
   }
 
-  get enableMinMaxScaleLimitToControl(): UntypedFormControl {
-    return this.formMaster.get('enableMinMaxScaleLimit') as UntypedFormControl;
+  get enableMinMaxScaleLimitToControl(): FormControl<boolean> {
+    return this.formMaster.get('enableMinMaxScaleLimit') as FormControl<boolean>;
   }
 
-  get showDatasetMinimumValueLineToControl(): UntypedFormControl {
-    return this.formMaster.get('showDatasetMinimumValueLine') as UntypedFormControl;
+  get showDatasetMinimumValueLineToControl(): FormControl<boolean> {
+    return this.formMaster.get('showDatasetMinimumValueLine') as FormControl<boolean>;
   }
 
-  get showDatasetMaximumValueLineToControl(): UntypedFormControl {
-    return this.formMaster.get('showDatasetMaximumValueLine') as UntypedFormControl;
+  get showDatasetMaximumValueLineToControl(): FormControl<boolean> {
+    return this.formMaster.get('showDatasetMaximumValueLine') as FormControl<boolean>;
   }
 
-  get showDatasetAverageValueLineToControl(): UntypedFormControl {
-    return this.formMaster.get('showDatasetAverageValueLine') as UntypedFormControl;
+  get showDatasetAverageValueLineToControl(): FormControl<boolean> {
+    return this.formMaster.get('showDatasetAverageValueLine') as FormControl<boolean>;
   }
 
-  get showDatasetAngleAverageValueLineToControl(): UntypedFormControl {
-    return this.formMaster.get('showDatasetAngleAverageValueLine') as UntypedFormControl;
+  get showDatasetAngleAverageValueLineToControl(): FormControl<boolean> {
+    return this.formMaster.get('showDatasetAngleAverageValueLine') as FormControl<boolean>;
   }
 
-  get startScaleAtZeroToControl(): UntypedFormControl {
-    return this.formMaster.get('startScaleAtZero') as UntypedFormControl;
+  get startScaleAtZeroToControl(): FormControl<boolean> {
+    return this.formMaster.get('startScaleAtZero') as FormControl<boolean>;
   }
 
-  get showTimeScaleToControl(): UntypedFormControl {
-    return this.formMaster.get('showTimeScale') as UntypedFormControl;
+  get showTimeScaleToControl(): FormControl<boolean> {
+    return this.formMaster.get('showTimeScale') as FormControl<boolean>;
   }
 
-  get showYScaleToControl(): UntypedFormControl {
-    return this.formMaster.get('showYScale') as UntypedFormControl;
+  get showYScaleToControl(): FormControl<boolean> {
+    return this.formMaster.get('showYScale') as FormControl<boolean>;
   }
 
-  get yScaleSuggestedMinToControl(): UntypedFormControl {
-    return this.formMaster.get('yScaleSuggestedMin') as UntypedFormControl;
+  get yScaleSuggestedMinToControl(): FormControl<number> {
+    return this.formMaster.get('yScaleSuggestedMin') as FormControl<number>;
   }
 
-  get yScaleMinToControl(): UntypedFormControl {
-    return this.formMaster.get('yScaleMin') as UntypedFormControl;
+  get yScaleMinToControl(): FormControl<number> {
+    return this.formMaster.get('yScaleMin') as FormControl<number>;
   }
 
-  get yScaleMaxToControl(): UntypedFormControl {
-    return this.formMaster.get('yScaleMax') as UntypedFormControl;
+  get yScaleMaxToControl(): FormControl<number> {
+    return this.formMaster.get('yScaleMax') as FormControl<number>;
   }
 
-  get datasetAverageArrayToControl(): UntypedFormControl {
-    return this.formMaster.get('datasetAverageArray') as UntypedFormControl;
+  get datasetAverageArrayToControl(): FormControl<string> {
+    return this.formMaster.get('datasetAverageArray') as FormControl<string>;
   }
 
-  get trackAgainstAverageToControl(): UntypedFormControl {
-    return this.formMaster.get('trackAgainstAverage') as UntypedFormControl;
+  get trackAgainstAverageToControl(): FormControl<boolean> {
+    return this.formMaster.get('trackAgainstAverage') as FormControl<boolean>;
   }
 
-  get showDataPointsToControl(): UntypedFormControl {
-    return this.formMaster.get('showDataPoints') as UntypedFormControl;
+  get showDataPointsToControl(): FormControl<boolean> {
+    return this.formMaster.get('showDataPoints') as FormControl<boolean>;
   }
 
-  get showAverageDataToControl(): UntypedFormControl {
-    return this.formMaster.get('showAverageData') as UntypedFormControl;
+  get showAverageDataToControl(): FormControl<boolean> {
+    return this.formMaster.get('showAverageData') as FormControl<boolean>;
   }
 
-  get numDecimalToControl(): UntypedFormControl {
-    return this.formMaster.get('numDecimal') as UntypedFormControl;
+  get numDecimalToControl(): FormControl<number> {
+    return this.formMaster.get('numDecimal') as FormControl<number>;
   }
 
-  get verticalChartToControl(): UntypedFormControl {
-    return this.formMaster.get('verticalChart') as UntypedFormControl;
+  get verticalChartToControl(): FormControl<boolean> {
+    return this.formMaster.get('verticalChart') as FormControl<boolean>;
   }
 
-  get inverseYAxisToControl(): UntypedFormControl {
-    return this.formMaster.get('inverseYAxis') as UntypedFormControl;
+  get inverseYAxisToControl(): FormControl<boolean> {
+    return this.formMaster.get('inverseYAxis') as FormControl<boolean>;
   }
 
-  get colorToControl(): UntypedFormControl {
-    return this.formMaster.get('color') as UntypedFormControl;
+  get colorToControl(): FormControl<string> {
+    return this.formMaster.get('color') as FormControl<string>;
   }
 
-  get dateFormatToControl(): UntypedFormControl {
-    return this.formMaster.get('dateFormat') as UntypedFormControl;
+  get dateFormatToControl(): FormControl<string> {
+    return this.formMaster.get('dateFormat') as FormControl<string>;
   }
 
   get multiChildCtrlsToControl(): UntypedFormArray {


### PR DESCRIPTION
Second slice of the #25 typed-forms migration (**Phase 1 — leaf input typing**). See the [plan](https://github.com/halos-org/skip/issues/25#issuecomment-4977756811).

## What

Retyped the form-control `@Input`s of the three leaf config children — `dataset-chart-options`, `display-chart-options`, `display-datetime` — from `UntypedFormControl` to Angular's typed `FormControl<T>`, and retyped the **29 feeder getters** in `root-modal-widget-config` that supply them to the matching `FormControl<T>`. Each `T` is derived from the corresponding `IWidgetSvcConfig` field (e.g. `color: string`, `numDecimal: number`, `filterSelfPaths: boolean`, `convertUnitTo: string | null`, `datachartAngleRange: 'signed' | 'direction' | null`). This gives compile-time value typing inside the leaf components; `.value` is now `T` instead of `any`.

`formMaster` itself stays untyped (that's Phase 3), so the getters still cast from it — but a child input and its feeder now share the same `FormControl<T>`, which `strictTemplates` enforces at the binding.

## Scope notes
- **`boolean-control-config` is NOT here** — it receives a `FormGroup` (IDynamicControl shape), not named FormControls, so it moves to Phase 2 (a plan refinement vs. the original grouping).
- `paths-options` untouched (Phase 0); its inputs stay `UntypedFormControl` and still accept the now-typed getters (`FormControl<T>` widens to `FormControl<any>`).
- No template changes — only TS types.

## One real fix surfaced by the stronger typing
Typing `datachartPath` as `FormControl<string | null>` made `.value` correctly `string | null`, which exposed that `dataset-chart-options` passed it to `getPathObject`/`getConversionsForPath` (which want `string`) without narrowing. Fixed by capturing the guarded value in a `const` so the truthy check narrows it to `string` (also de-duplicates three `this.datachartPath()` reads; behavior identical). This kept betterer at **182** (no strictNullChecks regression).

## Verification
Lint ✓ · `build:dev` (strictTemplates, the real gate) ✓ · betterer `182` held ✓ · all 4 modified components' specs pass (16/16). No behavior change.

Part of #25 (Phase 1). Does not close the issue.