### PR TITLE
fix(gen-mcp-schema): resolve widgets via lazy-loader map, regen artifact, gate drift in CI

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -8,3 +8,10 @@ tag = False
 [bumpversion:file:package.json]
 search = "version": "{current_version}"
 replace = "version": "{new_version}"
+
+# The generated MCP schema artifact stamps the app version as meta.kipVersion,
+# and test:mcp-schema gates it against drift in CI. Keep it in step on a bump so
+# a version change alone never fails CI (no schema regen needed).
+[bumpversion:file:src/assets/kip-dashboard-schema.json]
+search = "kipVersion": "{current_version}"
+replace = "kipVersion": "{new_version}"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "snc": "tsc -p tsconfig.strict.json",
     "betterer": "betterer --tsconfig tsconfig.betterer.json",
     "betterer:ci": "betterer ci --tsconfig tsconfig.betterer.json",
-    "ci": "npm run lint && npm run betterer:ci && npm run test:headless && npm run test:plugin",
+    "ci": "npm run lint && npm run betterer:ci && npm run test:headless && npm run test:plugin && npm run test:mcp-schema",
     "prepublishOnly": "npm run build:prod",
     "dev": "ng serve --configuration=dev --serve-path=/@halos-org/skip/",
     "build:dev": "ng build --configuration=dev",

