### PR TITLE
Make bootstrap Retry / recovery reloads offline-resilient (reachability-gated) (#272)

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -5,8 +5,8 @@
 //
 exports[`strictNullChecks`] = {
   value: `{
-    "src/app/app.component.ts:281943337": [
-      [111, 19, 25, "Object is possibly \'undefined\'.", "255143637"]
+    "src/app/app.component.ts:1479801840": [
+      [113, 19, 25, "Object is possibly \'undefined\'.", "255143637"]
     ],
     "src/app/core/components/dashboard/dashboard.component.ts:3995263170": [
       [121, 12, 22, "Object is possibly \'undefined\'.", "2187394131"],

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -10,7 +10,7 @@ import { uiEventService } from './core/services/uiEvent.service';
 import { AppService } from './core/services/app-service';
 import { ChromeVisibilityService } from './core/services/chrome-visibility.service';
 import { ToastService } from './core/services/toast.service';
-import { SettingsService } from './core/services/settings.service';
+import { ReloadService } from './core/services/reload.service';
 
 // Access the component's private surface without widening the class API.
 interface AppComponentHotkeyApi {
@@ -52,6 +52,7 @@ describe('AppComponent', () => {
     pulsePeek: ReturnType<typeof vi.fn>;
   };
   let toast: { show: ReturnType<typeof vi.fn> };
+  let reloadService: { reload: ReturnType<typeof vi.fn> };
 
   beforeEach(async () => {
     dashboard = {
@@ -72,6 +73,7 @@ describe('AppComponent', () => {
     appService = { toggleNightMode: vi.fn() };
     chrome = { revealed: signal(false), reveal: vi.fn(), hide: vi.fn(), pulsePeek: vi.fn() };
     toast = { show: vi.fn().mockReturnValue({ onAction: () => new Subject() }) };
+    reloadService = { reload: vi.fn() };
     appNetworkInitServiceStub.bootstrapIssue$.next({ reason: 'none' });
     appNetworkInitServiceStub.bootstrapStatus$.next('ready');
 
@@ -84,6 +86,7 @@ describe('AppComponent', () => {
         { provide: AppService, useValue: appService },
         { provide: ChromeVisibilityService, useValue: chrome },
         { provide: ToastService, useValue: toast },
+        { provide: ReloadService, useValue: reloadService },
       ],
     }).compileComponents();
   });
@@ -124,16 +127,15 @@ describe('AppComponent', () => {
       expect(toast.show).not.toHaveBeenCalledWith(expect.any(String), 0, true, 'warn', 'Retry');
     });
 
-    it('reloads the app via the settings seam when Retry is invoked', () => {
+    it('routes Retry through the reachability-gated reload seam', () => {
       const action$ = new Subject<void>();
       toast.show.mockReturnValue({ onAction: () => action$ });
-      const reloadSpy = vi.spyOn(TestBed.inject(SettingsService), 'reloadApp').mockImplementation(() => undefined);
       create();
       appNetworkInitServiceStub.bootstrapIssue$.next({ reason: 'network-unreachable' });
       TestBed.tick();
       action$.next();
 
-      expect(reloadSpy).toHaveBeenCalledTimes(1);
+      expect(reloadService.reload).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -21,6 +21,7 @@ import { NotificationsService } from './core/services/notifications.service';
 import { ConfigurationUpgradeService } from './core/services/configuration-upgrade.service';
 import { RemoteDashboardsService } from './core/services/remote-dashboards.service';
 import { ToastService } from './core/services/toast.service';
+import { ReloadService } from './core/services/reload.service';
 import { AppNetworkInitService, IBootstrapIssue } from './core/services/app-initNetwork.service';
 import { SsoRedirectService } from './core/services/sso-redirect.service';
 import { NotificationOverlayService } from './core/services/notification-overlay.service';
@@ -47,6 +48,7 @@ export class AppComponent implements AfterViewInit, OnDestroy {
   private readonly _dashboard = inject(DashboardService);
   private readonly _remoteControl = inject(RemoteDashboardsService);
   private readonly toast = inject(ToastService);
+  private readonly _reload = inject(ReloadService);
   private readonly _notifications = inject(NotificationsService);
   private readonly _uiEvent = inject(uiEventService);
   private readonly _app = inject(AppService);
@@ -190,7 +192,9 @@ export class AppComponent implements AfterViewInit, OnDestroy {
     });
 
     // Bootstrap could not reach or load from the Signal K server: keep the user in place (no
-    // redirect to the legacy connectivity page, #190) and offer a persistent Retry that reloads.
+    // redirect to the legacy connectivity page, #190) and offer a persistent Retry. The reload is
+    // reachability-gated so retrying against a still-down server keeps the degraded shell instead
+    // of navigating into the browser's error page (#272).
     effect(() => {
       const issue = this.bootstrapIssue();
       if ((issue.reason !== 'network-unreachable' && issue.reason !== 'unknown') || this.connectionErrorPromptShown) {
@@ -203,7 +207,7 @@ export class AppComponent implements AfterViewInit, OnDestroy {
       const ref = this.toast.show(message, 0, true, 'warn', 'Retry');
       ref.onAction()
         .pipe(takeUntilDestroyed(this._destroyRef))
-        .subscribe(() => this.settings.reloadApp());
+        .subscribe(() => { void this._reload.reload(); });
     });
   }
 

--- a/src/app/core/services/reload.service.spec.ts
+++ b/src/app/core/services/reload.service.spec.ts
@@ -1,0 +1,118 @@
+import { TestBed } from '@angular/core/testing';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Subject } from 'rxjs';
+import { ReloadService } from './reload.service';
+import { ToastService } from './toast.service';
+
+// Exposes the private raw-reload seam so a spec can assert the reload branch was taken without the
+// hard navigation actually running (it is a no-op under __KIP_TEST__ regardless).
+interface ReloadServiceInternals {
+  performReload(): void;
+}
+
+// Drain the microtask queue so the async probe-and-branch chain settles.
+async function flush(): Promise<void> {
+  for (let i = 0; i < 6; i++) {
+    await Promise.resolve();
+  }
+}
+
+describe('ReloadService', () => {
+  let service: ReloadService;
+  let toastShow: ReturnType<typeof vi.fn>;
+  let action$: Subject<void>;
+
+  beforeEach(() => {
+    action$ = new Subject<void>();
+    toastShow = vi.fn().mockReturnValue({ onAction: () => action$ });
+    TestBed.configureTestingModule({
+      providers: [{ provide: ToastService, useValue: { show: toastShow } }]
+    });
+    service = TestBed.inject(ReloadService);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function spyReload() {
+    return vi
+      .spyOn(service as unknown as ReloadServiceInternals, 'performReload')
+      .mockImplementation(() => undefined);
+  }
+
+  it('reloads when the probe resolves with a 2xx response', async () => {
+    vi.spyOn(window, 'fetch').mockResolvedValue({ status: 200 } as Response);
+    const reloadSpy = spyReload();
+
+    await service.reload();
+
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+    expect(toastShow).not.toHaveBeenCalled();
+  });
+
+  it('treats a 4xx response as reachable and reloads (Signal K itself answered)', async () => {
+    // Reachability is "Signal K answered", not "the request succeeded": a 401/404 from SK still
+    // means the reload will render, so it takes the reload branch. Only 5xx (proxy/backend-down)
+    // and network errors are unreachable.
+    vi.spyOn(window, 'fetch').mockResolvedValue({ status: 401 } as Response);
+    const reloadSpy = spyReload();
+
+    await service.reload();
+
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+    expect(toastShow).not.toHaveBeenCalled();
+  });
+
+  it('treats a 502 (proxy up, Signal K backend down) as UNREACHABLE — no reload, shows Retry toast', async () => {
+    // Skip is served through Traefik: with SK stopped the proxy answers 502 (confirmed on the boat).
+    // "Any completed response = reachable" would reload straight into the 502 page — the exact
+    // dead-end this guards against.
+    vi.spyOn(window, 'fetch').mockResolvedValue({ status: 502 } as Response);
+    const reloadSpy = spyReload();
+
+    await service.reload();
+
+    expect(reloadSpy).not.toHaveBeenCalled();
+    expect(toastShow).toHaveBeenCalledTimes(1);
+    expect(toastShow).toHaveBeenCalledWith(expect.any(String), 0, true, 'warn', 'Retry');
+  });
+
+  it('does not reload on a network error; shows a persistent warn Retry toast', async () => {
+    vi.spyOn(window, 'fetch').mockRejectedValue(new TypeError('Failed to fetch'));
+    const reloadSpy = spyReload();
+
+    await service.reload();
+
+    expect(reloadSpy).not.toHaveBeenCalled();
+    expect(toastShow).toHaveBeenCalledTimes(1);
+    expect(toastShow).toHaveBeenCalledWith(expect.any(String), 0, true, 'warn', 'Retry');
+  });
+
+  it('does not reload when the probe aborts (timeout)', async () => {
+    vi.spyOn(window, 'fetch').mockRejectedValue(new DOMException('Aborted', 'AbortError'));
+    const reloadSpy = spyReload();
+
+    await service.reload();
+
+    expect(reloadSpy).not.toHaveBeenCalled();
+    expect(toastShow).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-runs the gated reload when the Retry toast action fires (unbounded, user-driven retry)', async () => {
+    const fetchSpy = vi.spyOn(window, 'fetch').mockRejectedValue(new TypeError('offline'));
+    const reloadSpy = spyReload();
+
+    await service.reload();
+    expect(toastShow).toHaveBeenCalledTimes(1);
+    expect(reloadSpy).not.toHaveBeenCalled();
+
+    // Server is back; the user taps Retry on the persistent toast — the same gated reload re-runs
+    // and now takes the reload branch.
+    fetchSpy.mockResolvedValue({ status: 200 } as Response);
+    action$.next();
+    await flush();
+
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/core/services/reload.service.ts
+++ b/src/app/core/services/reload.service.ts
@@ -1,0 +1,79 @@
+import { Injectable, Injector, inject } from '@angular/core';
+import { ToastService } from './toast.service';
+
+/**
+ * Reachability-gated app reload.
+ *
+ * Recovery flows (the bootstrap "Retry", a connection/profile change, a config reset) recover by
+ * reloading the app — SettingsService.reloadApp() -> location.replace('./'). When the problem being
+ * recovered from is that the Signal K server serving index.html is unreachable, that navigation
+ * replaces the working (degraded) shell with the browser's "site can't be reached" page — strictly
+ * worse than staying put. This service probes the server first: it reloads only when the server
+ * answers, and otherwise keeps the shell alive and offers an unbounded, user-driven Retry.
+ */
+@Injectable({ providedIn: 'root' })
+export class ReloadService {
+  // ToastService injects SettingsService, which injects this service. Resolving the toast lazily —
+  // only when a reload is actually declined — keeps that back-edge out of the construction graph so
+  // the DI cycle never forms.
+  private readonly injector = inject(Injector);
+
+  // Same-origin app root, mirroring the target of reloadApp()'s location.replace('./').
+  private readonly probeUrl = './';
+  // Short enough that Retry never feels hung, long enough to tolerate a slow-but-alive server.
+  private readonly probeTimeoutMs = 4000;
+
+  /**
+   * Reload the app only if the server is reachable; otherwise keep the shell and show a persistent
+   * Retry toast that re-runs this same gated reload (so recovery never leaves the app).
+   */
+  public async reload(): Promise<void> {
+    if (await this.isServerReachable()) {
+      this.performReload();
+    } else {
+      this.showUnreachableToast();
+    }
+  }
+
+  private async isServerReachable(): Promise<boolean> {
+    const abortController = new AbortController();
+    const timeoutId = setTimeout(() => abortController.abort(), this.probeTimeoutMs);
+
+    try {
+      // cache: 'no-store' biases to a real network round-trip, mirroring the navigation reloadApp()
+      // performs, so a stale cached copy can't report a down server as reachable.
+      const response = await fetch(this.probeUrl, { method: 'GET', cache: 'no-store', signal: abortController.signal });
+      // Skip is served through a reverse proxy (Traefik). When the Signal K backend is down but the
+      // proxy is up, the proxy answers 502/503/504 — so "any completed response" would wrongly call
+      // the server reachable and reload straight into the proxy's error page (the exact dead-end this
+      // guards against; confirmed on the boat: SK stopped -> 502 through Traefik). Treat 5xx as
+      // unreachable; a 2xx/3xx/4xx means Signal K itself answered, so the reload will render. A
+      // network error, timeout, or DNS failure (the catch) is also unreachable.
+      return response.status < 500;
+    } catch {
+      return false;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  private performReload(): void {
+    // Prevent hard navigation under the unit-test runner (it tears down the test page).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if ((window as any).__KIP_TEST__) {
+      return;
+    }
+    location.replace('./');
+  }
+
+  private showUnreachableToast(): void {
+    const ref = this.injector.get(ToastService).show(
+      'Signal K server is still unreachable. Retry when the connection is restored.',
+      0,
+      true,
+      'warn',
+      'Retry'
+    );
+    ref.onAction().subscribe(() => { void this.reload(); });
+  }
+}

--- a/src/app/core/services/settings.service.spec.ts
+++ b/src/app/core/services/settings.service.spec.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { SettingsService } from './settings.service';
 import { StorageService } from './storage.service';
+import { ReloadService } from './reload.service';
 import { ensureLocalStorage } from '../../../test-helpers/local-storage.test-helper';
 import { DefaultAppConfig, DefaultConnectionConfig, DefaultThemeConfig } from '../../../default-config/config.blank.const';
 import { IAppConfig, IConfig, IConnectionConfig, INotificationConfig, IThemeConfig } from '../interfaces/app-settings.interfaces';
@@ -132,8 +133,12 @@ function createService(opts?: SeedOpts): SettingsService {
     seedConfig(opts);
   }
   // Provide both services in the module so transitive deps resolve to the global stubs
-  // (AuthenticationService / SignalKConnectionService) rather than the real root services.
-  TestBed.configureTestingModule({ providers: [SettingsService, StorageService] });
+  // (AuthenticationService / SignalKConnectionService) rather than the real root services. The
+  // ReloadService fake keeps the reconfigure/reset reload seam from firing a real reachability
+  // probe (network fetch) during these tests; tests that care spy on its reload().
+  TestBed.configureTestingModule({
+    providers: [SettingsService, StorageService, { provide: ReloadService, useValue: { reload: () => Promise.resolve() } }]
+  });
   return TestBed.inject(SettingsService);
 }
 
@@ -554,7 +559,7 @@ describe('SettingsService — resetSettings (characterization)', () => {
     const storage = TestBed.inject(StorageService);
     storage.storageServiceReady$.next(true);
     const setSpy = vi.spyOn(storage, 'setConfig').mockResolvedValue(null);
-    vi.spyOn(service, 'reloadApp').mockImplementation(() => undefined);
+    vi.spyOn(TestBed.inject(ReloadService), 'reload');
 
     service.resetSettings();
 
@@ -575,7 +580,7 @@ describe('SettingsService — resetSettings (characterization)', () => {
     vi.spyOn(storage, 'setConfig').mockReturnValue(
       new Promise((resolve) => { resolveSave = resolve; })
     );
-    const reloadSpy = vi.spyOn(service, 'reloadApp').mockImplementation(() => undefined);
+    const reloadSpy = vi.spyOn(TestBed.inject(ReloadService), 'reload');
 
     service.resetSettings();
     await Promise.resolve();
@@ -594,7 +599,7 @@ describe('SettingsService — resetSettings (characterization)', () => {
     const storage = TestBed.inject(StorageService);
     storage.storageServiceReady$.next(true);
     vi.spyOn(storage, 'setConfig').mockRejectedValue(new Error('network down'));
-    const reloadSpy = vi.spyOn(service, 'reloadApp').mockImplementation(() => undefined);
+    const reloadSpy = vi.spyOn(TestBed.inject(ReloadService), 'reload');
     const snack = TestBed.inject(MatSnackBar);
     const snackSpy = vi.spyOn(snack, 'open').mockImplementation(() => undefined as never);
 
@@ -613,7 +618,7 @@ describe('SettingsService — resetSettings (characterization)', () => {
     const storage = TestBed.inject(StorageService);
     storage.storageServiceReady$.next(false);
     const setSpy = vi.spyOn(storage, 'setConfig').mockResolvedValue(null);
-    const reloadSpy = vi.spyOn(service, 'reloadApp').mockImplementation(() => undefined);
+    const reloadSpy = vi.spyOn(TestBed.inject(ReloadService), 'reload');
     const snack = TestBed.inject(MatSnackBar);
     const snackSpy = vi.spyOn(snack, 'open').mockImplementation(() => undefined as never);
 
@@ -642,7 +647,7 @@ describe('SettingsService — getDefault* localStorage side effects (characteriz
     const storage = TestBed.inject(StorageService);
     storage.storageServiceReady$.next(true);
     vi.spyOn(storage, 'setConfig').mockResolvedValue(null);
-    vi.spyOn(service, 'reloadApp').mockImplementation(() => undefined);
+    vi.spyOn(TestBed.inject(ReloadService), 'reload');
 
     service.resetSettings();
 

--- a/src/app/core/services/settings.service.ts
+++ b/src/app/core/services/settings.service.ts
@@ -14,6 +14,7 @@ import { DefaultNotificationConfig } from '../../../default-config/config.blank.
 import { MatSnackBar } from '@angular/material/snack-bar';
 
 import { StorageService, TConfigObjectType } from './storage.service';
+import { ReloadService } from './reload.service';
 import { Dashboard } from './dashboard.service';
 import { LOCAL_CONFIG_KEYS, localConfigKey } from '../constants/config-storage.const';
 import { REMOTE_CONFIG_FILE_VERSION, LATEST_APP_CONFIG_VERSION, CONNECTION_CONFIG_VERSION, SUPPORTED_CONNECTION_CONFIG_VERSIONS } from '../constants/config-versions.const';
@@ -26,6 +27,7 @@ const defaultTheme = '';
 export class SettingsService {
   private readonly storage = inject(StorageService);
   private readonly snackBar = inject(MatSnackBar);
+  private readonly _reload = inject(ReloadService);
 
   // Source-of-truth signals for the profile/app-scope settings and the per-device identity.
   private readonly _unitDefaults = signal<IUnitDefaults>({});
@@ -154,7 +156,7 @@ export class SettingsService {
 
   public resetConnection() {
     localStorage.setItem(LOCAL_CONFIG_KEYS.connectionConfig, JSON.stringify(this.getDefaultConnectionConfig()));
-    this.reloadApp();
+    void this._reload.reload();
   }
 
   private checkConfigUpgradeRequired(isLocalStorageConfig: boolean, storageVersion?: number): void {
@@ -321,7 +323,7 @@ export class SettingsService {
     this.sharedConfigName = name;
     this.storage.sharedConfigName = name; // keep the storage write-path slot name coherent
     this.saveConnectionConfigToLocalStorage();
-    this.reloadApp();
+    void this._reload.reload();
   }
 
   public get KipUUID(): string {
@@ -453,7 +455,7 @@ export class SettingsService {
     this.storage.setConfig('user', this.sharedConfigName, newDefaultConfig)
       .then(() => {
         console.log("[AppSettings Service] Replaced server config name: " + this.sharedConfigName + ", with default configuration values");
-        this.reloadApp();
+        void this._reload.reload();
       })
       .catch(error => {
         console.error("[AppSettings Service] Error replacing server config name: " + this.sharedConfigName + ", with default configuration values", error);


### PR DESCRIPTION
Fixes #272. See the [design](https://github.com/halos-org/skip/issues/272#issuecomment-4978130357).

## Problem
The bootstrap "Retry" toast and the app's reconfig/reset recoveries reload via `location.replace('./')`. On the exact scenario Retry targets — SK unreachable at startup — that reload re-fetches `index.html` from the down server; with no service worker, the browser replaces the working degraded shell with its "site can't be reached" page. Strictly worse than staying put.

## Fix — reachability-gated recovery
New `ReloadService.reload()` probes the server (same-origin `GET './'`, 4 s timeout, `no-store`) **before** reloading: reachable → the normal `location.replace('./')`; unreachable → keep the degraded shell and show a persistent 'warn' Retry toast that re-runs the gated reload (unbounded, user-driven, never leaves the app). `__KIP_TEST__` no-op preserved so specs never navigate.

Wired the bootstrap Retry toast and the three interactive `SettingsService` reloads (`resetConnection`, `setActiveProfile`, `resetSettings`) through the seam. **`reloadApp()` itself is unchanged** (raw `location.replace`) — the four config-upgrade completion reloads keep calling it, because they rely on the reload destroying the document to tear down their blocking `upgrading()` overlay; gating them would strand the overlay. Manual retry only; no service worker, no in-place re-hydration (both rejected in the design, with reasons).

## ⚠️ Design correction caught by on-boat testing
The original probe treated **any** HTTP response (incl. 4xx/5xx) as reachable. **On the boat, with SK stopped, Traefik (the reverse proxy that fronts SK at `:4430`) returns `502` — not a connection failure.** So "any response = reachable" would classify a down SK as reachable and reload straight into the 502 page — the very dead-end this guards against. Verified live:

| Signal K | `GET /@halos-org/skip/` via Traefik |
|---|---|
| up | **200** |
| stopped | **502** |

Fix: the probe treats **5xx as unreachable** (proxy/backend-down) while a 2xx/3xx/4xx means SK itself answered and the reload will render. This is the load-bearing behavior unit tests cannot cover (they mock `fetch`; they can't see Traefik).

## Verification
- **On-boat:** SK up → probe 200 (reachable); SK stopped → probe 502 (now correctly unreachable). SK restarted cleanly (healthy in ~3 s).
- Lint ✓ · `build:dev` ✓ · betterer 182 held ✓ · specs: `reload.service` (incl. explicit 401→reachable / 502→unreachable / network-error→toast + retry-loop), `app.component`, `settings.service` — all pass.

## Follow-up (not here)
`signalk.component.ts`'s own `location.reload()` (cross-origin connect flow) is the same failure class but a separate, lower-priority case — noted in the design, deferred.