### PR TITLE
fix(gauge): stop value box flicker on fast values (RPM) (#222)

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -213,7 +213,7 @@ exports[`strictNullChecks`] = {
       [44, 9, 9, "Type \'null\' is not assignable to type \'string\'.", "2966443234"],
       [148, 40, 27, "Object is possibly \'undefined\'.", "3506675417"]
     ],
-    "src/app/widgets/widget-gauge-ng-compass/widget-gauge-ng-compass.component.ts:3154966941": [
+    "src/app/widgets/widget-gauge-ng-compass/widget-gauge-ng-compass.component.ts:716655136": [
       [237, 30, 9, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "4119212820"]
     ],
     "src/app/widgets/widget-iframe/widget-iframe.component.ts:2602616758": [

--- a/src/app/core/utils/gauge-animation.util.spec.ts
+++ b/src/app/core/utils/gauge-animation.util.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { GAUGE_ANIMATION_MS, gaugeAnimationDurationMs } from './gauge-animation.util';
+import { GAUGE_ANIMATION_MS, gaugeAnimationDurationMs, gaugeAnimationOptions } from './gauge-animation.util';
 
 describe('gaugeAnimationDurationMs', () => {
   it('uses a short fixed window instead of ~the whole sample interval', () => {
@@ -16,5 +16,25 @@ describe('gaugeAnimationDurationMs', () => {
   it('falls back to the fixed window for invalid sample times', () => {
     expect(gaugeAnimationDurationMs(0)).toBe(GAUGE_ANIMATION_MS);
     expect(gaugeAnimationDurationMs(Number.NaN)).toBe(GAUGE_ANIMATION_MS);
+  });
+});
+
+describe('gaugeAnimationOptions', () => {
+  // Both the initial gauge options and the post-bootstrap gauge.update() flow
+  // through this factory, so pinning it here pins the value box on every path
+  // (including the post-bootstrap re-enable that previously turned it back on).
+  it('never animates the value box, even once animation is enabled', () => {
+    expect(gaugeAnimationOptions(true).animatedValue).toBe(false);
+    expect(gaugeAnimationOptions(false).animatedValue).toBe(false);
+  });
+
+  it('gates the needle animation on the enabled flag', () => {
+    expect(gaugeAnimationOptions(true).animation).toBe(true);
+    expect(gaugeAnimationOptions(false).animation).toBe(false);
+  });
+
+  it('never animates on init', () => {
+    expect(gaugeAnimationOptions(true).animateOnInit).toBe(false);
+    expect(gaugeAnimationOptions(false).animateOnInit).toBe(false);
   });
 });

--- a/src/app/core/utils/gauge-animation.util.ts
+++ b/src/app/core/utils/gauge-animation.util.ts
@@ -20,6 +20,9 @@ export function gaugeAnimationDurationMs(sampleTimeMs: number): number {
   return Math.min(GAUGE_ANIMATION_MS, sampleTimeMs);
 }
 
+// These four fields live on the shared `GenericOptions` base that both radial and
+// linear gauge options extend, so the policy applies to every ng-canvas gauge. We
+// Pick from `RadialGaugeOptions` only because the package does not re-export the base.
 type GaugeAnimationOptions = Pick<RadialGaugeOptions, 'animation' | 'animatedValue' | 'animateOnInit' | 'animationRule'>;
 
 /**

--- a/src/app/core/utils/gauge-animation.util.ts
+++ b/src/app/core/utils/gauge-animation.util.ts
@@ -1,3 +1,5 @@
+import type { RadialGaugeOptions } from '@godind/ng-canvas-gauges';
+
 /**
  * Animation duration (ms) for live ng-canvas gauges.
  *
@@ -16,4 +18,22 @@ export const GAUGE_ANIMATION_MS = 120;
 export function gaugeAnimationDurationMs(sampleTimeMs: number): number {
   if (!Number.isFinite(sampleTimeMs) || sampleTimeMs <= 0) return GAUGE_ANIMATION_MS;
   return Math.min(GAUGE_ANIMATION_MS, sampleTimeMs);
+}
+
+type GaugeAnimationOptions = Pick<RadialGaugeOptions, 'animation' | 'animatedValue' | 'animateOnInit' | 'animationRule'>;
+
+/**
+ * Shared animation policy for the ng-canvas gauges. `animatedValue` is always
+ * off: on fast, large-range values (e.g. RPM) it tweens the numeric value box
+ * through every intermediate integer, which reads as a flicker (#222). The
+ * needle still animates via `animation`, gated on the enabled flag so the first
+ * frame lands statically instead of sweeping in from zero.
+ */
+export function gaugeAnimationOptions(animationEnabled: boolean): GaugeAnimationOptions {
+  return {
+    animation: animationEnabled,
+    animatedValue: false,
+    animateOnInit: false,
+    animationRule: 'linear'
+  };
 }

--- a/src/app/widgets/widget-gauge-ng-compass/widget-gauge-ng-compass.component.ts
+++ b/src/app/widgets/widget-gauge-ng-compass/widget-gauge-ng-compass.component.ts
@@ -6,7 +6,7 @@
  * instantiated gauge config.
  */
 import { Component, AfterViewInit, ElementRef, effect, viewChild, input, inject, untracked, computed, signal } from '@angular/core';
-import { gaugeAnimationDurationMs } from '../../core/utils/gauge-animation.util';
+import { gaugeAnimationDurationMs, gaugeAnimationOptions } from '../../core/utils/gauge-animation.util';
 import { ChangeDetectionStrategy } from '@angular/core';
 
 import { GaugesModule, RadialGaugeOptions, RadialGauge } from '@godind/ng-canvas-gauges';
@@ -170,9 +170,9 @@ export class WidgetGaugeNgCompassComponent implements AfterViewInit {
       });
     });
 
-    // Enable animatedValue transition only after the gauge canvas is first mounted.
-    // buildGaugeOptions starts with animatedValue=false so the initial @if render
-    // places the needle at the real value without any sweep animation.
+    // Enable the needle animation only after the gauge canvas is first mounted, so
+    // the initial @if render places the needle at the real value without a sweep.
+    // The value box tween (animatedValue) stays off on every path — see #222.
     effect(() => {
       const gauge = this.ngGauge();
       if (!gauge || this.gaugeBootstrapped()) return;
@@ -180,7 +180,7 @@ export class WidgetGaugeNgCompassComponent implements AfterViewInit {
         try {
           requestAnimationFrame(() => {
             this.gaugeBootstrapped.set(true);
-            try { gauge.update({ animation: true, animatedValue: true }); } catch { /* ignore */ }
+            try { gauge.update(gaugeAnimationOptions(true)); } catch { /* ignore */ }
           });
         } catch { /* ignore */ }
       });
@@ -233,7 +233,7 @@ export class WidgetGaugeNgCompassComponent implements AfterViewInit {
     else {
       g.animationTarget = this.ANIMATION_TARGET_NEEDLE; g.useMinPath = true;
     }
-    g.animateOnInit = false; g.animation = this.animationEnabled(); g.animatedValue = this.animationEnabled(); g.animationRule = 'linear'; g.animationDuration = gaugeAnimationDurationMs(cfg.paths?.['gaugePath']?.sampleTime ?? 500);
+    Object.assign(g, gaugeAnimationOptions(this.animationEnabled())); g.animationDuration = gaugeAnimationDurationMs(cfg.paths?.['gaugePath']?.sampleTime ?? 500);
     // Colors (RGBA unsupported -> convert)
     const palette = getColors(cfg.color, theme);
     const dim = rgbaToHex(palette.dim);

--- a/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.ts
+++ b/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.ts
@@ -10,7 +10,7 @@ import { ChangeDetectionStrategy } from '@angular/core';
 import { LinearGaugeOptions, LinearGauge, GaugesModule } from '@godind/ng-canvas-gauges';
 import { IWidgetSvcConfig, IDataHighlight } from '../../core/interfaces/widgets-interface';
 import { adjustLinearScaleAndMajorTicks, IScale } from '../../core/utils/dataScales.util';
-import { gaugeAnimationDurationMs } from '../../core/utils/gauge-animation.util';
+import { gaugeAnimationDurationMs, gaugeAnimationOptions } from '../../core/utils/gauge-animation.util';
 import { getHighlights } from '../../core/utils/zones-highlight.utils';
 import { getColors } from '../../core/utils/themeColors.utils';
 import { States } from '../../core/interfaces/signalk-interfaces';
@@ -192,7 +192,7 @@ export class WidgetGaugeNgLinearComponent implements AfterViewInit {
         try {
           requestAnimationFrame(() => {
             this.gaugeBootstrapped.set(true);
-            try { gauge.update({ animation: true, animatedValue: true }); } catch { /* ignore */ }
+            try { gauge.update(gaugeAnimationOptions(true)); } catch { /* ignore */ }
           });
         } catch { /* ignore */ }
       });
@@ -301,7 +301,7 @@ export class WidgetGaugeNgLinearComponent implements AfterViewInit {
     opt.ticksWidth = ticks ? (enableNeedle ? (isVertical ? 15 : 10) : 10) : 0;
     opt.ticksPadding = ticks ? (isVertical ? (enableNeedle ? 0 : 5) : (enableNeedle ? 9 : 8)) : 0;
     opt.tickSide = 'left';
-    opt.animation = this.animationEnabled(); opt.animationRule = 'linear'; opt.animatedValue = this.animationEnabled(); opt.animateOnInit = false; opt.animationDuration = gaugeAnimationDurationMs(cfg.paths?.['gaugePath']?.sampleTime ?? 500);
+    Object.assign(opt, gaugeAnimationOptions(this.animationEnabled())); opt.animationDuration = gaugeAnimationDurationMs(cfg.paths?.['gaugePath']?.sampleTime ?? 500);
     opt.highlights = []; opt.highlightsWidth = cfg.gauge?.highlightsWidth;
     // pre-populate highlights if already available
     const h = this.highlights();

--- a/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
+++ b/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
@@ -6,7 +6,7 @@
  * instantiated gauge config.
  */
 import { Component, AfterViewInit, ElementRef, effect, viewChild, inject, input, untracked, computed, signal } from '@angular/core';
-import { gaugeAnimationDurationMs } from '../../core/utils/gauge-animation.util';
+import { gaugeAnimationDurationMs, gaugeAnimationOptions } from '../../core/utils/gauge-animation.util';
 import { ChangeDetectionStrategy } from '@angular/core';
 import { GaugesModule, RadialGaugeOptions, RadialGauge } from '@godind/ng-canvas-gauges';
 import { IWidgetSvcConfig, IDataHighlight } from '../../core/interfaces/widgets-interface';
@@ -206,7 +206,7 @@ export class WidgetGaugeNgRadialComponent implements AfterViewInit {
         try {
           requestAnimationFrame(() => {
             this.gaugeBootstrapped.set(true);
-            try { gauge.update({ animation: true, animatedValue: true }); } catch { /* ignore */ }
+            try { gauge.update(gaugeAnimationOptions(true)); } catch { /* ignore */ }
           });
         } catch { /* ignore */ }
       });
@@ -303,8 +303,8 @@ export class WidgetGaugeNgRadialComponent implements AfterViewInit {
     g.fontNumbers = 'Roboto'; g.fontNumbersWeight = 'bold';
     g.valueInt = cfg.numInt ?? 1; g.valueDec = cfg.numDecimal ?? 2; g.majorTicksInt = g.valueInt; g.majorTicksDec = g.valueDec;
     g.highlightsWidth = cfg.gauge?.highlightsWidth;
-    g.animation = this.animationEnabled(); g.animateOnInit = false; g.animatedValue = this.animationEnabled(); g.animationRule = 'linear';
-    const st = cfg.paths?.['gaugePath']?.sampleTime ?? 500; g.animationDuration = gaugeAnimationDurationMs(st);
+    Object.assign(g, gaugeAnimationOptions(this.animationEnabled()));
+    g.animationDuration = gaugeAnimationDurationMs(cfg.paths?.['gaugePath']?.sampleTime ?? 500);
     g.colorBorderShadow = false; g.colorBorderOuter = theme.cardColor; g.colorBorderOuterEnd = ''; g.colorBorderMiddle = theme.cardColor; g.colorBorderMiddleEnd = '';
     g.colorPlate = g.colorPlateEnd = theme.cardColor; g.colorBar = theme.background;
 


### PR DESCRIPTION
## Why

A radial gauge bound to a fast, large-range value (e.g. engine RPM at ~500 ms sample time) appears to **flicker**: each new sample makes the numeric value box count from the old value to the new one across the 120 ms animation window, then sit idle until the next sample. Root cause is the gauge library's `animatedValue`, which tweens the value-box text through every intermediate integer instead of snapping to the new number. The **needle** animation is fine — it's specifically the animated value-box text that reads as flicker (#222).

## How

Introduce a single `gaugeAnimationOptions` policy factory (`src/app/core/utils/gauge-animation.util.ts`) and route **all three** ng-canvas gauges (radial, linear, compass) through it, at both the initial-options build **and** the post-bootstrap `gauge.update()` site that previously turned `animatedValue` back on (the known "line-209 trap"). The factory keeps `animatedValue` permanently off while leaving `animation` (needle) gated on the post-first-frame flag and the 120 ms duration cap (`gaugeAnimationDurationMs`) untouched. The only behavioural change at each site is `animatedValue` → `false`; `animation`, `animateOnInit`, and `animationRule` keep their prior values.

The value now snaps to each sample while the needle still animates smoothly. A pure unit spec pins the decoupling (value box never animates in either flag state; needle animation follows the flag; never animates on init) so the tween can't be silently re-enabled by a future edit to any of the six option sites.

`.betterer.results` carries only the compass file's content-hash key update — its one pre-existing strictNullChecks issue and the 179 total are unchanged.

**Boat-verify:** the no-flicker behaviour on live RPM is batched to the Stage-1-close boat session.

Closes #222.

🤖 Generated with [Claude Code](https://claude.com/claude-code)