--- a/src/assets/kip-dashboard-schema.json
+++ b/src/assets/kip-dashboard-schema.json
@@ -548,6 +548,29 @@
   "widgets": [
     {
       "bindingKind": "none",
+      "category": "Gauge",
+      "componentClassName": "WidgetAcComponent",
+      "defaultConfig": {
+        "ac": {
+          "optionsById": {},
+          "trackedDevices": []
+        },
+        "color": "contrast",
+        "ignoreZones": false
+      },
+      "defaultHeight": 6,
+      "defaultWidth": 6,
+      "description": "Monitor AC bus and line-level loads with real-time voltage, current, frequency, and power metrics.",
+      "icon": "acMonitor",
+      "minHeight": 2,
+      "minWidth": 2,
+      "name": "AC Monitor",
+      "pathSlots": [],
+      "requiredPlugins": [],
+      "selector": "widget-ac"
+    },
+    {
+      "bindingKind": "none",
       "category": "Component",
       "componentClassName": "WidgetAisRadarComponent",
       "defaultConfig": {
@@ -594,12 +617,35 @@
     },
     {
       "bindingKind": "none",
+      "category": "Gauge",
+      "componentClassName": "WidgetAlternatorComponent",
+      "defaultConfig": {
+        "alternator": {
+          "optionsById": {},
+          "trackedDevices": []
+        },
+        "color": "contrast",
+        "ignoreZones": false
+      },
+      "defaultHeight": 6,
+      "defaultWidth": 6,
+      "description": "Monitor alternator output and charging performance with voltage, current, power, revolutions and temperature metrics.",
+      "icon": "alternator",
+      "minHeight": 2,
+      "minWidth": 2,
+      "name": "Alternator",
+      "pathSlots": [],
+      "requiredPlugins": [],
+      "selector": "widget-alternator"
+    },
+    {
+      "bindingKind": "none",
       "category": "Component",
       "componentClassName": "WidgetAnchorAlarmComponent",
       "defaultConfig": {},
       "defaultHeight": 14,
       "defaultWidth": 6,
-      "description": "Monitors your anchor position and triggers an alarm if you drift outside a configured radius (anchor drag). Set the anchor point, watch radius, and alarm behavior (sound/notification) in the widget config. Requires internet connectivity to view map.",
+      "description": "Classic anchor monitoring focused on reliable server-side drift detection: configurable alarm radius, automatic radius calculation from rode/depth, intelligent anchor-position detection, position history, multiple warning/alarm types, GPS bow-offset compensation, plus REST API and Signal K PUT integration.",
       "icon": "anchorWatch",
       "minHeight": 8,
       "minWidth": 6,
@@ -1011,6 +1057,7 @@
       "defaultConfig": {
         "color": "contrast",
         "convertUnitTo": null,
+        "datachartAngleRange": null,
         "datachartPath": null,
         "datachartSource": null,
         "datasetAverageArray": "sma",
@@ -1032,19 +1079,15 @@
         "startScaleAtZero": false,
         "timeScale": "minute",
         "trackAgainstAverage": false,
-        "verticalChart": false,
-        "yScaleMax": null,
-        "yScaleMin": null,
-        "yScaleSuggestedMax": null,
-        "yScaleSuggestedMin": null
+        "verticalChart": false
       },
       "defaultHeight": 6,
       "defaultWidth": 6,
-      "description": "Visualizes data on a real-time chart with multiple preconfigured series including actuals, SMA and period overall averages and Min/Max. Requires the KIP Dataset to be configured.",
+      "description": "Visualizes data on a real-time plot with multiple preconfigured series including actuals, SMA and period overall averages and Min/Max. Requires the KIP Dataset to be configured.",
       "icon": "datachartWidget",
       "minHeight": 3,
       "minWidth": 2,
-      "name": "Realtime Data Chart",
+      "name": "Realtime Data Plot",
       "pathSlots": [],
       "requiredPlugins": [],
       "selector": "widget-data-chart"
@@ -1428,6 +1471,24 @@
       "selector": "widget-heel-gauge"
     },
     {
+      "bindingKind": "none",
+      "category": "Component",
+      "componentClassName": "WidgetHoekensAnchorAlarmComponent",
+      "defaultConfig": {},
+      "defaultHeight": 14,
+      "defaultWidth": 6,
+      "description": "Map-first anchor alarm experience for Signal K with advanced watch-zone tools (circle, sector, polygon), interactive setup, tracks/fleet overlays, scope calculator, and optional engine-start auto-silence for practical onboard use.",
+      "icon": "anchorWatch",
+      "minHeight": 8,
+      "minWidth": 6,
+      "name": "Hoeken's Anchor Alarm",
+      "pathSlots": [],
+      "requiredPlugins": [
+        "hoekens-anchor-alarm"
+      ],
+      "selector": "widget-hoekens-anchor-alarm"
+    },
+    {
       "bindingKind": "paths-record",
       "category": "Gauge",
       "componentClassName": "WidgetHorizonComponent",
@@ -1525,6 +1586,29 @@
       "pathSlots": [],
       "requiredPlugins": [],
       "selector": "widget-iframe"
+    },
+    {
+      "bindingKind": "none",
+      "category": "Gauge",
+      "componentClassName": "WidgetInverterComponent",
+      "defaultConfig": {
+        "color": "contrast",
+        "ignoreZones": false,
+        "inverter": {
+          "optionsById": {},
+          "trackedDevices": []
+        }
+      },
+      "defaultHeight": 6,
+      "defaultWidth": 6,
+      "description": "Monitor inverter input and output with AC voltage, current, power, and temperature metrics. Track real-time inverter state and mode. Manage multiple linked inverter units with grouped device configuration.",
+      "icon": "inverter",
+      "minHeight": 2,
+      "minWidth": 2,
+      "name": "Inverter",
+      "pathSlots": [],
+      "requiredPlugins": [],
+      "selector": "widget-inverter"
     },
     {
       "bindingKind": "none",
@@ -1637,7 +1721,7 @@
       },
       "defaultHeight": 6,
       "defaultWidth": 4,
-      "description": "Displays numeric data in a clear and concise format, with options to show minimum and/or maximum recorded values. Includes an optional background minichart for quick visual trend insights.",
+      "description": "Displays numeric data in a clear and concise format, with options to show minimum and/or maximum recorded values. Includes an optional background mini plot for quick visual trend insights.",
       "icon": "numericWidget",
       "minHeight": 2,
       "minWidth": 1,
@@ -1987,7 +2071,7 @@
       },
       "defaultHeight": 4,
       "defaultWidth": 4,
-      "description": "An advanced racing countdown timer that indicates OCS (On Course Side) status. Set the start line, choose or adjust the duration, or specify the exact start time. Automatically switches to the target dashboard at the start unless over early.",
+      "description": "An advanced racing countdown timer that indicates OCS (On Course Side) status. Set the start line, choose or adjust the duration, or specify the exact start time. Automatically switches to the target page at the start unless over early.",
       "icon": "racertimerWidget",
       "minHeight": 4,
       "minWidth": 4,
@@ -2528,7 +2612,6 @@
         "filterSelfPaths": true,
         "paths": {
           "gaugePath": {
-            "convertUnitTo": null,
             "description": "PUT Supported Numeric Path. IMPORTANT: Format must be set to (base)",
             "isPathConfigurable": true,
             "path": null,
@@ -2634,6 +2717,38 @@
       ],
       "requiredPlugins": [],
       "selector": "widget-text"
+    },
+    {
+      "bindingKind": "none",
+      "category": "Component",
+      "componentClassName": "WidgetVideoComponent",
+      "defaultConfig": {
+        "video": {
+          "autoplay": false,
+          "loop": false,
+          "muted": true,
+          "objectFit": "contain",
+          "preset": "balanced",
+          "snapshot": {
+            "defaultDestination": "download",
+            "embedLocation": true,
+            "embedTelemetry": true
+          },
+          "sourceKind": "url",
+          "transport": "auto",
+          "url": null
+        }
+      },
+      "defaultHeight": 6,
+      "defaultWidth": 8,
+      "description": "Play video from a URL with built-in player controls. IP-camera streaming, ONVIF pan/tilt/zoom and snapshots are added in later updates.",
+      "icon": "videoWidget",
+      "minHeight": 2,
+      "minWidth": 2,
+      "name": "Video",
+      "pathSlots": [],
+      "requiredPlugins": [],
+      "selector": "widget-video"
     },
     {
       "bindingKind": "paths-record",

--- a/tools/gen-mcp-schema/ast.spec.ts
+++ b/tools/gen-mcp-schema/ast.spec.ts
@@ -1,0 +1,64 @@
+import * as ts from 'typescript';
+import { describe, it, expect } from 'vitest';
+import { collectModuleConstants, findLazyLoadedModuleSpecifier, findPropertyInitializer, literalToValue } from './ast';
+
+function sourceOf(code: string): ts.SourceFile {
+  return ts.createSourceFile('inline.ts', code, ts.ScriptTarget.Latest, /* setParentNodes */ true);
+}
+
+describe('literalToValue', () => {
+  it('maps the `undefined` identifier to the unset value so its key drops from the JSON', () => {
+    const value = literalToValue(findPropertyInitializer(sourceOf('const c = { a: 1, b: undefined };'), 'c')) as Record<
+      string,
+      unknown
+    >;
+    expect('b' in value).toBe(true);
+    expect(value.b).toBeUndefined();
+    expect(JSON.stringify(value)).toBe('{"a":1}');
+  });
+
+  it('resolves a same-file module constant one hop to its literal', () => {
+    const src = sourceOf('const N = 5;\nconst c = { period: N };');
+    const value = literalToValue(findPropertyInitializer(src, 'c'), collectModuleConstants(src)) as Record<
+      string,
+      unknown
+    >;
+    expect(value.period).toBe(5);
+  });
+
+  it('throws (fail-loud) on an identifier it cannot resolve to a literal', () => {
+    const src = sourceOf('const c = { x: SOME_ENUM_MEMBER };');
+    expect(() => literalToValue(findPropertyInitializer(src, 'c'), collectModuleConstants(src))).toThrow(/non-literal/i);
+  });
+});
+
+describe('collectModuleConstants', () => {
+  it('resolves a top-level const but ignores let/var (their initializer is not a reliable static value)', () => {
+    const resolve = collectModuleConstants(sourceOf('const A = 1;\nlet B = 2;\nvar C = 3;'));
+    const a = resolve('A');
+    expect(a).toBeDefined();
+    expect(literalToValue(a as ts.Expression)).toBe(1);
+    expect(resolve('B')).toBeUndefined();
+    expect(resolve('C')).toBeUndefined();
+  });
+});
+
+describe('findLazyLoadedModuleSpecifier', () => {
+  const loaderMap =
+    'const _componentTypeMap = {\n' +
+    "  WidgetNumericComponent: () => import('../../widgets/widget-numeric/widget-numeric.component').then(m => m.WidgetNumericComponent),\n" +
+    "  WidgetAcComponent: () => import('../../widgets/widget-ac/widget-ac.component').then(m => m.WidgetAcComponent),\n" +
+    '};';
+
+  it('resolves the module specifier tied to the exported class via the .then callback', () => {
+    expect(findLazyLoadedModuleSpecifier(sourceOf(loaderMap), 'WidgetAcComponent')).toBe(
+      '../../widgets/widget-ac/widget-ac.component',
+    );
+  });
+
+  it('throws when no loader entry names the class', () => {
+    expect(() => findLazyLoadedModuleSpecifier(sourceOf(loaderMap), 'WidgetMissingComponent')).toThrow(
+      /lazy-loader entry/i,
+    );
+  });
+});

--- a/tools/gen-mcp-schema/ast.ts
+++ b/tools/gen-mcp-schema/ast.ts
@@ -15,15 +15,21 @@ export function parseSourceFile(filePath: string): ts.SourceFile {
   return ts.createSourceFile(filePath, content, ts.ScriptTarget.Latest, /* setParentNodes */ true);
 }
 
+/** Maps a same-file identifier to the initializer it was declared with, if any. */
+export type IdentifierResolver = (name: string) => ts.Expression | undefined;
+
 /**
  * Converts a literal expression node to a plain JS value.
  *
  * Supports strings, numbers (incl. unary minus), booleans, null, arrays and
- * object literals. Anything else (an identifier, function call, spread, computed
- * value, ...) throws — the generator fails loudly rather than emitting a wrong
- * default.
+ * object literals. The `undefined` identifier maps to the unset value (its key
+ * drops out of the emitted JSON), and — when a resolver is supplied — an
+ * identifier naming a same-file module constant is resolved one hop to its
+ * literal. Anything else (an unresolvable identifier, function call, spread,
+ * computed value, ...) throws: the generator fails loudly rather than emitting
+ * a wrong default.
  */
-export function literalToValue(node: ts.Expression): unknown {
+export function literalToValue(node: ts.Expression, resolveIdentifier?: IdentifierResolver): unknown {
   if (ts.isStringLiteralLike(node)) return node.text;
   if (ts.isNumericLiteral(node)) return Number(node.text);
 
@@ -36,30 +42,66 @@ export function literalToValue(node: ts.Expression): unknown {
       return null;
   }
 
+  if (ts.isIdentifier(node)) {
+    // `undefined` parses as an identifier, not a keyword. Treat only that exact
+    // identifier as the unset value (object keys valued `undefined` drop out of
+    // the JSON artifact).
+    if (node.text === 'undefined') return undefined;
+    // A reference to a module-scope `const NAME = <literal>` in the same file is
+    // still a static literal, one hop away — resolve it. Any identifier the
+    // resolver can't map to a literal falls through to the loud throw below.
+    const declared = resolveIdentifier?.(node.text);
+    if (declared) return literalToValue(declared, resolveIdentifier);
+  }
+
   if (ts.isParenthesizedExpression(node)) {
-    return literalToValue(node.expression);
+    return literalToValue(node.expression, resolveIdentifier);
   }
 
   if (ts.isPrefixUnaryExpression(node) && node.operator === ts.SyntaxKind.MinusToken) {
-    const inner = literalToValue(node.operand);
+    const inner = literalToValue(node.operand, resolveIdentifier);
     if (typeof inner === 'number') return -inner;
     throw unsupported(node);
   }
 
   if (ts.isArrayLiteralExpression(node)) {
-    return node.elements.map((element) => literalToValue(element));
+    return node.elements.map((element) => literalToValue(element, resolveIdentifier));
   }
 
   if (ts.isObjectLiteralExpression(node)) {
     const obj: Record<string, unknown> = {};
     for (const member of node.properties) {
       if (!ts.isPropertyAssignment(member)) throw unsupported(member);
-      obj[propertyName(member.name)] = literalToValue(member.initializer);
+      obj[propertyName(member.name)] = literalToValue(member.initializer, resolveIdentifier);
     }
     return obj;
   }
 
   throw unsupported(node);
+}
+
+/**
+ * Builds an identifier resolver over a source file's module-scope variable
+ * declarations, mapping each name to its initializer expression. Lets
+ * `literalToValue` resolve a DEFAULT_CONFIG value that references a same-file
+ * constant (e.g. `windSectorWindowSeconds: DEFAULT_WINDOW_SECONDS`) back to its
+ * literal. Only top-level declarations are collected, so function-local names
+ * never shadow the lookup.
+ */
+export function collectModuleConstants(sourceFile: ts.SourceFile): IdentifierResolver {
+  const byName = new Map<string, ts.Expression>();
+  for (const statement of sourceFile.statements) {
+    if (!ts.isVariableStatement(statement)) continue;
+    // Only `const` — a `let`/`var` binding could be reassigned, so its initializer
+    // is not a reliable static value.
+    if (!(statement.declarationList.flags & ts.NodeFlags.Const)) continue;
+    for (const declaration of statement.declarationList.declarations) {
+      if (ts.isIdentifier(declaration.name) && declaration.initializer && !byName.has(declaration.name.text)) {
+        byName.set(declaration.name.text, declaration.initializer);
+      }
+    }
+  }
+  return (name) => byName.get(name);
 }
 
 function propertyName(name: ts.PropertyName): string {
@@ -156,36 +198,80 @@ export function getObjectProperties(node: ts.ObjectLiteralExpression): Map<strin
 }
 
 /**
- * Returns the module specifier a named import comes from, e.g. for
- * `import { WidgetNumericComponent } from '../../widgets/.../x.component'`
- * returns `../../widgets/.../x.component`. Throws if the import is not found.
+ * Returns the module specifier of the lazy-loader entry that resolves
+ * `componentClassName`.
+ *
+ * Widget components are never imported statically; `widget.service.ts` loads each
+ * through its `_componentTypeMap` as
+ * `ComponentClassName: () => import('SPECIFIER').then(m => m.ComponentClassName)`.
+ * This finds the dynamic `import('SPECIFIER')` whose `.then` callback returns
+ * `<param>.componentClassName`, tying the specifier to the actual exported class.
+ * Throws if no such loader entry is found.
  */
-export function findImportModuleSpecifier(sourceFile: ts.SourceFile, importedName: string): string {
+export function findLazyLoadedModuleSpecifier(
+  sourceFile: ts.SourceFile,
+  componentClassName: string,
+): string {
   let specifier: string | undefined;
 
   const visit = (node: ts.Node): void => {
-    if (specifier) return;
-    if (
-      ts.isImportDeclaration(node) &&
-      node.importClause?.namedBindings &&
-      ts.isNamedImports(node.importClause.namedBindings) &&
-      ts.isStringLiteral(node.moduleSpecifier)
-    ) {
-      for (const element of node.importClause.namedBindings.elements) {
-        if (element.name.text === importedName) {
-          specifier = (node.moduleSpecifier as ts.StringLiteral).text;
-          return;
-        }
-      }
+    if (specifier !== undefined) return;
+    const found = lazyLoaderSpecifier(node, componentClassName);
+    if (found !== undefined) {
+      specifier = found;
+      return;
     }
     ts.forEachChild(node, visit);
   };
 
   visit(sourceFile);
   if (specifier === undefined) {
-    throw new Error(`Could not find an import for "${importedName}" in ${sourceFile.fileName}`);
+    throw new Error(
+      `Could not find a lazy-loader entry for "${componentClassName}" in ${sourceFile.fileName}`,
+    );
   }
   return specifier;
+}
+
+/**
+ * If `node` is `import('SPECIFIER').then(param => param.componentClassName)`,
+ * returns SPECIFIER; otherwise undefined.
+ */
+function lazyLoaderSpecifier(node: ts.Node, componentClassName: string): string | undefined {
+  if (!ts.isCallExpression(node)) return undefined;
+
+  const callee = node.expression;
+  if (!ts.isPropertyAccessExpression(callee) || callee.name.text !== 'then') return undefined;
+
+  const importCall = callee.expression;
+  if (
+    !ts.isCallExpression(importCall) ||
+    importCall.expression.kind !== ts.SyntaxKind.ImportKeyword
+  ) {
+    return undefined;
+  }
+
+  const moduleArg = importCall.arguments[0];
+  if (!moduleArg || !ts.isStringLiteralLike(moduleArg)) return undefined;
+
+  const callback = node.arguments[0];
+  if (!callback || !returnsMember(callback, componentClassName)) return undefined;
+
+  return moduleArg.text;
+}
+
+/** True when `fn` is an arrow `param => param.memberName` (concise or single-return body). */
+function returnsMember(fn: ts.Expression, memberName: string): boolean {
+  if (!ts.isArrowFunction(fn)) return false;
+  const returned = ts.isBlock(fn.body) ? singleReturnExpression(fn.body) : fn.body;
+  return !!returned && ts.isPropertyAccessExpression(returned) && returned.name.text === memberName;
+}
+
+function singleReturnExpression(block: ts.Block): ts.Expression | undefined {
+  const [statement] = block.statements;
+  return block.statements.length === 1 && statement && ts.isReturnStatement(statement)
+    ? statement.expression
+    : undefined;
 }
 
 /**

--- a/tools/gen-mcp-schema/generate.spec.ts
+++ b/tools/gen-mcp-schema/generate.spec.ts
@@ -23,11 +23,11 @@ describe('extractWidgetCatalog', () => {
     expect(numeric?.requiredPlugins).toEqual([]);
   });
 
-  it('excludes the commented-out widgets (alternator, inverter, ac)', () => {
-    const selectors = widgets.map((w) => w.selector);
-    expect(selectors).not.toContain('widget-alternator');
-    expect(selectors).not.toContain('widget-inverter');
-    expect(selectors).not.toContain('widget-ac');
+  it('includes the live electrical widgets (alternator, inverter, ac)', () => {
+    for (const selector of ['widget-alternator', 'widget-inverter', 'widget-ac']) {
+      const widget = widgets.find((w) => w.selector === selector);
+      expect(widget, selector).toBeDefined();
+    }
   });
 
   it('captures the four required plugins for Freeboard-SK', () => {

--- a/tools/gen-mcp-schema/generate.ts
+++ b/tools/gen-mcp-schema/generate.ts
@@ -8,8 +8,9 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as ts from 'typescript';
 import {
+  collectModuleConstants,
   findArrayLiteral,
-  findImportModuleSpecifier,
+  findLazyLoadedModuleSpecifier,
   findPropertyInitializer,
   findStaticPropertyInitializer,
   getObjectProperties,
@@ -40,6 +41,7 @@ const UNITS_SERVICE = 'src/app/core/services/units.service.ts';
 const DASHBOARD_COMPONENT = 'src/app/core/components/dashboard/dashboard.component.ts';
 const ICONS_SVG = 'src/assets/svg/icons.svg';
 const M3_DARK = 'src/themes/_m3dark.scss';
+const CONFIG_VERSIONS_CONST = 'src/app/core/constants/config-versions.const.ts';
 
 // KIP applies themes as body CSS classes; the default (dark) theme is the empty
 // string. There is no single source literal to read, so these are listed here and
@@ -47,10 +49,6 @@ const M3_DARK = 'src/themes/_m3dark.scss';
 const THEME_NAMES: readonly string[] = ['', 'light-theme', 'night-theme'];
 
 const SCHEMA_VERSION = 1;
-// Two distinct KIP version numbers (see storage.service.ts):
-// the applicationData file version in the URL, and app.configVersion in the body.
-const CONFIG_FILE_VERSION = 11;
-const CONFIG_VERSION = 12;
 
 /**
  * Extracts KIP's widget catalog (`_widgetDefinition`) from widget.service.ts.
@@ -87,17 +85,28 @@ export function extractWidgetSchemas(opts: GenerateOptions): WidgetSchemaEntry[]
   const catalog = extractCatalogFromSource(serviceSource, serviceFile);
 
   return catalog.map((entry) => {
-    const moduleSpecifier = findImportModuleSpecifier(serviceSource, entry.componentClassName);
+    const moduleSpecifier = findLazyLoadedModuleSpecifier(serviceSource, entry.componentClassName);
     const componentFile = path.resolve(serviceDir, `${moduleSpecifier}.ts`);
+    const componentSource = parseSourceFile(componentFile);
     const initializer = findStaticPropertyInitializer(
-      parseSourceFile(componentFile),
+      componentSource,
       entry.componentClassName,
       'DEFAULT_CONFIG',
     );
     if (!ts.isObjectLiteralExpression(initializer)) {
       throw new Error(`DEFAULT_CONFIG of ${entry.componentClassName} is not an object literal`);
     }
-    const defaultConfig = literalToValue(initializer) as Record<string, unknown>;
+    const resolveConst = collectModuleConstants(componentSource);
+    let defaultConfig: Record<string, unknown>;
+    try {
+      defaultConfig = literalToValue(initializer, resolveConst) as Record<string, unknown>;
+    } catch (cause) {
+      throw new Error(
+        `Cannot read DEFAULT_CONFIG of ${entry.componentClassName} (${componentFile}): ${
+          cause instanceof Error ? cause.message : String(cause)
+        }`,
+      );
+    }
     const bindingKind = deriveBindingKind(defaultConfig);
     const pathSlots = bindingKind === 'paths-record' ? extractPathSlots(defaultConfig) : [];
     return { ...entry, bindingKind, defaultConfig, pathSlots };
@@ -254,16 +263,41 @@ function booleanProp(props: Map<string, ts.Expression>, key: string, file: strin
  * artifact only changes when KIP source changes.
  */
 export function buildSchema(opts: GenerateOptions): KipDashboardSchema {
+  const versions = readConfigVersions(opts.projectRoot);
   return {
     meta: {
       schemaVersion: SCHEMA_VERSION,
       kipVersion: readKipVersion(opts.projectRoot),
-      configFileVersion: CONFIG_FILE_VERSION,
-      configVersion: CONFIG_VERSION,
+      configFileVersion: versions.fileVersion,
+      configVersion: versions.appVersion,
     },
     widgets: extractWidgetSchemas(opts),
     designSystem: extractDesignSystem(opts),
   };
+}
+
+/**
+ * Reads the current config version numbers from their single definition site
+ * (config-versions.const.ts) so the artifact can never drift from the app:
+ * configFileVersion = REMOTE_CONFIG_FILE_VERSION (the applicationData URL
+ * segment), configVersion = LATEST_APP_CONFIG_VERSION (app.configVersion in the
+ * config body).
+ */
+function readConfigVersions(root: string): { fileVersion: number; appVersion: number } {
+  const file = path.join(root, CONFIG_VERSIONS_CONST);
+  const source = parseSourceFile(file);
+  return {
+    fileVersion: requireNumberConstant(source, 'REMOTE_CONFIG_FILE_VERSION', file),
+    appVersion: requireNumberConstant(source, 'LATEST_APP_CONFIG_VERSION', file),
+  };
+}
+
+function requireNumberConstant(source: ts.SourceFile, name: string, file: string): number {
+  const value = literalToValue(findPropertyInitializer(source, name));
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    throw new Error(`Expected numeric "${name}" in ${file}, got ${describe(value)}`);
+  }
+  return value;
 }
 
 function readKipVersion(root: string): string {

--- a/tools/gen-mcp-schema/schema.spec.ts
+++ b/tools/gen-mcp-schema/schema.spec.ts
@@ -1,16 +1,20 @@
 import { fileURLToPath } from 'node:url';
 import { describe, it, expect } from 'vitest';
 import { buildSchema } from './generate';
+import {
+  LATEST_APP_CONFIG_VERSION,
+  REMOTE_CONFIG_FILE_VERSION,
+} from '../../src/app/core/constants/config-versions.const';
 
 const projectRoot = fileURLToPath(new URL('../../', import.meta.url));
 const schema = buildSchema({ projectRoot });
 
 describe('buildSchema', () => {
-  it('stamps meta with the KIP version and config versions', () => {
+  it('stamps meta with the KIP version and the config versions from their source of truth', () => {
     expect(schema.meta).toMatchObject({
       schemaVersion: 1,
-      configFileVersion: 11,
-      configVersion: 12,
+      configFileVersion: REMOTE_CONFIG_FILE_VERSION,
+      configVersion: LATEST_APP_CONFIG_VERSION,
     });
     expect(schema.meta.kipVersion).toMatch(/^\d+\.\d+\.\d+/);
   });


### PR DESCRIPTION
## What

`npm run gen:mcp-schema` was broken on `main` — it threw `Could not find an import for "WidgetAcComponent"` and no schema could be regenerated, so the committed `kip-dashboard-schema.json` had silently gone stale. Fixes #293.

## Root cause

`widget.service.ts` loads every widget through a **dynamic lazy-loader map** — `ComponentClass: () => import('…').then(m => m.ComponentClass)` — with **zero static imports**. The schema generator resolved each widget's source file via `findImportModuleSpecifier`, which only understood static `import {} from '…'`. It therefore failed on the alphabetically-first widget (`widget-ac` → `WidgetAcComponent`; not special, just first) and produced nothing. Because `test:mcp-schema` wasn't part of `npm run ci`, the failure never blocked a PR.

## Changes

1. **Resolve widgets from the lazy-loader map** (`findLazyLoadedModuleSpecifier`): finds the `import('SPECIFIER').then(m => m.ComponentClass)` entry, tying the module specifier to the actual exported class via the `.then` callback (not just the map key). Replaces the now-dead `findImportModuleSpecifier`.
2. **Handle the non-literal `DEFAULT_CONFIG` values current widgets use** (surfaced only once resolution worked, because the generator resolves all 36 widgets for the first time since the lazy-loader conversion):
   - `undefined` (an identifier in the AST, not a keyword) → the unset value; keys valued `undefined` drop out of the JSON artifact. *(widget-data-chart yScale keys)*
   - **same-file module-scope constant references** → resolved one hop to their literal. *(widget-windsteer `windSectorWindowSeconds: DEFAULT_WIND_SECTOR_WINDOW_SECONDS`)*
   - Every **other** identifier still throws loudly — and now **names the offending component**, so the next drift is diagnosable instead of an anonymous `Unsupported syntax: Identifier`.
3. **Flip the stale spec** — the ac/inverter/alternator electrical family is live in `_widgetDefinition`, so `excludes the commented-out widgets` becomes `includes the live electrical widgets`.
4. **Regenerated the artifact**: **31 → 36 widgets** (ac, alternator, inverter, hoekens-anchor-alarm, video were all absent because the generator was fully broken), and it picks up F1's **"Realtime Data Chart" → "Realtime Data Plot"** rename (#126/#247) that couldn't reach the schema until now.
5. **Gate against recurrence** — added `test:mcp-schema` to `npm run ci` (alongside `test:plugin`), so a widget name/`DEFAULT_CONFIG` change that leaves the artifact stale now fails CI instead of drifting silently.

## Testing

- `npm run test:mcp-schema` — 6 files / 24 tests green (drift gate passes against the committed artifact).
- `npm run lint` clean; `npm run betterer:ci` unchanged (179; no `src/**/*.ts` touched); generator type-checks under `--strict`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
