### PR TITLE
feat(boolean): resizable controls + OFF-state visibility (port Kip #1106/#1107)

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -193,9 +193,9 @@ exports[`strictNullChecks`] = {
       [1358, 21, 11, "\'b.longitude\' is possibly \'undefined\'.", "3370058570"],
       [1358, 35, 11, "\'a.longitude\' is possibly \'undefined\'.", "2985066057"]
     ],
-    "src/app/widgets/widget-boolean-switch/widget-boolean-switch.component.ts:800795185": [
-      [71, 38, 9, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "4119212820"],
-      [94, 10, 12, "Object is possibly \'null\'.", "4261782498"]
+    "src/app/widgets/widget-boolean-switch/widget-boolean-switch.component.ts:1261729337": [
+      [77, 38, 9, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "4119212820"],
+      [100, 10, 12, "Object is possibly \'null\'.", "4261782498"]
     ],
     "src/app/widgets/widget-datetime/widget-datetime.component.ts:3033260432": [
       [60, 40, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'string\'.", "2620553983"],

--- a/src/app/widgets/svg-boolean-button/svg-boolean-button.component.svg
+++ b/src/app/widgets/svg-boolean-button/svg-boolean-button.component.svg
@@ -1,71 +1,45 @@
 <svg
    [attr.height]="dimensions().height"
    [attr.width]="dimensions().width"
-   [attr.viewBox]="viewBox"
+   [attr.viewBox]="'0 0 ' + dimensions().width + ' ' + dimensions().height"
+  (pointerup)="handleClickUp()"
+  (pointerleave)="handleClickUp()"
+  (pointerdown)="handleClickDown($event)"
+  (pointermove)="handlePointerMove($event)"
+  (pointercancel)="handlePointerCancel()"
    version="1.1"
    id="svg9"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg">
-  <defs id="defs9" />
-  <g (pointerup)="handleClickUp()" (pointerleave)="handleClickUp()" (pointerdown)="handleClickDown($event)" (pointermove)="handlePointerMove($event)">
-    <g id="disabled" transform="translate(0,35)">
-      <rect
-        id="clickRecDisabled"
-        width="180"
-        height="35"
-        x="0"
-        y="0"
-        pointer-events="all"
-        style="display:inline;opacity:1;fill:transparent;fill-opacity:1;stroke:none;stroke-width:0;stroke-dasharray:none;stroke-opacity:0" />
-      <rect
-        id="buttonDisabled"
-        width="165.02518"
-        height="25.025183"
-        rx="3.6672263"
-        x="7.4874101"
-        y="4.9874086"
-        [attr.fill]="labelColorDisabled"
-        style="display:inline;mix-blend-mode:normal;fill-opacity:1;stroke:#ffffff;stroke-width:1.5;stroke-dasharray:none;stroke-opacity:0.2" />
-      <svg x="12" y="0" width="156" height="35" viewBox="0 0 156 35">
-        <text
-          id="textDisabled"
-          [attr.fill]="labelColorDisabled"
-          style="text-anchor: middle;text-align: center;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14px;font-family:arial;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal"
-          x="77.968102"
-          y="22">
-            {{ data().ctrlLabel }}
-        </text>
-      </svg>
-    </g>
-    <g id="enabled">
-      <rect
-        width="180"
-        height="35"
-        id="rect1"
-        x="0"
-        y="0"
-        pointer-events="all"
-        style="display:inline;opacity:1;fill:transparent;fill-opacity:1;stroke:none;stroke-width:0;stroke-dasharray:none;stroke-opacity:0"/>
-      <rect
-        id="buttonEnabled"
-        width="165.02518"
-        height="25.025183"
-        rx="3.6672263"
-        x="5.9874086"
-        y="4.9874086"
-        [attr.fill]="valueColor"
-        style="display:inline;opacity:1;mix-blend-mode:normal;stroke:#000000;stroke-width:1.5;stroke-dasharray:none;stroke-opacity:0.2"
-        transform="translate(1.5)" />
-      <svg x="12" y="0" width="156" height="35" viewBox="0 0 156 35">
-      <text
-          id="textEnabled"
-          [attr.fill]="labelColorEnabled"
-          style="text-anchor: middle;text-align: center;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14px;font-family:arial;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal"
-          x="77.968102"
-          y="22">
-            {{ data().ctrlLabel }}
-        </text>
-      </svg>
-    </g>
-  </g>
+  <rect
+    [attr.width]="dimensions().width"
+    [attr.height]="dimensions().height"
+    x="0"
+    y="0"
+    pointer-events="all"
+    style="display:inline;opacity:1;fill:transparent;fill-opacity:1;stroke:none;stroke-width:0" />
+
+  <rect
+    [attr.x]="layout.buttonX"
+    [attr.y]="layout.buttonY"
+    [attr.width]="layout.buttonWidth"
+    [attr.height]="layout.buttonHeight"
+    [attr.rx]="layout.buttonRadius"
+    [attr.fill]="isPressed ? valueColor : labelColorDisabled"
+    style="display:inline;mix-blend-mode:normal;stroke:black;stroke-width:1.5;stroke-opacity:0.2" />
+
+  <foreignObject
+    [attr.x]="layout.labelX"
+    y="0"
+    [attr.width]="layout.labelWidth"
+    [attr.height]="dimensions().height"
+    style="pointer-events:none;">
+    <div
+      xmlns="http://www.w3.org/1999/xhtml"
+      [style.color]="isPressed ? labelColorEnabled : labelColorDisabled"
+      [style.fontSize.px]="layout.labelFontSize"
+      style="width:100%;height:100%;display:flex;align-items:center;justify-content:center;font-family:Roboto,sans-serif;font-weight:700;line-height:1;white-space:nowrap;overflow:hidden;text-overflow:clip;">
+      {{ data()?.ctrlLabel }}
+    </div>
+  </foreignObject>
 </svg>

--- a/src/app/widgets/svg-boolean-button/svg-boolean-button.component.ts
+++ b/src/app/widgets/svg-boolean-button/svg-boolean-button.component.ts
@@ -2,6 +2,7 @@ import { cloneDeep } from 'lodash-es';
 import { Component, DoCheck, OnDestroy, input, output, ChangeDetectionStrategy } from '@angular/core';
 import type { IDynamicControl, IDimensions } from '../../core/interfaces/widgets-interface';
 import type { ITheme } from '../../core/services/app-service';
+import { BooleanControlLayout, getBooleanControlLayout } from '../widget-boolean-switch/boolean-control-layout.util';
 
 @Component({
   selector: 'app-svg-boolean-button',
@@ -16,8 +17,6 @@ export class SvgBooleanButtonComponent implements DoCheck, OnDestroy {
   readonly dimensions = input.required<IDimensions>();
   readonly toggleClick = output<IDynamicControl>();
 
-  private toggleOff = "0 35 180 35";
-  private toggleOn = "0 0 180 35";
   private oldTheme: ITheme | null = null;
 
   private emitIntervalId: ReturnType<typeof setInterval> | null = null; // repeating emit while pressed
@@ -26,14 +25,12 @@ export class SvgBooleanButtonComponent implements DoCheck, OnDestroy {
   private pointerStartX = 0;
   private pointerStartY = 0;
 
-  public viewBox: string = this.toggleOff;
   public labelColorEnabled: string | null = null;
   public labelColorDisabled: string | null = null;
   public valueColor: string | null = null;
   private ctrlColor = '';
 
   ngDoCheck(): void {
-    this.viewBox = this.pressed ? this.toggleOn : this.toggleOff;
     const data = this.data();
     if (!data) return;
     if (data.color != this.ctrlColor) {
@@ -82,13 +79,27 @@ export class SvgBooleanButtonComponent implements DoCheck, OnDestroy {
 
   public handleClickUp(): void {
     if (this.isSwiping) {
-      // Ignore pointerup if it was a swipe
+      // Ignore swipe as an activation, but still reset transient state.
       this.isSwiping = false;
-      return;
     }
 
     this.pressed = false;
     this.clearTimers();
+  }
+
+  public handlePointerCancel(): void {
+    this.isSwiping = false;
+    this.pressed = false;
+    this.clearTimers();
+  }
+
+  public get layout(): BooleanControlLayout {
+    const dimensions = this.dimensions();
+    return getBooleanControlLayout('2', dimensions.width, dimensions.height);
+  }
+
+  public get isPressed(): boolean {
+    return this.pressed;
   }
 
   private getColors(color: string): void {

--- a/src/app/widgets/svg-boolean-light/svg-boolean-light.component.spec.ts
+++ b/src/app/widgets/svg-boolean-light/svg-boolean-light.component.spec.ts
@@ -1,0 +1,59 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SvgBooleanLightComponent } from './svg-boolean-light.component';
+import type { IDynamicControl, IDimensions } from '../../core/interfaces/widgets-interface';
+import type { ITheme } from '../../core/services/app-service';
+
+const COLOR_KEYS = ['blue', 'green', 'purple', 'yellow', 'pink', 'orange', 'contrast', 'grey'] as const;
+
+function makeTheme(): ITheme {
+  const theme: Record<string, string> = {
+    port: 'port', starboard: 'starboard',
+    zoneNominal: 'zoneNominal', zoneAlert: 'zoneAlert', zoneWarn: 'zoneWarn',
+    zoneAlarm: 'zoneAlarm', zoneEmergency: 'zoneEmergency',
+    background: 'background', cardColor: 'cardColor'
+  };
+  for (const key of COLOR_KEYS) {
+    theme[key] = key;
+    theme[`${key}Dim`] = `${key}Dim`;
+    theme[`${key}Dimmer`] = `${key}Dimmer`;
+  }
+  return theme as unknown as ITheme;
+}
+
+const dimensionsMock: IDimensions = { width: 180, height: 35 };
+
+function control(color: string): IDynamicControl {
+  return { ctrlLabel: 'Nav', type: '3', pathID: 'p', value: false, color, isNumeric: false };
+}
+
+describe('SvgBooleanLightComponent OFF-state', () => {
+  let fixture: ComponentFixture<SvgBooleanLightComponent>;
+  let component: SvgBooleanLightComponent;
+
+  const setup = (color: string) => {
+    TestBed.configureTestingModule({ imports: [SvgBooleanLightComponent] });
+    fixture = TestBed.createComponent(SvgBooleanLightComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('controlData', control(color));
+    fixture.componentRef.setInput('theme', makeTheme());
+    fixture.componentRef.setInput('dimensions', dimensionsMock);
+    fixture.detectChanges();
+  };
+
+  beforeEach(() => TestBed.resetTestingModule());
+  afterEach(() => TestBed.resetTestingModule());
+
+  it('lights the OFF bulb with the dedicated dimmer color, not the label color', () => {
+    setup('green');
+
+    expect(component.offColor).toBe('greenDimmer');
+    expect(component.offColor).not.toBe(component.labelColor);
+  });
+
+  it('falls back to the contrast dimmer for an unknown color', () => {
+    setup('bogus');
+
+    expect(component.offColor).toBe('contrastDimmer');
+  });
+});

--- a/src/app/widgets/svg-boolean-light/svg-boolean-light.component.svg
+++ b/src/app/widgets/svg-boolean-light/svg-boolean-light.component.svg
@@ -7,17 +7,20 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg">
   <defs id="defs1">
-    <linearGradient id="linearGradient32">
-      <stop style="stop-color:#000000;stop-opacity:0.88486844;" offset="0" />
-      <stop style="stop-color:#f7f7f7;stop-opacity:0.17763157;" offset="1" />
-    </linearGradient>
-    <linearGradient
-      xlink:href="#linearGradient32"
-      id="linearGradient33"
-      x1="0"
-      y1="0"
-      x2="1"
-      y2="1">
+    <radialGradient id="lightSpecular" cx="36%" cy="32%" r="68%">
+      <stop offset="0" stop-color="#ffffff" stop-opacity="0.5" />
+      <stop offset="0.55" stop-color="#ffffff" stop-opacity="0.16" />
+      <stop offset="1" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+    <radialGradient id="lightDepth" cx="68%" cy="70%" r="68%">
+      <stop offset="0" stop-color="#000000" stop-opacity="0" />
+      <stop offset="0.62" stop-color="#000000" stop-opacity="0.05" />
+      <stop offset="1" stop-color="#000000" stop-opacity="0.22" />
+    </radialGradient>
+    <linearGradient id="lightRim" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ffffff" stop-opacity="0.36" />
+      <stop offset="0.45" stop-color="#ffffff" stop-opacity="0.09" />
+      <stop offset="1" stop-color="#000000" stop-opacity="0.3" />
     </linearGradient>
   </defs>
 
@@ -29,8 +32,9 @@
     <div
       xmlns="http://www.w3.org/1999/xhtml"
       [style.color]="isEnabled ? valueColor : labelColor"
+      [style.opacity]="isEnabled ? 1 : 0.6"
       [style.fontSize.px]="layout.labelFontSize"
-      [style.textShadow]="isEnabled ? '0 0 6px currentColor, 0 0 6px currentColor' : 'none'"
+      [style.textShadow]="isEnabled ? '0 0 4px currentColor, 0 0 4px currentColor' : 'none'"
       style="width:100%;height:100%;display:flex;align-items:center;justify-content:flex-start;font-family:Roboto,sans-serif;font-weight:700;line-height:1;white-space:nowrap;overflow:hidden;text-overflow:clip;">
       {{ data()?.ctrlLabel }}
     </div>
@@ -40,7 +44,29 @@
     [attr.cx]="layout.lightCenterX"
     [attr.cy]="layout.lightCenterY"
     [attr.r]="layout.lightRadius"
-    [attr.fill]="isEnabled ? valueColor : labelColor"
-    style="stroke:url(#linearGradient33);stroke-opacity:0.2;stroke-dasharray:none"
+    [attr.fill]="isEnabled ? valueColor : offColor"
+    style="stroke:url(#lightRim);stroke-opacity:0.4;stroke-dasharray:none"
     [attr.stroke-width]="layout.lightStrokeWidth" />
+
+  <circle
+    [attr.cx]="layout.lightCenterX"
+    [attr.cy]="layout.lightCenterY"
+    [attr.r]="layout.lightRadius"
+    fill="url(#lightSpecular)"
+    [attr.opacity]="isEnabled ? 0.62 : 0.42" />
+
+  <circle
+    [attr.cx]="layout.lightCenterX"
+    [attr.cy]="layout.lightCenterY"
+    [attr.r]="layout.lightRadius"
+    fill="url(#lightDepth)"
+    [attr.opacity]="isEnabled ? 0.62 : 0.48" />
+
+  <ellipse
+    [attr.cx]="layout.lightCenterX - (layout.lightRadius * 0.32)"
+    [attr.cy]="layout.lightCenterY - (layout.lightRadius * 0.34)"
+    [attr.rx]="layout.lightRadius * 0.34"
+    [attr.ry]="layout.lightRadius * 0.2"
+    fill="#ffffff"
+    [attr.opacity]="isEnabled ? 0.2 : 0.12" />
 </svg>

--- a/src/app/widgets/svg-boolean-light/svg-boolean-light.component.svg
+++ b/src/app/widgets/svg-boolean-light/svg-boolean-light.component.svg
@@ -1,96 +1,46 @@
 <svg
    [attr.height]="dimensions().height"
    [attr.width]="dimensions().width"
-   [attr.viewBox]="viewBox"
+   [attr.viewBox]="'0 0 ' + dimensions().width + ' ' + dimensions().height"
    version="1.1"
    id="svg9"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg">
-  <defs
-     id="defs1">
-    <linearGradient
-       id="linearGradient32">
-      <stop
-         style="stop-color:#000000;stop-opacity:0.88486844;"
-         offset="0"
-         id="stop32" />
-      <stop
-         style="stop-color:#f7f7f7;stop-opacity:0.17763157;"
-         offset="1"
-         id="stop33" />
+  <defs id="defs1">
+    <linearGradient id="linearGradient32">
+      <stop style="stop-color:#000000;stop-opacity:0.88486844;" offset="0" />
+      <stop style="stop-color:#f7f7f7;stop-opacity:0.17763157;" offset="1" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient32"
-       id="linearGradient33"
-       x1="7.0431595"
-       y1="17.869596"
-       x2="39.043159"
-       y2="17.869596"
-       gradientUnits="userSpaceOnUse" />
+      xlink:href="#linearGradient32"
+      id="linearGradient33"
+      x1="0"
+      y1="0"
+      x2="1"
+      y2="1">
+    </linearGradient>
   </defs>
-  <g id="disabled" transform="translate(0,35)">
-    <rect
-       width="180"
-       height="35"
-       id="rect1-5"
-       x="0"
-       y="0"
-       style="display:inline;opacity:1;fill:black;fill-opacity:0;stroke:none;stroke-width:0;stroke-dasharray:none;stroke-opacity:1" />
-    <svg x="0" y="0" width="175" height="35" viewBox="0 0 175 35">
-      <text
-        id="text1-5"
-        [attr.fill]="labelColor"
-        style="text-align:center;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14px;font-family:arial;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal"
-        x="47.083984"
-        y="22.636719">
-        {{ data().ctrlLabel }}
-      </text>
-    </svg>
-    <g transform="translate(6,2)" id="disabledToogleControl">
-      <circle
-        cx="18"
-        cy="16"
-        [attr.fill]="labelColor"
-        id="circle3-7"
-        r="13.5"
-        style="stroke-width:5;stroke:url(#linearGradient33);stroke-opacity:0.2;stroke-dasharray:none" />
-    </g>
-  </g>
-  <g id="enabled">
-    <rect
-      width="180"
-      height="35"
-      id="rect1"
-      x="0"
-      y="0"
-      style="display:inline;opacity:1;fill:black;fill-opacity:0;stroke:none;stroke-width:0;stroke-dasharray:none;stroke-opacity:1"
-    />
-    <svg x="0" y="0" width="175" height="35" viewBox="0 0 175 35">
-      <defs>
-        <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-          <feGaussianBlur stdDeviation="2.5" result="coloredBlur"/>
-          <feMerge>
-            <feMergeNode in="coloredBlur"/>
-            <feMergeNode in="SourceGraphic"/>
-          </feMerge>
-        </filter>
-      </defs>
-      <text filter="url(#glow)"
-        id="text1"
-        [attr.fill]="valueColor"
-        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14px;font-family:arial;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal"
-        x="47.083984"
-        y="22.636719">{{ data().ctrlLabel }}
-      </text>
-    </svg>
-    <g transform="translate(6,2)" id="enabledToogleControl">
-      <circle filter="url(#glow)"
-        cx="18"
-        cy="16"
-        [attr.fill]="valueColor"
-        id="circle3"
-        r="13.5"
-        style="stroke:url(#linearGradient33);stroke-width:5;stroke-opacity:0.2;stroke-dasharray:none" />
-    </g>
-  </g>
+
+  <foreignObject
+    [attr.x]="layout.labelX"
+    y="0"
+    [attr.width]="layout.labelWidth"
+    [attr.height]="dimensions().height">
+    <div
+      xmlns="http://www.w3.org/1999/xhtml"
+      [style.color]="isEnabled ? valueColor : labelColor"
+      [style.fontSize.px]="layout.labelFontSize"
+      [style.textShadow]="isEnabled ? '0 0 6px currentColor, 0 0 6px currentColor' : 'none'"
+      style="width:100%;height:100%;display:flex;align-items:center;justify-content:flex-start;font-family:Roboto,sans-serif;font-weight:700;line-height:1;white-space:nowrap;overflow:hidden;text-overflow:clip;">
+      {{ data()?.ctrlLabel }}
+    </div>
+  </foreignObject>
+
+  <circle
+    [attr.cx]="layout.lightCenterX"
+    [attr.cy]="layout.lightCenterY"
+    [attr.r]="layout.lightRadius"
+    [attr.fill]="isEnabled ? valueColor : labelColor"
+    style="stroke:url(#linearGradient33);stroke-opacity:0.2;stroke-dasharray:none"
+    [attr.stroke-width]="layout.lightStrokeWidth" />
 </svg>

--- a/src/app/widgets/svg-boolean-light/svg-boolean-light.component.ts
+++ b/src/app/widgets/svg-boolean-light/svg-boolean-light.component.ts
@@ -2,6 +2,7 @@ import { Component, DoCheck, input, output } from '@angular/core';
 import { ChangeDetectionStrategy } from '@angular/core';
 import type { IDynamicControl, IDimensions } from '../../core/interfaces/widgets-interface';
 import type { ITheme } from '../../core/services/app-service';
+import { BooleanControlLayout, getBooleanControlLayout } from '../widget-boolean-switch/boolean-control-layout.util';
 
 
 
@@ -17,13 +18,10 @@ export class SvgBooleanLightComponent implements DoCheck {
   readonly dimensions = input.required<IDimensions>();
   readonly toggleClick = output<IDynamicControl>();
 
-  private toggleOff = "0 35 180 35";
-  private toggleOn = "0 0 180 35";
   private ctrlState: boolean | null = null;
   private ctrlColor = '';
   private oldTheme: ITheme | null = null;
 
-  public viewBox: string = this.toggleOff;
   public labelColor: string | null = null;
   public valueColor: string | null = null;
 
@@ -34,7 +32,6 @@ export class SvgBooleanLightComponent implements DoCheck {
     if (!data) return;
     if (data.value != this.ctrlState) {
       this.ctrlState = data.value;
-      this.viewBox = data.value ? this.toggleOn : this.toggleOff;
     }
     if(data.color != this.ctrlColor) {
       this.ctrlColor = data.color;
@@ -53,6 +50,15 @@ export class SvgBooleanLightComponent implements DoCheck {
     if (!data) return;
     data.value = state;
     this.toggleClick.emit(data);
+  }
+
+  public get layout(): BooleanControlLayout {
+    const dimensions = this.dimensions();
+    return getBooleanControlLayout('3', dimensions.width, dimensions.height);
+  }
+
+  public get isEnabled(): boolean {
+    return Boolean(this.ctrlState);
   }
 
   private getColors(color: string): void {

--- a/src/app/widgets/svg-boolean-light/svg-boolean-light.component.ts
+++ b/src/app/widgets/svg-boolean-light/svg-boolean-light.component.ts
@@ -22,6 +22,7 @@ export class SvgBooleanLightComponent implements DoCheck {
   private ctrlColor = '';
   private oldTheme: ITheme | null = null;
 
+  public offColor: string | null = null;
   public labelColor: string | null = null;
   public valueColor: string | null = null;
 
@@ -66,38 +67,47 @@ export class SvgBooleanLightComponent implements DoCheck {
     if (!theme) return;
     switch (color) {
       case "contrast":
+        this.offColor = theme.contrastDimmer;
         this.labelColor = theme.contrastDim;
         this.valueColor = theme.contrast;
         break;
       case "blue":
+        this.offColor = theme.blueDimmer;
         this.labelColor = theme.blueDim;
         this.valueColor = theme.blue;
         break;
       case "green":
+        this.offColor = theme.greenDimmer;
         this.labelColor = theme.greenDim;
         this.valueColor = theme.green;
         break;
       case "pink":
+        this.offColor = theme.pinkDimmer;
         this.labelColor = theme.pinkDim;
         this.valueColor = theme.pink;
         break;
       case "orange":
+        this.offColor = theme.orangeDimmer;
         this.labelColor = theme.orangeDim;
         this.valueColor = theme.orange;
         break;
       case "purple":
+        this.offColor = theme.purpleDimmer;
         this.labelColor = theme.purpleDim;
         this.valueColor = theme.purple;
         break;
       case "grey":
+        this.offColor = theme.greyDimmer;
         this.labelColor = theme.greyDim;
         this.valueColor = theme.grey;
         break;
       case "yellow":
+        this.offColor = theme.yellowDimmer;
         this.labelColor = theme.yellowDim;
         this.valueColor = theme.yellow;
         break;
       default:
+        this.offColor = theme.contrastDimmer;
         this.labelColor = theme.contrastDim;
         this.valueColor = theme.contrast;
         break;

--- a/src/app/widgets/svg-boolean-switch/svg-boolean-switch.component.spec.ts
+++ b/src/app/widgets/svg-boolean-switch/svg-boolean-switch.component.spec.ts
@@ -1,0 +1,59 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SvgBooleanSwitchComponent } from './svg-boolean-switch.component';
+import type { IDynamicControl, IDimensions } from '../../core/interfaces/widgets-interface';
+import type { ITheme } from '../../core/services/app-service';
+
+const COLOR_KEYS = ['blue', 'green', 'purple', 'yellow', 'pink', 'orange', 'contrast', 'grey'] as const;
+
+function makeTheme(): ITheme {
+  const theme: Record<string, string> = {
+    port: 'port', starboard: 'starboard',
+    zoneNominal: 'zoneNominal', zoneAlert: 'zoneAlert', zoneWarn: 'zoneWarn',
+    zoneAlarm: 'zoneAlarm', zoneEmergency: 'zoneEmergency',
+    background: 'background', cardColor: 'cardColor'
+  };
+  for (const key of COLOR_KEYS) {
+    theme[key] = key;
+    theme[`${key}Dim`] = `${key}Dim`;
+    theme[`${key}Dimmer`] = `${key}Dimmer`;
+  }
+  return theme as unknown as ITheme;
+}
+
+const dimensionsMock: IDimensions = { width: 180, height: 35 };
+
+function control(color: string): IDynamicControl {
+  return { ctrlLabel: 'Nav', type: '1', pathID: 'p', value: false, color, isNumeric: false };
+}
+
+describe('SvgBooleanSwitchComponent OFF-state', () => {
+  let fixture: ComponentFixture<SvgBooleanSwitchComponent>;
+  let component: SvgBooleanSwitchComponent;
+
+  const setup = (color: string) => {
+    TestBed.configureTestingModule({ imports: [SvgBooleanSwitchComponent] });
+    fixture = TestBed.createComponent(SvgBooleanSwitchComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('controlData', control(color));
+    fixture.componentRef.setInput('theme', makeTheme());
+    fixture.componentRef.setInput('dimensions', dimensionsMock);
+    fixture.detectChanges();
+  };
+
+  beforeEach(() => TestBed.resetTestingModule());
+  afterEach(() => TestBed.resetTestingModule());
+
+  it('paints the OFF indicator with the dedicated dimmer color, not the label color', () => {
+    setup('blue');
+
+    expect(component.offColor).toBe('blueDimmer');
+    expect(component.offColor).not.toBe(component.labelColor);
+  });
+
+  it('falls back to the contrast dimmer for an unknown color', () => {
+    setup('bogus');
+
+    expect(component.offColor).toBe('contrastDimmer');
+  });
+});

--- a/src/app/widgets/svg-boolean-switch/svg-boolean-switch.component.svg
+++ b/src/app/widgets/svg-boolean-switch/svg-boolean-switch.component.svg
@@ -10,6 +10,20 @@
    id="svg9"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg">
+   <defs id="defs1">
+    <linearGradient id="linearGradient32">
+      <stop style="stop-color:#000000;stop-opacity:0.88486844;" offset="0" />
+      <stop style="stop-color:#f7f7f7;stop-opacity:0.17763157;" offset="1" />
+    </linearGradient>
+    <linearGradient
+      xlink:href="#linearGradient32"
+      id="linearGradient33"
+      x1="0"
+      y1="0"
+      x2="1"
+      y2="1">
+    </linearGradient>
+  </defs>
   <rect
     [attr.width]="dimensions().width"
     [attr.height]="dimensions().height"
@@ -26,8 +40,9 @@
     style="pointer-events:none;">
     <div
       [style.color]="isEnabled ? valueColor : labelColor"
+      [style.opacity]="isEnabled ? 1 : 0.6"
       [style.fontSize.px]="layout.labelFontSize"
-      [style.textShadow]="isEnabled ? '0 0 6px currentColor, 0 0 6px currentColor' : 'none'"
+      [style.textShadow]="isEnabled ? '0 0 4px currentColor, 0 0 4px currentColor' : 'none'"
       style="width:100%;height:100%;display:flex;align-items:center;justify-content: flex-start;font-family:Roboto,sans-serif;font-weight:700;line-height:1;white-space:nowrap;overflow:hidden;text-overflow:clip;">
       {{ data()?.ctrlLabel }}
     </div>
@@ -39,13 +54,14 @@
     [attr.width]="layout.switchTrackWidth"
     [attr.height]="layout.switchTrackHeight"
     [attr.rx]="layout.switchTrackRadius"
-    [attr.fill]="isEnabled ? labelColor : 'var(--mat-sys-outline)'"
+    [attr.fill]="isEnabled ? labelColor : offColor"
     style="stroke-width:1.5;stroke:black;stroke-opacity:0.12" />
 
   <circle
     [attr.cx]="isEnabled ? layout.switchKnobOnX : layout.switchKnobOffX"
     [attr.cy]="layout.switchKnobY"
     [attr.r]="layout.switchKnobRadius"
-    [attr.fill]="isEnabled ? valueColor : labelColor"
-    style="stroke-width:1.5;stroke:black;stroke-opacity:0.2;stroke-dasharray:none" />
+    [attr.fill]="isEnabled ? valueColor : offColor"
+    style="stroke:url(#linearGradient33);stroke-opacity:0.4;stroke-dasharray:none"
+    [attr.stroke-width]="layout.switchStrokeWidth" />
 </svg>

--- a/src/app/widgets/svg-boolean-switch/svg-boolean-switch.component.svg
+++ b/src/app/widgets/svg-boolean-switch/svg-boolean-switch.component.svg
@@ -1,94 +1,51 @@
 <svg
    [attr.height]="dimensions().height"
    [attr.width]="dimensions().width"
-   [attr.viewBox]="viewBox"
+   [attr.viewBox]="'0 0 ' + dimensions().width + ' ' + dimensions().height"
+  (pointerdown)="onPointerDown($event)"
+  (pointermove)="onPointerMove($event)"
+  (pointerup)="onPointerUp($event, nextState)"
+  (pointercancel)="onPointerCancel($event)"
    version="1.1"
    id="svg9"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg">
-  <defs id="defs9" />
-  <g id="disabled" transform="translate(0,35)" (pointerdown)="onPointerDown($event)" (pointermove)="onPointerMove($event)" (pointerup)="onPointerUp($event, true)" (pointercancel)="onPointerCancel($event)">
-    <rect
-      width="180"
-      height="35"
-      id="rect1-5"
-      x="0"
-      y="0"
-      pointer-events="all"
-      style="display:inline;opacity:0.001;fill:black;fill-opacity:0.001;stroke:none;stroke-width:0;stroke-dasharray:none;stroke-opacity:0" />
-    <svg x="0" y="0" width="175" height="35" viewBox="0 0 175 35">
-      <text
-        id="text1-5"
-        [attr.fill]="labelColor"
-        style="text-align:center;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14px;font-family:arial;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal"
-        x="47.083984"
-        y="22.636719">
-        {{ data().ctrlLabel }}
-      </text>
-    </svg>
-    <g transform="translate(6,2)" id="disabledToogleControl">
-      <rect
-         width="37.714306"
-         height="22"
-         rx="10.999999"
-         id="rect3-4"
-         x="0"
-         y="5"
-         style="stroke-width:1.57144;fill:var(--mat-sys-outline);fill-opacity:1" />
-      <circle
-        cx="11.5"
-        cy="16"
-        [attr.fill]="labelColor"
-        id="circle3-7"
-        r="10"
-        style="stroke-width:1.5;stroke:black;stroke-opacity:0.2;stroke-dasharray:none" />
-    </g>
-  </g>
-  <g id="enabled" (pointerdown)="onPointerDown($event)" (pointermove)="onPointerMove($event)" (pointerup)="onPointerUp($event, false)" (pointercancel)="onPointerCancel($event)">
-    <rect
-      width="180"
-      height="35"
-      id="rect1"
-      x="0"
-      y="0"
-      pointer-events="all"
-      style="display:inline;opacity:0.001;fill:black;fill-opacity:0.001;stroke:none;stroke-width:0;stroke-dasharray:none;stroke-opacity:0"
-    />
-    <svg x="0" y="0" width="175" height="35" viewBox="0 0 175 35">
-      <defs>
-        <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-          <feGaussianBlur stdDeviation="2.5" result="coloredBlur"/>
-          <feMerge>
-            <feMergeNode in="coloredBlur"/>
-            <feMergeNode in="SourceGraphic"/>
-          </feMerge>
-        </filter>
-      </defs>
-      <text filter="url(#glow)"
-        id="text1"
-        [attr.fill]="valueColor"
-        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14px;font-family:arial;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal"
-        x="47.083984"
-        y="22.636719">{{ data().ctrlLabel }}
-      </text>
-    </svg>
-    <g transform="translate(6,2)" id="enabledToogleControl">
-      <rect filter="url(#glow)"
-         width="37.714306"
-         height="22"
-         rx="10.999999"
-         [attr.fill]="labelColor"
-         id="rect3"
-         x="0"
-         y="5"
-         style="stroke-width:1.57144" />
-      <circle
-         cx="26.5"
-         cy="16"
-         [attr.fill]="valueColor"
-         id="circle3"
-         r="10"
-         style="stroke-width:1.5;stroke:black;stroke-opacity:0.2;stroke-dasharray:none" />
-    </g>
-  </g>
+  <rect
+    [attr.width]="dimensions().width"
+    [attr.height]="dimensions().height"
+    x="0"
+    y="0"
+    pointer-events="all"
+    style="display:inline;opacity:0.001;fill:black;fill-opacity:0.001;stroke:none;stroke-width:0" />
+
+  <foreignObject
+    [attr.x]="layout.labelX"
+    y="0"
+    [attr.width]="layout.labelWidth"
+    [attr.height]="dimensions().height"
+    style="pointer-events:none;">
+    <div
+      [style.color]="isEnabled ? valueColor : labelColor"
+      [style.fontSize.px]="layout.labelFontSize"
+      [style.textShadow]="isEnabled ? '0 0 6px currentColor, 0 0 6px currentColor' : 'none'"
+      style="width:100%;height:100%;display:flex;align-items:center;justify-content: flex-start;font-family:Roboto,sans-serif;font-weight:700;line-height:1;white-space:nowrap;overflow:hidden;text-overflow:clip;">
+      {{ data()?.ctrlLabel }}
+    </div>
+  </foreignObject>
+
+  <rect
+    [attr.x]="layout.switchTrackX"
+    [attr.y]="layout.switchTrackY"
+    [attr.width]="layout.switchTrackWidth"
+    [attr.height]="layout.switchTrackHeight"
+    [attr.rx]="layout.switchTrackRadius"
+    [attr.fill]="isEnabled ? labelColor : 'var(--mat-sys-outline)'"
+    style="stroke-width:1.5;stroke:black;stroke-opacity:0.12" />
+
+  <circle
+    [attr.cx]="isEnabled ? layout.switchKnobOnX : layout.switchKnobOffX"
+    [attr.cy]="layout.switchKnobY"
+    [attr.r]="layout.switchKnobRadius"
+    [attr.fill]="isEnabled ? valueColor : labelColor"
+    style="stroke-width:1.5;stroke:black;stroke-opacity:0.2;stroke-dasharray:none" />
 </svg>

--- a/src/app/widgets/svg-boolean-switch/svg-boolean-switch.component.ts
+++ b/src/app/widgets/svg-boolean-switch/svg-boolean-switch.component.ts
@@ -20,6 +20,7 @@ export class SvgBooleanSwitchComponent implements DoCheck {
   private oldTheme: ITheme | null = null;
   private readonly swipeGuard = createSwipeGuard();
 
+  public offColor: string | null = null;
   public labelColor: string | null = null;
   public valueColor: string | null = null;
   private ctrlColor = '';
@@ -86,38 +87,47 @@ export class SvgBooleanSwitchComponent implements DoCheck {
     if (!theme) return;
     switch (color) {
       case "contrast":
+        this.offColor = theme.contrastDimmer;
         this.labelColor = theme.contrastDim;
         this.valueColor = theme.contrast;
         break;
       case "blue":
+        this.offColor = theme.blueDimmer;
         this.labelColor = theme.blueDim;
         this.valueColor = theme.blue;
         break;
       case "green":
+        this.offColor = theme.greenDimmer;
         this.labelColor = theme.greenDim;
         this.valueColor = theme.green;
         break;
       case "pink":
+        this.offColor = theme.pinkDimmer;
         this.labelColor = theme.pinkDim;
         this.valueColor = theme.pink;
         break;
       case "orange":
+        this.offColor = theme.orangeDimmer;
         this.labelColor = theme.orangeDim;
         this.valueColor = theme.orange;
         break;
       case "purple":
+        this.offColor = theme.purpleDimmer;
         this.labelColor = theme.purpleDim;
         this.valueColor = theme.purple;
         break;
       case "grey":
+        this.offColor = theme.greyDimmer;
         this.labelColor = theme.greyDim;
         this.valueColor = theme.grey;
         break;
       case "yellow":
+        this.offColor = theme.yellowDimmer;
         this.labelColor = theme.yellowDim;
         this.valueColor = theme.yellow;
         break;
       default:
+        this.offColor = theme.contrastDimmer;
         this.labelColor = theme.contrastDim;
         this.valueColor = theme.contrast;
         break;

--- a/src/app/widgets/svg-boolean-switch/svg-boolean-switch.component.ts
+++ b/src/app/widgets/svg-boolean-switch/svg-boolean-switch.component.ts
@@ -2,6 +2,7 @@ import { Component, DoCheck, input, output, ChangeDetectionStrategy } from '@ang
 import type { IDynamicControl, IDimensions } from '../../core/interfaces/widgets-interface';
 import type { ITheme } from '../../core/services/app-service';
 import { createSwipeGuard } from '../../core/utils/pointer-swipe-guard.util';
+import { BooleanControlLayout, getBooleanControlLayout } from '../widget-boolean-switch/boolean-control-layout.util';
 
 @Component({
     selector: 'app-svg-boolean-switch',
@@ -15,13 +16,10 @@ export class SvgBooleanSwitchComponent implements DoCheck {
   readonly dimensions = input.required<IDimensions>();
   readonly toggleClick = output<IDynamicControl>();
 
-  private toggleOff = "0 35 180 35";
-  private toggleOn = "0 0 180 35";
   private ctrlState: boolean | null = null;
   private oldTheme: ITheme | null = null;
   private readonly swipeGuard = createSwipeGuard();
 
-  public viewBox: string = this.toggleOff;
   public labelColor: string | null = null;
   public valueColor: string | null = null;
   private ctrlColor = '';
@@ -33,7 +31,6 @@ export class SvgBooleanSwitchComponent implements DoCheck {
     if (!data) return;
     if (data.value != this.ctrlState) {
       this.ctrlState = data.value;
-      this.viewBox = data.value ? this.toggleOn : this.toggleOff;
     }
     if(data.color != this.ctrlColor) {
       this.ctrlColor = data.color;
@@ -62,6 +59,19 @@ export class SvgBooleanSwitchComponent implements DoCheck {
 
   public onPointerCancel(event: PointerEvent): void {
     this.swipeGuard.onPointerCancel(event);
+  }
+
+  public get layout(): BooleanControlLayout {
+    const dimensions = this.dimensions();
+    return getBooleanControlLayout('1', dimensions.width, dimensions.height);
+  }
+
+  public get isEnabled(): boolean {
+    return Boolean(this.ctrlState);
+  }
+
+  public get nextState(): boolean {
+    return !this.isEnabled;
   }
 
   public toggle(state: boolean): void {

--- a/src/app/widgets/widget-boolean-switch/boolean-control-layout.util.spec.ts
+++ b/src/app/widgets/widget-boolean-switch/boolean-control-layout.util.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { getBooleanControlLayout, measureBooleanControlsHeight } from './boolean-control-layout.util';
+
+describe('boolean-control-layout util', () => {
+  const measureTextWidth = (text: string, fontSize: number): number => text.length * fontSize * 0.6;
+
+  it('uses the full vertical budget when labels fit', () => {
+    const height = measureBooleanControlsHeight(
+      320,
+      200,
+      [
+        { type: '1', ctrlLabel: 'Port' },
+        { type: '3', ctrlLabel: 'Stbd' },
+      ],
+      measureTextWidth,
+    );
+
+    expect(height).toBe(100);
+  });
+
+  it('caps height when a long label would overflow', () => {
+    const height = measureBooleanControlsHeight(
+      180,
+      200,
+      [{ type: '1', ctrlLabel: 'Very long generator control label' }],
+      measureTextWidth,
+    );
+
+    expect(height).toBeLessThan(40);
+    expect(height).toBeGreaterThan(0);
+  });
+
+  it('gives button labels more horizontal room than switch labels', () => {
+    const switchLayout = getBooleanControlLayout('1', 220, 35);
+    const buttonLayout = getBooleanControlLayout('2', 220, 35);
+
+    expect(buttonLayout.labelWidth).toBeGreaterThan(switchLayout.labelWidth);
+  });
+});

--- a/src/app/widgets/widget-boolean-switch/boolean-control-layout.util.spec.ts
+++ b/src/app/widgets/widget-boolean-switch/boolean-control-layout.util.spec.ts
@@ -46,4 +46,45 @@ describe('boolean-control-layout util', () => {
     expect(doubled.switchStrokeWidth).toBe(3);
     expect(doubled.lightStrokeWidth).toBe(6);
   });
+
+  it('keeps every geometry field finite and non-negative for degenerate dimensions', () => {
+    const cases: [number, number][] = [[0, 0], [-100, 35], [180, -50], [-10, -10]];
+    for (const [width, height] of cases) {
+      for (const type of ['1', '2', '3']) {
+        const layout = getBooleanControlLayout(type, width, height) as unknown as Record<string, number>;
+        for (const value of Object.values(layout)) {
+          expect(Number.isFinite(value)).toBe(true);
+          expect(value).toBeGreaterThanOrEqual(0);
+        }
+      }
+    }
+  });
+
+  it('returns 0 for an empty control set', () => {
+    expect(measureBooleanControlsHeight(320, 200, [], measureTextWidth)).toBe(0);
+  });
+
+  it('terminates with a finite height of at least 1 for a label that cannot fit', () => {
+    const height = measureBooleanControlsHeight(
+      20,
+      200,
+      [{ type: '1', ctrlLabel: 'A label far wider than a twenty pixel panel can ever hold' }],
+      measureTextWidth,
+    );
+
+    expect(Number.isFinite(height)).toBe(true);
+    expect(height).toBeGreaterThanOrEqual(1);
+  });
+
+  it('returns a finite, non-negative height when the panel height is zero', () => {
+    const height = measureBooleanControlsHeight(
+      320,
+      0,
+      [{ type: '1', ctrlLabel: 'Port' }],
+      measureTextWidth,
+    );
+
+    expect(Number.isFinite(height)).toBe(true);
+    expect(height).toBeGreaterThanOrEqual(0);
+  });
 });

--- a/src/app/widgets/widget-boolean-switch/boolean-control-layout.util.spec.ts
+++ b/src/app/widgets/widget-boolean-switch/boolean-control-layout.util.spec.ts
@@ -36,4 +36,14 @@ describe('boolean-control-layout util', () => {
 
     expect(buttonLayout.labelWidth).toBeGreaterThan(switchLayout.labelWidth);
   });
+
+  it('scales the OFF-state stroke widths with height', () => {
+    const base = getBooleanControlLayout('1', 220, 35);
+    expect(base.switchStrokeWidth).toBe(1.5);
+    expect(base.lightStrokeWidth).toBe(3);
+
+    const doubled = getBooleanControlLayout('3', 220, 70);
+    expect(doubled.switchStrokeWidth).toBe(3);
+    expect(doubled.lightStrokeWidth).toBe(6);
+  });
 });

--- a/src/app/widgets/widget-boolean-switch/boolean-control-layout.util.ts
+++ b/src/app/widgets/widget-boolean-switch/boolean-control-layout.util.ts
@@ -1,0 +1,101 @@
+import type { IDynamicControl } from '../../core/interfaces/widgets-interface';
+
+export const BOOLEAN_CONTROL_BASE_HEIGHT = 35;
+export const BOOLEAN_CONTROL_BASE_FONT_SIZE = 14;
+
+export interface BooleanControlLayout {
+  labelX: number;
+  labelWidth: number;
+  labelFontSize: number;
+  shapeLaneWidth: number;
+  switchTrackX: number;
+  switchTrackY: number;
+  switchTrackWidth: number;
+  switchTrackHeight: number;
+  switchTrackRadius: number;
+  switchKnobOffX: number;
+  switchKnobOnX: number;
+  switchKnobY: number;
+  switchKnobRadius: number;
+  lightCenterX: number;
+  lightCenterY: number;
+  lightRadius: number;
+  lightStrokeWidth: number;
+  buttonX: number;
+  buttonY: number;
+  buttonWidth: number;
+  buttonHeight: number;
+  buttonRadius: number;
+}
+
+function scaleValue(height: number): number {
+  return Math.max(height, 1) / BOOLEAN_CONTROL_BASE_HEIGHT;
+}
+
+export function getBooleanControlLayout(type: string, width: number, height: number): BooleanControlLayout {
+  const safeWidth = Math.max(width, 0);
+  const scale = scaleValue(height);
+  const shapeLaneWidth = type === '2' ? 0 : 48 * scale;
+  const rightPadding = type === '2' ? 12 * scale : 6 * scale;
+  const labelX = type === '2' ? 12 * scale : shapeLaneWidth;
+  const labelWidth = Math.max(0, safeWidth - labelX - rightPadding);
+
+  return {
+    labelX,
+    labelWidth,
+    labelFontSize: BOOLEAN_CONTROL_BASE_FONT_SIZE * scale,
+    shapeLaneWidth,
+    switchTrackX: 6 * scale,
+    switchTrackY: 6 * scale,
+    switchTrackWidth: 37.714306 * scale,
+    switchTrackHeight: 22 * scale,
+    switchTrackRadius: 11 * scale,
+    switchKnobOffX: 17.5 * scale,
+    switchKnobOnX: 32.5 * scale,
+    switchKnobY: 17 * scale,
+    switchKnobRadius: 10 * scale,
+    lightCenterX: 24.5 * scale,
+    lightCenterY: 17.5 * scale,
+    lightRadius: 13.5 * scale,
+    lightStrokeWidth: 5 * scale,
+    buttonX: 6 * scale,
+    buttonY: 5 * scale,
+    buttonWidth: Math.max(0, safeWidth - (12 * scale)),
+    buttonHeight: 25.025183 * scale,
+    buttonRadius: 3.6672263 * scale,
+  };
+}
+
+export function measureBooleanControlsHeight(
+  panelWidth: number,
+  panelHeight: number,
+  controls: Pick<IDynamicControl, 'type' | 'ctrlLabel'>[],
+  measureTextWidth: (text: string, fontSize: number) => number,
+): number {
+  if (controls.length === 0) {
+    return 0;
+  }
+
+  const maxByPanel = Math.max(1, Math.floor(panelHeight / controls.length));
+  let low = 1;
+  let high = maxByPanel;
+  let best = 1;
+
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    const fits = controls.every(ctrl => {
+      const layout = getBooleanControlLayout(ctrl.type, panelWidth, mid);
+      return measureTextWidth(ctrl.ctrlLabel ?? '', layout.labelFontSize) <= layout.labelWidth;
+    });
+
+    if (fits) {
+      best = mid;
+      low = mid + 1;
+      continue;
+    }
+
+    high = mid - 1;
+  }
+
+  return Math.min(best, maxByPanel);
+}

--- a/src/app/widgets/widget-boolean-switch/boolean-control-layout.util.ts
+++ b/src/app/widgets/widget-boolean-switch/boolean-control-layout.util.ts
@@ -17,6 +17,7 @@ export interface BooleanControlLayout {
   switchKnobOnX: number;
   switchKnobY: number;
   switchKnobRadius: number;
+  switchStrokeWidth: number;
   lightCenterX: number;
   lightCenterY: number;
   lightRadius: number;
@@ -54,10 +55,11 @@ export function getBooleanControlLayout(type: string, width: number, height: num
     switchKnobOnX: 32.5 * scale,
     switchKnobY: 17 * scale,
     switchKnobRadius: 10 * scale,
+    switchStrokeWidth: 1.5 * scale,
     lightCenterX: 24.5 * scale,
     lightCenterY: 17.5 * scale,
     lightRadius: 13.5 * scale,
-    lightStrokeWidth: 5 * scale,
+    lightStrokeWidth: 3 * scale,
     buttonX: 6 * scale,
     buttonY: 5 * scale,
     buttonWidth: Math.max(0, safeWidth - (12 * scale)),

--- a/src/app/widgets/widget-boolean-switch/boolean-control-layout.util.ts
+++ b/src/app/widgets/widget-boolean-switch/boolean-control-layout.util.ts
@@ -29,18 +29,19 @@ export interface BooleanControlLayout {
   buttonRadius: number;
 }
 
-function scaleValue(height: number): number {
+function scaleFactor(height: number): number {
   return Math.max(height, 1) / BOOLEAN_CONTROL_BASE_HEIGHT;
 }
 
 export function getBooleanControlLayout(type: string, width: number, height: number): BooleanControlLayout {
   const safeWidth = Math.max(width, 0);
-  const scale = scaleValue(height);
+  const scale = scaleFactor(height);
   const shapeLaneWidth = type === '2' ? 0 : 48 * scale;
   const rightPadding = type === '2' ? 12 * scale : 6 * scale;
   const labelX = type === '2' ? 12 * scale : shapeLaneWidth;
   const labelWidth = Math.max(0, safeWidth - labelX - rightPadding);
 
+  // Coordinates are the original 180x35 artwork geometry; every value scales by height/35 (see BOOLEAN_CONTROL_BASE_HEIGHT).
   return {
     labelX,
     labelWidth,

--- a/src/app/widgets/widget-boolean-switch/widget-boolean-switch.component.ts
+++ b/src/app/widgets/widget-boolean-switch/widget-boolean-switch.component.ts
@@ -13,6 +13,8 @@ import { getColors } from '../../core/utils/themeColors.utils';
 import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
 import { WidgetStreamsDirective } from '../../core/directives/widget-streams.directive';
 import { KipResizeObserverDirective } from '../../core/directives/kip-resize-observer.directive';
+import { CanvasService } from '../../core/services/canvas.service';
+import { measureBooleanControlsHeight } from './boolean-control-layout.util';
 
 @Component({
   selector: 'widget-boolean-switch',
@@ -50,6 +52,7 @@ export class WidgetBooleanSwitchComponent implements OnDestroy {
   protected dashboard = inject(DashboardService);
   private readonly signalkRequestsService = inject(SignalkRequestsService);
   private readonly toast = inject(ToastService);
+  private readonly canvas = inject(CanvasService);
 
   // Reactive state
   public switchControls = signal<IDynamicControl[]>([]);
@@ -58,9 +61,12 @@ export class WidgetBooleanSwitchComponent implements OnDestroy {
     const cfg = this.runtime?.options();
     return (cfg?.showLabel === false) ? 'widgets-container-no-title' : 'widgets-container';
   });
-  private nbCtrl: number | null = null;
   public ctrlDimensions: IDimensions = { width: 0, height: 0 };
+  private hostSize: IDimensions = { width: 0, height: 0 };
   private skRequestSub = new Subscription();
+  private readonly measureCtx = typeof document !== 'undefined'
+    ? document.createElement('canvas').getContext('2d')
+    : null;
 
   constructor() {
     // Effect: theme / label color
@@ -78,9 +84,9 @@ export class WidgetBooleanSwitchComponent implements OnDestroy {
       const cfg = this.runtime?.options();
       if (!cfg) return;
       const controls = (cfg.multiChildCtrls || []).map(c => ({ ...c, isNumeric: c.isNumeric ?? false }));
-      this.nbCtrl = controls.length;
       untracked(() => {
         this.switchControls.set(controls);
+        this.updateCtrlDimensions();
         // Register path observers for each control (idempotent via directive)
         if (!this.streams) return;
         controls.forEach(ctrl => {
@@ -112,11 +118,31 @@ export class WidgetBooleanSwitchComponent implements OnDestroy {
   }
 
   onResized(event: ResizeObserverEntry): void {
-    const nb = this.nbCtrl || 1;
-    const calcH: number = event.contentRect.height / nb;
-    const ctrlHeightProportion = (35 * event.contentRect.width / 180);
-    const h: number = (ctrlHeightProportion < calcH) ? ctrlHeightProportion : calcH;
-    this.ctrlDimensions = { width: event.contentRect.width, height: h };
+    this.hostSize = {
+      width: event.contentRect.width,
+      height: event.contentRect.height,
+    };
+    this.updateCtrlDimensions();
+  }
+
+  private updateCtrlDimensions(): void {
+    const width = this.hostSize.width;
+    const height = this.hostSize.height;
+    const controls = this.switchControls();
+
+    if (!width || !height || !controls.length) {
+      this.ctrlDimensions = { width, height: 0 };
+      return;
+    }
+
+    const measuredHeight = this.measureCtx
+      ? measureBooleanControlsHeight(width, height, controls, (text, fontSize) => {
+        this.measureCtx!.font = `700 ${fontSize}px ${this.canvas.DEFAULT_FONT}`;
+        return this.measureCtx!.measureText(text).width;
+      })
+      : Math.max(1, Math.floor(height / controls.length));
+
+    this.ctrlDimensions = { width, height: measuredHeight };
   }
 
   public toggle(ctrl: IDynamicControl): void {


### PR DESCRIPTION
## Why

The boolean switch-panel controls (switch, indicator button, light) rendered at a fixed 180×35 viewBox, so labels clipped on large or multi-control panels, and an OFF switch/light was only *dimmed* rather than clearly off — hard to read at a glance on the water.

## How

Ports two upstream Kip commits as a stacked pair (kept separate, never squashed):

- **Resize (`5a8c0895`, #240):** new `boolean-control-layout.util` (copied verbatim from upstream) derives every shape coordinate from `(type, width, height)` and binary-searches the largest per-control height whose label still fits, measured against a real canvas font via `CanvasService`. The three `svg-boolean-*` components move to a single layout-driven `foreignObject` template. The fork's fixed `35·w/180` proportional resize is replaced; the now-dead `nbCtrl` field is dropped (no-dead-code).
- **OFF-state (`f9d657cf`, #241b):** the OFF indicator gets a dedicated `offColor` (theme `*Dimmer`) instead of reusing the label color, the OFF label is dimmed, and the light gains layered specular/depth gradients for a 3D lit look; stroke widths scale with height.

**Fork divergence preserved:** all three components keep `ChangeDetectionStrategy.OnPush`; the fork's swipe-guard pointer logic is untouched. Upstream's rewritten templates use `data()?.ctrlLabel` (null-safe) vs the fork's old `data().ctrlLabel`, so adopting them is strictly safer. `IDimensions` was *not* re-added to the interfaces (the fork dedups it).

**Scope guard:** the momentary-button half of Kip #1107 (#241a) already shipped separately (#286) and is untouched here.

## Verification

`npm run lint` clean; `betterer:ci` 179 (unchanged — `widget-boolean-switch` entry re-hashed only, same 2 errors at shifted lines); the runnable layout-util spec passes 4/4. The two new `svg-boolean-{switch,light}` offColor specs are CI-verified (component specs require the Angular builder, which the boat Pi doesn't run), mirroring the proven `svg-boolean-button` spec pattern — they inject no services.

**Boat-verify:** label fit across panel sizes/counts, OFF-state colors, and the 3D light appearance are batched to the Stage-1-close boat session. One thing to eyeball there: the switch template's `foreignObject` div omits the XHTML `xmlns` the button/light divs carry (ported faithfully from upstream `5a8c0895`).

Closes #240. Addresses #241 (the 241b visual half; 241a already shipped in #286).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
