### PR TITLE
fix(data): wire refcounted path-registration release + prune evicted-context caches (#243 stage 2)

### DIFF
--- a/src/app/core/components/remote-control/remote-control.component.spec.ts
+++ b/src/app/core/components/remote-control/remote-control.component.spec.ts
@@ -1,6 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Observable, Subject } from 'rxjs';
 import { RemoteControlComponent } from './remote-control.component';
+import { DataService, IPathUpdate, IPathUpdateWithPath } from '../../services/data.service';
+import { SettingsService } from '../../services/settings.service';
+import { SignalkRequestsService } from '../../services/signalk-requests.service';
 
 describe('RemoteControlComponent', () => {
   let component: RemoteControlComponent;
@@ -19,5 +23,84 @@ describe('RemoteControlComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+});
+
+/**
+ * Faithful-enough DataService double for the two per-display registrations: it records each
+ * acquirePath path and hands back a distinct release spy per acquire, so the release-before-rebind
+ * and release-on-destroy wiring can be asserted directly.
+ */
+class FakeRemoteDataService {
+  acquireCalls: string[] = [];
+  releaseSpies: ReturnType<typeof vi.fn>[] = [];
+
+  subscribePathTree(): Observable<IPathUpdateWithPath> {
+    return new Subject<IPathUpdateWithPath>().asObservable();
+  }
+
+  acquirePath(path: string): { data$: Observable<IPathUpdate>; release: () => void } {
+    this.acquireCalls.push(path);
+    const release = vi.fn();
+    this.releaseSpies.push(release);
+    return { data$: new Subject<IPathUpdate>().asObservable(), release };
+  }
+}
+
+describe('RemoteControlComponent registration release balance', () => {
+  let component: RemoteControlComponent;
+  let fakeData: FakeRemoteDataService;
+
+  beforeEach(async () => {
+    fakeData = new FakeRemoteDataService();
+    await TestBed.configureTestingModule({
+      imports: [RemoteControlComponent],
+      providers: [
+        { provide: DataService, useValue: fakeData },
+        { provide: SettingsService, useValue: { KipUUID: 'test-uuid' } },
+        { provide: SignalkRequestsService, useValue: { putRequest: vi.fn() } }
+      ]
+    }).compileComponents();
+
+    // Construct without detectChanges: the constructor wires the subscriptions/effects, and we drive
+    // the private rebind directly — so no template render (and no child-component DI) is needed.
+    component = TestBed.createComponent(RemoteControlComponent).componentInstance;
+  });
+
+  function rebind(displayId: string | null): void {
+    (component as unknown as { rebindSelectedDisplaySubscriptions(id: string | null): void })
+      .rebindSelectedDisplaySubscriptions(displayId);
+  }
+
+  it('releases the two prior display registrations before rebinding to a new display', () => {
+    rebind('display-1');
+    expect(fakeData.acquireCalls).toEqual([
+      'self.displays.display-1',
+      'self.displays.display-1.screenIndex'
+    ]);
+    const prior = fakeData.releaseSpies.slice(); // the two display-1 handles
+
+    rebind('display-2');
+
+    // Both prior handles are released (release-before-rebind), and two new acquires happen.
+    expect(prior[0]).toHaveBeenCalledTimes(1);
+    expect(prior[1]).toHaveBeenCalledTimes(1);
+    expect(fakeData.acquireCalls).toEqual([
+      'self.displays.display-1',
+      'self.displays.display-1.screenIndex',
+      'self.displays.display-2',
+      'self.displays.display-2.screenIndex'
+    ]);
+  });
+
+  it('releases the two currently-held display registrations on destroy', () => {
+    rebind('display-1');
+    const held = fakeData.releaseSpies.slice();
+    expect(held.length).toBe(2);
+
+    (component as unknown as { ngOnDestroy(): void }).ngOnDestroy();
+
+    expect(held[0]).toHaveBeenCalledTimes(1);
+    expect(held[1]).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/core/components/remote-control/remote-control.component.ts
+++ b/src/app/core/components/remote-control/remote-control.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, effect, inject, signal, DestroyRef } from '@angular/core';
+import { Component, computed, effect, inject, signal, DestroyRef, OnDestroy } from '@angular/core';
 import { PageHeaderComponent } from '../page-header/page-header.component';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatListModule } from '@angular/material/list';
@@ -19,7 +19,7 @@ import { SignalkRequestsService } from '../../services/signalk-requests.service'
   templateUrl: './remote-control.component.html',
   styleUrl: './remote-control.component.scss'
 })
-export class RemoteControlComponent {
+export class RemoteControlComponent implements OnDestroy {
   private readonly COMMAND_REQUEST_ACTIVE_SCREEN_PATH = 'self.kip.remote.requestActiveScreen';
 
   private readonly _settings = inject(SettingsService);
@@ -35,6 +35,8 @@ export class RemoteControlComponent {
   private readonly displaysMap = signal<Record<string, IKipDisplayInfo>>({});
   private selectedDisplaySub: Subscription | null = null;
   private selectedScreenIndexSub: Subscription | null = null;
+  private selectedDisplayRelease: (() => void) | null = null;
+  private selectedScreenIndexRelease: (() => void) | null = null;
 
   protected readonly displays = computed<IKipDisplayInfo[]>(() => {
     const items = Object.values(this.displaysMap());
@@ -117,6 +119,12 @@ export class RemoteControlComponent {
     this.selectedDisplaySub = null;
     this.selectedScreenIndexSub?.unsubscribe();
     this.selectedScreenIndexSub = null;
+    // Release the previously-acquired registrations before rebinding to the new display, so a user
+    // cycling through remote displays does not pin one (path, source) registration per selection.
+    this.selectedDisplayRelease?.();
+    this.selectedDisplayRelease = null;
+    this.selectedScreenIndexRelease?.();
+    this.selectedScreenIndexRelease = null;
 
     if (!displayId) {
       this.screensLoading.set(false);
@@ -127,7 +135,9 @@ export class RemoteControlComponent {
 
     this.screensLoading.set(true);
 
-    this.selectedDisplaySub = this._data.subscribePath(`self.displays.${displayId}`, 'default')
+    const displayHandle = this._data.acquirePath(`self.displays.${displayId}`, 'default');
+    this.selectedDisplayRelease = displayHandle.release;
+    this.selectedDisplaySub = displayHandle.data$
       .pipe(takeUntilDestroyed(this._destroyRef))
       .subscribe(update => {
         this.screensLoading.set(false);
@@ -171,7 +181,9 @@ export class RemoteControlComponent {
         }
       });
 
-    this.selectedScreenIndexSub = this._data.subscribePath(`self.displays.${displayId}.screenIndex`, 'default')
+    const screenIndexHandle = this._data.acquirePath(`self.displays.${displayId}.screenIndex`, 'default');
+    this.selectedScreenIndexRelease = screenIndexHandle.release;
+    this.selectedScreenIndexSub = screenIndexHandle.data$
       .pipe(takeUntilDestroyed(this._destroyRef))
       .subscribe(update => {
         const nextValue = update.data.value;
@@ -208,5 +220,10 @@ export class RemoteControlComponent {
       console.error('Failed to set active screen: request was not accepted');
       this.activeScreenIdx.set(previous);
     }
+  }
+
+  ngOnDestroy(): void {
+    this.selectedDisplayRelease?.();
+    this.selectedScreenIndexRelease?.();
   }
 }

--- a/src/app/core/directives/widget-streams.directive.spec.ts
+++ b/src/app/core/directives/widget-streams.directive.spec.ts
@@ -11,6 +11,10 @@ class FakeDataService {
         path: string;
         source: string;
     }[] = [];
+    releases: {
+        path: string;
+        source: string;
+    }[] = [];
     subjects = new Map<string, Subject<IPathUpdate>>();
     timeoutCalls: {
         path: string;
@@ -26,6 +30,20 @@ class FakeDataService {
             this.subjects.set(key, new Subject<IPathUpdate>());
         }
         return this.subjects.get(key)!.asObservable();
+    }
+
+    // Mirrors the real DataService: acquirePath composes subscribePath (so `calls` still records the
+    // base acquisition) and hands back an idempotent release that records the balanced teardown.
+    acquirePath(path: string, source?: string): { data$: Observable<IPathUpdate>; release: () => void } {
+        const src = (source?.trim() || 'default');
+        const data$ = this.subscribePath(path, src);
+        let released = false;
+        const release = () => {
+            if (released) return;
+            released = true;
+            this.releases.push({ path, source: src });
+        };
+        return { data$, release };
     }
 
     timeoutPathObservable(path: string, source: string, pathType: string): void {
@@ -493,6 +511,78 @@ describe('WidgetStreamsDirective', () => {
         await vi.advanceTimersByTimeAsync(35);
         expect(hits).toEqual(['A', 'C', 'D', 'E', 'F']);
     });
+
+    it('releases the old base exactly once when the source rebinds', () => {
+        const cfg1 = makeCfg({ path: 'env.rebind', source: null, pathType: 'string', sampleTime: 50 });
+        directive.setStreamsConfig(cfg1);
+        directive.observe('p', () => { });
+        expect(dataSvc.calls).toEqual([{ path: 'env.rebind', source: 'default' }]);
+        expect(dataSvc.releases).toEqual([]);
+
+        const cfg2 = makeCfg({ path: 'env.rebind', source: 'n2k', pathType: 'string', sampleTime: 50 });
+        directive.applyStreamsConfigDiff(cfg2);
+
+        // The old (default) base is released once; the new (n2k) base is acquired.
+        expect(dataSvc.releases).toEqual([{ path: 'env.rebind', source: 'default' }]);
+        expect(dataSvc.calls).toEqual([
+            { path: 'env.rebind', source: 'default' },
+            { path: 'env.rebind', source: 'n2k' }
+        ]);
+    });
+
+    it('does NOT release or re-acquire the base on a sampleTime or convertUnitTo change (the trap)', () => {
+        const cfg1 = makeCfg({ path: 'env.trap', source: null, pathType: 'number', sampleTime: 100 });
+        directive.setStreamsConfig(cfg1);
+        directive.observe('p', () => { });
+        expect(dataSvc.calls.length).toBe(1);
+
+        // Same base identity (path+source): pipeline rebuilds, but releasing here would over-release
+        // a live registration, so the base must be neither released nor re-acquired.
+        directive.applyStreamsConfigDiff(makeCfg({ path: 'env.trap', source: null, pathType: 'number', sampleTime: 30 }));
+        expect(dataSvc.calls.length).toBe(1);
+        expect(dataSvc.releases).toEqual([]);
+
+        directive.applyStreamsConfigDiff(makeCfg({ path: 'env.trap', source: null, pathType: 'number', sampleTime: 30, convertUnitTo: 'x10' }));
+        expect(dataSvc.calls.length).toBe(1);
+        expect(dataSvc.releases).toEqual([]);
+    });
+
+    it('releases the base when its path key is removed from the config', () => {
+        directive.setStreamsConfig(makeCfg({ key: 'p', path: 'env.keep', source: null }));
+        directive.observe('p', () => { });
+        expect(dataSvc.calls.length).toBe(1);
+
+        // New config drops key 'p' entirely (replaced by 'q').
+        directive.applyStreamsConfigDiff(makeCfg({ key: 'q', path: 'env.other', source: null }));
+        expect(dataSvc.releases).toEqual([{ path: 'env.keep', source: 'default' }]);
+    });
+
+    it('releases the base when the path becomes empty', () => {
+        directive.setStreamsConfig(makeCfg({ path: 'env.clean', source: null }));
+        directive.observe('p', () => { });
+        expect(dataSvc.calls.length).toBe(1);
+
+        directive.applyStreamsConfigDiff(makeCfg({ path: '' as string, source: null }));
+        expect(dataSvc.releases).toEqual([{ path: 'env.clean', source: 'default' }]);
+    });
+
+    it('releases all held bases in the bulk config-reset branch', () => {
+        directive.setStreamsConfig(makeCfg({ path: 'env.reset', source: null }));
+        directive.observe('p', () => { });
+        expect(dataSvc.calls.length).toBe(1);
+
+        directive.applyStreamsConfigDiff(undefined);
+        expect(dataSvc.releases).toEqual([{ path: 'env.reset', source: 'default' }]);
+    });
+
+    it('releases all held bases on destroy (the primary current leak vector)', () => {
+        directive.setStreamsConfig(makeCfg({ path: 'env.destroy', source: null }));
+        directive.observe('p', () => { });
+        expect(dataSvc.releases).toEqual([]);
+
+        directive.ngOnDestroy();
+        expect(dataSvc.releases).toEqual([{ path: 'env.destroy', source: 'default' }]);
+    });
 });
 
 /**
@@ -516,6 +606,10 @@ class TtlFakeDataService {
             ));
         }
         return this.subjects.get(key)!.asObservable();
+    }
+
+    acquirePath(path: string, source?: string): { data$: Observable<IPathUpdate>; release: () => void } {
+        return { data$: this.subscribePath(path, source), release: () => undefined };
     }
 
     timeoutPathObservable(path: string, source: string, pathType: string): void {

--- a/src/app/core/directives/widget-streams.directive.spec.ts
+++ b/src/app/core/directives/widget-streams.directive.spec.ts
@@ -101,6 +101,33 @@ function makeCfg(opts: {
     };
 }
 
+/** Build a config holding several distinct path bases so the multi-base release paths can be exercised. */
+function makeMultiCfg(entries: { key: string; path: string }[]): IWidgetSvcConfig {
+    const paths: Record<string, IWidgetPath> = {};
+    for (const e of entries) {
+        paths[e.key] = {
+            description: 'Test path',
+            path: e.path,
+            pathID: `id-${e.key}`,
+            source: null,
+            pathType: 'string',
+            suppressBootstrapNull: false,
+            isPathConfigurable: true,
+            showPathSkUnitsFilter: false,
+            pathSkUnitsFilter: null,
+            convertUnitTo: undefined as unknown as string,
+            sampleTime: 1000,
+            supportsPut: false
+        };
+    }
+    return { ...makeCfg(), paths };
+}
+
+/** Read the directive's private held-handle map size to assert releaseAllBases emptied it. */
+function heldBaseCount(directive: WidgetStreamsDirective): number {
+    return (directive as unknown as { baseReleases: Map<string, unknown> }).baseReleases.size;
+}
+
 describe('WidgetStreamsDirective', () => {
     let directive: WidgetStreamsDirective;
     let dataSvc: FakeDataService;
@@ -582,6 +609,44 @@ describe('WidgetStreamsDirective', () => {
 
         directive.ngOnDestroy();
         expect(dataSvc.releases).toEqual([{ path: 'env.destroy', source: 'default' }]);
+    });
+
+    it('does NOT release or re-acquire the base on a timeout-setting change (rootChanged rebuild)', () => {
+        directive.setStreamsConfig(makeCfg({ path: 'env.root', source: null, pathType: 'string', sampleTime: 50, enableTimeout: false, dataTimeout: 5 }));
+        directive.observe('p', () => { });
+        expect(dataSvc.calls.length).toBe(1);
+
+        // A dataTimeout change flips the ROOT signature, taking the distinct rootChanged branch that
+        // force-rebuilds every path's pipeline even though the per-path signature is unchanged. baseKey
+        // (path+source) is still identical, so the base must be neither released nor re-acquired.
+        directive.applyStreamsConfigDiff(makeCfg({ path: 'env.root', source: null, pathType: 'string', sampleTime: 50, enableTimeout: false, dataTimeout: 7 }));
+        expect(dataSvc.calls.length).toBe(1);
+        expect(dataSvc.releases).toEqual([]);
+    });
+
+    it('releases every held base (not just one) in the bulk config-reset branch', () => {
+        directive.setStreamsConfig(makeMultiCfg([{ key: 'a', path: 'env.a' }, { key: 'b', path: 'env.b' }]));
+        directive.observe('a', () => { });
+        directive.observe('b', () => { });
+        expect(dataSvc.calls.length).toBe(2);
+        expect(heldBaseCount(directive)).toBe(2);
+
+        directive.applyStreamsConfigDiff(undefined);
+
+        expect(dataSvc.releases.map(r => r.path).sort()).toEqual(['env.a', 'env.b']);
+        expect(heldBaseCount(directive)).toBe(0);
+    });
+
+    it('releases every held base (not just one) on destroy', () => {
+        directive.setStreamsConfig(makeMultiCfg([{ key: 'a', path: 'env.a' }, { key: 'b', path: 'env.b' }]));
+        directive.observe('a', () => { });
+        directive.observe('b', () => { });
+        expect(heldBaseCount(directive)).toBe(2);
+
+        directive.ngOnDestroy();
+
+        expect(dataSvc.releases.map(r => r.path).sort()).toEqual(['env.a', 'env.b']);
+        expect(heldBaseCount(directive)).toBe(0);
     });
 });
 

--- a/src/app/core/directives/widget-streams.directive.ts
+++ b/src/app/core/directives/widget-streams.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, DestroyRef, inject, signal } from '@angular/core';
+import { Directive, DestroyRef, OnDestroy, inject, signal } from '@angular/core';
 import { DataService, IPathUpdate } from '../services/data.service';
 import { UnitsService } from '../services/units.service';
 import { IWidgetSvcConfig } from '../interfaces/widgets-interface';
@@ -31,7 +31,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
  * - Config changes automatically trigger diff-based subscription updates
  * - All subscriptions auto-cleanup on directive destroy
  */
-export class WidgetStreamsDirective {
+export class WidgetStreamsDirective implements OnDestroy {
   private _streamsConfig = signal<IWidgetSvcConfig | undefined>(undefined);
   private readonly dataService = inject(DataService);
   private readonly unitsService = inject(UnitsService);
@@ -43,6 +43,9 @@ export class WidgetStreamsDirective {
   private subscriptions = new Map<string, { sub: Subscription; signature: string }>();
   // Track identity of the cached base observable (path + normalized source) per path key
   private baseSignatures = new Map<string, string>();
+  // Release handle for each acquired base, held 1:1 with the baseSignatures keyset so every base
+  // registration is released exactly when its cached base is dropped (and all of them on destroy).
+  private baseReleases = new Map<string, () => void>();
   // Root-level signature (timeout settings) to detect when all paths need pipeline rebuild
   private reset$ = new Subject<void>();
   private rootSignature: string | undefined;
@@ -83,6 +86,18 @@ export class WidgetStreamsDirective {
     if (!this.streams) this.streams = new Map<string, Observable<IPathUpdate>>();
   }
 
+  /** Release and forget the base registration held for a path key (idempotent, safe when absent). */
+  private releaseBase(pathName: string): void {
+    this.baseReleases.get(pathName)?.();
+    this.baseReleases.delete(pathName);
+  }
+
+  /** Release every held base registration (used on config reset and directive destroy). */
+  private releaseAllBases(): void {
+    this.baseReleases.forEach(release => release());
+    this.baseReleases.clear();
+  }
+
   /** Create (or reuse) base observable, assemble pipeline, and subscribe with diff-aware replacement. */
   private buildAndSubscribe(pathName: string, next: (value: IPathUpdate) => void, cfg: IWidgetSvcConfig, pathCfg: { path: string; pathType: string; sampleTime?: number; convertUnitTo?: string; source?: string; suppressBootstrapNull?: boolean }): void {
     const normalizedPath = this.normalizePath(pathCfg.path);
@@ -91,6 +106,7 @@ export class WidgetStreamsDirective {
       if (existing) existing.sub.unsubscribe();
       this.subscriptions.delete(pathName);
       this.streams?.delete(pathName);
+      this.releaseBase(pathName);
       this.baseSignatures.delete(pathName);
       return;
     }
@@ -101,7 +117,13 @@ export class WidgetStreamsDirective {
     const effectiveSource = pathCfg.source?.trim() || 'default';
     const currentBaseKey = this.baseSignatures.get(pathName);
     if (!this.streams!.has(pathName) || currentBaseKey !== baseKey) {
-      this.streams!.set(pathName, this.dataService.subscribePath(normalizedPath, effectiveSource));
+      // Base identity (path+source) changed: release the old registration before overwriting so the
+      // superseded (path, source) is not leaked. Never reached on a sampleTime/unit/timeout change —
+      // those keep baseKey identical and only rebuild the RxJS pipeline downstream.
+      this.releaseBase(pathName);
+      const handle = this.dataService.acquirePath(normalizedPath, effectiveSource);
+      this.streams!.set(pathName, handle.data$);
+      this.baseReleases.set(pathName, handle.release);
       this.baseSignatures.set(pathName, baseKey);
     }
     const base$ = this.streams!.get(pathName)!;
@@ -247,6 +269,7 @@ export class WidgetStreamsDirective {
       // All removed
       this.subscriptions.forEach(s => s.sub.unsubscribe());
       this.subscriptions.clear();
+      this.releaseAllBases();
       this.streams = undefined;
       this.baseSignatures.clear();
       this.registrations = [];
@@ -260,6 +283,7 @@ export class WidgetStreamsDirective {
       if (existing) existing.sub.unsubscribe();
       this.subscriptions.delete(r);
       this.streams?.delete(r);
+      this.releaseBase(r);
       this.baseSignatures.delete(r);
       this.registrations = this.registrations.filter(x => x.pathName !== r);
     }
@@ -272,6 +296,7 @@ export class WidgetStreamsDirective {
         if (existing) existing.sub.unsubscribe();
         this.subscriptions.delete(p);
         this.streams?.delete(p);
+        this.releaseBase(p);
         this.baseSignatures.delete(p);
         continue;
       }
@@ -353,6 +378,7 @@ export class WidgetStreamsDirective {
         existing.sub.unsubscribe();
         this.subscriptions.delete(pathName);
         this.streams?.delete(pathName);
+        this.releaseBase(pathName);
         this.baseSignatures.delete(pathName);
       }
       return;
@@ -367,6 +393,7 @@ export class WidgetStreamsDirective {
         existing.sub.unsubscribe();
         this.subscriptions.delete(pathName);
         this.streams?.delete(pathName);
+        this.releaseBase(pathName);
         this.baseSignatures.delete(pathName);
       }
       this.registrations = this.registrations.filter(r => r.pathName !== pathName);
@@ -380,5 +407,14 @@ export class WidgetStreamsDirective {
     if (existing && existing.signature === sig && prevReg === next) return;
 
     this.buildAndSubscribe(pathName, next, cfg, normalizedCfg);
+  }
+
+  /**
+   * Release every base registration this directive acquired. The RxJS subscriptions self-clean via
+   * takeUntilDestroyed, but the DataService registrations do not — without this, a destroyed widget
+   * leaves its (path, source) registrations pinned forever (the primary current leak vector).
+   */
+  ngOnDestroy(): void {
+    this.releaseAllBases();
   }
 }

--- a/src/app/core/services/ais-processing.service.spec.ts
+++ b/src/app/core/services/ais-processing.service.spec.ts
@@ -72,7 +72,9 @@ describe('AisProcessingService applyAisUpdate dispatch', () => {
       // Every prefix subscription shares the same stream; the merged pipeline
       // forwards anything we push. The self-nav stream also reads this but our
       // test paths only match AIS contexts, so they're routed correctly.
-      subscribePathTree: () => stream$.asObservable()
+      subscribePathTree: () => stream$.asObservable(),
+      // removeTrack prunes the DataService cache for the evicted context.
+      removePathsForContext: vi.fn()
     };
 
     TestBed.configureTestingModule({
@@ -206,6 +208,7 @@ describe('AisProcessingService target eviction (bounds unbounded growth)', () =>
     stream$.next({ path: fullPath, update: { data: { value, timestamp: new Date(tsMs) }, state: 'normal' } } as IPathUpdateWithPath);
     vi.advanceTimersByTime(300);
   }
+  let removePathsForContext: ReturnType<typeof vi.fn>;
   const internals = () => service as unknown as {
     tracks: Map<string, unknown>;
     contextIndex: Map<string, string>;
@@ -217,8 +220,9 @@ describe('AisProcessingService target eviction (bounds unbounded growth)', () =>
   beforeEach(() => {
     vi.useFakeTimers();
     stream$ = new Subject<IPathUpdateWithPath>();
+    removePathsForContext = vi.fn();
     TestBed.configureTestingModule({
-      providers: [AisProcessingService, { provide: DataService, useValue: { subscribePathTree: () => stream$.asObservable() } as Partial<DataService> }]
+      providers: [AisProcessingService, { provide: DataService, useValue: { subscribePathTree: () => stream$.asObservable(), removePathsForContext } as Partial<DataService> }]
     });
     service = TestBed.inject(AisProcessingService);
   });
@@ -324,6 +328,29 @@ describe('AisProcessingService target eviction (bounds unbounded growth)', () =>
       }
     }
   });
+
+  it('prunes the DataService cache for the context on an explicit status:"remove"', () => {
+    const ctx = 'vessels.urn:mrn:imo:mmsi:400000001';
+    push(`${ctx}.navigation.position.latitude`, 10);
+    push(`${ctx}.sensors.ais.status`, 'remove');
+    expect(removePathsForContext).toHaveBeenCalledWith(ctx);
+  });
+
+  it('prunes the DataService cache for the context evicted by the cap', () => {
+    internals().maxTargets = 1;
+    const oldCtx = 'vessels.urn:mrn:imo:mmsi:400000002';
+    const newCtx = 'vessels.urn:mrn:imo:mmsi:400000003';
+    pushAt(`${oldCtx}.navigation.position.latitude`, 10, EVENT_TS + 1000);
+    pushAt(`${newCtx}.navigation.position.latitude`, 11, EVENT_TS + 2000);
+    expect(removePathsForContext).toHaveBeenCalledWith(oldCtx);
+  });
+
+  it('prunes the DataService cache for the context evicted by the TTL sweep', () => {
+    const ctx = 'vessels.urn:mrn:imo:mmsi:400000004';
+    pushAt(`${ctx}.navigation.position.latitude`, 12, EVENT_TS);
+    internals().evictStaleTracks(EVENT_TS + 11 * 60 * 1000);
+    expect(removePathsForContext).toHaveBeenCalledWith(ctx);
+  });
 });
 
 /**
@@ -345,7 +372,7 @@ describe('AisProcessingService own-ship throttling', () => {
     vi.useFakeTimers();
     stream$ = new Subject<IPathUpdateWithPath>();
     TestBed.configureTestingModule({
-      providers: [AisProcessingService, { provide: DataService, useValue: { subscribePathTree: () => stream$.asObservable() } as Partial<DataService> }]
+      providers: [AisProcessingService, { provide: DataService, useValue: { subscribePathTree: () => stream$.asObservable(), removePathsForContext: vi.fn() } as Partial<DataService> }]
     });
     service = TestBed.inject(AisProcessingService);
   });

--- a/src/app/core/services/ais-processing.service.ts
+++ b/src/app/core/services/ais-processing.service.ts
@@ -635,6 +635,10 @@ export class AisProcessingService {
     for (const [context, id] of this.contextIndex.entries()) {
       if (id === track.id) this.contextIndex.delete(context);
     }
+    // Single funnel for all three eviction reasons (status:'remove', cap, TTL sweep): free the
+    // DataService per-path cache/meta for this vessel context too, so evicting a target releases the
+    // memory its paths held rather than leaving orphaned entries to grow unbounded.
+    this.data.removePathsForContext(track.context);
     if (AIS_DEBUG) {
       console.debug('[AIS] removed', { id: track.id, mmsi: track.mmsi, status: track.ais.status });
     }

--- a/src/app/core/services/data.service.spec.ts
+++ b/src/app/core/services/data.service.spec.ts
@@ -153,6 +153,74 @@ describe('DataService', () => {
     });
   });
 
+  describe('acquirePath (disposable handle)', () => {
+    const PATH = 'self.navigation.speedOverGround';
+
+    it('shares the same stream subscribePath returns and refcounts co-acquirers', () => {
+      // data$ IS the shared subject subscribePath hands out (acquirePath composes subscribePath).
+      const shared$ = service.subscribePath(PATH, 'default'); // refCount 1
+      const a = service.acquirePath(PATH, 'default');         // refCount 2
+      expect(a.data$).toBe(shared$);
+      service.unsubscribePath(PATH, 'default');               // balance the bare subscribePath → refCount 1
+
+      let completed = false;
+      a.data$.subscribe({ complete: () => (completed = true) });
+      const b = service.acquirePath(PATH, 'default');         // refCount 2
+      expect(b.data$).toBe(a.data$);
+
+      a.release();                                            // refCount 1
+      expect(completed).toBe(false); // b still holds it
+      b.release();                                            // refCount 0 → teardown
+      expect(completed).toBe(true);
+    });
+
+    it('release is idempotent: extra calls do not tear down a co-acquirer still holding the path', () => {
+      let firstCompleted = false;
+      let secondCompleted = false;
+      const first = service.acquirePath(PATH, 'default');
+      const second = service.acquirePath(PATH, 'default');
+      first.data$.subscribe({ complete: () => (firstCompleted = true) });
+      second.data$.subscribe({ complete: () => (secondCompleted = true) });
+
+      first.release();
+      first.release();
+      first.release(); // 2nd/3rd calls are no-ops
+      expect(firstCompleted).toBe(false);
+      expect(secondCompleted).toBe(false);
+
+      // The surviving co-acquirer's stream stays live and still delivers values.
+      let latest: IPathUpdate | undefined;
+      second.data$.subscribe(update => (latest = update));
+      dataPathUpdates$.next({
+        context: 'self',
+        path: 'navigation.speedOverGround',
+        source: 'gps',
+        timestamp: '2026-01-01T00:00:01.000Z',
+        value: 4.4,
+      });
+      expect(latest!.data.value).toBe(4.4);
+
+      // A balanced release finally tears it down.
+      second.release();
+      expect(secondCompleted).toBe(true);
+    });
+
+    it('a handle cannot decrement a registration below its own single acquire', () => {
+      // Two independent acquisitions of the SAME (path, source): refCount == 2.
+      const doomed = service.acquirePath(PATH, 'default');
+      const survivor = service.acquirePath(PATH, 'default');
+      let survivorCompleted = false;
+      survivor.data$.subscribe({ complete: () => (survivorCompleted = true) });
+
+      // Over-calling release cannot decrement more than the one acquire this handle made.
+      doomed.release();
+      doomed.release();
+      doomed.release();
+
+      expect(survivorCompleted).toBe(false); // the survivor's acquire is intact
+    });
+  });
+
   describe('removePathsForContext', () => {
     const vesselA = 'vessels.urn:mrn:imo:mmsi:100000001';
     const vesselB = 'vessels.urn:mrn:imo:mmsi:100000002';

--- a/src/app/core/services/data.service.spec.ts
+++ b/src/app/core/services/data.service.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { Subject } from 'rxjs';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { IMeta, IPathValueData, IPathMetaData } from '../interfaces/app-interfaces';
-import { ISignalKDataValueUpdate, States } from '../interfaces/signalk-interfaces';
+import { ISignalKDataValueUpdate, ISkMetadata, States } from '../interfaces/signalk-interfaces';
 import { DataService, IPathUpdate, IPathUpdateWithPath } from './data.service';
 import { SignalKDeltaService } from './signalk-delta.service';
 
@@ -239,6 +239,69 @@ describe('DataService', () => {
 
       expect(service.getPathObject(`${shortCtx}.navigation.speedOverGround`)).toBeNull();
       expect(service.getPathObject(`${longCtx}.navigation.speedOverGround`)).not.toBeNull();
+    });
+  });
+
+  describe('getPathMetaObservable (meta decoupled from registrations)', () => {
+    const PATH = 'self.electrical.batteries.10.voltage';
+
+    function pushMeta(context: string, path: string, meta: ISkMetadata): void {
+      metadataUpdates$.next({ context, path, meta });
+    }
+
+    it('keeps the shared meta stream live when a sibling source registration is released', () => {
+      // Two sources registered for the same path: releasing one must not complete the path's meta.
+      service.subscribePath(PATH, 'default');
+      service.subscribePath(PATH, 'gps-2');
+
+      let latestMeta: ISkMetadata | null | undefined;
+      let completed = false;
+      service.getPathMetaObservable(PATH).subscribe({
+        next: m => (latestMeta = m),
+        complete: () => (completed = true),
+      });
+
+      service.unsubscribePath(PATH, 'default');
+
+      pushMeta('self', 'electrical.batteries.10.voltage', { description: 'Voltage', units: 'V', properties: {} });
+
+      expect(completed).toBe(false);
+      expect(latestMeta?.units).toBe('V');
+    });
+
+    it('emits to a subscriber that observed meta before any path registration (no dead of(null))', () => {
+      const PATH2 = 'self.environment.outside.temperature';
+      const metas: (ISkMetadata | null)[] = [];
+      // Subscribe BEFORE any subscribePath — the pre-decoupling code returned a dead of(null) here.
+      service.getPathMetaObservable(PATH2).subscribe(m => metas.push(m));
+      expect(metas).toEqual([null]); // seeded null from the BehaviorSubject
+
+      pushMeta('self', 'environment.outside.temperature', { description: 'Temp', units: 'K', properties: {} });
+
+      // The later delta reaches the same live subscriber, proving it is not a completed of(null).
+      expect(metas.length).toBe(2);
+      expect(metas[1]?.units).toBe('K');
+    });
+
+    it('prunes the decoupled meta subject for a removed foreign context, leaving self untouched', () => {
+      const vessel = 'vessels.urn:mrn:imo:mmsi:100000001';
+      const foreignPath = `${vessel}.navigation.speedOverGround`;
+      const selfPath = 'self.navigation.speedOverGround';
+
+      service.getPathMetaObservable(foreignPath).subscribe();
+      service.getPathMetaObservable(selfPath).subscribe();
+
+      const metaMap = (service as unknown as { _pathMetaByPath: Map<string, unknown> })._pathMetaByPath;
+      expect(metaMap.has(foreignPath)).toBe(true);
+      expect(metaMap.has(selfPath)).toBe(true);
+
+      service.removePathsForContext(vessel);
+      expect(metaMap.has(foreignPath)).toBe(false);
+      expect(metaMap.has(selfPath)).toBe(true);
+
+      // The self context is a no-op, its meta subject survives.
+      service.removePathsForContext('self');
+      expect(metaMap.has(selfPath)).toBe(true);
     });
   });
 

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -241,6 +241,15 @@ export class DataService implements OnDestroy {
     this._isReset.next(true);
   }
 
+  /**
+   * Subscribe to a `(path, source)` stream, sharing one registration across co-subscribers and
+   * bumping its refCount. Callers must balance every call with an {@link unsubscribePath}.
+   *
+   * Churning and lifecycle-scoped consumers (widgets, per-selection rebinds, chart streams) should
+   * prefer {@link acquirePath}, whose idempotent, forgery-proof release closure makes balanced
+   * teardown far harder to get wrong than a raw `unsubscribePath(path, source)` call. App-lifetime
+   * singletons that subscribe once and never release may call this directly.
+   */
   public subscribePath(path: string, source: string): Observable<IPathUpdate> {
     const registrations = this._pathRegisterByPath.get(path);
     const matching = registrations?.find(item => item.path === path && item.source === source);
@@ -334,6 +343,29 @@ export class DataService implements OnDestroy {
     if (registrations.length === 0) {
       this._pathRegisterByPath.delete(path);
     }
+  }
+
+  /**
+   * Acquire a disposable handle to a `(path, source)` stream. `data$` is the very same shared
+   * Observable {@link subscribePath} returns; `release` is an idempotent teardown that decrements the
+   * shared registration exactly once no matter how many times it is called, and is forgery-proof —
+   * the caller never passes a path/source into it, so it can only release the registration it took.
+   * This makes balanced acquire/release the default for churning and lifecycle-scoped consumers.
+   *
+   * @param {string} path The Signal K path
+   * @param {string} source The source to read from ('default' for the server-priority value)
+   * @returns The shared stream plus a one-shot release closure.
+   * @memberof DataService
+   */
+  public acquirePath(path: string, source: string): { data$: Observable<IPathUpdate>; release: () => void } {
+    const data$ = this.subscribePath(path, source);
+    let released = false;
+    const release = (): void => {
+      if (released) return;
+      released = true;
+      this.unsubscribePath(path, source);
+    };
+    return { data$, release };
   }
 
   /**

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -1,5 +1,5 @@
 import { DestroyRef, inject, Injectable, OnDestroy } from '@angular/core';
-import { Observable, BehaviorSubject, ReplaySubject, Subject, map, combineLatest, of, interval, filter, Subscription } from 'rxjs';
+import { Observable, BehaviorSubject, ReplaySubject, Subject, map, combineLatest, interval, filter, Subscription } from 'rxjs';
 import { ISkPathData, IPathValueData, IPathMetaData, IMeta, IPathUpdateEvent } from "../interfaces/app-interfaces";
 import { ISignalKDataValueUpdate, ISkMetadata, ISignalKNotification, States, TState } from '../interfaces/signalk-interfaces'
 import { SignalKDeltaService } from './signalk-delta.service';
@@ -90,7 +90,6 @@ const buildPathData = (value: unknown, rawTimestamp: string | number | Date | nu
  * @property {BehaviorSubject<IPathData>} _pathData$ - A BehaviorSubject of the private path value.
  * @property {BehaviorSubject<TState>} _pathState$ - A BehaviorSubject of the private path data state property.
  * @property {BehaviorSubject<IPathUpdate>} pathDataUpdate$ - A BehaviorSubject that contains path value and value state.
- * @property {BehaviorSubject<ISkMetadata | null>} pathMeta$ - A BehaviorSubject containing available meta or null.
  * @property {Subscription} combinedSub - The internal combineLatest subscription feeding pathDataUpdate$, torn down on release.
  *
  * @interface IPathRegistration
@@ -102,7 +101,6 @@ interface IPathRegistration {
   _pathData$: BehaviorSubject<IPathData>;
   _pathState$: BehaviorSubject<TState>;
   pathDataUpdate$: BehaviorSubject<IPathUpdate>;
-  pathMeta$: BehaviorSubject<ISkMetadata | null>;
   combinedSub?: Subscription;
 }
 
@@ -162,6 +160,13 @@ export class DataService implements OnDestroy {
   private _skDataIndexByPath = new Map<string, number>();
   /** Path -> registrations index for fast lookups during updates. */
   private _pathRegisterByPath = new Map<string, IPathRegistration[]>();
+  /**
+   * Path -> shared meta subject, kept as a sibling of `_pathRegisterByPath` rather than inside a
+   * registration. Meta is per-path, not per-source, so decoupling it means releasing one source's
+   * registration can never complete a still-live path's meta stream, and a consumer can observe meta
+   * before any value registration exists.
+   */
+  private _pathMetaByPath = new Map<string, BehaviorSubject<ISkMetadata | null>>();
 
   constructor() {
     // Emit Delta message update counter every second (RxJS based)
@@ -255,7 +260,6 @@ export class DataService implements OnDestroy {
       },
       state: state
     };
-    let metaUpdate: ISkMetadata | null = null;
 
     const dataPath = this._skData.get(path);
 
@@ -273,7 +277,6 @@ export class DataService implements OnDestroy {
       };
 
       state = dataPath.state || state;
-      metaUpdate = dataPath.meta || null;
     }
 
     const newPathSubject: IPathRegistration = {
@@ -282,8 +285,7 @@ export class DataService implements OnDestroy {
       refCount: 1,
       _pathData$: new BehaviorSubject<IPathData>(pathUpdate.data),
       _pathState$: new BehaviorSubject<TState>(pathUpdate.state),
-      pathDataUpdate$: new BehaviorSubject<IPathUpdate>(pathUpdate),
-      pathMeta$: new BehaviorSubject<ISkMetadata | null>(metaUpdate ? cloneDeep(metaUpdate) : null)
+      pathDataUpdate$: new BehaviorSubject<IPathUpdate>(pathUpdate)
     };
 
     const combined$ = combineLatest([newPathSubject._pathData$, newPathSubject._pathState$]).pipe(
@@ -327,7 +329,6 @@ export class DataService implements OnDestroy {
     registration._pathData$.complete();
     registration._pathState$.complete();
     registration.pathDataUpdate$.complete();
-    registration.pathMeta$.complete();
 
     registrations.splice(pathIndex, 1);
     if (registrations.length === 0) {
@@ -376,6 +377,15 @@ export class DataService implements OnDestroy {
       this._dataServiceMeta = Array.from(this._dataServiceMetaByPath.values());
       if (this._isSkMetaFullTreeActive) {
         this._dataServiceMetaSubject$.next(this._dataServiceMeta);
+      }
+    }
+
+    // Prune the decoupled per-path meta subjects. Delete-only (no .complete()): this method leaves
+    // active registrations alive by contract, so a widget still bound to the context simply stops
+    // receiving meta rather than having its stream torn down.
+    for (const path of Array.from(this._pathMetaByPath.keys())) {
+      if (path.startsWith(prefix)) {
+        this._pathMetaByPath.delete(path);
       }
     }
   }
@@ -584,13 +594,10 @@ export class DataService implements OnDestroy {
         pathObject.meta = merge({}, pathObject.meta, meta.meta);
       }
 
-      const entries = this._pathRegisterByPath.get(metaPath);
-      if (entries?.length) {
-        for (const entry of entries) {
-          // Emit a snapshot to guarantee a new reference for downstream consumers.
-          entry.pathMeta$.next(pathObject.meta ? cloneDeep(pathObject.meta) : null);
-        }
-      }
+      // Emit a snapshot (new reference) to the path's shared meta subject if one has been observed.
+      // A plain get() — not get-or-create — so a meta delta for an un-queried path does not grow the
+      // map. Meta is per-path, so a single subject serves every source's consumers.
+      this._pathMetaByPath.get(metaPath)?.next(cloneDeep(pathObject.meta) ?? null);
 
       // If full meta tree is active, push the full tree
       if (this._isSkMetaFullTreeActive) {
@@ -834,16 +841,30 @@ export class DataService implements OnDestroy {
   }
 
   /**
-   * Returns an Observable that emits metadata updates for a registered Signal K path.
+   * Returns an Observable that emits metadata updates for a Signal K path.
    *
    * Notes:
-   * - The path must already be registered via {@link subscribePath}; otherwise this returns an Observable that emits `null`.
-   * - If multiple registrations exist for the same path (e.g. different sources), this returns the first match by path.
-   * - Registrations are app-lifetime, so the returned Observable stays live for the session and does not complete on its own.
+   * - Meta is per-path (not per-source): the returned subject is shared across every source's
+   *   consumers, and releasing one source's value registration does not complete it.
+   * - Does not require a prior {@link subscribePath}: the subject is created on demand, seeded from
+   *   any cached meta, and stays live for the session (it does not complete on its own).
    */
   public getPathMetaObservable(path: string): Observable<ISkMetadata | null> {
-    const registration = this._pathRegisterByPath.get(path)?.[0];
-    return registration?.pathMeta$.asObservable() || of(null);
+    return this.getOrCreatePathMeta(path).asObservable();
+  }
+
+  /**
+   * Returns the shared meta subject for a path, creating and storing it (seeded from any cached
+   * meta) on first request. Only observation grows the map; incoming meta deltas use a plain get()
+   * so un-queried paths never allocate a subject.
+   */
+  private getOrCreatePathMeta(path: string): BehaviorSubject<ISkMetadata | null> {
+    let subject = this._pathMetaByPath.get(path);
+    if (!subject) {
+      subject = new BehaviorSubject<ISkMetadata | null>(cloneDeep(this._skData.get(path)?.meta) ?? null);
+      this._pathMetaByPath.set(path, subject);
+    }
+    return subject;
   }
 
   /**

--- a/src/app/core/services/history-chart-stream.service.spec.ts
+++ b/src/app/core/services/history-chart-stream.service.spec.ts
@@ -23,7 +23,7 @@ describe('HistoryChartStreamService', () => {
   const history = { getValues: vi.fn() };
   const mapper = { mapValuesToChartDatapoints: vi.fn() };
   const releasePath = vi.fn();
-  const data = { subscribePath: vi.fn(), acquirePath: vi.fn(), getPathUnitType: vi.fn() };
+  const data = { acquirePath: vi.fn(), getPathUnitType: vi.fn() };
 
   function make(): HistoryChartStreamService {
     TestBed.configureTestingModule({
@@ -46,7 +46,6 @@ describe('HistoryChartStreamService', () => {
     history.getValues.mockReset();
     mapper.mapValuesToChartDatapoints.mockReset().mockReturnValue([]);
     releasePath.mockReset();
-    data.subscribePath.mockReset().mockReturnValue(path$);
     // The service consumes acquirePath now; data$ is the same subject the tests push into.
     data.acquirePath.mockReset().mockReturnValue({ data$: path$, release: releasePath });
     data.getPathUnitType.mockReset().mockReturnValue(null); // scalar unless a test overrides

--- a/src/app/core/services/history-chart-stream.service.spec.ts
+++ b/src/app/core/services/history-chart-stream.service.spec.ts
@@ -22,7 +22,8 @@ describe('HistoryChartStreamService', () => {
   let state$: BehaviorSubject<ConnectionState>;
   const history = { getValues: vi.fn() };
   const mapper = { mapValuesToChartDatapoints: vi.fn() };
-  const data = { subscribePath: vi.fn(), getPathUnitType: vi.fn() };
+  const releasePath = vi.fn();
+  const data = { subscribePath: vi.fn(), acquirePath: vi.fn(), getPathUnitType: vi.fn() };
 
   function make(): HistoryChartStreamService {
     TestBed.configureTestingModule({
@@ -44,7 +45,10 @@ describe('HistoryChartStreamService', () => {
     state$ = new BehaviorSubject<ConnectionState>(ConnectionState.Connected);
     history.getValues.mockReset();
     mapper.mapValuesToChartDatapoints.mockReset().mockReturnValue([]);
+    releasePath.mockReset();
     data.subscribePath.mockReset().mockReturnValue(path$);
+    // The service consumes acquirePath now; data$ is the same subject the tests push into.
+    data.acquirePath.mockReset().mockReturnValue({ data$: path$, release: releasePath });
     data.getPathUnitType.mockReset().mockReturnValue(null); // scalar unless a test overrides
   });
 
@@ -290,7 +294,7 @@ describe('HistoryChartStreamService', () => {
 
     // The transient failure must NOT surface HISTORY_UNAVAILABLE; the live tail is subscribed instead.
     expect(emissions.some(e => !Array.isArray(e) && 'unavailable' in e)).toBe(false);
-    expect(data.subscribePath).toHaveBeenCalled();
+    expect(data.acquirePath).toHaveBeenCalled();
 
     // A live delta still renders, so the chart keeps working through the blip.
     const before = Date.now();
@@ -339,7 +343,7 @@ describe('HistoryChartStreamService', () => {
     history.getValues.mockRejectedValue(new Error('boom'));
     const first = await firstValueFrom(make().getBackfillThenLive(PARAMS));
     expect(isHistoryUnavailable(first)).toBe(true);
-    expect(data.subscribePath).not.toHaveBeenCalled();
+    expect(data.acquirePath).not.toHaveBeenCalled();
   });
 
   it('unsubscribing tears down the live delta subscription', async () => {
@@ -367,7 +371,32 @@ describe('HistoryChartStreamService', () => {
     await Promise.resolve();
     await Promise.resolve();
     expect(emissions.length).toBe(0); // the disposed guard prevents the batch
-    expect(data.subscribePath).not.toHaveBeenCalled();
+    expect(data.acquirePath).not.toHaveBeenCalled();
+  });
+
+  it('releases the live path handle when the stream is torn down after backfill', async () => {
+    history.getValues.mockResolvedValue({ context: 'vessels.self', range: {}, values: [], data: [] });
+    mapper.mapValuesToChartDatapoints.mockReturnValue([]);
+    const sub = make().getBackfillThenLive(PARAMS).subscribe();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(data.acquirePath).toHaveBeenCalledTimes(1);
+    expect(releasePath).not.toHaveBeenCalled();
+
+    sub.unsubscribe();
+    expect(releasePath).toHaveBeenCalledTimes(1);
+  });
+
+  it('neither acquires nor releases the path when disposed before the backfill resolves', async () => {
+    history.getValues.mockResolvedValue({ context: 'vessels.self', range: {}, values: [], data: [] });
+    mapper.mapValuesToChartDatapoints.mockReturnValue([{ timestamp: 1000, data: { value: 1 } }]);
+    const sub = make().getBackfillThenLive(PARAMS).subscribe();
+    sub.unsubscribe(); // before the backfill promise settles
+    await Promise.resolve();
+    await Promise.resolve();
+    // startLive never ran → nothing acquired, so releaseLive stays null and the teardown is a no-op.
+    expect(data.acquirePath).not.toHaveBeenCalled();
+    expect(releasePath).not.toHaveBeenCalled();
   });
 
   it('resolves a radian path with no override to a circular domain — live stats wrap correctly (#6)', async () => {

--- a/src/app/core/services/history-chart-stream.service.ts
+++ b/src/app/core/services/history-chart-stream.service.ts
@@ -119,6 +119,9 @@ export class HistoryChartStreamService {
       const buffer: number[] = [];
       let liveSub: Subscription | null = null;
       let reconnectSub: Subscription | null = null;
+      // Release for the live tail's shared path registration; set atomically with the acquire inside
+      // startLive. Stays null if disposed before the backfill settles (startLive never runs).
+      let releaseLive: (() => void) | null = null;
 
       // Track the delta stream's connection and re-backfill on reconnect (#85). A WS drop/reconnect
       // resumes the live tail but never re-fetches the interval that elapsed during the drop, leaving a
@@ -140,7 +143,9 @@ export class HistoryChartStreamService {
           }
           if (!ctx.seeded || sawDisconnected) void this.reBackfill(params, domain, buffer, subscriber, ctx);
         });
-        liveSub = this.startLive(params, domain, buffer, offsetMs, newestBackfillTs, subscriber, ctx);
+        const live = this.startLive(params, domain, buffer, offsetMs, newestBackfillTs, subscriber, ctx);
+        liveSub = live.sub;
+        releaseLive = live.release;
       };
 
       this.fetchBackfill(params, domain)
@@ -183,6 +188,10 @@ export class HistoryChartStreamService {
         ctx.disposed = true;
         liveSub?.unsubscribe();
         reconnectSub?.unsubscribe();
+        // Release the shared path registration after the live subscriptions that used it are torn
+        // down. No-op when disposed before the backfill settled (releaseLive still null → nothing was
+        // acquired); the ctx.disposed guards in the backfill handlers block a late acquisition.
+        releaseLive?.();
       };
     });
   }
@@ -195,10 +204,12 @@ export class HistoryChartStreamService {
     newestBackfillTs: number | null,
     subscriber: { next: (v: StreamEmission) => void },
     ctx: IStreamCtx
-  ): Subscription {
+  ): { sub: Subscription; release: () => void } {
     // One shared upstream so the freshness tracker, the immediate first value and the resampler all
-    // draw from a single path subscription.
-    const path$ = this.data.subscribePath(params.path, params.source).pipe(
+    // draw from a single path registration; its release is returned so getBackfillThenLive's teardown
+    // frees it once the live subscriptions below are gone.
+    const handle = this.data.acquirePath(params.path, params.source);
+    const path$ = handle.data$.pipe(
       filter(u => u?.data?.value !== null && u?.data?.value !== undefined),
       shareReplay({ bufferSize: 1, refCount: true })
     );
@@ -283,7 +294,7 @@ export class HistoryChartStreamService {
       const stats = computeWindowStats(buffer, params.smoothingPeriod, domain);
       subscriber.next({ timestamp: now, data: { ...stats } });
     }));
-    return sub;
+    return { sub, release: handle.release };
   }
 
   private async fetchBackfill(params: IHistoryChartStreamParams, domain: ChartStatsDomain, fromMs: number = Date.now() - params.windowMs): Promise<{ points: IDatasetServiceDatapoint[]; offsetMs: number } | null> {

--- a/src/app/core/services/history-chart-stream.service.ts
+++ b/src/app/core/services/history-chart-stream.service.ts
@@ -189,8 +189,9 @@ export class HistoryChartStreamService {
         liveSub?.unsubscribe();
         reconnectSub?.unsubscribe();
         // Release the shared path registration after the live subscriptions that used it are torn
-        // down. No-op when disposed before the backfill settled (releaseLive still null → nothing was
-        // acquired); the ctx.disposed guards in the backfill handlers block a late acquisition.
+        // down. Balanced two ways: when disposed before the backfill settled, startLive never ran, so
+        // releaseLive is still null and this is a no-op; and the release closure is idempotent, so any
+        // redundant call is harmless.
         releaseLive?.();
       };
     });


### PR DESCRIPTION
## What

Stage 2 of #243 — wire the release sites and harden the release contract so `DataService`'s per-path caches stop growing without bound (the "app goes unresponsive after a while" freeze, port of Kip #1129). Stage 1 (the `refCount` + `unsubscribePath(path, source)` + `removePathsForContext` foundation) landed in #256; this makes the churning consumers actually release, and prunes evicted-context path data.

## Design decisions (settled in a design pass; flagged here for review)

- **Additive `acquirePath(path, source)` → `{ data$, release }`** — an **idempotent, forgery-proof** disposable handle wrapping the stage-1 `unsubscribePath` primitive (`release` captures a private `released` flag → tears down exactly once; the caller passes no path/source, so it can't aim a release at another registration or over-decrement its own). **This takes the maintainer's explicitly-allowed "(or a companion acquire API)" branch rather than changing `subscribePath`'s signature.** Verified rationale: `subscribePath` has exactly **3 churning consumers** (widget-streams, remote-control, history-chart-stream — migrated here) and **2 bounded app-lifetime singletons** (`app-service`, `remote-dashboards` — both `toSignal(subscribePath(CONST,'default'))`, left untouched). Additive keeps the blast radius on the 3 sites that matter and is strictly lower-risk than breaking every caller. A doc note on `subscribePath` steers future churning consumers to the handle.
- **Meta decoupled from `registration[0]` (mandatory, lands first)** — `getPathMetaObservable` now serves from a new `_pathMetaByPath` subject map, not `registration[0].pathMeta$`, so releasing one source can never `complete` a live path's meta stream and freeze the metadata directive's zones. Bonus: fixes a pre-existing `of(null)` dead-stream (meta subscribed before any registration) and drops meta fan-out from O(sources) to O(1) per delta. `_pathMetaByPath` is pruned in `removePathsForContext` (delete-only) or it would reproduce the same unbounded growth.
- **D2 → keep skip's AIS constants** (TTL 10 min, sweep 15 s, cap 500). Upstream's 60 min/5 min would hold an evicted target's ~25-30 `_skData` entries **6× longer** — skip has no authoritative AIS-removal signal, so TTL is the *primary* eviction path, and a longer TTL works *against* the leak fix.

## The five release sites (6-commit chain)

1. **meta-decouple** (DataService) — `_pathMetaByPath`, rewrite `getPathMetaObservable`/`setMeta`, delete `pathMeta$` from `IPathRegistration`, prune on context removal.
2. **`acquirePath`** (DataService) — the handle.
3. **widget-streams.directive** — handle held 1:1 with the `baseSignatures` keyset; release-before-overwrite on base-key change, per removed path, on empty/invalid path, on bulk reset, and a **new `ngOnDestroy`** (the primary current leak vector). **Never** releases on the RxJS pipeline swap (sample-time/unit/timeout changes keep the same base key).
4. **remote-control.component** — release the two display registrations before rebind + a new `ngOnDestroy`.
5. **history-chart-stream.service** — release on `stop()` teardown after the live unsub; start/stop race handled (handle var stays null if disposed before backfill → release is a no-op; `ctx.disposed` already blocks late acquisition; idempotency is a second layer).
6. **ais-processing.service** — `removeTrack → removePathsForContext(track.context)` (single funnel for all 3 eviction reasons); the three `Partial<DataService>` spec mocks gain the method in the same commit (mandatory — else 8 eviction tests `TypeError`).

## Testing

- **Full local suite green: 148 files / 1282 tests.** New unit coverage locks the invariants: handle idempotency / over-release with a live co-acquirer / cannot-decrement-below-own-acquire; meta-survives-sibling-release + meta-before-registration + foreign-context meta prune; per-site acquire/release balance incl. the **no-release-on-pipeline-swap** trap and `ngOnDestroy` release-all; `removePathsForContext` fired on each of the 3 AIS eviction paths.
- Lint clean; betterer unchanged (179 — the touched files are strict-clean).

## ⚠️ CI-green ≠ leak-fixed

Unit tests prove per-site acquire/release balance and the meta invariant, but **cannot** prove the end-to-end leak is closed. The real proof is an **off-box soak**: sustained AIS churn (continuous create/evict of foreign contexts) while watching `_pathRegisterByPath.size` and `_skData.size` **stabilize** rather than grow. That needs a dev-machine/boat run with a small size-reading hook (perf-harness heap MB is noise-dominated per the repo docs and won't substitute). **Do not read green CI as "leak fixed"** — soak-verify separately before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
