### PR TITLE
feat(windtrends): make wind series paths user-configurable (fix blank TWS on ground-referenced vessels)

### DIFF
--- a/src/app/core/services/dashboard-history-series-sync.service.spec.ts
+++ b/src/app/core/services/dashboard-history-series-sync.service.spec.ts
@@ -3,12 +3,43 @@ import { TestBed } from '@angular/core/testing';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { DashboardHistorySeriesSyncService } from './dashboard-history-series-sync.service';
 import { IKipSeriesDefinition } from '../contracts/kip-series-contract';
-import { IWidget } from '../interfaces/widgets-interface';
+import { IWidget, IWidgetPath, IWidgetSvcConfig } from '../interfaces/widgets-interface';
 import { WidgetService } from './widget.service';
 
 function seriesIds(series: IKipSeriesDefinition[]): string[] {
     return series.map(item => item.seriesId).sort();
 }
+
+// Mirrors the two configurable slots the widget's DEFAULT_CONFIG ships. resolveWidgetConfig merges
+// these into a windtrends widget config that lacks its own paths, so the default mapping still
+// resolves the shipped TWD/TWS paths.
+const WIND_DIRECTION_SLOT: IWidgetPath = {
+    description: 'True Wind Direction',
+    path: 'self.environment.wind.directionTrue',
+    source: 'default',
+    pathType: 'number',
+    isPathConfigurable: true,
+    pathRequired: false,
+    sampleTime: 1000,
+};
+const WIND_SPEED_SLOT: IWidgetPath = {
+    description: 'True Wind Speed',
+    path: 'self.environment.wind.speedTrue',
+    source: 'default',
+    pathType: 'number',
+    isPathConfigurable: true,
+    pathRequired: false,
+    sampleTime: 1000,
+};
+const WINDTRENDS_DEFAULT_CONFIG: IWidgetSvcConfig = {
+    filterSelfPaths: true,
+    color: 'contrast',
+    timeScale: 'Last 30 Minutes',
+    paths: {
+        trueWindDirection: WIND_DIRECTION_SLOT,
+        trueWindSpeed: WIND_SPEED_SLOT,
+    },
+};
 
 describe('DashboardHistorySeriesSyncService', () => {
     let widgetServiceMock: {
@@ -17,7 +48,9 @@ describe('DashboardHistorySeriesSyncService', () => {
 
     beforeEach(() => {
         widgetServiceMock = {
-            getDefaultConfig: vi.fn().mockReturnValue(undefined)
+            getDefaultConfig: vi.fn().mockImplementation((selector: string) =>
+                selector === 'widget-windtrends-chart' ? structuredClone(WINDTRENDS_DEFAULT_CONFIG) : undefined
+            )
         };
 
         TestBed.configureTestingModule({
@@ -69,6 +102,47 @@ describe('DashboardHistorySeriesSyncService', () => {
         const windByPath = Object.fromEntries(windSeries.map(s => [s.seriesId, s.path]));
         expect(windByPath['widget-wind-1:wind-direction']).toBe('self.environment.wind.directionTrue');
         expect(windByPath['widget-wind-1:wind-speed']).toBe('self.environment.wind.speedTrue');
+    });
+
+    it('maps the wind trends speed series from a configured slot path and source', () => {
+        const service = TestBed.inject(DashboardHistorySeriesSyncService);
+        const widget: IWidget = {
+            uuid: 'widget-wind-cfg',
+            type: 'widget-windtrends-chart',
+            config: {
+                timeScale: 'Last 30 Minutes',
+                paths: {
+                    trueWindDirection: { ...WIND_DIRECTION_SLOT },
+                    trueWindSpeed: { ...WIND_SPEED_SLOT, path: 'self.navigation.speedOverGround', source: 'gps1' },
+                },
+            },
+        };
+
+        const series = service.resolveSeriesForWidget(widget);
+        const byId = Object.fromEntries(series.map(s => [s.seriesId, s]));
+        expect(byId['widget-wind-cfg:wind-speed']).toMatchObject({
+            path: 'self.navigation.speedOverGround',
+            source: 'gps1',
+        });
+        expect(byId['widget-wind-cfg:wind-direction'].path).toBe('self.environment.wind.directionTrue');
+    });
+
+    it('omits the wind trends speed series when its slot path is cleared', () => {
+        const service = TestBed.inject(DashboardHistorySeriesSyncService);
+        const widget: IWidget = {
+            uuid: 'widget-wind-nil',
+            type: 'widget-windtrends-chart',
+            config: {
+                timeScale: 'Last 30 Minutes',
+                paths: {
+                    trueWindDirection: { ...WIND_DIRECTION_SLOT },
+                    trueWindSpeed: { ...WIND_SPEED_SLOT, path: null },
+                },
+            },
+        };
+
+        const series = service.resolveSeriesForWidget(widget);
+        expect(series.map(s => s.seriesId)).toEqual(['widget-wind-nil:wind-direction']);
     });
 
     it('resolves widget-bms as an unexpanded battery template series (the dialog expands concretes)', () => {

--- a/src/app/core/services/dashboard-history-series-sync.service.ts
+++ b/src/app/core/services/dashboard-history-series-sync.service.ts
@@ -131,7 +131,6 @@ export class DashboardHistorySeriesSyncService {
       ownerWidgetUuid: widgetUuid,
       ownerWidgetSelector: widgetType,
       context: null,
-      source: 'default',
       timeScale: this.normalizeString(cfg?.timeScale),
       period: 30,
       retentionDurationMs: null,
@@ -139,20 +138,46 @@ export class DashboardHistorySeriesSyncService {
       enabled: true,
     };
 
-    return [
-      {
+    // Read the same configurable slots the widget consumes. resolveWidgetConfig already merged the
+    // widget's default paths, so cfg carries either the shipped defaults or the user's overrides.
+    // A slot whose path was cleared (pathRequired is false) contributes no series, mirroring the
+    // widget's per-series gating and mapDataChartWidget's null-path omission.
+    const dir = this.resolveWindTrendsSlot(cfg, 'trueWindDirection');
+    const spd = this.resolveWindTrendsSlot(cfg, 'trueWindSpeed');
+    const series: IKipConcreteSeriesDefinition[] = [];
+
+    const dirPath = this.normalizeString(dir?.path);
+    if (dirPath) {
+      series.push({
         ...shared,
         seriesId: `${widgetUuid}:wind-direction`,
         datasetUuid: `${widgetUuid}-twd`,
-        path: 'self.environment.wind.directionTrue',
-      },
-      {
+        path: dirPath,
+        source: this.normalizeString(dir?.source) ?? 'default',
+      });
+    }
+
+    const spdPath = this.normalizeString(spd?.path);
+    if (spdPath) {
+      series.push({
         ...shared,
         seriesId: `${widgetUuid}:wind-speed`,
         datasetUuid: `${widgetUuid}-tws`,
-        path: 'self.environment.wind.speedTrue',
-      }
-    ];
+        path: spdPath,
+        source: this.normalizeString(spd?.source) ?? 'default',
+      });
+    }
+
+    return series;
+  }
+
+  /** Read a single configurable path slot from a widget config, tolerating the array path form. */
+  private resolveWindTrendsSlot(cfg: IWidgetSvcConfig | undefined, slot: string): IWidgetPath | undefined {
+    const paths = cfg?.paths;
+    if (!paths || Array.isArray(paths)) {
+      return undefined;
+    }
+    return paths[slot];
   }
 
   private mapElectricalTemplateWidget(

--- a/src/app/widgets/widget-windtrends-chart/widget-windtrends-chart.component.spec.ts
+++ b/src/app/widgets/widget-windtrends-chart/widget-windtrends-chart.component.spec.ts
@@ -36,8 +36,15 @@ import { UnitsService } from '../../core/services/units.service';
 import { CanvasService } from '../../core/services/canvas.service';
 import type { ITheme } from '../../core/services/app-service';
 import type { IDatasetServiceDatapoint } from '../../core/interfaces/dataset.interfaces';
+import type { IPathArray } from '../../core/interfaces/widgets-interface';
 
 const themeMock = new Proxy({}, { get: () => '#000000' }) as unknown as ITheme;
+
+// The merged config the widget runtime hands the component always carries the record-form `paths`
+// (from DEFAULT_CONFIG or a user override). The runtime directive is mocked here, so the spec has to
+// supply that record explicitly — a bare `{ timeScale, color }` would gate out both series.
+const cloneDefaultPaths = (): IPathArray =>
+  structuredClone(WidgetWindTrendsChartComponent.DEFAULT_CONFIG.paths) as IPathArray;
 
 describe('WidgetWindTrendsChartComponent', () => {
   let fixture: ComponentFixture<WidgetWindTrendsChartComponent>;
@@ -48,8 +55,8 @@ describe('WidgetWindTrendsChartComponent', () => {
   const canvasMock = { registerCanvas: vi.fn(), releaseCanvas: vi.fn(), unregisterCanvas: vi.fn() };
   const breakpointMock = { observe: vi.fn().mockReturnValue(of({ matches: false, breakpoints: {} })) };
 
-  const setup = async (timeScale = 'Last 30 Minutes'): Promise<void> => {
-    runtimeMock.options.mockReturnValue({ timeScale, color: 'contrast' });
+  const setup = async (timeScale = 'Last 30 Minutes', paths: IPathArray = cloneDefaultPaths()): Promise<void> => {
+    runtimeMock.options.mockReturnValue({ timeScale, color: 'contrast', paths });
 
     await TestBed.configureTestingModule({
       imports: [WidgetWindTrendsChartComponent],
@@ -69,6 +76,13 @@ describe('WidgetWindTrendsChartComponent', () => {
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();
+  };
+
+  // The "Data acquisition…" overlay's readiness gate is internal to the chart plugin; isChartReady is
+  // its testable seam. Reads the component's live chart (both share the same datasets reference).
+  const readiness = (): boolean => {
+    const probe = fixture.componentInstance as unknown as { chart: unknown; isChartReady(chart: unknown): boolean };
+    return probe.isChartReady(probe.chart);
   };
 
   beforeEach(() => {
@@ -124,5 +138,130 @@ describe('WidgetWindTrendsChartComponent', () => {
       { timestamp: 2000, data: { value: 350, sma: 340, lastAverage: 345, lastMinimum: 10, lastMaximum: 350 } }
     ];
     expect(() => { dir.next(batch); spd.next(batch); }).not.toThrow();
+  });
+
+  it('opens the History streams on the user-configured direction and speed paths', async () => {
+    const paths = cloneDefaultPaths();
+    paths.trueWindDirection.path = 'self.environment.wind.directionMagnetic';
+    paths.trueWindDirection.source = 'vane1';
+    paths.trueWindSpeed.path = 'self.navigation.speedOverGround';
+    paths.trueWindSpeed.source = 'gps2';
+
+    await setup('Last 30 Minutes', paths);
+
+    expect(historyMock.getBackfillThenLive).toHaveBeenCalledTimes(2);
+    const calls = historyMock.getBackfillThenLive.mock.calls.map(c => ({ path: c[0].path, source: c[0].source }));
+    expect(calls).toContainEqual({ path: 'self.environment.wind.directionMagnetic', source: 'vane1' });
+    expect(calls).toContainEqual({ path: 'self.navigation.speedOverGround', source: 'gps2' });
+  });
+
+  it('opens the direction stream only when the speed slot path is cleared', async () => {
+    const paths = cloneDefaultPaths();
+    paths.trueWindSpeed.path = null;
+
+    await setup('Last 30 Minutes', paths);
+
+    expect(historyMock.getBackfillThenLive).toHaveBeenCalledTimes(1);
+    expect(historyMock.getBackfillThenLive.mock.calls[0][0].path).toBe('self.environment.wind.directionTrue');
+  });
+
+  it('opens the speed stream only when the direction slot path is cleared, and renders it', async () => {
+    const spd = new Subject();
+    historyMock.getBackfillThenLive.mockReturnValueOnce(spd);
+    const paths = cloneDefaultPaths();
+    paths.trueWindDirection.path = null;
+
+    await setup('Last 30 Minutes', paths);
+
+    expect(historyMock.getBackfillThenLive).toHaveBeenCalledTimes(1);
+    expect(historyMock.getBackfillThenLive.mock.calls[0][0].path).toBe('self.environment.wind.speedTrue');
+
+    const batch: IDatasetServiceDatapoint[] = [
+      { timestamp: 1000, data: { value: 5, sma: 5, lastAverage: 5, lastMinimum: 5, lastMaximum: 5 } },
+      { timestamp: 2000, data: { value: 7, sma: 6, lastAverage: 6, lastMinimum: 5, lastMaximum: 7 } }
+    ];
+    expect(() => spd.next(batch)).not.toThrow();
+  });
+
+  it('rebuilds the streams when a slot path changes after the initial render', async () => {
+    await setup('Last 30 Minutes');
+    expect(historyMock.getBackfillThenLive).toHaveBeenCalledTimes(2);
+
+    const nextPaths = cloneDefaultPaths();
+    nextPaths.trueWindSpeed.path = 'self.navigation.speedOverGround';
+    runtimeMock.options.mockReturnValue({ timeScale: 'Last 30 Minutes', color: 'contrast', paths: nextPaths });
+
+    // The runtime directive is a plain mock (options() is not a signal), so drive the rebuild effect
+    // by changing a tracked input (theme); in the real app the merged-config signal re-fires directly.
+    const nextTheme = new Proxy({}, { get: () => '#111111' }) as unknown as ITheme;
+    fixture.componentRef.setInput('theme', nextTheme);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const streamedPaths = historyMock.getBackfillThenLive.mock.calls.map(c => c[0].path);
+    expect(streamedPaths).toContain('self.navigation.speedOverGround');
+    expect(historyMock.getBackfillThenLive.mock.calls.length).toBeGreaterThan(2);
+  });
+
+  it('clears the loading overlay once the only active series (direction) has data', async () => {
+    const dir = new Subject();
+    historyMock.getBackfillThenLive.mockReturnValueOnce(dir);
+    const paths = cloneDefaultPaths();
+    paths.trueWindSpeed.path = '';
+    await setup('Last 30 Minutes', paths);
+
+    expect(readiness()).toBe(false);
+    dir.next([
+      { timestamp: 1000, data: { value: 10, sma: 10, lastAverage: 10, lastMinimum: 10, lastMaximum: 10 } },
+      { timestamp: 2000, data: { value: 20, sma: 15, lastAverage: 15, lastMinimum: 10, lastMaximum: 20 } }
+    ]);
+    expect(readiness()).toBe(true);
+  });
+
+  it('clears the loading overlay once the only active series (speed) has data', async () => {
+    const spd = new Subject();
+    historyMock.getBackfillThenLive.mockReturnValueOnce(spd);
+    const paths = cloneDefaultPaths();
+    paths.trueWindDirection.path = '';
+    await setup('Last 30 Minutes', paths);
+
+    expect(readiness()).toBe(false);
+    spd.next([
+      { timestamp: 1000, data: { value: 5, sma: 5, lastAverage: 5, lastMinimum: 5, lastMaximum: 5 } },
+      { timestamp: 2000, data: { value: 7, sma: 6, lastAverage: 6, lastMinimum: 5, lastMaximum: 7 } }
+    ]);
+    expect(readiness()).toBe(true);
+  });
+
+  it('keeps the loading overlay when both slots are cleared (nothing configured)', async () => {
+    const paths = cloneDefaultPaths();
+    paths.trueWindDirection.path = '';
+    paths.trueWindSpeed.path = '';
+    await setup('Last 30 Minutes', paths);
+
+    expect(historyMock.getBackfillThenLive).not.toHaveBeenCalled();
+    expect(readiness()).toBe(false);
+  });
+
+  it('keeps the loading overlay until both configured series have data', async () => {
+    const dir = new Subject();
+    const spd = new Subject();
+    historyMock.getBackfillThenLive
+      .mockReturnValueOnce(dir)
+      .mockReturnValueOnce(spd);
+    await setup('Last 30 Minutes');
+
+    dir.next([
+      { timestamp: 1000, data: { value: 10, sma: 10, lastAverage: 10, lastMinimum: 10, lastMaximum: 10 } },
+      { timestamp: 2000, data: { value: 20, sma: 15, lastAverage: 15, lastMinimum: 10, lastMaximum: 20 } }
+    ]);
+    expect(readiness()).toBe(false);
+
+    spd.next([
+      { timestamp: 1000, data: { value: 5, sma: 5, lastAverage: 5, lastMinimum: 5, lastMaximum: 5 } },
+      { timestamp: 2000, data: { value: 7, sma: 6, lastAverage: 6, lastMinimum: 5, lastMaximum: 7 } }
+    ]);
+    expect(readiness()).toBe(true);
   });
 });

--- a/src/app/widgets/widget-windtrends-chart/widget-windtrends-chart.component.ts
+++ b/src/app/widgets/widget-windtrends-chart/widget-windtrends-chart.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy, ElementRef, viewChild, inject, effect, NgZone, input, untracked, Signal, ChangeDetectionStrategy } from '@angular/core';
 import { BreakpointObserver, Breakpoints, BreakpointState } from '@angular/cdk/layout';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
+import { IWidgetSvcConfig, IWidgetPath } from '../../core/interfaces/widgets-interface';
 import { HistoryChartStreamService, IHistoryChartStreamParams, isHistoryUnavailable } from '../../core/services/history-chart-stream.service';
 import { IDatasetServiceDatapoint } from '../../core/interfaces/dataset.interfaces';
 import { resolveWindowMs, deriveDataSourceInfo, IChartDataSourceInfo } from '../../core/utils/chart-window.util';
@@ -18,10 +18,8 @@ import { registerChartComponents } from '../../core/utils/chart-registration.uti
 
 registerChartComponents();
 
-/** Windtrends plots two fixed wind paths (direction + speed) over the widget's configured window. */
+/** Rolling-window period (in the widget's time-scale units) the trend backfill/live streams span. */
 const WINDTRENDS_PERIOD = 30;
-const WINDTRENDS_TWD_PATH = 'self.environment.wind.directionTrue';
-const WINDTRENDS_TWS_PATH = 'self.environment.wind.speedTrue';
 
 interface IChartColors {
   valueLine: string | null,
@@ -55,7 +53,38 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
   public static readonly DEFAULT_CONFIG: IWidgetSvcConfig = {
     filterSelfPaths: true,
     color: 'contrast',
-    timeScale: 'Last 30 Minutes'
+    timeScale: 'Last 30 Minutes',
+    // The axes are fixed to degrees (TWD) / knots (TWS) and the widget hardcodes those conversions,
+    // so the slots hide the unit-filter and Format dropdowns (showPathSkUnitsFilter/showConvertUnitTo
+    // false) — a picker there would be inert and misleading; only path and source are configurable.
+    paths: {
+      trueWindDirection: {
+        description: 'True Wind Direction',
+        path: 'self.environment.wind.directionTrue',
+        source: 'default',
+        pathType: 'number',
+        isPathConfigurable: true,
+        pathRequired: false,
+        showPathSkUnitsFilter: false,
+        pathSkUnitsFilter: 'rad',
+        convertUnitTo: 'deg',
+        showConvertUnitTo: false,
+        sampleTime: 1000
+      },
+      trueWindSpeed: {
+        description: 'True Wind Speed',
+        path: 'self.environment.wind.speedTrue',
+        source: 'default',
+        pathType: 'number',
+        isPathConfigurable: true,
+        pathRequired: false,
+        showPathSkUnitsFilter: false,
+        pathSkUnitsFilter: 'm/s',
+        convertUnitTo: 'knots',
+        showConvertUnitTo: false,
+        sampleTime: 1000
+      }
+    }
   };
   private readonly ngZone = inject(NgZone);
   private readonly historyStream = inject(HistoryChartStreamService);
@@ -89,6 +118,12 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
   /** Pending coalesced chart recompute+repaint frame id (one per animation frame across both streams). */
   private _chartUpdateRafId: number | null = null;
   private timeScale: TimeScaleFormat | null = null;
+  /** Signature of the last inputs a full rebuild was performed for (see computeRebuildSignature). */
+  private previousRebuildSignature: string | undefined = undefined;
+  /** Whether each series has a configured (non-empty) path, i.e. is expected to stream. Set by
+   * startStreaming and read by the overlay-readiness gate so a cleared slot is not awaited forever. */
+  private dirSeriesActive = false;
+  private spdSeriesActive = false;
   private dataSourceInfo: IChartDataSourceInfo | null = null;
   private xCenter: number | null = null;
   private xStep: number | null = null;
@@ -145,9 +180,7 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
       const optScales = chart.options?.scales as Record<string, { min?: number; max?: number }> | undefined;
 
       // Loading overlay flag; do not skip drawings so all lines are visible on load
-      const dirVals = chart.data?.datasets?.[0]?.data as (IDataSetRow[] | undefined);
-      const spdVals = chart.data?.datasets?.[5]?.data as (IDataSetRow[] | undefined);
-      const ready = (dirVals?.length ?? 0) >= 2 && (spdVals?.length ?? 0) >= 2;
+      const ready = this.isChartReady(chart);
 
       const drawForAxis = (axisKey: 'x' | 'xSpeed', format: (v: number) => string) => {
         const scale = scaleMap?.[axisKey] as (Scale | undefined);
@@ -324,15 +357,15 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
       });
     });
 
-    // Config lifecycle (timeScale or color): recreate datasets when timeScale changes
+    // Config lifecycle: rebuild the streams + datasets when the time scale or either series'
+    // path/source changes; a color-only edit leaves the signature unchanged and just refreshes options.
     effect(() => {
       const cfg = this.runtime?.options();
       if (!cfg) return;
-      const needsRebuild = this.timeScale !== cfg.timeScale;
-      if (needsRebuild) {
+      const signature = this.computeRebuildSignature(cfg);
+      if (signature !== this.previousRebuildSignature) {
         this.startWidget();
       } else if (this.chart) {
-        // color-only change already handled above, but ensure labels updated
         this.setChartOptions();
       }
     });
@@ -344,6 +377,9 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
     if (!widgetDataChartRef) return;
     const cfg = this.runtime?.options();
     if (!cfg || !cfg.timeScale) return;
+    // Commit the signature only once the canvas is ready and the build proceeds, so a pre-canvas
+    // effect run cannot mark it seen and suppress the real first build.
+    this.previousRebuildSignature = this.computeRebuildSignature(cfg);
     const timeScale = cfg.timeScale as TimeScaleFormat;
     this.timeScale = timeScale;
     this.dataSourceInfo = deriveDataSourceInfo(resolveWindowMs(timeScale, WINDTRENDS_PERIOD));
@@ -716,49 +752,92 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
     this.setDatasetsColors();
   }
 
+  /** Read a single configurable path slot from the merged config, tolerating the array path form. */
+  private windPathSlot(cfg: IWidgetSvcConfig | undefined, slot: string): IWidgetPath | undefined {
+    const paths = cfg?.paths;
+    if (!paths || Array.isArray(paths)) return undefined;
+    return paths[slot];
+  }
+
+  /** Signature over the inputs that require a full stream/dataset rebuild (time scale + both series). */
+  private computeRebuildSignature(cfg: IWidgetSvcConfig): string {
+    const dir = this.windPathSlot(cfg, 'trueWindDirection');
+    const spd = this.windPathSlot(cfg, 'trueWindSpeed');
+    return [cfg.timeScale, dir?.path, dir?.source, spd?.path, spd?.source].join('|');
+  }
+
+  /**
+   * Whether the loading overlay can clear: every *configured* series must have enough points. A
+   * cleared slot (per-series stream gating) is not awaited — otherwise its empty datasets would hold
+   * the overlay up forever. With no series configured at all, stay in the acquiring state.
+   */
+  private isChartReady(chart: Chart): boolean {
+    const dirVals = chart.data?.datasets?.[0]?.data as (IDataSetRow[] | undefined);
+    const spdVals = chart.data?.datasets?.[5]?.data as (IDataSetRow[] | undefined);
+    const dirReady = !this.dirSeriesActive || (dirVals?.length ?? 0) >= 2;
+    const spdReady = !this.spdSeriesActive || (spdVals?.length ?? 0) >= 2;
+    return (this.dirSeriesActive || this.spdSeriesActive) && dirReady && spdReady;
+  }
+
   private startStreaming(): void {
     this._dsDirectionSub?.unsubscribe();
     this._dsSpeedSub?.unsubscribe();
+    this._dsDirectionSub = null;
+    this._dsSpeedSub = null;
 
     const timeScale = this.timeScale;
     const info = this.dataSourceInfo;
-    if (!timeScale || !info) return;
+    const cfg = this.runtime?.options();
+    if (!timeScale || !info || !cfg) return;
     const baseParams = {
-      source: 'default',
       windowMs: resolveWindowMs(timeScale, WINDTRENDS_PERIOD),
       sampleTime: info.sampleTime,
       maxDataPoints: info.maxDataPoints,
       smoothingPeriod: info.smoothingPeriod
     };
-    // TWD is a direction path; the History engine auto-resolves its circular domain from the unit.
-    const twdParams: IHistoryChartStreamParams = { ...baseParams, path: WINDTRENDS_TWD_PATH };
-    const twsParams: IHistoryChartStreamParams = { ...baseParams, path: WINDTRENDS_TWS_PATH };
 
-    this._dsDirectionSub = this.historyStream.getBackfillThenLive(twdParams).subscribe(emission => {
-      if (isHistoryUnavailable(emission)) return;
-      if (Array.isArray(emission)) {
-        this.pushRowsToDatasets(emission);
-      } else {
-        this.pushRowsToDatasets([emission]);
-        if (this.chart.data.datasets[0].data.length > info.maxDataPoints) {
-          for (let i = 0; i <= 4; i++) this.chart.data.datasets[i].data.shift();
-        }
-      }
-      this.scheduleChartUpdate();
-    });
+    // Each series subscribes independently on its own configured path. pathRequired is false, so a
+    // user can clear one slot; gating per series keeps the other one rendering rather than tearing
+    // down the whole chart. Source falls back to the SK default when the slot leaves it unset.
+    const dir = this.windPathSlot(cfg, 'trueWindDirection');
+    const dirPath = dir?.path;
+    const spd = this.windPathSlot(cfg, 'trueWindSpeed');
+    const spdPath = spd?.path;
+    this.dirSeriesActive = !!dirPath;
+    this.spdSeriesActive = !!spdPath;
 
-    this._dsSpeedSub = this.historyStream.getBackfillThenLive(twsParams).subscribe(emission => {
-      if (isHistoryUnavailable(emission)) return;
-      if (Array.isArray(emission)) {
-        this.pushRowsToSpeedDatasets(emission);
-      } else {
-        this.pushRowsToSpeedDatasets([emission]);
-        if (this.chart.data.datasets[5].data.length > info.maxDataPoints) {
-          for (let i = 5; i <= 9; i++) this.chart.data.datasets[i].data.shift();
+    if (dirPath) {
+      // TWD is a direction path; the History engine auto-resolves its circular domain from the unit.
+      const twdParams: IHistoryChartStreamParams = { ...baseParams, path: dirPath, source: dir?.source ?? 'default' };
+      this._dsDirectionSub = this.historyStream.getBackfillThenLive(twdParams).subscribe(emission => {
+        if (isHistoryUnavailable(emission)) return;
+        if (Array.isArray(emission)) {
+          this.pushRowsToDatasets(emission);
+        } else {
+          this.pushRowsToDatasets([emission]);
+          if (this.chart.data.datasets[0].data.length > info.maxDataPoints) {
+            for (let i = 0; i <= 4; i++) this.chart.data.datasets[i].data.shift();
+          }
         }
-      }
-      this.scheduleChartUpdate();
-    });
+        this.scheduleChartUpdate();
+      });
+    }
+
+    if (spdPath) {
+      const twsParams: IHistoryChartStreamParams = { ...baseParams, path: spdPath, source: spd?.source ?? 'default' };
+      this._dsSpeedSub = this.historyStream.getBackfillThenLive(twsParams).subscribe(emission => {
+        if (isHistoryUnavailable(emission)) return;
+        if (Array.isArray(emission)) {
+          this.pushRowsToSpeedDatasets(emission);
+        } else {
+          this.pushRowsToSpeedDatasets([emission]);
+          if (this.chart.data.datasets[5].data.length > info.maxDataPoints) {
+            for (let i = 5; i <= 9; i++) this.chart.data.datasets[i].data.shift();
+          }
+        }
+        this.scheduleChartUpdate();
+      });
+    }
   }
 
   private unwrapAngles(degrees: (number | null)[]): (number | null)[] {
@@ -953,10 +1032,12 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
       this.xStepSpeed = spStep;
     }
 
-    // Fixed, non-scrolling y-axis window (relative age)
+    // Fixed, non-scrolling y-axis window (relative age). Gate on either series so a cleared
+    // direction slot still lets the speed series recompute its age-based y positions.
     const windowMs = this.getWindowMs(this.timeScale);
-    const data0 = this.chart.data.datasets[0].data as (IDataSetRow[]);
-    if (data0.length > 0) {
+    const dirData = this.chart.data.datasets[0].data as (IDataSetRow[]);
+    const speedData = this.chart.data.datasets[5].data as (IDataSetRow[]);
+    if (dirData.length > 0 || speedData.length > 0) {
       const nowTs = Date.now();
       // Recompute y for all datasets as age (ms) relative to now
       this.chart.data.datasets.forEach(ds => {

--- a/src/assets/kip-dashboard-schema.json
+++ b/src/assets/kip-dashboard-schema.json
@@ -3009,12 +3009,40 @@
       "selector": "widget-wind-steer"
     },
     {
-      "bindingKind": "none",
+      "bindingKind": "paths-record",
       "category": "Racing",
       "componentClassName": "WidgetWindTrendsChartComponent",
       "defaultConfig": {
         "color": "contrast",
         "filterSelfPaths": true,
+        "paths": {
+          "trueWindDirection": {
+            "convertUnitTo": "deg",
+            "description": "True Wind Direction",
+            "isPathConfigurable": true,
+            "path": "self.environment.wind.directionTrue",
+            "pathRequired": false,
+            "pathSkUnitsFilter": "rad",
+            "pathType": "number",
+            "sampleTime": 1000,
+            "showConvertUnitTo": false,
+            "showPathSkUnitsFilter": false,
+            "source": "default"
+          },
+          "trueWindSpeed": {
+            "convertUnitTo": "knots",
+            "description": "True Wind Speed",
+            "isPathConfigurable": true,
+            "path": "self.environment.wind.speedTrue",
+            "pathRequired": false,
+            "pathSkUnitsFilter": "m/s",
+            "pathType": "number",
+            "sampleTime": 1000,
+            "showConvertUnitTo": false,
+            "showPathSkUnitsFilter": false,
+            "source": "default"
+          }
+        },
         "timeScale": "Last 30 Minutes"
       },
       "defaultHeight": 8,
@@ -3024,7 +3052,32 @@
       "minHeight": 6,
       "minWidth": 8,
       "name": "Wind Trends",
-      "pathSlots": [],
+      "pathSlots": [
+        {
+          "defaultConvertUnitTo": "deg",
+          "defaultPath": "self.environment.wind.directionTrue",
+          "description": "True Wind Direction",
+          "expectedSkUnit": "rad",
+          "isPathConfigurable": true,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 1000,
+          "slot": "trueWindDirection",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "knots",
+          "defaultPath": "self.environment.wind.speedTrue",
+          "description": "True Wind Speed",
+          "expectedSkUnit": "m/s",
+          "isPathConfigurable": true,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 1000,
+          "slot": "trueWindSpeed",
+          "source": "default"
+        }
+      ],
       "requiredPlugins": [],
       "selector": "widget-windtrends-chart"
     },

--- a/tools/gen-mcp-schema/widget-schema.spec.ts
+++ b/tools/gen-mcp-schema/widget-schema.spec.ts
@@ -23,8 +23,20 @@ describe('extractWidgetSchemas', () => {
     expect(bySelector('widget-boolean-switch')?.bindingKind).toBe('paths-array');
     expect(bySelector('widget-zones-state-panel')?.bindingKind).toBe('paths-array');
     expect(bySelector('widget-data-chart')?.bindingKind).toBe('datachart');
-    expect(bySelector('widget-windtrends-chart')?.bindingKind).toBe('none');
+    expect(bySelector('widget-windtrends-chart')?.bindingKind).toBe('paths-record');
     expect(bySelector('widget-bms')?.bindingKind).toBe('none');
+  });
+
+  it('captures the windtrends configurable wind slots', () => {
+    const slots = bySelector('widget-windtrends-chart')?.pathSlots ?? [];
+    expect(slots.map((s) => s.slot)).toEqual(['trueWindDirection', 'trueWindSpeed']);
+    expect(slots.find((s) => s.slot === 'trueWindSpeed')).toMatchObject({
+      defaultPath: 'self.environment.wind.speedTrue',
+      expectedSkUnit: 'm/s',
+      defaultConvertUnitTo: 'knots',
+      isPathConfigurable: true,
+      pathRequired: false,
+    });
   });
 
   it('extracts path slots for a record-bound widget (numeric)', () => {


### PR DESCRIPTION
## What

The Wind Trends widget hardcoded its two series paths (TWD `self.environment.wind.directionTrue`, TWS `self.environment.wind.speedTrue`) as module constants with no `config.paths`. On a ground-referenced-only vessel (`speedOverGround` present, `speedTrue` absent) the TWS line was **permanently blank** with no way to repoint it. Fixes #290.

## Approach (maintainer decision)

Make both series **user-configurable** via the standard `config.paths` record — reuse the existing paths-config machinery, build no new UI. **The shipped defaults are unchanged** (`speedTrue` kept as the TWS default; `directionTrue` for TWD; **no auto-fallback**): existing installs behave identically, and a ground-referenced vessel repoints TWS to `speedOverGround` through the now-available Paths tab. The fix is *configurability*, not a default change.

## Changes (four coordinated sites, reuse-only)

1. **`DEFAULT_CONFIG`** — a two-slot `paths` record (`trueWindDirection`, `trueWindSpeed`, shaped like windsteer's). Declaring `paths` alone surfaces the generic **Paths** config tab (`root-modal` renders `<paths-options>` on `paths !== undefined` — zero widget-specific UI).
2. **Consumption** — streaming reads each slot's `path`/`source` (→ `'default'` when unset) and subscribes **per series independently**, gated on its own non-empty path, so clearing one slot (`pathRequired: false`) still renders the other. Stays on `HistoryChartStreamService.getBackfillThenLive`.
3. **Rebuild trigger** — broadened from `timeScale`-only to a signature over `[timeScale, both slots' path/source]` (mirrors `widget-data-chart`'s `pathSignature`), so edited paths take effect. The y-axis age recompute is gated on *either* series so a cleared direction slot still positions the speed series.
4. **History-dialog sync** — `mapWindTrendsWidget` reads the same slots and omits a series when its path is cleared (mirrors `mapDataChartWidget`).

MCP schema regenerated: windtrends `bindingKind` `none → paths-record` with the two slots.

## Notes (deliberate, for review)

- **`showConvertUnitTo: false` on both slots** — the widget's axes are fixed deg/kts and the conversion is hardcoded regardless of the slot, so exposing a Format dropdown that does nothing would mislead. (windsteer's speed slot similarly omits it.)
- **Known minor limitation (out of scope):** the center-tick "Data acquisition…" overlay clears only when *both* series have ≥2 points, so clearing one slot leaves the overlay box over the chart center while the other series still renders. Fixing needs the plugin to know which slots are active — left per the minimal-scope decision.

## Testing

- Windtrends component spec (7): default **unchanged** (`directionTrue` + `speedTrue`) + configured-paths + both NIL-gating directions + rebuild-on-path-change. Sync-service spec (15): default **unchanged** + configured + NIL.
- Local gate on halpi: `lint` clean, `betterer:ci` unchanged (179), schema drift gate green (7 suites/31 tests), both modified specs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
