### PR TITLE
fix(history-chart): bound reconnect re-backfill hold and cancel abandoned fetch (#281)

### DIFF
--- a/src/app/core/services/history-api-client.service.spec.ts
+++ b/src/app/core/services/history-api-client.service.spec.ts
@@ -305,6 +305,24 @@ describe('HistoryApiClientService', () => {
     await expect(promise).rejects.toMatchObject({ name: 'HistoryRequestError', status: 0 });
   });
 
+  it('cancels the in-flight HTTP request when the abort signal fires', async () => {
+    connectionStub.serverServiceEndpoint$.next(CONNECTED_ENDPOINT);
+    const controller = new AbortController();
+
+    const promise = service.getValues({ paths: 'navigation.speedThroughWater:avg', resolution: 1 }, controller.signal);
+    await new Promise(resolve => setTimeout(resolve));
+
+    const req = httpMock.expectOne(request => request.url === VALUES_URL);
+    expect(req.cancelled).toBe(false);
+
+    controller.abort();
+
+    // Aborting unsubscribes the request (cancelling the underlying GET) and settles the promise as a
+    // benign request error, rather than leaving the request to hang until the 30s timeout.
+    await expect(promise).rejects.toBeInstanceOf(HistoryRequestError);
+    expect(req.cancelled).toBe(true);
+  });
+
   it('should return null when history paths endpoint returns 500', async () => {
     connectionStub.serverServiceEndpoint$.next({
       state: EndpointStatus.Connected,

--- a/src/app/core/services/history-api-client.service.ts
+++ b/src/app/core/services/history-api-client.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject, DestroyRef } from '@angular/core';
 import { HttpClient, HttpErrorResponse, HttpParams } from '@angular/common/http';
-import { firstValueFrom, timeout } from 'rxjs';
+import { firstValueFrom, fromEvent, takeUntil, timeout } from 'rxjs';
 
 /** A backfill request that hangs past this is treated as a transient failure, not left to spin forever. */
 const HISTORY_VALUES_TIMEOUT_MS = 30_000;
@@ -207,6 +207,9 @@ export class HistoryApiClientService {
    *   - from, to, duration: define the time range
    *   - resolution: optional downsampling window
    *   - context: optional Signal K context (defaults to 'vessels.self')
+   * @param {AbortSignal} [signal] - Aborts the in-flight request, cancelling the underlying HTTP GET so
+   *   a caller that has abandoned the fetch (e.g. a reconnect re-backfill past its hold cap) does not
+   *   leave it running until the 30s timeout.
    *
    * @returns {Promise<IHistoryValuesResponse | null>} The history response, or `null` when the server
    *   has no history provider (no service URL, or a 404/501 response).
@@ -228,7 +231,7 @@ export class HistoryApiClientService {
    *
    * @memberof HistoryApiClientService
    */
-  public async getValues(params: IHistoryValuesQueryParams): Promise<IHistoryValuesResponse | null> {
+  public async getValues(params: IHistoryValuesQueryParams, signal?: AbortSignal): Promise<IHistoryValuesResponse | null> {
     try {
       if (!this.historyServiceUrl) {
         console.warn('[HistoryApiClientService] No HTTP service URL available');
@@ -259,15 +262,23 @@ export class HistoryApiClientService {
       const fullUrl = `${historyUrl}?${httpParams.toString()}`;
       console.log(`[HistoryApiClientService] GET ${fullUrl}`);
 
+      const request$ = this.http.get<IHistoryValuesResponse>(historyUrl, { params: httpParams }).pipe(
+        timeout(HISTORY_VALUES_TIMEOUT_MS)
+      );
       const response = await firstValueFrom(
-        this.http.get<IHistoryValuesResponse>(historyUrl, { params: httpParams }).pipe(
-          timeout(HISTORY_VALUES_TIMEOUT_MS)
-        )
+        // An abort unsubscribes the request, which cancels the underlying HTTP GET instead of leaving it
+        // to run until the timeout.
+        signal ? request$.pipe(takeUntil(fromEvent(signal, 'abort'))) : request$
       );
 
       console.log(`[HistoryApiClientService] History fetch successful, received ${response.data?.length ?? 0} data points`);
       return response;
     } catch (error) {
+      if (signal?.aborted) {
+        // Cancelled by the caller, not a server/network failure: surface a benign request error the
+        // caller already discards, without logging it as a failure.
+        throw new HistoryRequestError(0, error);
+      }
       const status = error instanceof HttpErrorResponse ? error.status : 0;
       // 404 / 501: the server has no history provider (plugin/API missing) — a stable "unavailable",
       // reported as null so trend charts degrade to a clean empty state.

--- a/src/app/core/services/history-chart-stream.service.spec.ts
+++ b/src/app/core/services/history-chart-stream.service.spec.ts
@@ -870,10 +870,12 @@ describe('HistoryChartStreamService', () => {
         await vi.advanceTimersByTimeAsync(0);
         path$.next({ data: { value: 5, timestamp: new Date(1_000_000) }, state: 'normal' }); // seam 1_000_000
 
-        // Reconnect while the provider hangs (never resolves) — run 1 of the coalesced chain.
+        // Reconnect while the provider hangs (never resolves) — run 1 of the coalesced chain. Offset the
+        // outage by 100ms so the shared cap (1_043_100) lands between resampler ticks (multiples of the
+        // 500ms sampleTime), avoiding a fake-timer tie between the hold timer and a sampled$ tick.
         history.getValues.mockReturnValue(new Promise<never>(() => { /* hangs */ }));
         state$.next(ConnectionState.Disconnected);
-        vi.setSystemTime(1_040_000);
+        vi.setSystemTime(1_040_100);
         state$.next(ConnectionState.Connected);
         await vi.advanceTimersByTimeAsync(0);
         expect(history.getValues.mock.calls.length).toBe(2); // one initial backfill + one run-1 fetch
@@ -885,9 +887,15 @@ describe('HistoryChartStreamService', () => {
         await vi.advanceTimersByTimeAsync(0);
         expect(history.getValues.mock.calls.length).toBe(2); // coalesced, no run-2 fetch yet
 
-        // Just past ONE RECONNECT_HOLD_MS (3000ms): the shared budget is spent, so the chain stops and the
-        // honest gap is drawn now rather than re-running for a second 3s window.
-        await vi.advanceTimersByTimeAsync(3_100);
+        // Just before the single shared cap (deadline 1_043_100): still held, no gap.
+        await vi.advanceTimersByTimeAsync(2_800); // → 1_042_900
+        expect(emissions.some(
+          e => !Array.isArray(e) && !('unavailable' in e) && Number.isNaN((e as IDatasetServiceDatapoint).data.value)
+        )).toBe(false);
+
+        // Just past the shared cap, within one sample interval so no stale-tail tick intrudes: the chain
+        // stops and draws exactly one honest gap rather than re-running for a second 3s window.
+        await vi.advanceTimersByTimeAsync(300); // → 1_043_200
         const gaps = emissions.filter(
           e => !Array.isArray(e) && !('unavailable' in e) && Number.isNaN((e as IDatasetServiceDatapoint).data.value)
         );
@@ -926,6 +934,140 @@ describe('HistoryChartStreamService', () => {
         // to self-terminate at the 30s HTTP timeout and stack on the struggling provider.
         await vi.advanceTimersByTimeAsync(3_100);
         expect(signal?.aborted).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('re-arms a fresh hold budget for the next healthy reconnect after a budget-spent storm', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(1_000_000);
+      try {
+        history.getValues.mockResolvedValue({ context: 'vessels.self', range: { to: new Date(1_000_000).toISOString() }, values: [], data: [] });
+        mapper.mapValuesToChartDatapoints.mockReturnValue([]);
+        const emissions: (IDatasetServiceDatapoint | IDatasetServiceDatapoint[] | { unavailable: true })[] = [];
+        make().getBackfillThenLive(PARAMS).subscribe(e => emissions.push(e));
+        await vi.advanceTimersByTimeAsync(0);
+        path$.next({ data: { value: 5, timestamp: new Date(1_000_000) }, state: 'normal' }); // seam 1_000_000
+
+        // A hung-provider storm plus a coalesced flap spends the whole shared budget and resets holdDeadline.
+        history.getValues.mockReturnValue(new Promise<never>(() => { /* hangs */ }));
+        state$.next(ConnectionState.Disconnected);
+        vi.setSystemTime(1_040_100);
+        state$.next(ConnectionState.Connected);
+        await vi.advanceTimersByTimeAsync(0);
+        state$.next(ConnectionState.Disconnected);
+        state$.next(ConnectionState.Connected);
+        await vi.advanceTimersByTimeAsync(3_200); // past the single shared cap → gap, budget cleared to null
+        const gapsAfterStorm = emissions.filter(
+          e => !Array.isArray(e) && !('unavailable' in e) && Number.isNaN((e as IDatasetServiceDatapoint).data.value)
+        ).length;
+        expect(gapsAfterStorm).toBeGreaterThanOrEqual(1);
+
+        // A subsequent HEALTHY reconnect: a slow-but-alive provider that resolves WITHIN a fresh full budget.
+        let releaseHealthy: (v: unknown) => void = () => { /* set below */ };
+        const healthyFetch = new Promise(res => { releaseHealthy = res; });
+        history.getValues.mockReturnValueOnce(healthyFetch);
+        state$.next(ConnectionState.Disconnected);
+        vi.setSystemTime(1_060_000);
+        state$.next(ConnectionState.Connected);
+        await vi.advanceTimersByTimeAsync(0);
+
+        // 2s into the hold — under a FRESHLY-ARMED RECONNECT_HOLD_MS. A latched (spent) deadline would have
+        // capped at ~0ms and drawn a gap with no delivery; a re-armed full budget keeps holding.
+        await vi.advanceTimersByTimeAsync(2_000);
+        expect(emissions.filter(
+          e => !Array.isArray(e) && !('unavailable' in e) && Number.isNaN((e as IDatasetServiceDatapoint).data.value)
+        ).length).toBe(gapsAfterStorm);
+
+        // The healthy fetch resolves inside the fresh budget and backfills the missed interval.
+        mapper.mapValuesToChartDatapoints.mockReturnValue([{ timestamp: 1_050_000, data: { value: 9 } }]);
+        releaseHealthy({ context: 'vessels.self', range: { to: new Date(1_062_000).toISOString() }, values: [], data: [] });
+        await vi.advanceTimersByTimeAsync(0);
+        const batch = emissions.filter(e => Array.isArray(e)).pop() as IDatasetServiceDatapoint[];
+        expect(batch.map(p => p.data.value)).toEqual([9]);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('aborts a hung re-backfill fetch on teardown and emits nothing after disposal', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(1_000_000);
+      try {
+        history.getValues.mockResolvedValue({ context: 'vessels.self', range: { to: new Date(1_000_000).toISOString() }, values: [], data: [] });
+        mapper.mapValuesToChartDatapoints.mockReturnValue([]);
+        const emissions: (IDatasetServiceDatapoint | IDatasetServiceDatapoint[] | { unavailable: true })[] = [];
+        const sub = make().getBackfillThenLive(PARAMS).subscribe(e => emissions.push(e));
+        await vi.advanceTimersByTimeAsync(0);
+        path$.next({ data: { value: 5, timestamp: new Date(1_000_000) }, state: 'normal' });
+
+        // Reconnect while the provider hangs; capture the fetch's abort signal.
+        history.getValues.mockReturnValueOnce(new Promise<never>(() => { /* hangs */ }));
+        state$.next(ConnectionState.Disconnected);
+        vi.setSystemTime(1_040_000);
+        state$.next(ConnectionState.Connected);
+        await vi.advanceTimersByTimeAsync(0);
+        const signal = history.getValues.mock.calls[history.getValues.mock.calls.length - 1][1] as AbortSignal | undefined;
+        const countBeforeDispose = emissions.length;
+
+        // Tear the stream down mid-fetch.
+        sub.unsubscribe();
+
+        // The hold timer still fires (bounded by the remaining budget); it aborts the abandoned fetch and
+        // the disposed guard suppresses any post-dispose emission or gap.
+        await vi.advanceTimersByTimeAsync(3_100);
+        expect(signal?.aborted).toBe(true);
+        expect(emissions.length).toBe(countBeforeDispose);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('runs a coalesced re-backfill under the remaining shared budget, not a fresh cap', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(1_000_000);
+      try {
+        history.getValues.mockResolvedValue({ context: 'vessels.self', range: { to: new Date(1_000_000).toISOString() }, values: [], data: [] });
+        mapper.mapValuesToChartDatapoints.mockReturnValue([]);
+        const emissions: (IDatasetServiceDatapoint | IDatasetServiceDatapoint[] | { unavailable: true })[] = [];
+        make().getBackfillThenLive(PARAMS).subscribe(e => emissions.push(e));
+        await vi.advanceTimersByTimeAsync(0);
+        path$.next({ data: { value: 5, timestamp: new Date(1_000_000) }, state: 'normal' }); // seam 1_000_000
+
+        // Run 1: a held fetch that delivers partway through the shared budget (chain start at 1_040_000,
+        // shared deadline 1_043_000).
+        let releaseRun1: (v: unknown) => void = () => { /* set below */ };
+        const run1Fetch = new Promise(res => { releaseRun1 = res; });
+        history.getValues.mockReturnValueOnce(run1Fetch);
+        state$.next(ConnectionState.Disconnected);
+        vi.setSystemTime(1_040_000);
+        state$.next(ConnectionState.Connected);
+        await vi.advanceTimersByTimeAsync(0);
+
+        // A coalesced flap lands while run 1 is in flight → the re-run is pending.
+        state$.next(ConnectionState.Disconnected);
+        state$.next(ConnectionState.Connected);
+        await vi.advanceTimersByTimeAsync(0);
+
+        // 1s into the budget, run 1 delivers; the coalesced run 2 then fires and hangs.
+        await vi.advanceTimersByTimeAsync(1_000); // → 1_041_000
+        mapper.mapValuesToChartDatapoints.mockReturnValue([{ timestamp: 1_041_000, data: { value: 8 } }]);
+        history.getValues.mockReturnValue(new Promise<never>(() => { /* run 2 hangs */ }));
+        releaseRun1({ context: 'vessels.self', range: { to: new Date(1_041_000).toISOString() }, values: [], data: [] });
+        await vi.advanceTimersByTimeAsync(0);
+
+        const batch = emissions.filter(e => Array.isArray(e)).pop() as IDatasetServiceDatapoint[];
+        expect(batch.map(p => p.data.value)).toEqual([8]); // run 1 delivered, seam advanced to 1_041_000
+        const run2Signal = history.getValues.mock.calls[history.getValues.mock.calls.length - 1][1] as AbortSignal | undefined;
+        expect(run2Signal?.aborted).toBe(false);
+
+        // Run 2 started at 1_041_000 with only the REMAINING 2000ms of the shared budget. A fresh per-run
+        // cap would abort at 1_044_000; the shared budget aborts at 1_043_000.
+        await vi.advanceTimersByTimeAsync(1_900); // → 1_042_900, before the shared deadline
+        expect(run2Signal?.aborted).toBe(false);
+        await vi.advanceTimersByTimeAsync(200); // → 1_043_100, past the shared deadline
+        expect(run2Signal?.aborted).toBe(true);
       } finally {
         vi.useRealTimers();
       }

--- a/src/app/core/services/history-chart-stream.service.spec.ts
+++ b/src/app/core/services/history-chart-stream.service.spec.ts
@@ -859,6 +859,78 @@ describe('HistoryChartStreamService', () => {
       }
     });
 
+    it('bounds the coalesced-chain hold to one budget under sustained flapping (no N×cap stacking)', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(1_000_000);
+      try {
+        history.getValues.mockResolvedValue({ context: 'vessels.self', range: { to: new Date(1_000_000).toISOString() }, values: [], data: [] });
+        mapper.mapValuesToChartDatapoints.mockReturnValue([]);
+        const emissions: (IDatasetServiceDatapoint | IDatasetServiceDatapoint[] | { unavailable: true })[] = [];
+        make().getBackfillThenLive(PARAMS).subscribe(e => emissions.push(e));
+        await vi.advanceTimersByTimeAsync(0);
+        path$.next({ data: { value: 5, timestamp: new Date(1_000_000) }, state: 'normal' }); // seam 1_000_000
+
+        // Reconnect while the provider hangs (never resolves) — run 1 of the coalesced chain.
+        history.getValues.mockReturnValue(new Promise<never>(() => { /* hangs */ }));
+        state$.next(ConnectionState.Disconnected);
+        vi.setSystemTime(1_040_000);
+        state$.next(ConnectionState.Connected);
+        await vi.advanceTimersByTimeAsync(0);
+        expect(history.getValues.mock.calls.length).toBe(2); // one initial backfill + one run-1 fetch
+
+        // A second drop/reconnect lands WHILE run 1 hangs: coalesced (reconnectPending). Without a shared
+        // budget this would earn the coalesced re-run a fresh RECONNECT_HOLD_MS and hold the tail 2× the cap.
+        state$.next(ConnectionState.Disconnected);
+        state$.next(ConnectionState.Connected);
+        await vi.advanceTimersByTimeAsync(0);
+        expect(history.getValues.mock.calls.length).toBe(2); // coalesced, no run-2 fetch yet
+
+        // Just past ONE RECONNECT_HOLD_MS (3000ms): the shared budget is spent, so the chain stops and the
+        // honest gap is drawn now rather than re-running for a second 3s window.
+        await vi.advanceTimersByTimeAsync(3_100);
+        const gaps = emissions.filter(
+          e => !Array.isArray(e) && !('unavailable' in e) && Number.isNaN((e as IDatasetServiceDatapoint).data.value)
+        );
+        expect(gaps.length).toBe(1);
+        // The coalesced re-run never issued a fetch — the spent budget pre-empted it.
+        expect(history.getValues.mock.calls.length).toBe(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('aborts the abandoned re-backfill fetch when the hold cap fires', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(1_000_000);
+      try {
+        history.getValues.mockResolvedValue({ context: 'vessels.self', range: { to: new Date(1_000_000).toISOString() }, values: [], data: [] });
+        mapper.mapValuesToChartDatapoints.mockReturnValue([]);
+        const emissions: (IDatasetServiceDatapoint | IDatasetServiceDatapoint[] | { unavailable: true })[] = [];
+        make().getBackfillThenLive(PARAMS).subscribe(e => emissions.push(e));
+        await vi.advanceTimersByTimeAsync(0);
+        path$.next({ data: { value: 5, timestamp: new Date(1_000_000) }, state: 'normal' });
+
+        // Reconnect while the provider hangs; the fetch is threaded an AbortSignal (2nd getValues arg).
+        history.getValues.mockReturnValueOnce(new Promise<never>(() => { /* hangs */ }));
+        state$.next(ConnectionState.Disconnected);
+        vi.setSystemTime(1_040_000);
+        state$.next(ConnectionState.Connected);
+        await vi.advanceTimersByTimeAsync(0);
+
+        const lastCall = history.getValues.mock.calls[history.getValues.mock.calls.length - 1];
+        const signal = lastCall[1] as AbortSignal | undefined;
+        expect(signal).toBeInstanceOf(AbortSignal);
+        expect(signal?.aborted).toBe(false); // still within the hold — not yet abandoned
+
+        // Past the hold cap (RECONNECT_HOLD_MS = 3000ms): the abandoned fetch is aborted rather than left
+        // to self-terminate at the 30s HTTP timeout and stack on the struggling provider.
+        await vi.advanceTimersByTimeAsync(3_100);
+        expect(signal?.aborted).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('advances the seam past a drawn gap so a lagging provider cannot backfill behind it', async () => {
       vi.useFakeTimers();
       vi.setSystemTime(1_000_000);

--- a/src/app/core/services/history-chart-stream.service.ts
+++ b/src/app/core/services/history-chart-stream.service.ts
@@ -393,8 +393,10 @@ export class HistoryChartStreamService {
         new Promise<typeof HOLD_TIMEOUT>(resolve => { holdTimer = setTimeout(() => resolve(HOLD_TIMEOUT), remainingHoldMs); })
       ]);
       if (outcome === HOLD_TIMEOUT || ctx.disposed) {
-        // The chain's hold budget elapsed (or the stream was torn down): abort the abandoned fetch so its
-        // HTTP GET is cancelled now rather than left to self-terminate at the 30s timeout and stack.
+        // The chain's hold budget elapsed, or the stream was torn down: abort the abandoned fetch so its
+        // HTTP GET is cancelled rather than left to self-terminate at the 30s timeout and stack. On
+        // teardown this fires at the next race resolution (bounded by the remaining hold budget), not the
+        // instant of disposal — harmless, since the disposed guard below blocks any post-dispose emission.
         controller.abort();
       }
       if (ctx.disposed) return;

--- a/src/app/core/services/history-chart-stream.service.ts
+++ b/src/app/core/services/history-chart-stream.service.ts
@@ -91,6 +91,10 @@ interface IStreamCtx {
   seeded: boolean;
   /** Set on teardown so an in-flight async re-backfill does not emit after disposal. */
   disposed: boolean;
+  /** Wall-clock deadline shared by every run in one coalesced re-backfill chain, so back-to-back re-runs
+   * cannot each earn a fresh {@link RECONNECT_HOLD_MS} and stack the live-tail hold to N× the cap. Null
+   * between chains; armed by the first run and cleared when the chain ends. */
+  holdDeadline: number | null;
 }
 
 /**
@@ -115,7 +119,7 @@ export class HistoryChartStreamService {
   public getBackfillThenLive(params: IHistoryChartStreamParams): Observable<StreamEmission> {
     return new Observable<StreamEmission>(subscriber => {
       const domain = resolveAngleDomain(params.path, this.data.getPathUnitType(params.path), params.angleDomainOverride);
-      const ctx: IStreamCtx = { lastEmittedTs: null, connected: true, backfillInFlight: false, reconnectPending: false, sourceIntervalMs: null, resetCadenceBaseline: false, seeded: false, disposed: false };
+      const ctx: IStreamCtx = { lastEmittedTs: null, connected: true, backfillInFlight: false, reconnectPending: false, sourceIntervalMs: null, resetCadenceBaseline: false, seeded: false, disposed: false, holdDeadline: null };
       const buffer: number[] = [];
       let liveSub: Subscription | null = null;
       let reconnectSub: Subscription | null = null;
@@ -298,7 +302,7 @@ export class HistoryChartStreamService {
     return { sub, release: handle.release };
   }
 
-  private async fetchBackfill(params: IHistoryChartStreamParams, domain: ChartStatsDomain, fromMs: number = Date.now() - params.windowMs): Promise<{ points: IDatasetServiceDatapoint[]; offsetMs: number } | null> {
+  private async fetchBackfill(params: IHistoryChartStreamParams, domain: ChartStatsDomain, fromMs: number = Date.now() - params.windowMs, signal?: AbortSignal): Promise<{ points: IDatasetServiceDatapoint[]; offsetMs: number } | null> {
     const normalizedPath = params.path.replace(/^(vessels\.)?self\./, '');
     // Only the raw per-bucket value is fetched; the SMA overlay is derived client-side below so it
     // uses the same circular-aware smoothing as the live tail (#162).
@@ -309,7 +313,7 @@ export class HistoryChartStreamService {
       paths,
       from: new Date(fromMs).toISOString(),
       resolution: resolutionSeconds
-    });
+    }, signal);
     if (!response) {
       return null;
     }
@@ -346,9 +350,11 @@ export class HistoryChartStreamService {
    * Re-fetch the interval missed during a WS drop and emit it as a batch so the live tail's gap is
    * filled (#85). Covers only [max(seam - skew margin, now - windowMs), now] and drops points at or
    * before the seam, so the batch appends cleanly and in order against the buffered/live points. The
-   * live tail is held only until the fetch resolves or {@link RECONNECT_HOLD_MS} elapses (whichever comes
-   * first), so a slow provider cannot freeze the chart; if the re-backfill delivers nothing (empty, error,
-   * or hold-timeout), {@link emitReconnectGap} breaks the trace so the live tail does not interpolate.
+   * live tail is held only until the fetch resolves or the coalesced chain's shared {@link RECONNECT_HOLD_MS}
+   * budget elapses (whichever comes first), so a slow provider cannot freeze the chart even under sustained
+   * WS flapping; when the budget wins, the abandoned fetch's HTTP request is aborted so stale GETs do not
+   * stack on the struggling provider. If the re-backfill delivers nothing (empty, error, or hold-timeout),
+   * {@link emitReconnectGap} breaks the trace so the live tail does not interpolate.
    */
   private async reBackfill(
     params: IHistoryChartStreamParams,
@@ -366,20 +372,31 @@ export class HistoryChartStreamService {
     }
     ctx.backfillInFlight = true;
     ctx.reconnectPending = false;
+    // Arm the coalesced chain's shared hold budget on its first run; every coalesced re-run then races the
+    // REMAINING budget, so a storm of re-runs holds the live tail for one RECONNECT_HOLD_MS total rather
+    // than a fresh cap each.
+    if (ctx.holdDeadline === null) ctx.holdDeadline = Date.now() + RECONNECT_HOLD_MS;
     const seam = ctx.lastEmittedTs;
     let delivered = false;
     let holdTimer: ReturnType<typeof setTimeout> | null = null;
+    const controller = new AbortController();
     try {
       const earliest = Date.now() - params.windowMs;
       const fromMs = seam !== null ? Math.max(seam - RECONNECT_FROM_SKEW_MARGIN_MS, earliest) : earliest;
-      const fetchPromise = this.fetchBackfill(params, domain, fromMs);
-      // If the hold cap wins the race we abandon this fetch; swallow its late rejection so it does not
+      const fetchPromise = this.fetchBackfill(params, domain, fromMs, controller.signal);
+      // If the hold budget wins the race we abandon this fetch; swallow its late rejection so it does not
       // surface as an unhandled rejection.
       fetchPromise.catch(() => undefined);
+      const remainingHoldMs = Math.max(0, ctx.holdDeadline - Date.now());
       const outcome = await Promise.race([
         fetchPromise,
-        new Promise<typeof HOLD_TIMEOUT>(resolve => { holdTimer = setTimeout(() => resolve(HOLD_TIMEOUT), RECONNECT_HOLD_MS); })
+        new Promise<typeof HOLD_TIMEOUT>(resolve => { holdTimer = setTimeout(() => resolve(HOLD_TIMEOUT), remainingHoldMs); })
       ]);
+      if (outcome === HOLD_TIMEOUT || ctx.disposed) {
+        // The chain's hold budget elapsed (or the stream was torn down): abort the abandoned fetch so its
+        // HTTP GET is cancelled now rather than left to self-terminate at the 30s timeout and stack.
+        controller.abort();
+      }
       if (ctx.disposed) return;
       // outcome === HOLD_TIMEOUT: the provider is too slow — stop holding the live tail and fall through
       // to the honest gap below rather than freeze the chart for up to the 30s HTTP timeout.
@@ -406,11 +423,16 @@ export class HistoryChartStreamService {
       if (holdTimer !== null) clearTimeout(holdTimer);
       ctx.backfillInFlight = false;
       if (!ctx.disposed) {
-        if (ctx.reconnectPending && ctx.connected) {
-          // A reconnect landed mid-fetch; run it now from the current seam and defer the gap decision to it.
+        const budgetSpent = ctx.holdDeadline !== null && Date.now() >= ctx.holdDeadline;
+        if (ctx.reconnectPending && ctx.connected && !budgetSpent) {
+          // A reconnect landed mid-fetch and the shared budget is not yet spent; run it now from the
+          // current seam under the same deadline and defer the gap decision to it.
           void this.reBackfill(params, domain, buffer, subscriber, ctx);
-        } else if (!delivered) {
-          this.emitReconnectGap(subscriber, ctx);
+        } else {
+          // The chain ends here (delivered, budget spent, or nothing pending): re-arm a fresh budget on the
+          // next reconnect, and break the trace honestly if this run drew nothing.
+          ctx.holdDeadline = null;
+          if (!delivered) this.emitReconnectGap(subscriber, ctx);
         }
       }
     }


### PR DESCRIPTION
## Why

Follow-up to #85 (surfaced in its round-5 review). Behind the non-default History engine flag, the reconnect re-backfill holds the live tail while a fetch is in flight to keep append-only chart consumers chronological. Two residual problems under a slow/hung history provider (InfluxDB / parquet, which commonly restart alongside the SK server) with sustained WebSocket flapping:

1. The `RECONNECT_HOLD_MS` (3s) cap was **per run**. `reconnectPending` re-runs the re-backfill back-to-back in the `finally`, each earning a fresh 3s hold, so a coalesced chain could freeze the tail for ~N×3s.
2. When the cap won the race, the superseded fetch was dropped but its HTTP GET was **not aborted** — it self-terminated only at the 30s timeout, so flapping faster than the cap could stack up to ~10 concurrent History GETs onto an already-struggling provider.

## How

- **Shared hold budget:** a single wall-clock deadline (`ctx.holdDeadline`) is armed by the first run of a coalesced chain and shared by every re-run, which races only the *remaining* budget. Once the budget is spent the chain stops and draws the honest gap. Total hold is one `RECONNECT_HOLD_MS`, not N×.
- **Fetch cancellation:** an `AbortController` is threaded through `fetchBackfill` into `HistoryApiClientService.getValues`; on cap (or teardown) the abandoned fetch is aborted, and `getValues` bridges the signal via `takeUntil(fromEvent(signal, 'abort'))` to unsubscribe the request — cancelling the underlying `HttpClient` GET instead of leaving it to time out and stack.

`getValues` gained an optional `signal?: AbortSignal` — additive, no existing caller affected. Single-run behaviour is unchanged (a length-1 chain arms `deadline = now + RECONNECT_HOLD_MS`, so the remaining budget equals the full cap). Adds 3 tests (chain-hold bound, abort-on-cap wiring, real HTTP cancellation via `HttpTestingController`). Lint clean; betterer 179 (neither service was in the baseline).

closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)
