### PR TITLE
Typed path/control factories, removing the last widget-config any (#25 Phase 2a)

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -102,11 +102,10 @@ exports[`strictNullChecks`] = {
       [72, 6, 5, "Type \'number | null\' is not assignable to type \'number\'.\\n  Type \'null\' is not assignable to type \'number\'.", "173263814"],
       [78, 6, 5, "Type \'number | null\' is not assignable to type \'number\'.\\n  Type \'null\' is not assignable to type \'number\'.", "183473191"]
     ],
-    "src/app/widget-config/boolean-control-config/boolean-control-config.component.ts:3033536446": [
-      [25, 40, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"],
-      [26, 39, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"],
-      [33, 4, 11, "Type \'{ label: string; value: string; }[]\' is not assignable to type \'never[]\'.\\n  Type \'{ label: string; value: string; }\' is not assignable to type \'never\'.", "3027418051"],
-      [37, 79, 34, "Object is possibly \'null\'.", "3704244789"]
+    "src/app/widget-config/boolean-control-config/boolean-control-config.component.ts:37806614": [
+      [26, 40, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"],
+      [27, 39, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"],
+      [34, 4, 11, "Type \'{ label: string; value: string; }[]\' is not assignable to type \'never[]\'.\\n  Type \'{ label: string; value: string; }\' is not assignable to type \'never\'.", "3027418051"]
     ],
     "src/app/widget-config/boolean-multicontrol-options/boolean-multicontrol-options.component.ts:1795746450": [
       [35, 9, 14, "Type \'null\' is not assignable to type \'UntypedFormGroup\'.", "3522031013"],
@@ -139,10 +138,8 @@ exports[`strictNullChecks`] = {
       [85, 26, 49, "Object is possibly \'null\'.", "3725617003"],
       [89, 26, 49, "Object is possibly \'null\'.", "3725617003"]
     ],
-    "src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.ts:1740588238": [
-      [80, 4, 11, "Type \'{ label: string; value: string; }[]\' is not assignable to type \'never[]\'.\\n  Type \'{ label: string; value: string; }\' is not assignable to type \'never\'.", "3027418051"],
-      [215, 8, 4, "Type \'null\' is not assignable to type \'UntypedFormControl\'.", "2087777580"],
-      [236, 4, 9, "\'ctrlLabel\' is possibly \'null\'.", "2892925034"]
+    "src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.ts:393658683": [
+      [85, 4, 11, "Type \'{ label: string; value: string; }[]\' is not assignable to type \'never[]\'.\\n  Type \'{ label: string; value: string; }\' is not assignable to type \'never\'.", "3027418051"]
     ],
     "src/app/widget-config/solar-charger-setup/solar-charger-setup.component.ts:3993417046": [
       [47, 48, 28, "Object is possibly \'undefined\'.", "758680035"],

--- a/src/app/core/interfaces/widgets-interface.ts
+++ b/src/app/core/interfaces/widgets-interface.ts
@@ -2,6 +2,7 @@ import { ITheme } from '../services/app-service';
 import { TValidSkUnits } from '../services/units.service';
 import { TScaleType } from './signalk-interfaces';
 import type { IElectricalCardModeConfig } from '../contracts/electrical-topology-card.contract';
+import type { FormControl } from '@angular/forms';
 
 /**
  * Ownership: Normalized widget app config interfaces.
@@ -546,6 +547,21 @@ export interface IDynamicControl {
   color: string;
   /** If the control should use numeric path instead of boolean */
   isNumeric: boolean;
+}
+
+/**
+ * Typed reactive-form control map for a single {@link IDynamicControl}, as produced by the
+ * widget-config multi-control factory. Each leaf control type is derived from the matching
+ * {@link IDynamicControl} field; controls are nullable because they are built by the untyped
+ * FormBuilder.
+ */
+export interface IDynamicControlGroup {
+  ctrlLabel: FormControl<IDynamicControl['ctrlLabel'] | null>;
+  type: FormControl<IDynamicControl['type'] | null>;
+  pathID: FormControl<IDynamicControl['pathID'] | null>;
+  color: FormControl<IDynamicControl['color'] | null>;
+  isNumeric: FormControl<IDynamicControl['isNumeric'] | null>;
+  value: FormControl<IDynamicControl['value']>;
 }
 
 /**

--- a/src/app/widget-config/boolean-control-config/boolean-control-config.component.ts
+++ b/src/app/widget-config/boolean-control-config/boolean-control-config.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, input, output, inject } from '@angular/core';
 import { AppService } from './../../core/services/app-service';
-import { UntypedFormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { IDynamicControlGroup } from './../../core/interfaces/widgets-interface';
 import { MatIconButton } from '@angular/material/button';
 import { MatOption } from '@angular/material/core';
 import { MatSelect } from '@angular/material/select';
@@ -22,7 +23,7 @@ export interface IDeleteEventObj {
 })
 export class BooleanControlConfigComponent implements OnInit {
   private app = inject(AppService);
-  readonly ctrlFormGroup = input.required<UntypedFormGroup>();
+  readonly ctrlFormGroup = input.required<FormGroup<IDynamicControlGroup>>();
   readonly controlIndex = input<number>(undefined);
   readonly arrayLength = input<number>(undefined);
   public readonly deleteCtrl = output<IDeleteEventObj>();
@@ -35,7 +36,7 @@ export class BooleanControlConfigComponent implements OnInit {
   }
 
   public deleteControl() {
-    const delEvent: IDeleteEventObj = {ctrlIndex: this.controlIndex(), pathID: this.ctrlFormGroup().get('pathID').value};
+    const delEvent: IDeleteEventObj = {ctrlIndex: this.controlIndex(), pathID: this.ctrlFormGroup().controls.pathID.value ?? ''};
     this.deleteCtrl.emit(delEvent);
   }
 

--- a/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.spec.ts
+++ b/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
+import { UntypedFormArray, UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { RootModalWidgetConfigComponent } from './root-modal-widget-config.component';
 import { IConversionPathList, UnitsService } from '../../core/services/units.service';
@@ -159,5 +159,102 @@ describe('ModalWidgetComponent title composition (#180)', () => {
   it('falls back to the base title when no widget name is provided', () => {
     const component = createComponentWithData({});
     expect(component.titleDialog).toBe('Widget Settings');
+  });
+});
+
+// Characterization of the two closed leaf shapes built reflectively by the widget-config
+// form generator: the multiChildCtrls control group and the array-mode path group. Locks the
+// exact control tree + required validators so the typed-factory refactor cannot drift them.
+describe('ModalWidgetComponent leaf control/path shapes (#25 Phase 2a)', () => {
+  const unitsServiceStub: Pick<UnitsService, 'getConversionsForPath'> = {
+    getConversionsForPath: (): IConversionPathList => ({ base: 'unitless', conversions: [] }),
+  };
+  const appServiceStub: Pick<AppService, 'configurableThemeColors'> = {
+    configurableThemeColors: []
+  };
+
+  // A realistic boolean/switch multi-control config: one IDynamicControl plus a matching
+  // IWidgetPath array entry (mirrors the shape BooleanMultiControlOptions.addCtrlGroup emits).
+  const multiControlConfig: IWidgetSvcConfig = {
+    displayName: 'Switch Panel Label',
+    multiChildCtrls: [
+      { ctrlLabel: 'Nav Lights', type: '1', pathID: 'ctrl-uuid-1', color: 'contrast', isNumeric: false, value: null }
+    ],
+    paths: [
+      {
+        description: null,
+        path: null,
+        pathID: 'ctrl-uuid-1',
+        source: 'default',
+        pathType: 'boolean',
+        zonesOnlyPaths: false,
+        supportsPut: true,
+        isPathConfigurable: true,
+        showPathSkUnitsFilter: false,
+        pathSkUnitsFilter: null,
+        convertUnitTo: null,
+        sampleTime: 500
+      }
+    ]
+  };
+
+  beforeEach(() => TestBed.resetTestingModule());
+
+  function buildForm(data: IWidgetSvcConfig): RootModalWidgetConfigComponent {
+    TestBed.configureTestingModule({
+      imports: [RootModalWidgetConfigComponent],
+      providers: [
+        { provide: UnitsService, useValue: unitsServiceStub },
+        { provide: AppService, useValue: appServiceStub },
+        { provide: MAT_DIALOG_DATA, useValue: data },
+        { provide: MatDialogRef, useValue: { close: vi.fn() } },
+      ],
+    });
+    ensureTestIconsReady();
+    const component = TestBed.createComponent(RootModalWidgetConfigComponent).componentInstance;
+    component.ngOnInit();
+    return component;
+  }
+
+  it('builds each multiChildCtrls entry as a group with a required ctrlLabel and the other control keys', () => {
+    const component = buildForm(multiControlConfig);
+    const multiArray = component.formMaster.get('multiChildCtrls') as UntypedFormArray;
+    expect(multiArray.length).toBe(1);
+
+    const ctrlGroup = multiArray.at(0) as UntypedFormGroup;
+    const ctrlLabel = ctrlGroup.get('ctrlLabel') as UntypedFormControl;
+    expect(ctrlLabel.hasValidator(Validators.required)).toBe(true);
+    ctrlLabel.setValue('');
+    expect(ctrlLabel.hasError('required')).toBe(true);
+
+    ['type', 'pathID', 'color', 'isNumeric', 'value'].forEach(key => {
+      expect(ctrlGroup.get(key)).not.toBeNull();
+    });
+  });
+
+  it('builds each paths-array entry with source/sampleTime required and other keys plain', () => {
+    const component = buildForm(multiControlConfig);
+    const pathsArray = component.formMaster.get('paths') as UntypedFormArray;
+    expect(pathsArray.length).toBe(1);
+
+    const pathGroup = pathsArray.at(0) as UntypedFormGroup;
+    ['description', 'path', 'source', 'pathType', 'zonesOnlyPaths', 'supportsPut', 'isPathConfigurable', 'showPathSkUnitsFilter', 'pathSkUnitsFilter', 'convertUnitTo', 'sampleTime'].forEach(key => {
+      expect(pathGroup.get(key)).not.toBeNull();
+    });
+
+    const source = pathGroup.get('source') as UntypedFormControl;
+    const sampleTime = pathGroup.get('sampleTime') as UntypedFormControl;
+    const path = pathGroup.get('path') as UntypedFormControl;
+
+    expect(source.hasValidator(Validators.required)).toBe(true);
+    expect(sampleTime.hasValidator(Validators.required)).toBe(true);
+    expect(path.hasValidator(Validators.required)).toBe(false);
+
+    source.setValue(null);
+    sampleTime.setValue(null);
+    path.setValue(null);
+    expect(source.hasError('required')).toBe(true);
+    expect(sampleTime.hasError('required')).toBe(true);
+    expect(path.hasError('required')).toBe(false);
   });
 });

--- a/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.ts
+++ b/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, inject, signal, DestroyRef } from '@angular/core';
-import { UntypedFormGroup, UntypedFormControl, FormControl, Validators, UntypedFormBuilder, UntypedFormArray, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { UntypedFormGroup, UntypedFormControl, FormControl, FormGroup, Validators, UntypedFormBuilder, UntypedFormArray, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatDialogRef, MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
@@ -15,7 +15,7 @@ import { DisplayChartOptionsComponent } from '../display-chart-options/display-c
 import { DatasetChartOptionsComponent } from '../dataset-chart-options/dataset-chart-options.component';
 import { IUnitGroup, UnitsService } from '../../core/services/units.service';
 import { AppService } from '../../core/services/app-service';
-import type { ElectricalTrackedDevice, IDynamicControl, IWidgetPath, IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
+import type { ElectricalTrackedDevice, IDynamicControl, IDynamicControlGroup, IWidgetPath, IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
 import { PathsOptionsComponent } from '../paths-options/paths-options.component';
 import { IDeleteEventObj } from '../boolean-control-config/boolean-control-config.component';
 import { DisplayDatetimeComponent } from '../display-datetime/display-datetime.component';
@@ -26,6 +26,11 @@ import { SolarChargerSetupComponent } from '../solar-charger-setup/solar-charger
 import { ElectricalFamilySetupComponent } from '../electrical-family-setup/electrical-family-setup.component';
 import { VideoCameraSetupComponent } from '../video-camera-setup/video-camera-setup.component';
 import { MatTabsModule } from '@angular/material/tabs';
+
+/** Typed reactive-form control map for an array-mode {@link IWidgetPath}: one control per field. */
+type IWidgetPathControls = {
+  [K in keyof IWidgetPath]: FormControl<IWidgetPath[K] | null>;
+};
 
 @Component({
   selector: 'modal-widget-config',
@@ -202,39 +207,30 @@ export class RootModalWidgetConfigComponent implements OnInit {
     return groups;
   }
 
-  private generatePathArray(pathKey: string, formData: IWidgetPath): UntypedFormGroup {
+  private generatePathArray(pathKey: string, formData: IWidgetPath): FormGroup<IWidgetPathControls> {
     // use addControl for formGroup and addControl for formControl
     const fg = new UntypedFormGroup({});
-    Object.keys(formData).forEach(key => {
+    (Object.keys(formData) as (keyof IWidgetPath)[]).forEach(key => {
       fg.addControl(key, this.generatePathFields(key, formData[key]));
     });
-    return fg;
+    return fg as FormGroup<IWidgetPathControls>;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private generatePathFields(key: string, value: any): UntypedFormControl {
-    let ctrl: UntypedFormControl = null;
-
+  private generatePathFields(key: keyof IWidgetPath, value: IWidgetPath[keyof IWidgetPath]): FormControl<IWidgetPath[keyof IWidgetPath] | null> {
     switch (key) {
-      case "path": ctrl = new UntypedFormControl(value);
-        break;
+      case "path": return new FormControl(value);
 
-      case "source": ctrl = new UntypedFormControl(value, Validators.required);
-        break;
+      case "source": return new FormControl(value, Validators.required);
 
-      case "sampleTime": ctrl = new UntypedFormControl(value, Validators.required);
-        break;
+      case "sampleTime": return new FormControl(value, Validators.required);
 
-      default: ctrl = new UntypedFormControl(value);
-        break;
+      default: return new FormControl(value);
     }
-    return ctrl;
   }
 
-  private generateCtrlArray(formData: IDynamicControl): UntypedFormGroup {
-    const fg = this.fb.group(formData);
-    const ctrlLabel = fg.get('ctrlLabel');
-    ctrlLabel.addValidators(Validators.required);
+  private generateCtrlArray(formData: IDynamicControl): FormGroup<IDynamicControlGroup> {
+    const fg = this.fb.group(formData) as FormGroup<IDynamicControlGroup>;
+    fg.controls.ctrlLabel.addValidators(Validators.required);
     return fg;
   }
 


### PR DESCRIPTION
Third slice of the #25 typed-forms migration (**Phase 2a — typed leaf factories**). See the [plan](https://github.com/halos-org/skip/issues/25#issuecomment-4977756811) and the [Phase 2 split note](https://github.com/halos-org/skip/issues/25#issuecomment-4978351083).

## What

Typed the two genuinely-closed, single-behavior leaf shapes the reflective builder constructs:
- **`IWidgetPath`** (array-mode paths): `generatePathArray` + `generatePathFields` now build a typed `FormGroup<IWidgetPathControls>` with a `FormControl<T>` per field, `source`/`sampleTime` required, others plain. **This removes the last `any` in the widget-config layer** (`generatePathFields`'s `value: any` + its eslint-disable — #25's second `any`).
- **`IDynamicControl`** (multi-control entries): `generateCtrlArray` returns a typed `FormGroup<IDynamicControlGroup>` with `ctrlLabel` required. The shared `IDynamicControlGroup` control-map is exported from `widgets-interface.ts`.
- **`boolean-control-config`** is now fully typed — its `ctrlFormGroup` input is `FormGroup<IDynamicControlGroup>`. The parent binding needed no change (`UntypedFormGroup` = `FormGroup<any>` assigns cleanly).

## Byte-identical, guarded by a characterization test
The factories are `as`-typed views over the **exact same dynamically-built control trees** — same keys, validators, `disable()` behavior, and initial values (`new FormControl(value)` is runtime-identical to `new UntypedFormControl(value)`, only the static type differs). A new **characterization test** (`test(widget-config): lock leaf control/path shapes`) locks both shapes against drift: it asserts the multi-control `ctrlLabel` is required, and that a paths-array element makes `source`/`sampleTime` required but `path` not. It passes on the pre-refactor code and after.

## Deliberately deferred to Phase 2b
The recursion-built shapes (gauge/displayScale/autopilot/ais/electrical family) and record-mode path unification — record-mode paths intentionally lack the `source`/`sampleTime` required validators that array-mode applies, so unifying them is behavior-sensitive and gets its own PR.

## Verification
No `any` remains in `widget-config` · lint ✓ · `build:dev` (strictTemplates) ✓ · **betterer 182 → 179** (the stronger typing let three latent strictNullChecks issues be removed) · the characterization test + `boolean-control-config` + `boolean-multicontrol-options` specs pass.

Part of #25 (Phase 2a). Does not close the issue.