### PR TITLE
fix(boolean): floor control height at a tappable minimum, ellipsize long labels (#318)

### DIFF
--- a/src/app/widgets/svg-boolean-button/svg-boolean-button.component.svg
+++ b/src/app/widgets/svg-boolean-button/svg-boolean-button.component.svg
@@ -38,8 +38,8 @@
       xmlns="http://www.w3.org/1999/xhtml"
       [style.color]="isPressed ? labelColorEnabled : labelColorDisabled"
       [style.fontSize.px]="layout.labelFontSize"
-      style="width:100%;height:100%;display:flex;align-items:center;justify-content:center;font-family:Roboto,sans-serif;font-weight:700;line-height:1;white-space:nowrap;overflow:hidden;text-overflow:clip;">
-      {{ data()?.ctrlLabel }}
+      style="width:100%;height:100%;display:flex;align-items:center;justify-content:center;font-family:Roboto,sans-serif;font-weight:700;line-height:1;overflow:hidden;">
+      <span style="min-width:0;overflow:hidden;white-space:nowrap;text-overflow:ellipsis;">{{ data()?.ctrlLabel }}</span>
     </div>
   </foreignObject>
 </svg>

--- a/src/app/widgets/svg-boolean-light/svg-boolean-light.component.svg
+++ b/src/app/widgets/svg-boolean-light/svg-boolean-light.component.svg
@@ -35,8 +35,8 @@
       [style.opacity]="isEnabled ? 1 : 0.6"
       [style.fontSize.px]="layout.labelFontSize"
       [style.textShadow]="isEnabled ? '0 0 4px currentColor, 0 0 4px currentColor' : 'none'"
-      style="width:100%;height:100%;display:flex;align-items:center;justify-content:flex-start;font-family:Roboto,sans-serif;font-weight:700;line-height:1;white-space:nowrap;overflow:hidden;text-overflow:clip;">
-      {{ data()?.ctrlLabel }}
+      style="width:100%;height:100%;display:flex;align-items:center;justify-content:flex-start;font-family:Roboto,sans-serif;font-weight:700;line-height:1;overflow:hidden;">
+      <span style="min-width:0;overflow:hidden;white-space:nowrap;text-overflow:ellipsis;">{{ data()?.ctrlLabel }}</span>
     </div>
   </foreignObject>
 

--- a/src/app/widgets/svg-boolean-switch/svg-boolean-switch.component.svg
+++ b/src/app/widgets/svg-boolean-switch/svg-boolean-switch.component.svg
@@ -43,8 +43,8 @@
       [style.opacity]="isEnabled ? 1 : 0.6"
       [style.fontSize.px]="layout.labelFontSize"
       [style.textShadow]="isEnabled ? '0 0 4px currentColor, 0 0 4px currentColor' : 'none'"
-      style="width:100%;height:100%;display:flex;align-items:center;justify-content: flex-start;font-family:Roboto,sans-serif;font-weight:700;line-height:1;white-space:nowrap;overflow:hidden;text-overflow:clip;">
-      {{ data()?.ctrlLabel }}
+      style="width:100%;height:100%;display:flex;align-items:center;justify-content: flex-start;font-family:Roboto,sans-serif;font-weight:700;line-height:1;overflow:hidden;">
+      <span style="min-width:0;overflow:hidden;white-space:nowrap;text-overflow:ellipsis;">{{ data()?.ctrlLabel }}</span>
     </div>
   </foreignObject>
 

--- a/src/app/widgets/widget-boolean-switch/boolean-control-layout.util.spec.ts
+++ b/src/app/widgets/widget-boolean-switch/boolean-control-layout.util.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getBooleanControlLayout, measureBooleanControlsHeight } from './boolean-control-layout.util';
+import { getBooleanControlLayout, measureBooleanControlsHeight, MIN_BOOLEAN_CONTROL_HEIGHT, MIN_BOOLEAN_LABEL_WIDTH } from './boolean-control-layout.util';
 
 describe('boolean-control-layout util', () => {
   const measureTextWidth = (text: string, fontSize: number): number => text.length * fontSize * 0.6;
@@ -18,7 +18,7 @@ describe('boolean-control-layout util', () => {
     expect(height).toBe(100);
   });
 
-  it('caps height when a long label would overflow', () => {
+  it('floors the control height at the touch-target minimum instead of collapsing to fit a long label (#318)', () => {
     const height = measureBooleanControlsHeight(
       180,
       200,
@@ -26,8 +26,140 @@ describe('boolean-control-layout util', () => {
       measureTextWidth,
     );
 
-    expect(height).toBeLessThan(40);
-    expect(height).toBeGreaterThan(0);
+    // Old behaviour shrank the control to a sub-tap sliver (~19px) so the label fit;
+    // now the label ellipsizes and the control stays tappable.
+    expect(height).toBe(MIN_BOOLEAN_CONTROL_HEIGHT);
+  });
+
+  it('does not shrink every control in a panel just because one label is long (#318)', () => {
+    const height = measureBooleanControlsHeight(
+      220,
+      300,
+      [
+        { type: '1', ctrlLabel: 'Nav' },
+        { type: '3', ctrlLabel: 'Aux' },
+        { type: '2', ctrlLabel: 'Emergency Bilge Pump Override Switch' },
+      ],
+      measureTextWidth,
+    );
+
+    // maxByPanel = 100; the one long label would collapse all three to ~23px, but
+    // the shared height floors at the minimum instead.
+    expect(height).toBe(MIN_BOOLEAN_CONTROL_HEIGHT);
+  });
+
+  it('backs a narrow switch tile off the floor to keep its label visible (#318)', () => {
+    const height = measureBooleanControlsHeight(
+      60,
+      200,
+      [{ type: '1', ctrlLabel: 'Nav' }],
+      measureTextWidth,
+    );
+
+    // At the 44px floor the height-scaled shape lane would clamp the label lane to 0
+    // and hide the label, so the height backs off toward the fit-height where the
+    // label is still visible.
+    const layout = getBooleanControlLayout('1', 60, height);
+    expect(height).toBeLessThan(MIN_BOOLEAN_CONTROL_HEIGHT);
+    expect(layout.labelWidth).toBeGreaterThan(0);
+    expect(measureTextWidth('Nav', layout.labelFontSize)).toBeLessThanOrEqual(layout.labelWidth);
+  });
+
+  it('is monotonic in tile height: a taller tile never shrinks the control (#318)', () => {
+    const controls = [{ type: '1', ctrlLabel: 'Navigation Lights' }];
+    // panelWidth 91 is the band where the switch label lane straddles 24px across
+    // floored 43 vs 44 — the case an all-or-nothing gate collapsed on resize.
+    const heights = [40, 43, 44, 60, 200].map(ph => measureBooleanControlsHeight(91, ph, controls, measureTextWidth));
+    for (let i = 1; i < heights.length; i++) {
+      expect(heights[i]).toBeGreaterThanOrEqual(heights[i - 1]);
+    }
+    // and it settles near the floor, never crashing back to the tiny fit-height.
+    expect(heights[heights.length - 1]).toBeGreaterThanOrEqual(40);
+  });
+
+  it('does not drop a clean control to the fit-height because a sibling label is marginal (#318)', () => {
+    const height = measureBooleanControlsHeight(
+      91,
+      400,
+      [
+        { type: '1', ctrlLabel: '' },
+        { type: '1', ctrlLabel: 'Navigation Lights' },
+      ],
+      measureTextWidth,
+    );
+
+    // The empty control renders fine at the floor; a sibling whose lane is ~1px
+    // short must not collapse the whole panel to a sub-tap height.
+    expect(height).toBeGreaterThanOrEqual(40);
+  });
+
+  it('holds the tap-target floor for an empty-labeled shape control on a narrow tile (#318)', () => {
+    const height = measureBooleanControlsHeight(
+      80,
+      300,
+      [
+        { type: '1', ctrlLabel: '' },
+        { type: '2', ctrlLabel: 'Emergency Bilge Pump Override Switch' },
+      ],
+      measureTextWidth,
+    );
+
+    // The empty switch has no label to keep legible, so it must not drag the shared
+    // height below the floor — that would reintroduce #318's sub-tap slivers.
+    expect(height).toBe(MIN_BOOLEAN_CONTROL_HEIGHT);
+  });
+
+  it('treats a whitespace-only label as empty for the floor (#318)', () => {
+    const height = measureBooleanControlsHeight(
+      80,
+      300,
+      [{ type: '1', ctrlLabel: '   ' }],
+      measureTextWidth,
+    );
+
+    expect(height).toBe(MIN_BOOLEAN_CONTROL_HEIGHT);
+  });
+
+  it('keeps a legible label lane at the floor on a roomy tile (does not over-ellipsize)', () => {
+    const height = measureBooleanControlsHeight(
+      180,
+      200,
+      [{ type: '1', ctrlLabel: 'Very long generator control label' }],
+      measureTextWidth,
+    );
+
+    // 180px is wide enough that the floored 44px control still leaves a usable lane.
+    expect(height).toBe(MIN_BOOLEAN_CONTROL_HEIGHT);
+    expect(getBooleanControlLayout('1', 180, height).labelWidth).toBeGreaterThanOrEqual(MIN_BOOLEAN_LABEL_WIDTH);
+  });
+
+  it('lets a long-labeled button drive the backoff without an empty switch sibling blocking or over-scaling it (#318)', () => {
+    const height = measureBooleanControlsHeight(
+      50,
+      300,
+      [
+        { type: '2', ctrlLabel: 'Emergency Bilge Pump Override' },
+        { type: '1', ctrlLabel: '' },
+      ],
+      measureTextWidth,
+    );
+
+    // The button's starved lane drives the shared height down; the empty switch
+    // neither blocks that backoff nor is scaled above the floor by it.
+    expect(height).toBeLessThan(MIN_BOOLEAN_CONTROL_HEIGHT);
+    expect(height).toBeGreaterThanOrEqual(1);
+  });
+
+  it('degrades to the largest height the panel allows when it cannot fit even the floor', () => {
+    const controls = [
+      { type: '1', ctrlLabel: 'C0' }, { type: '1', ctrlLabel: 'C1' }, { type: '1', ctrlLabel: 'C2' },
+      { type: '1', ctrlLabel: 'C3' }, { type: '1', ctrlLabel: 'C4' }, { type: '1', ctrlLabel: 'C5' },
+    ];
+    const height = measureBooleanControlsHeight(320, 120, controls, measureTextWidth);
+
+    // 6 controls in 120px => 20px each, below the floor: take all the panel allows, never less.
+    expect(height).toBe(20);
+    expect(height).toBeLessThan(MIN_BOOLEAN_CONTROL_HEIGHT);
   });
 
   it('gives button labels more horizontal room than switch labels', () => {

--- a/src/app/widgets/widget-boolean-switch/boolean-control-layout.util.ts
+++ b/src/app/widgets/widget-boolean-switch/boolean-control-layout.util.ts
@@ -3,6 +3,19 @@ import type { IDynamicControl } from '../../core/interfaces/widgets-interface';
 export const BOOLEAN_CONTROL_BASE_HEIGHT = 35;
 export const BOOLEAN_CONTROL_BASE_FONT_SIZE = 14;
 
+// Minimum per-control height. A long label must never shrink the shared control
+// height below a tappable target (#318) — controls stay this tall and the label
+// ellipsizes instead. Only sacrificed when the panel itself can't fit one control
+// this tall (many controls in a short tile), or when raising the height would
+// starve the label lane on a narrow tile (see MIN_BOOLEAN_LABEL_WIDTH).
+export const MIN_BOOLEAN_CONTROL_HEIGHT = 44;
+
+// Minimum label lane to preserve. The switch/light shape lane is height-scaled,
+// so raising the height widens the shape and eats horizontal label room. On a
+// narrow tile the floor would clamp the label lane to zero and hide the label
+// entirely; back off from the floor to keep at least this much lane for it.
+export const MIN_BOOLEAN_LABEL_WIDTH = 24;
+
 export interface BooleanControlLayout {
   labelX: number;
   labelWidth: number;
@@ -100,5 +113,27 @@ export function measureBooleanControlsHeight(
     high = mid - 1;
   }
 
-  return Math.min(best, maxByPanel);
+  // Floor the shared height at a tappable minimum: a label too long to fit is
+  // ellipsized (see the SVG templates) rather than collapsing every control.
+  // Never exceed what the panel can fit, so a short/crowded tile still degrades
+  // to the largest height it allows.
+  // Start at the tappable floor, then back off toward `best` (where every label
+  // fully fits) one step at a time while any *labeled* control's height-scaled
+  // shape lane would starve its label lane below a legible minimum. The height-
+  // scaled shape lane means a taller control leaves less room for its label, so a
+  // narrow tile trades a little height for a visible label; a roomy tile keeps the
+  // full floor and ellipsizes. Backing off is monotonic in the tile dimensions
+  // (no all-or-nothing jump), and an empty/whitespace label is skipped — there is
+  // nothing to keep legible, so it never forces a control below the floor.
+  let height = Math.min(maxByPanel, Math.max(best, MIN_BOOLEAN_CONTROL_HEIGHT));
+  while (
+    height > best &&
+    controls.some(ctrl =>
+      (ctrl.ctrlLabel ?? '').trim() !== '' &&
+      getBooleanControlLayout(ctrl.type, panelWidth, height).labelWidth < MIN_BOOLEAN_LABEL_WIDTH)
+  ) {
+    height--;
+  }
+
+  return height;
 }


### PR DESCRIPTION
## Why

#318 (confirmed by headless render): a boolean-switch panel picks **one shared height** for all its controls — the tallest at which *every* label fits (`measureBooleanControlsHeight`). So a single long label dragged every control in the panel down to ~23px sub-tap-target slivers, wasting most of the tile and rendering an **Emergency Bilge Pump** switch as an unreadable, barely-tappable line. The mechanism shipped in #316 (the Kip #1106/#1107 port).

## How

1. **Tap-target floor** — `MIN_BOOLEAN_CONTROL_HEIGHT = 44`: the shared height floors at a tappable minimum instead of collapsing to fit a long label; the overlong label **ellipsizes** instead (each label wrapped in a `min-width:0` flex-item span with `text-overflow:ellipsis`).
2. **Label-lane backoff** — `MIN_BOOLEAN_LABEL_WIDTH = 24`: the switch/light shape lane is itself height-scaled (`48·height/35`), so a taller control leaves *less* horizontal room for its label. Starting at the floor, the height backs off one px at a time toward the natural fit-height while any **labeled** control's lane would fall below a legible minimum. A narrow tile therefore trades a little height for a visible label (pre-#318 behavior there); a roomy tile keeps the full floor and ellipsizes. Empty/whitespace labels are skipped — there is nothing to keep legible, so they never force a control below the floor.

The backoff is **monotone in both tile dimensions** (the returned height reduces to `max(best, min(height_start, Hs−1))`, a max/min of monotone terms), so a resize can never crash a control to a sliver.

### Review journey (this is why it took the shape it did)

Four adversarial passes, three of which found a real hole and drove a redesign:
1. Naive floor → *labels vanished* on narrow switch/light tiles (the floor inflates the height-scaled shape lane, zeroing the label lane) → added a backoff.
2. Backoff was label-blind → an *empty-labeled* control could drag the panel below the floor (reintroducing #318) → made the trigger label-aware.
3. An interim all-or-nothing gated variant → *non-monotonic collapse* on resize + all-or-nothing sibling drag-down → replaced with the monotone one-px backoff (this version).
4. Final pass: **no findings** — soundness confirmed by analytical proof + a ~1.5M-point sweep.

## Verification

- Util spec **17/17** — including the exact repros the review surfaced: the floor, the narrow-tile backoff, the empty/whitespace-label cases, a **width-91 monotonicity sweep** (the resize-crash case), the sibling drag-down, and a cross-type button+empty-switch guard. Lint clean; `betterer:ci` 179 (the util carries no strict-null baseline entry).
- **Headless render (perf-harness, real prod bundle, element-clipped, toolbar-free)** — control heights + label visibility confirmed by pixels + DOM metrics:

| tile | before | after |
|---|---|---|
| 203px, 3 mixed (one long) | 23px slivers | **44px** tappable; long label "Emergency Bilg…" ellipsized, short labels full |
| 91px, single "Navigation Lights" | (gated variant crashed to ~15px) | **43px** (backoff shed 1px), label "N…" |
| 91px, empty switch + long switch | — | **both 43px** (empty not dragged to a sliver) |
| 65px, single "Nav" | 44px, **label vanished** | **29px**, "Nav" fully visible |

Rendering behavior can't be unit-tested (jsdom canvas is a stub), so the ellipsis, no-vanish, tap-floor, and monotonicity were verified visually.

Two documented, pre-existing degenerate branches (an empty-label shape can still overflow a sub-shape-width tile; a genuinely unfittable label on a sub-30px tile degrades toward 1px) are **not regressions** — the fix only ever *lowers* height from the floor, so they are ≤ #316's behavior.

Closes #318.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
