### PR TITLE
fix(data): clear stale path only when all sources silent + deep-reset resurfacing (#254)

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -130,7 +130,7 @@ exports[`strictNullChecks`] = {
       [119, 4, 20, "Object is possibly \'undefined\'.", "2522653710"],
       [120, 4, 20, "Object is possibly \'undefined\'.", "2522653710"]
     ],
-    "src/app/widget-config/paths-options/paths-options.component.ts:3797853945": [
+    "src/app/widget-config/paths-options/paths-options.component.ts:2311600985": [
       [31, 51, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'IAddNewPathObject\'.", "2620553983"],
       [32, 40, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'string\'.", "2620553983"],
       [33, 54, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'IDynamicControl[]\'.", "2620553983"],

--- a/src/app/core/directives/widget-streams.directive.spec.ts
+++ b/src/app/core/directives/widget-streams.directive.spec.ts
@@ -20,6 +20,7 @@ class FakeDataService {
         path: string;
         source: string;
         pathType: string;
+        dataTimeoutMs: number;
     }[] = [];
 
     subscribePath(path: string, source?: string): Observable<IPathUpdate> {
@@ -46,8 +47,8 @@ class FakeDataService {
         return { data$, release };
     }
 
-    timeoutPathObservable(path: string, source: string, pathType: string): void {
-        this.timeoutCalls.push({ path, source, pathType });
+    timeoutPathObservable(path: string, source: string, pathType: string, dataTimeoutMs: number): void {
+        this.timeoutCalls.push({ path, source, pathType, dataTimeoutMs });
     }
 }
 
@@ -411,7 +412,9 @@ describe('WidgetStreamsDirective', () => {
         // Do not emit anything; advance virtual time beyond 20ms to trigger timeout
         await vi.advanceTimersByTimeAsync(30);
         expect(dataSvc.timeoutCalls.length).toBe(1);
-        expect(dataSvc.timeoutCalls[0]).toEqual({ path: 'env.to', source: 'default', pathType: 'string' });
+        // dataTimeout (0.02 s) is threaded through as the ms window; compute it the same way the
+        // directive does so the assertion is exact regardless of float representation.
+        expect(dataSvc.timeoutCalls[0]).toEqual({ path: 'env.to', source: 'default', pathType: 'string', dataTimeoutMs: 0.02 * 1000 });
     });
 
     it('forwards a configured non-default source into timeoutPathObservable', async () => {
@@ -426,7 +429,7 @@ describe('WidgetStreamsDirective', () => {
         // The stream's effective source must reach the reset so a source-bound widget
         // clears its own registration, not the default bucket (#206).
         await vi.advanceTimersByTimeAsync(30);
-        expect(dataSvc.timeoutCalls[0]).toEqual({ path: 'env.to', source: 'n2k-1', pathType: 'string' });
+        expect(dataSvc.timeoutCalls[0]).toEqual({ path: 'env.to', source: 'n2k-1', pathType: 'string', dataTimeoutMs: 0.02 * 1000 });
     });
 
     it('applies convertUnitTo to numeric values (initial + sampled)', async () => {
@@ -657,7 +660,7 @@ describe('WidgetStreamsDirective', () => {
  */
 class TtlFakeDataService {
     subjects = new Map<string, BehaviorSubject<IPathUpdate>>();
-    timeoutCalls: { path: string; source: string; pathType: string }[] = [];
+    timeoutCalls: { path: string; source: string; pathType: string; dataTimeoutMs: number }[] = [];
 
     private keyFor(path: string, source?: string): string {
         return `${path}|${source?.trim() || 'default'}`;
@@ -677,8 +680,8 @@ class TtlFakeDataService {
         return { data$: this.subscribePath(path, source), release: () => undefined };
     }
 
-    timeoutPathObservable(path: string, source: string, pathType: string): void {
-        this.timeoutCalls.push({ path, source, pathType });
+    timeoutPathObservable(path: string, source: string, pathType: string, dataTimeoutMs: number): void {
+        this.timeoutCalls.push({ path, source, pathType, dataTimeoutMs });
         // Mirror the real DataService: a TTL timeout resets the timed-out source's value to null.
         this.subjects.get(this.keyFor(path, source))?.next(
             { data: { value: null, timestamp: null }, state: 'normal' } as IPathUpdate

--- a/src/app/core/directives/widget-streams.directive.ts
+++ b/src/app/core/directives/widget-streams.directive.ts
@@ -177,7 +177,7 @@ export class WidgetStreamsDirective implements OnDestroy {
           each: dataTimeout,
           with: () => throwError(() => {
             console.log(timeoutErrorMsg + normalizedPath);
-            this.dataService.timeoutPathObservable(normalizedPath, effectiveSource, pathType);
+            this.dataService.timeoutPathObservable(normalizedPath, effectiveSource, pathType, dataTimeout);
           })
         }),
         retryWhen(error => error.pipe(

--- a/src/app/core/interfaces/widgets-interface.ts
+++ b/src/app/core/interfaces/widgets-interface.ts
@@ -243,7 +243,10 @@ export interface IWidgetSvcConfig {
   /** Don't apply any background color */
   noBgColor?: boolean;
 
-  /** Enables data stream to emit null values (permitting Widgets to reset) after a given timeout smoothingPeriod. See dataTimeout */
+  /**
+   * Enables data stream to emit null values (permitting Widgets to reset) after a given timeout smoothingPeriod. See dataTimeout.
+   * When several sources feed the same path, a timeout blanks the widget only once every source has gone silent; while any source is still live the reading is kept.
+   */
   enableTimeout?: boolean;
   /** Sets data stream no-data timeout notification in minutes */
   dataTimeout?: number;

--- a/src/app/core/services/data.service.spec.ts
+++ b/src/app/core/services/data.service.spec.ts
@@ -308,6 +308,20 @@ describe('DataService', () => {
       expect(service.getPathObject(`${shortCtx}.navigation.speedOverGround`)).toBeNull();
       expect(service.getPathObject(`${longCtx}.navigation.speedOverGround`)).not.toBeNull();
     });
+
+    it('prunes the per-path last-observed receipt for a removed foreign context, leaving self intact', () => {
+      seedSog('self', 1.1);
+      seedSog(vesselA, 2.2);
+
+      const lastObserved = (service as unknown as { _lastObservedByPath: Map<string, number> })._lastObservedByPath;
+      expect(lastObserved.has(`${vesselA}.navigation.speedOverGround`)).toBe(true);
+      expect(lastObserved.has('self.navigation.speedOverGround')).toBe(true);
+
+      service.removePathsForContext(vesselA);
+
+      expect(lastObserved.has(`${vesselA}.navigation.speedOverGround`)).toBe(false);
+      expect(lastObserved.has('self.navigation.speedOverGround')).toBe(true);
+    });
   });
 
   describe('getPathMetaObservable (meta decoupled from registrations)', () => {

--- a/src/app/core/services/data.service.spec.ts
+++ b/src/app/core/services/data.service.spec.ts
@@ -674,6 +674,50 @@ describe('DataService', () => {
     expect(latest!.state).toBe(States.Warn);
   });
 
+  it('leaves a persistent alarm state intact across a timeout then resume (does not clobber to Normal)', () => {
+    const PATH = 'self.electrical.batteries.10.voltage';
+    let latest: IPathUpdate | undefined;
+    service.subscribePath(PATH, 'default').subscribe(update => (latest = update));
+
+    dataPathUpdates$.next({
+      context: 'self',
+      path: 'electrical.batteries.10.voltage',
+      source: 'test-source',
+      timestamp: '2026-01-01T00:00:01.000Z',
+      value: 12.0,
+    });
+    // The server raises an alarm on the low voltage.
+    notificationUpdates$.next({
+      path: 'notifications.electrical.batteries.10.voltage',
+      value: {
+        method: ['visual'],
+        state: States.Alarm,
+        message: 'Low voltage',
+        timestamp: '2026-01-01T00:00:02.000Z',
+      },
+    });
+    expect(latest!.data.value).toBe(12.0);
+    expect(latest!.state).toBe(States.Alarm);
+
+    // The data stream times out. The value blanks, but the alarm is still active on the server, so
+    // the reset must not force the state back to Normal.
+    service.timeoutPathObservable(PATH, 'default', 'number', 5000);
+    expect(latest!.data.value).toBeNull();
+    expect(latest!.state).toBe(States.Alarm);
+
+    // Data resumes still-low: a value delta arrives, but the alarm never cleared so no new state
+    // transition notification fires. The alarm coloring must survive rather than reverting to Normal.
+    dataPathUpdates$.next({
+      context: 'self',
+      path: 'electrical.batteries.10.voltage',
+      source: 'test-source',
+      timestamp: '2026-01-01T00:00:03.000Z',
+      value: 11.5,
+    });
+    expect(latest!.data.value).toBe(11.5);
+    expect(latest!.state).toBe(States.Alarm);
+  });
+
   it('resets only the timed-out source registration, leaving sibling sources live', () => {
     let latestDefault: IPathUpdate | undefined;
     let latestSourceA: IPathUpdate | undefined;
@@ -849,6 +893,27 @@ describe('DataService', () => {
 
       expect(latestDefault!.data.value).toBeNull();
       expect(latestDefault!.state).toBe(States.Alarm);
+    });
+
+    it('treats a path with no recency receipt as all-silent (undefined disjunct of the liveness gate)', () => {
+      let latestDefault: IPathUpdate | undefined;
+      let latestA: IPathUpdate | undefined;
+      service.subscribePath(VOLTAGE, 'default').subscribe(u => (latestDefault = u));
+      service.subscribePath(VOLTAGE, 'source-a').subscribe(u => (latestA = u));
+
+      feed('source-a', 13.0);
+      expect(latestDefault!.data.value).toBe(13.0);
+
+      // Simulate a path that holds a value but has no recency receipt (never fed this session, or the
+      // receipt was pruned): the gate must fall to its `lastObserved === undefined` disjunct and treat
+      // the path as silent so the cross-clear still fires.
+      const lastObserved = (service as unknown as { _lastObservedByPath: Map<string, number> })._lastObservedByPath;
+      lastObserved.delete(VOLTAGE);
+
+      service.timeoutPathObservable(VOLTAGE, 'source-a', 'number', 5000);
+
+      expect(latestA!.data.value).toBeNull();
+      expect(latestDefault!.data.value).toBeNull();
     });
   });
 

--- a/src/app/core/services/data.service.spec.ts
+++ b/src/app/core/services/data.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { Subject } from 'rxjs';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { IMeta, IPathValueData, IPathMetaData } from '../interfaces/app-interfaces';
 import { ISignalKDataValueUpdate, ISkMetadata, States } from '../interfaces/signalk-interfaces';
 import { DataService, IPathUpdate, IPathUpdateWithPath } from './data.service';
@@ -36,6 +36,11 @@ describe('DataService', () => {
     });
 
     service = TestBed.inject(DataService);
+  });
+
+  afterEach(() => {
+    // Recency-dependent timeout tests fake the clock; always restore so real-time tests are unaffected.
+    vi.useRealTimers();
   });
 
   it('should be created', () => {
@@ -626,7 +631,7 @@ describe('DataService', () => {
     });
     expect(latest!.data.value).toBe(5.5);
 
-    service.timeoutPathObservable('self.environment.wind.speedApparent', 'default', 'number');
+    service.timeoutPathObservable('self.environment.wind.speedApparent', 'default', 'number', 5000);
 
     expect(latest!.data.value).toBeNull();
     expect(latest!.data.timestamp).toBeNull();
@@ -648,7 +653,7 @@ describe('DataService', () => {
     });
     expect(latest!.data.value).toBe(5.5);
 
-    service.timeoutPathObservable('self.environment.wind.speedApparent', 'default', 'number');
+    service.timeoutPathObservable('self.environment.wind.speedApparent', 'default', 'number', 5000);
     expect(latest!.data.value).toBeNull();
 
     // A later notification re-pushes state onto every registration of the path. A shallow reset
@@ -702,8 +707,9 @@ describe('DataService', () => {
     expect(latestDefault!.data.value).toBe(13.0);
 
     // Only test-source-a's stream timed out; its live siblings (test-source-b and
-    // the default bucket, still fed by test-source-b) must be left untouched.
-    service.timeoutPathObservable('self.electrical.batteries.10.voltage', 'test-source-a', 'number');
+    // the default bucket, still fed by test-source-b) must be left untouched. The path was fed
+    // moments ago (real clock), so the liveness gate treats it as live and skips the cross-clear.
+    service.timeoutPathObservable('self.electrical.batteries.10.voltage', 'test-source-a', 'number', 5000);
 
     expect(latestSourceA!.data.value).toBeNull();
     expect(latestSourceA!.state).toBe(States.Normal);
@@ -718,10 +724,132 @@ describe('DataService', () => {
       .subscribe(update => updates.push(update));
 
     const countBefore = updates.length;
-    service.timeoutPathObservable('self.navigation.position', 'default', 'object');
+    service.timeoutPathObservable('self.navigation.position', 'default', 'object', 5000);
 
     expect(updates.length).toBe(countBefore);
     expect(updates.every(update => update !== undefined)).toBe(true);
+  });
+
+  describe('timeout liveness-gated cross-clear (#254)', () => {
+    const VOLTAGE = 'self.electrical.batteries.10.voltage';
+    const TTL_MS = 5000;
+
+    function feed(source: string, value: number | boolean): void {
+      dataPathUpdates$.next({
+        context: 'self',
+        path: 'electrical.batteries.10.voltage',
+        source,
+        timestamp: '2026-01-01T00:00:01.000Z',
+        value,
+      });
+    }
+
+    it('skips the sibling cross-clear while a source fed the path within the TTL window (preserves #252)', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(0);
+
+      let latestDefault: IPathUpdate | undefined;
+      let latestA: IPathUpdate | undefined;
+      let latestB: IPathUpdate | undefined;
+      service.subscribePath(VOLTAGE, 'default').subscribe(u => (latestDefault = u));
+      service.subscribePath(VOLTAGE, 'source-a').subscribe(u => (latestA = u));
+      service.subscribePath(VOLTAGE, 'source-b').subscribe(u => (latestB = u));
+
+      feed('source-a', 12.5);
+      feed('source-b', 13.0);
+      expect(latestA!.data.value).toBe(12.5);
+      expect(latestB!.data.value).toBe(13.0);
+      expect(latestDefault!.data.value).toBe(13.0);
+
+      // source-b fed the path 4.999 s ago — still inside the 5 s window, so the path is "live".
+      vi.setSystemTime(TTL_MS - 1);
+      service.timeoutPathObservable(VOLTAGE, 'source-a', 'number', TTL_MS);
+
+      // Only the timed-out source is reset; the live sibling and the default bucket are untouched.
+      expect(latestA!.data.value).toBeNull();
+      expect(latestB!.data.value).toBe(13.0);
+      expect(latestDefault!.data.value).toBe(13.0);
+    });
+
+    it('cross-clears sibling sources and the default bucket once the path has gone all-silent', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(0);
+
+      let latestDefault: IPathUpdate | undefined;
+      let latestA: IPathUpdate | undefined;
+      let latestB: IPathUpdate | undefined;
+      service.subscribePath(VOLTAGE, 'default').subscribe(u => (latestDefault = u));
+      service.subscribePath(VOLTAGE, 'source-a').subscribe(u => (latestA = u));
+      service.subscribePath(VOLTAGE, 'source-b').subscribe(u => (latestB = u));
+
+      feed('source-a', 12.5);
+      feed('source-b', 13.0);
+
+      // Nothing has fed the path for the full TTL window: every source is silent.
+      vi.setSystemTime(TTL_MS);
+      service.timeoutPathObservable(VOLTAGE, 'source-a', 'number', TTL_MS);
+
+      expect(latestA!.data.value).toBeNull();
+      expect(latestB!.data.value).toBeNull();
+      expect(latestDefault!.data.value).toBeNull();
+    });
+
+    it('cross-clears an enableTimeout:false sibling (which never times out itself) when the path is all-silent', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(0);
+
+      // A widget-boolean-switch / autopilot ships enableTimeout:false and reads the shared default
+      // bucket, so it never calls timeoutPathObservable. A sensor widget on a specific source of the
+      // same path does have a TTL. When that source times out all-silent, the frozen switch reading
+      // (a plausible-but-stale hazard) must still be cleared.
+      let latestSwitch: IPathUpdate | undefined;
+      let latestSensor: IPathUpdate | undefined;
+      service.subscribePath(VOLTAGE, 'default').subscribe(u => (latestSwitch = u));
+      service.subscribePath(VOLTAGE, 'sensor-a').subscribe(u => (latestSensor = u));
+
+      feed('sensor-a', true);
+      expect(latestSwitch!.data.value).toBe(true);
+      expect(latestSensor!.data.value).toBe(true);
+
+      vi.setSystemTime(TTL_MS);
+      // The sensor's whitelisted pathType ('number') admits the call; the target switch registration
+      // is reached and reset regardless of its own (boolean) value type.
+      service.timeoutPathObservable(VOLTAGE, 'sensor-a', 'number', TTL_MS);
+
+      expect(latestSensor!.data.value).toBeNull();
+      expect(latestSwitch!.data.value).toBeNull();
+    });
+
+    it('keeps a cross-cleared sibling cleared when a later notification changes the path state', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(0);
+
+      let latestDefault: IPathUpdate | undefined;
+      service.subscribePath(VOLTAGE, 'default').subscribe(u => (latestDefault = u));
+      service.subscribePath(VOLTAGE, 'source-a').subscribe();
+
+      feed('source-a', 13.0);
+      expect(latestDefault!.data.value).toBe(13.0);
+
+      vi.setSystemTime(TTL_MS);
+      service.timeoutPathObservable(VOLTAGE, 'source-a', 'number', TTL_MS);
+      expect(latestDefault!.data.value).toBeNull();
+
+      // The deep upstream reset must survive a later notification state change on the path: the
+      // state advances but the cross-cleared value must not resurface.
+      notificationUpdates$.next({
+        path: 'notifications.electrical.batteries.10.voltage',
+        value: {
+          method: ['visual'],
+          state: States.Alarm,
+          message: 'Low voltage',
+          timestamp: '2026-01-01T00:00:03.000Z',
+        },
+      });
+
+      expect(latestDefault!.data.value).toBeNull();
+      expect(latestDefault!.state).toBe(States.Alarm);
+    });
   });
 
   it('derives path type from meta units when meta precedes the value', () => {

--- a/src/app/core/services/data.service.spec.ts
+++ b/src/app/core/services/data.service.spec.ts
@@ -633,6 +633,42 @@ describe('DataService', () => {
     expect(latest!.state).toBe(States.Normal);
   });
 
+  it('keeps a timed-out value cleared when a later notification changes its state (no resurface)', () => {
+    let latest: IPathUpdate | undefined;
+    service
+      .subscribePath('self.environment.wind.speedApparent', 'default')
+      .subscribe(update => (latest = update));
+
+    dataPathUpdates$.next({
+      context: 'self',
+      path: 'environment.wind.speedApparent',
+      source: 'test-source',
+      timestamp: '2026-01-01T00:00:01.000Z',
+      value: 5.5,
+    });
+    expect(latest!.data.value).toBe(5.5);
+
+    service.timeoutPathObservable('self.environment.wind.speedApparent', 'default', 'number');
+    expect(latest!.data.value).toBeNull();
+
+    // A later notification re-pushes state onto every registration of the path. A shallow reset
+    // leaves the upstream value subject caching 5.5, so combineLatest re-pairs it with the new state
+    // and resurfaces the stale reading. The deep reset nulled that upstream value, so the reading
+    // stays cleared and only the state advances.
+    notificationUpdates$.next({
+      path: 'notifications.environment.wind.speedApparent',
+      value: {
+        method: ['visual'],
+        state: States.Warn,
+        message: 'Apparent wind warning',
+        timestamp: '2026-01-01T00:00:02.000Z',
+      },
+    });
+
+    expect(latest!.data.value).toBeNull();
+    expect(latest!.state).toBe(States.Warn);
+  });
+
   it('resets only the timed-out source registration, leaving sibling sources live', () => {
     let latestDefault: IPathUpdate | undefined;
     let latestSourceA: IPathUpdate | undefined;

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -876,25 +876,44 @@ export class DataService implements OnDestroy {
   }
 
   /**
-   * Set the value of a path to null and state to Normal. This is used to
-   * timeout a path value and reset it to null. This is useful for widgets
-   * that need to know if a path has timed out.
+   * Reset a path's registrations after a widget's data TTL fired for `source`.
    *
-   * Only the registration matching `source` is reset: one source timing out
-   * must not null a sibling widget bound to a different, still-live source of
-   * the same path (e.g. redundant GPS or wind sensors).
+   * The timed-out source's own registration is always deep-reset — its value nulled on the upstream
+   * subjects (see {@link resetRegistrationValue}) so a later notification cannot resurface it.
+   *
+   * The path's OTHER registrations — its sibling sources and the shared `default` bucket — are
+   * cross-cleared only when the path has gone all-silent: nothing has fed it within `dataTimeoutMs`.
+   * While any source is still delivering deltas, its receipt in `_lastObservedByPath` keeps the path
+   * live and the cross-clear is skipped, so a redundant sensor (a second GPS or wind source) is never
+   * blanked by a peer's timeout. The all-silent case is what lets a widget with its own timeout
+   * disabled — which never calls this itself — still clear once every source behind its path has
+   * stopped, instead of holding a frozen, plausible-looking last reading.
+   *
+   * Only the timing-out TRIGGER's `pathType` is whitelisted; cross-clear targets are reset regardless
+   * of their own type, so a boolean sibling can still be cleared.
    *
    * @param {string} path The Signal K path to timeout
-   * @param {string} source The source whose stream timed out; only its registration is reset
-   * @param {string} pathType The type of the path value (string, Date, number, multiple, etc)
+   * @param {string} source The source whose stream timed out; always deep-reset
+   * @param {string} pathType The type of the timing-out source's value (string, Date, number, multiple, etc)
+   * @param {number} dataTimeoutMs The timing-out widget's TTL window in ms; the path counts as
+   *   all-silent (and its siblings/default get cross-cleared) when nothing has fed it within it.
    * @memberof SignalKDataService
    */
-  public timeoutPathObservable(path: string, source: string, pathType: string): void {
+  public timeoutPathObservable(path: string, source: string, pathType: string, dataTimeoutMs: number): void {
     if (!['string', 'Date', 'number', 'multiple'].includes(pathType)) return;
     const registrations = this._pathRegisterByPath.get(path);
     if (!registrations) return;
-    for (const registration of registrations) {
-      if (registration.source !== source) continue;
+
+    const direct = registrations.find(registration => registration.source === source);
+    if (direct) {
+      this.resetRegistrationValue(direct);
+    }
+
+    const lastObserved = this._lastObservedByPath.get(path);
+    const allSilent = lastObserved === undefined || Date.now() - lastObserved >= dataTimeoutMs;
+    if (!allSilent) return;
+
+    for (const registration of registrations.filter(registration => registration.source !== source)) {
       this.resetRegistrationValue(registration);
     }
   }

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -854,32 +854,35 @@ export class DataService implements OnDestroy {
   }
 
   /**
-   * Deep-reset a single registration's value to cleared/Normal by pushing onto its two UPSTREAM
-   * BehaviorSubjects, never by writing the derived `pathDataUpdate$` directly. The standing
-   * `combineLatest([_pathData$, _pathState$])` then produces the derived emission itself.
+   * Deep-reset a registration's VALUE by nulling its upstream `_pathData$` BehaviorSubject — never by
+   * writing the derived `pathDataUpdate$` directly. The standing `combineLatest([_pathData$,
+   * _pathState$])` then produces the derived emission itself, pairing the nulled value with whatever
+   * state is current.
    *
-   * Order is load-bearing: null the data FIRST, then re-assert Normal state. Writing the derived
-   * subject alone (the previous shallow reset) left `_pathData$` still caching the pre-timeout value,
-   * so a later `_pathState$` emission from the notification handler would re-pair that stale value
-   * via combineLatest and resurface it on a blanked widget. Nulling `_pathData$` makes the cache
-   * genuinely null, so any subsequent state emission re-pairs a null value and the reading stays
-   * cleared. Nulling data before state keeps the transient intermediate emission `{null, staleState}`
-   * (a blank widget with a briefly-wrong badge — safe) rather than `{staleValue, Normal}` (the exact
-   * resurrection being prevented).
+   * Nulling the upstream value (rather than the previous shallow write to the derived subject, which
+   * left `_pathData$` still caching the pre-timeout value) is what prevents resurfacing: a later
+   * `_pathState$` emission from the notification handler now re-pairs `{null, newState}` instead of
+   * `{staleValue, newState}`.
    *
-   * This produces TWO synchronous combineLatest emissions per reset (was one); the final value is
-   * identical.
+   * `_pathState$` is DELIBERATELY left untouched — state is a separate, server-notification-driven
+   * channel and the timeout has no business forcing it to Normal. Clobbering it to Normal would drop
+   * a persistent alarm/zone that is still active on the server: no state-transition notification
+   * would re-arrive to restore it (the notification handler dedupes on transitions and the `_skData`
+   * state is unchanged), so on resume `combineLatest` would re-pair `{value, Normal}` and the alarm
+   * coloring would be lost for the rest of the alarm's life. Leaving state as-is yields
+   * `{null, realState}` on reset and `{value, realState}` on resume, so an active alarm survives a
+   * timeout/resume cycle.
    */
   private resetRegistrationValue(registration: IPathRegistration): void {
     registration._pathData$.next({ value: null, timestamp: null });
-    registration._pathState$.next(States.Normal);
   }
 
   /**
    * Reset a path's registrations after a widget's data TTL fired for `source`.
    *
    * The timed-out source's own registration is always deep-reset — its value nulled on the upstream
-   * subjects (see {@link resetRegistrationValue}) so a later notification cannot resurface it.
+   * `_pathData$` (see {@link resetRegistrationValue}) so a later notification cannot resurface it; its
+   * state is left at the real server-driven value so a persistent alarm survives.
    *
    * The path's OTHER registrations — its sibling sources and the shared `default` bucket — are
    * cross-cleared only when the path has gone all-silent: nothing has fed it within `dataTimeoutMs`.
@@ -888,6 +891,12 @@ export class DataService implements OnDestroy {
    * blanked by a peer's timeout. The all-silent case is what lets a widget with its own timeout
    * disabled — which never calls this itself — still clear once every source behind its path has
    * stopped, instead of holding a frozen, plausible-looking last reading.
+   *
+   * Liveness is per-PATH against the TRIGGERING widget's `dataTimeoutMs`, so on an all-silent path the
+   * strictest-tolerance (shortest-TTL) widget's timeout can cross-clear a longer-tolerance sibling's
+   * value earlier than that sibling's own threshold. This is the intended safety-conscious behavior;
+   * per-source recency is deliberately not used (see the cross-clear site for why it would reintroduce
+   * the frozen-widget bug).
    *
    * Only the timing-out TRIGGER's `pathType` is whitelisted; cross-clear targets are reset regardless
    * of their own type, so a boolean sibling can still be cleared.
@@ -909,6 +918,13 @@ export class DataService implements OnDestroy {
       this.resetRegistrationValue(direct);
     }
 
+    // Liveness is per-PATH, not per-(path, source): the path counts as silent once the
+    // strictest-tolerance (shortest dataTimeout) widget on it times out, which can blank a
+    // longer-tolerance sibling's value earlier than that sibling's own threshold — the intended,
+    // safety-conscious behavior. Per-source recency is deliberately NOT used: the widget timeout
+    // operator is one-shot (it never re-arms), so if a still-fresh sibling source were skipped here,
+    // nothing would re-fire the cross-clear when that source later goes silent, and an
+    // enableTimeout:false widget on it would stay frozen forever (the original #254 bug).
     const lastObserved = this._lastObservedByPath.get(path);
     const allSilent = lastObserved === undefined || Date.now() - lastObserved >= dataTimeoutMs;
     if (!allSilent) return;

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -167,6 +167,15 @@ export class DataService implements OnDestroy {
    * before any value registration exists.
    */
   private _pathMetaByPath = new Map<string, BehaviorSubject<ISkMetadata | null>>();
+  /**
+   * Path -> local wall-clock ms of the last delta received for that path. Sibling of
+   * `_pathRegisterByPath`, feeding the timeout subsystem's liveness gate: a cross-clear of a path's
+   * sibling/default registrations only fires once nothing has fed the path within the timing-out
+   * widget's TTL. Recorded from local `Date.now()`, not the SK-reported timestamp, so it measures
+   * locally-elapsed silence and never inherits SK clock skew. Pruned per-context in
+   * {@link removePathsForContext} so it stays bounded under AIS context churn.
+   */
+  private _lastObservedByPath = new Map<string, number>();
 
   constructor() {
     // Emit Delta message update counter every second (RxJS based)
@@ -393,6 +402,11 @@ export class DataService implements OnDestroy {
         this._pendingPathStates.delete(path);
       }
     }
+    for (const path of Array.from(this._lastObservedByPath.keys())) {
+      if (path.startsWith(prefix)) {
+        this._lastObservedByPath.delete(path);
+      }
+    }
     if (removedSkData && this._isSkDataFullTreeActive) {
       this.refreshSkDataCache();
       this.scheduleSkDataFullTreeEmit();
@@ -559,6 +573,11 @@ export class DataService implements OnDestroy {
         sourceValue: dataPath.value,
       };
     }
+
+    // Local receipt clock for the timeout liveness gate: record that *some* source fed this path
+    // just now. Uses Date.now() (not the SK timestamp) so silence is measured against local elapsed
+    // time, matching how the widget-side timeout operator measures its window.
+    this._lastObservedByPath.set(updatePath, Date.now());
 
     // Update path register Subjects with new data
     const pathRegisterItems = this._pathRegisterByPath.get(updatePath) ?? [];

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -854,6 +854,28 @@ export class DataService implements OnDestroy {
   }
 
   /**
+   * Deep-reset a single registration's value to cleared/Normal by pushing onto its two UPSTREAM
+   * BehaviorSubjects, never by writing the derived `pathDataUpdate$` directly. The standing
+   * `combineLatest([_pathData$, _pathState$])` then produces the derived emission itself.
+   *
+   * Order is load-bearing: null the data FIRST, then re-assert Normal state. Writing the derived
+   * subject alone (the previous shallow reset) left `_pathData$` still caching the pre-timeout value,
+   * so a later `_pathState$` emission from the notification handler would re-pair that stale value
+   * via combineLatest and resurface it on a blanked widget. Nulling `_pathData$` makes the cache
+   * genuinely null, so any subsequent state emission re-pairs a null value and the reading stays
+   * cleared. Nulling data before state keeps the transient intermediate emission `{null, staleState}`
+   * (a blank widget with a briefly-wrong badge — safe) rather than `{staleValue, Normal}` (the exact
+   * resurrection being prevented).
+   *
+   * This produces TWO synchronous combineLatest emissions per reset (was one); the final value is
+   * identical.
+   */
+  private resetRegistrationValue(registration: IPathRegistration): void {
+    registration._pathData$.next({ value: null, timestamp: null });
+    registration._pathState$.next(States.Normal);
+  }
+
+  /**
    * Set the value of a path to null and state to Normal. This is used to
    * timeout a path value and reset it to null. This is useful for widgets
    * that need to know if a path has timed out.
@@ -873,13 +895,7 @@ export class DataService implements OnDestroy {
     if (!registrations) return;
     for (const registration of registrations) {
       if (registration.source !== source) continue;
-      registration.pathDataUpdate$.next({
-        data: {
-          value: null,
-          timestamp: null
-        },
-        state: States.Normal
-      });
+      this.resetRegistrationValue(registration);
     }
   }
 

--- a/src/app/widget-config/paths-options/paths-options.component.html
+++ b/src/app/widget-config/paths-options/paths-options.component.html
@@ -12,6 +12,7 @@
       min="2"
       required>
     <span matTextSuffix>Seconds</span>
+    <mat-hint>When data stops arriving for this long, the widget clears its reading instead of holding the last value. For a path shared by several sources, it clears only once every source has gone quiet.</mat-hint>
   </mat-form-field>
 </div>
 <ng-container [formGroup]="pathsGroup">

--- a/src/app/widget-config/paths-options/paths-options.component.ts
+++ b/src/app/widget-config/paths-options/paths-options.component.ts
@@ -4,7 +4,7 @@ import type { IDynamicControl, IWidgetPath } from '../../core/interfaces/widgets
 import { ObjectKeysPipe } from '../../core/pipes/object-keys.pipe';
 import { PathControlConfigComponent } from '../path-control-config/path-control-config.component';
 import { MatInput } from '@angular/material/input';
-import { MatFormField, MatLabel, MatSuffix } from '@angular/material/form-field';
+import { MatFormField, MatLabel, MatSuffix, MatHint } from '@angular/material/form-field';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { IAddNewPathObject } from '../boolean-multicontrol-options/boolean-multicontrol-options.component';
 
@@ -18,7 +18,7 @@ export interface IAddNewPath {
     selector: 'paths-options',
     templateUrl: './paths-options.component.html',
     styleUrls: ['./paths-options.component.scss'],
-    imports: [MatCheckbox, FormsModule, ReactiveFormsModule, MatFormField, MatLabel, MatInput, MatSuffix, PathControlConfigComponent, ObjectKeysPipe]
+    imports: [MatCheckbox, FormsModule, ReactiveFormsModule, MatFormField, MatLabel, MatInput, MatSuffix, MatHint, PathControlConfigComponent, ObjectKeysPipe]
 })
 export class PathsOptionsComponent implements OnInit, OnChanges {
   private rootFormGroup = inject(FormGroupDirective);


### PR DESCRIPTION
## What

Two linked fixes in the timeout/clearing path of `DataService`. Fixes #254. Builds on B2 (#243, #311).

**1. The `enableTimeout:false` frozen-widget reversal.** After #252 scoped timeout clearing to the source that actually timed out, a widget with `enableTimeout:false` (shipped default for `widget-boolean-switch`, `widget-autopilot`) bound to a dead source renders its **last value forever** — it has no `timeout()` operator, so it only ever cleared as a side effect of the old null-all reset. A frozen-but-plausible reading is a hazard for safety-adjacent widgets.

**2. A pre-existing shallow reset.** `timeoutPathObservable` nulled the *derived* `pathDataUpdate$` but left the upstream `_pathData$` holding the stale value, so a later `_pathState$` emission (a notification/zone change) re-paired the stale value via `combineLatest` and **resurfaced** it.

## Approach (Gate A Option 2 — clear only when *no source is live*)

Re-add cross-clearing of the sibling/default registrations, but **only in the genuinely all-silent case**, so #252's live-sibling fix is never reintroduced (cross-clearing provably cannot fire while any source is live).

- **Liveness is a per-path wall-clock receipt, not `refCount`.** `refCount` counts live *subscribers*, not live *data* — the frozen widget keeps refCount>0 while on-screen with a dead sensor, so refCount could never fire the cross-clear. New `_lastObservedByPath: Map<path, number>` is stamped with `Date.now()` on every delta. A path is "stale" iff nothing fed it within the timing-out widget's TTL. A live sibling produces deltas → refreshes the clock → `stale=false` → cross-clear is never entered (the exact #252 guarantee). `_pathRegisterByPath` is used only to *enumerate* the sibling registrations to clear.
- **`_lastObservedByPath` is pruned in `removePathsForContext`** alongside `_skData`/`_pathMetaByPath` — a new per-path map would otherwise reintroduce the unbounded-growth leak B2 just fixed.
- **Deep reset (shallow-fix core):** a shared `resetRegistrationValue` helper pushes onto the **upstream** subjects — `_pathData$.next({value:null,timestamp:null})` **then** `_pathState$.next(States.Normal)` — and lets the standing `combineLatest` produce the derived emission. Nulling the upstream cache means a later `_pathState$` emission re-pairs *null* with the new state; the value stays cleared. Order is load-bearing (null-data first → the transient is `{null, staleState}`, a blank widget with a briefly-old badge; the reverse would flash the stale value with a fresh `Normal` state — the exact resurrection being fixed). Same helper is used for the direct reset and every cross-cleared sibling, so cross-cleared siblings can't resurface either.

## Notes for review

- **`timeoutPathObservable` gains a required 4th param `dataTimeoutMs`** (threaded from `widget-streams.directive` — the sole production caller); the liveness window is the timing-out widget's own TTL.
- **Double emission:** the deep reset now produces two synchronous `combineLatest` emissions per reset (was one) — final value identical, documented in the helper's JSDoc.
- With multiple `enableTimeout:true` widgets of different TTLs on one path, the shortest window wins the cross-clear check — bounded and self-healing (a later delta recovers). Recovery is automatic everywhere: any new delta re-populates `_pathData$` and refreshes the receipt clock.

## Testing

- **Full local suite green (148 files.)** New coverage: the **#252 live-sibling guard** (a source fed within the TTL → no cross-clear, siblings keep their value); all-silent cross-clear fires; the `enableTimeout:false` victim registration (which never calls `timeoutPathObservable` itself) is reached; the shallow-reset resurface bug (null, then push a notification state change → value stays null); a cross-cleared sibling stays null after a notification; and `_lastObservedByPath` foreign-context prune. Recency-dependent cases use vitest fake timers (`setSystemTime`).
- Lint clean; betterer:ci 179 (a `paths-options.component.ts` hash update for the new `MatHint` import is regenerated in the docs commit).
- A plain-English `<mat-hint>` documents the semantic in the path config; the `enableTimeout` JSDoc got a one-line shared-path addendum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
