### PR TITLE
feat(embed): suppress remote-control delta publication under embed mode

### DIFF
--- a/src/app/core/services/remote-dashboards.service.spec.ts
+++ b/src/app/core/services/remote-dashboards.service.spec.ts
@@ -8,6 +8,7 @@ import { Dashboard, DashboardService } from './dashboard.service';
 import { DataService, IPathUpdate } from './data.service';
 import { SettingsService } from './settings.service';
 import { SignalkRequestsService } from './signalk-requests.service';
+import { EmbedModeService } from './embed-mode.service';
 import { States } from '../interfaces/signalk-interfaces';
 
 const KIP_UUID = 'test-kip-uuid';
@@ -410,6 +411,40 @@ describe('RemoteDashboardsService', () => {
 
       expect(errorSpy).toHaveBeenCalledTimes(3);
       errorSpy.mockRestore();
+    });
+  });
+
+  describe('under embed mode', () => {
+    beforeEach(() => {
+      TestBed.overrideProvider(EmbedModeService, { useValue: { embed: () => true, profile: () => null } });
+    });
+
+    it('publishes no remote-control deltas at all, even with remote control enabled at construction', () => {
+      settings.isRemoteControl.set(true);
+      dashboard.activeDashboard.set(1);
+
+      createService();
+
+      expect(requests.putRequest).not.toHaveBeenCalled();
+    });
+
+    it('does not act as a remote-control target (ignores incoming activeScreen requests)', () => {
+      settings.isRemoteControl.set(true);
+      createService();
+
+      data.push(OWN_ACTIVE_SCREEN_PATH, 2);
+      TestBed.tick();
+
+      expect(dashboard.navigateTo).not.toHaveBeenCalled();
+    });
+
+    it('does not publish when remote control is toggled on during the session', () => {
+      createService();
+      requests.putRequest.mockClear();
+
+      enableRemoteControl();
+
+      expect(requests.putRequest).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/core/services/remote-dashboards.service.ts
+++ b/src/app/core/services/remote-dashboards.service.ts
@@ -4,6 +4,7 @@ import { DashboardService, Dashboard } from './dashboard.service';
 import { DataService } from './data.service';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { SignalkRequestsService } from './signalk-requests.service';
+import { EmbedModeService } from './embed-mode.service';
 
 /**
  * Lightweight dashboard descriptor shared to remote displays.
@@ -58,6 +59,7 @@ export class RemoteDashboardsService {
   private readonly dashboard = inject(DashboardService);
   private readonly data = inject(DataService);
   private readonly requests = inject(SignalkRequestsService);
+  private readonly embedMode = inject(EmbedModeService);
 
   private readonly KIP_UUID = this.settings.KipUUID;
   private readonly CHANGE_SCREEN_PATH = `self.displays.${this.KIP_UUID}.activeScreen`;
@@ -68,6 +70,13 @@ export class RemoteDashboardsService {
   private previousIsRemoteControl = false;
 
   constructor() {
+    // A chromeless embed panel is strictly read-only and must not advertise itself as a
+    // remote-control target: suppress all remote-control delta publication and the
+    // incoming-command navigation by never wiring the clears or the effects (#306).
+    if (this.embedMode.embed()) {
+      return;
+    }
+
     // Clear all remote paths on service initialization
     this.setActiveDashboardOnRemote(this.KIP_UUID, null);
     this.setScreensOnRemote(this.KIP_UUID, null);


### PR DESCRIPTION
## What

A chromeless **embed** panel is strictly read-only and should not advertise itself as a remote-control target. `RemoteDashboardsService` published this device's screen list + active-dashboard index to the SK server on `self.kip.remote.*`, and acted on incoming `activeScreen` requests — **none of it gated by embed**. Closes #306.

## Why it matters (beyond hygiene)

The embed iframe shares the device `KipUUID` + `connectionConfig` (localStorage) with the full Skip app on the same origin. So:
- The three **ungated** constructor "clear" PUTs fire on *every* embed boot regardless of `isRemoteControl`.
- If remote control is enabled in the full app, the embed panel inherits `isRemoteControl=true` and both publishes and acts as a nav target — and its boot clears can **stomp the remote paths the full app just published for the same UUID**.

## Change

Inject the leaf `EmbedModeService` (no DI-cycle risk — it injects nothing) and **early-return at the top of the constructor**, before the boot clears and before the effects are wired. Under embed there is therefore zero remote-control delta publication *and* no incoming-command navigation (effect 4 is never created). The passive `activeScreen` subscription (a read) runs in a field initializer and is left in place — a read is consistent with read-only embed.

9 lines of source, one guard.

## Notes for review

- This is *not* a breach of the E6 persisted-write invariant (these are transient pub/sub deltas, not `applicationData` writes) — it closes the shared-UUID stomp + "advertises as remote-control target" gap.
- The `self.kip.remote.*` command channel is currently publish-only-orphaned (its server-side handler was removed in `7ccc3990`), so this suppresses publication of an already-consumer-less channel plus the still-live incoming-nav side.
- Sequencing: the kip→skip wire-path rename (#192, Stage 2) will later rename `self.kip.remote.*` in this same file; this lands first, so no collision.

## Testing

- `remote-dashboards.service.spec.ts` — 28 green (25 existing + 3 new): under embed, zero `putRequest` even with remote control enabled at construction; no `navigateTo` on an incoming `activeScreen`; no publish when remote control is toggled on mid-session. Existing tests unaffected (the real `EmbedModeService` reads empty jsdom `location.search` → `embed=false`).
- Local gate on halpi: lint clean, betterer:ci unchanged (179).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
