### PR TITLE
test(perf-harness): headless boolean-widget render matrix

### DIFF
--- a/perf-harness/README.md
+++ b/perf-harness/README.md
@@ -84,6 +84,14 @@ reusing a label for a different build.
 visual before/after; `verify-click.mjs` checks radar hit-testing (overlapping
 targets under view rotation) end-to-end.
 
+`shot-boolean.mjs` renders the boolean-switch (Switch Panel) widget across a
+control-count × label-length × tile-size matrix (day + light themes), writes
+`results/shots/boolean/<name>.png` per tile, and prints per-control shared height
+with a 44px tap-target flag — the #318 long-label panel-shrink probe. It boot-asserts
+that each tile rendered its seeded control count (exits non-zero otherwise). Invoke
+with `CHROME_BIN=/usr/bin/chromium node shot-boolean.mjs --public ../public` after a
+`../public` build.
+
 ## Interpreting the numbers
 
 | Question | Metric | Caveat |

--- a/perf-harness/lib/kip-config.mjs
+++ b/perf-harness/lib/kip-config.mjs
@@ -97,6 +97,39 @@ export function aisRadarWidget() {
   });
 }
 
+/**
+ * Switch-panel (widget-boolean-switch) factory. Mirrors the persisted config
+ * shape: multiChildCtrls holds the IDynamicControl list, paths holds one
+ * IWidgetPath per control keyed by a matching pathID. Each control:
+ *   { label, type ('1' switch | '2' button | '3' light), color, value, isNumeric, path }
+ * Controls render from multiChildCtrls regardless of live data; paths only feed
+ * value streaming (left un-streamed here for deterministic on/off states).
+ */
+export function booleanControlWidget({ controls, w = 4, h = 6, displayName = 'Switch Panel', showLabel = true, color = 'contrast' } = {}) {
+  const uuid = uid('bool');
+  const multiChildCtrls = [];
+  const paths = [];
+  controls.forEach((c, i) => {
+    const pathID = `bctrl-${String(++seq).padStart(4, '0')}`;
+    multiChildCtrls.push({
+      ctrlLabel: c.label, type: c.type ?? '1', pathID,
+      value: c.value ?? false, color: c.color ?? color, isNumeric: c.isNumeric ?? false,
+    });
+    paths.push({
+      description: c.label, path: c.path ?? `self.electrical.switches.bank.0.${i}.state`,
+      source: 'default', pathType: 'boolean', isPathConfigurable: true, sampleTime: 500, pathID,
+    });
+  });
+  return (x, y) => node(w, h, x, y, {
+    type: 'widget-boolean-switch', uuid,
+    config: {
+      displayName, showLabel, filterSelfPaths: true, paths,
+      enableTimeout: false, dataTimeout: 5, color, zonesOnlyPaths: false,
+      putEnable: true, putMomentary: false, multiChildCtrls,
+    },
+  });
+}
+
 /** Lay out widget factories in a grid and wrap them in one dashboard. */
 export function buildDashboards(factories, cols = 12) {
   let x = 0, y = 0, rowH = 0;

--- a/perf-harness/lib/kip-config.mjs
+++ b/perf-harness/lib/kip-config.mjs
@@ -102,8 +102,10 @@ export function aisRadarWidget() {
  * shape: multiChildCtrls holds the IDynamicControl list, paths holds one
  * IWidgetPath per control keyed by a matching pathID. Each control:
  *   { label, type ('1' switch | '2' button | '3' light), color, value, isNumeric, path }
- * Controls render from multiChildCtrls regardless of live data; paths only feed
- * value streaming (left un-streamed here for deterministic on/off states).
+ * Controls render from multiChildCtrls regardless of live data. Each path carries
+ * suppressBootstrapNull so the widget keeps the control's configured on/off value
+ * instead of being clobbered by DataService's synchronous bootstrap null (nothing
+ * streams these paths here, so without it every control would render OFF).
  */
 export function booleanControlWidget({ controls, w = 4, h = 6, displayName = 'Switch Panel', showLabel = true, color = 'contrast' } = {}) {
   const uuid = uid('bool');
@@ -118,6 +120,7 @@ export function booleanControlWidget({ controls, w = 4, h = 6, displayName = 'Sw
     paths.push({
       description: c.label, path: c.path ?? `self.electrical.switches.bank.0.${i}.state`,
       source: 'default', pathType: 'boolean', isPathConfigurable: true, sampleTime: 500, pathID,
+      suppressBootstrapNull: true,
     });
   });
   return (x, y) => node(w, h, x, y, {

--- a/perf-harness/shot-boolean.mjs
+++ b/perf-harness/shot-boolean.mjs
@@ -70,9 +70,11 @@ const scenarios = [
   { name: 'c4-mixed-repro-large', ...LARGE, controls: [sw(LONG, { color: 'green' }), lt('Aux', { value: true, color: 'blue' }), btn('Bilge', { color: 'orange' }), sw('Deck', { color: 'purple' })] },
 ];
 
-// Second theme axis: config-driven light theme (faithful, colors recompute at boot).
-// Night mode is a runtime brightness/sepia filter, not an appConfig field, and is
-// geometrically inert -- see report notes.
+// Second theme axis: config-driven light theme (colors recompute at boot). NOTE the
+// #318 shared-height geometry is a pure function of tile/label/font with NO theme
+// input, so these rows verify color/contrast only -- not an independent geometric
+// result. (Night mode is a runtime brightness/sepia CSS filter, not an appConfig
+// field, and is likewise geometrically inert.)
 const lightScenarios = [
   { name: 'c3-mixed-repro-narrow-light', ...NARROW, controls: [sw(LONG, { color: 'green' }), lt('Aux', { value: true, color: 'blue' }), btn('Bilge', { color: 'orange' })] },
   { name: 'c3-mixed-repro-large-light', ...LARGE, controls: [sw(LONG, { color: 'green' }), lt('Aux', { value: true, color: 'blue' }), btn('Bilge', { color: 'orange' })] },
@@ -88,13 +90,16 @@ function dashboardsFor(list) {
   }));
 }
 
-const MIN_TAP = 44; // px accessibility floor (iOS 44 / Material 48)
+const MIN_TAP = 44;   // px accessibility floor (iOS 44 / Material 48)
+const SLIVER_PX = 8;  // below this a control is a near-invisible sliver, not a usable target
 
 async function measure(page) {
   return page.evaluate(() => {
     const w = document.querySelector('widget-boolean-switch');
     if (!w) return { ok: false };
     const wr = w.getBoundingClientRect();
+    // Selectors mirror widget-boolean-switch.component.html (.svg-widget class,
+    // app-svg-boolean-{switch,button,light} hosts); a template rename breaks these.
     const svgs = [...w.querySelectorAll('.svg-widget svg')].map((s) => {
       const r = s.getBoundingClientRect();
       return {
@@ -116,14 +121,27 @@ async function runTheme({ ctx, url, list, dir }) {
     await page.goto(`${url}#/page/${i}`, { waitUntil: 'load', timeout: 30000 });
     await page.waitForSelector('widget-boolean-switch', { timeout: 20000 });
     await page.waitForSelector('.svg-widget svg', { timeout: 20000 });
+    await page.evaluate(() => document.fonts.ready.then(() => true)); // labels are canvas-measured; wait for the real font, not a fallback
     await page.waitForTimeout(700); // let ResizeObserver + measure effect settle
     const m = await measure(page);
     const out = join(dir, `${s.name}.png`);
     await page.locator('widget-boolean-switch').screenshot({ path: out });
-    const h = m.ok ? m.svgs[0]?.hAttr ?? 0 : 0;
+    // All controls share one ctrlDimensions, so svgs[0] height IS the shared height.
+    const h = m.ok ? Number(m.svgs[0]?.hAttr) : NaN;
     const painted = m.ok ? Math.round((m.svgs.reduce((a, x) => a + x.rectH, 0))) : 0;
-    const flag = !m.ok ? 'NO-WIDGET' : (h < 8 ? 'SLIVER' : h < MIN_TAP ? 'sub-tap' : 'ok');
-    rows.push({ name: s.name, tile: m.ok ? `${m.widget.w}x${m.widget.h}` : '-', ctrls: m.ok ? m.count : 0, ctrlH: h, paintedSum: painted, flag });
+    const expected = s.controls.length;
+    // Boot integrity: the seeded controls must actually render and yield a measurable
+    // shared height. A count mismatch means a silent defaults/empty render (schema
+    // drift), not a widget bug -- that fails the run. SLIVER/sub-tap are the real
+    // findings the tool exists to surface, so they stay flags, not failures.
+    const bad = !m.ok || m.count !== expected || !Number.isFinite(h) || h <= 0;
+    const flag = !m.ok ? 'NO-WIDGET'
+      : m.count !== expected ? `COUNT ${m.count}/${expected}`
+      : !Number.isFinite(h) || h <= 0 ? 'BAD-H'
+      : h < SLIVER_PX ? 'SLIVER'
+      : h < MIN_TAP ? 'sub-tap'
+      : 'ok';
+    rows.push({ name: s.name, tile: m.ok ? `${m.widget.w}x${m.widget.h}` : '-', ctrls: m.ok ? m.count : 0, ctrlH: Number.isFinite(h) ? h : 0, paintedSum: painted, flag, bad });
     console.log(`[shot] ${out}`);
     await page.close();
   }
@@ -167,3 +185,12 @@ for (const r of all) {
 
 await browser.close();
 await server.stop();
+
+// Boot-integrity assert (mirrors run.mjs): a tile that didn't render its seeded
+// control count, or yielded an unmeasurable height, means the run measured the wrong
+// thing -- fail loudly rather than leave a plausible-but-wrong screenshot to eyeball.
+const failed = all.filter((r) => r.bad);
+if (failed.length) {
+  console.error(`\nboot check failed: ${failed.length} tile(s) rendered wrong -> ${failed.map((r) => `${r.name}[${r.flag}]`).join(', ')}`);
+  process.exit(1);
+}

--- a/perf-harness/shot-boolean.mjs
+++ b/perf-harness/shot-boolean.mjs
@@ -1,0 +1,169 @@
+/*
+ * #318 boolean-switch (Switch Panel) rendering probe. Renders the widget headless
+ * across a control-count x label-length x tile-size matrix and screenshots each
+ * tile, so the long-label panel-shrink risk can be judged from real pixels instead
+ * of an eyeball on the boat.
+ *
+ *   CHROME_BIN=/usr/bin/chromium node shot-boolean.mjs --public ../public
+ *
+ * The #318 mechanism (boolean-control-layout.util.ts): every control in a panel
+ * shares ONE height, the largest at which EVERY label fits its scaled lane. One
+ * long label therefore drives the shared control height (and font) down for all
+ * controls -- so a mixed panel with one very-long label is the exact repro.
+ *
+ * Writes results/shots/boolean/<name>.png and prints per-tile control geometry.
+ */
+import { chromium } from 'playwright-core';
+import { mkdir } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { startServer } from './lib/server.mjs';
+import { appConfig, booleanControlWidget, localStorageBundle } from './lib/kip-config.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CHROME = process.env.CHROME_BIN || '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const arg = (n, d) => { const i = process.argv.indexOf(`--${n}`); return i >= 0 ? process.argv[i + 1] : d; };
+
+const publicDir = arg('public', join(HERE, '..', 'public'));
+const port = Number(arg('port', '4422'));
+const VIEWPORT = { width: 1280, height: 800 }; // 24-col grid -> col ~53px, row ~33px
+
+const SHORT = 'Nav';
+const MED = 'Anchor Light';
+const LONG = 'Emergency Bilge Pump Override Switch';
+// control types: '1' switch, '2' button, '3' light
+const sw = (label, extra = {}) => ({ label, type: '1', ...extra });
+const btn = (label, extra = {}) => ({ label, type: '2', ...extra });
+const lt = (label, extra = {}) => ({ label, type: '3', ...extra });
+
+// Tile presets (grid cells). narrow width is the #318-binding constraint.
+const NARROW = { w: 4, h: 8 };   // ~213 x 267 px
+const XNARROW = { w: 3, h: 8 };  // ~160 x 267 px
+const LARGE = { w: 14, h: 14 };  // ~747 x 467 px
+const SMALL1 = { w: 4, h: 6 };   // single-control small
+const LARGE1 = { w: 14, h: 10 };
+
+const scenarios = [
+  // --- single control: short vs very-long, small vs large ---
+  { name: 'c1-short-switch-small', ...SMALL1, controls: [sw(SHORT, { value: true, color: 'green' })] },
+  { name: 'c1-short-switch-large', ...LARGE1, controls: [sw(SHORT, { value: true, color: 'green' })] },
+  { name: 'c1-long-switch-small', ...SMALL1, controls: [sw(LONG)] },
+  { name: 'c1-long-switch-large', ...LARGE1, controls: [sw(LONG)] },
+  { name: 'c1-long-button-small', ...SMALL1, controls: [btn(LONG)] },
+  { name: 'c1-long-light-small', ...SMALL1, controls: [lt(LONG)] },
+
+  // --- 3 controls (switch/light/button mix) across label lengths ---
+  { name: 'c3-short-narrow', ...NARROW, controls: [sw(SHORT, { value: true, color: 'green' }), lt('Aux', { color: 'blue' }), btn('Bilge', { color: 'orange' })] },
+  { name: 'c3-short-large', ...LARGE, controls: [sw(SHORT, { value: true, color: 'green' }), lt('Aux', { color: 'blue' }), btn('Bilge', { color: 'orange' })] },
+  { name: 'c3-medium-narrow', ...NARROW, controls: [sw(MED, { color: 'green' }), lt('Steaming Light', { color: 'blue' }), btn('Nav Lights', { color: 'orange' })] },
+  { name: 'c3-long-all-narrow', ...NARROW, controls: [sw(LONG, { color: 'green' }), lt(LONG, { color: 'blue' }), btn(LONG, { color: 'orange' })] },
+
+  // --- #318 repro: 3 controls, ONE very-long label, the rest short ---
+  { name: 'c3-mixed-repro-narrow', ...NARROW, controls: [sw(LONG, { color: 'green' }), lt('Aux', { value: true, color: 'blue' }), btn('Bilge', { color: 'orange' })] },
+  { name: 'c3-mixed-repro-large', ...LARGE, controls: [sw(LONG, { color: 'green' }), lt('Aux', { value: true, color: 'blue' }), btn('Bilge', { color: 'orange' })] },
+  { name: 'c3-mixed-repro-xnarrow', ...XNARROW, controls: [sw(LONG, { color: 'green' }), lt('Aux', { value: true, color: 'blue' }), btn('Bilge', { color: 'orange' })] },
+
+  // --- 4 controls: short vs #318 mixed-long repro ---
+  { name: 'c4-short-narrow', ...NARROW, controls: [sw(SHORT, { value: true, color: 'green' }), lt('Aux', { color: 'blue' }), btn('Bilge', { color: 'orange' }), sw('Deck', { color: 'purple' })] },
+  { name: 'c4-short-large', ...LARGE, controls: [sw(SHORT, { value: true, color: 'green' }), lt('Aux', { color: 'blue' }), btn('Bilge', { color: 'orange' }), sw('Deck', { color: 'purple' })] },
+  { name: 'c4-mixed-repro-narrow', ...NARROW, controls: [sw(LONG, { color: 'green' }), lt('Aux', { value: true, color: 'blue' }), btn('Bilge', { color: 'orange' }), sw('Deck', { color: 'purple' })] },
+  { name: 'c4-mixed-repro-large', ...LARGE, controls: [sw(LONG, { color: 'green' }), lt('Aux', { value: true, color: 'blue' }), btn('Bilge', { color: 'orange' }), sw('Deck', { color: 'purple' })] },
+];
+
+// Second theme axis: config-driven light theme (faithful, colors recompute at boot).
+// Night mode is a runtime brightness/sepia filter, not an appConfig field, and is
+// geometrically inert -- see report notes.
+const lightScenarios = [
+  { name: 'c3-mixed-repro-narrow-light', ...NARROW, controls: [sw(LONG, { color: 'green' }), lt('Aux', { value: true, color: 'blue' }), btn('Bilge', { color: 'orange' })] },
+  { name: 'c3-mixed-repro-large-light', ...LARGE, controls: [sw(LONG, { color: 'green' }), lt('Aux', { value: true, color: 'blue' }), btn('Bilge', { color: 'orange' })] },
+  { name: 'c3-short-narrow-light', ...NARROW, controls: [sw(SHORT, { value: true, color: 'green' }), lt('Aux', { color: 'blue' }), btn('Bilge', { color: 'orange' })] },
+];
+
+let dseq = 0;
+function dashboardsFor(list) {
+  return list.map((s) => ({
+    id: `dash-0000-0000-0000-${String(++dseq).padStart(12, '0')}`,
+    name: s.name, icon: 'dashboard-dashboard',
+    configuration: [booleanControlWidget({ controls: s.controls, w: s.w, h: s.h, displayName: s.name })(0, 0)],
+  }));
+}
+
+const MIN_TAP = 44; // px accessibility floor (iOS 44 / Material 48)
+
+async function measure(page) {
+  return page.evaluate(() => {
+    const w = document.querySelector('widget-boolean-switch');
+    if (!w) return { ok: false };
+    const wr = w.getBoundingClientRect();
+    const svgs = [...w.querySelectorAll('.svg-widget svg')].map((s) => {
+      const r = s.getBoundingClientRect();
+      return {
+        type: (s.parentElement?.tagName || '').toLowerCase().replace('app-svg-boolean-', ''),
+        hAttr: Number(s.getAttribute('height')),
+        rectH: Math.round(r.height), rectW: Math.round(r.width),
+      };
+    });
+    return { ok: true, widget: { w: Math.round(wr.width), h: Math.round(wr.height) }, count: svgs.length, svgs };
+  });
+}
+
+async function runTheme({ ctx, url, list, dir }) {
+  const rows = [];
+  for (let i = 0; i < list.length; i++) {
+    const s = list[i];
+    const page = await ctx.newPage();
+    await page.goto('about:blank');
+    await page.goto(`${url}#/page/${i}`, { waitUntil: 'load', timeout: 30000 });
+    await page.waitForSelector('widget-boolean-switch', { timeout: 20000 });
+    await page.waitForSelector('.svg-widget svg', { timeout: 20000 });
+    await page.waitForTimeout(700); // let ResizeObserver + measure effect settle
+    const m = await measure(page);
+    const out = join(dir, `${s.name}.png`);
+    await page.locator('widget-boolean-switch').screenshot({ path: out });
+    const h = m.ok ? m.svgs[0]?.hAttr ?? 0 : 0;
+    const painted = m.ok ? Math.round((m.svgs.reduce((a, x) => a + x.rectH, 0))) : 0;
+    const flag = !m.ok ? 'NO-WIDGET' : (h < 8 ? 'SLIVER' : h < MIN_TAP ? 'sub-tap' : 'ok');
+    rows.push({ name: s.name, tile: m.ok ? `${m.widget.w}x${m.widget.h}` : '-', ctrls: m.ok ? m.count : 0, ctrlH: h, paintedSum: painted, flag });
+    console.log(`[shot] ${out}`);
+    await page.close();
+  }
+  return rows;
+}
+
+const server = await startServer({ publicDir, base: '/@halos-org/skip/', port });
+const browser = await chromium.launch({ executablePath: CHROME, headless: true });
+const outDir = join(HERE, 'results', 'shots', 'boolean');
+await mkdir(outDir, { recursive: true });
+
+const bundle = localStorageBundle({ origin: server.origin, subscribeAll: false });
+const initScript = { content: `window.__KIP_TEST__=true;` + Object.entries(bundle).map(([k, v]) => `localStorage.setItem(${JSON.stringify(k)}, ${JSON.stringify(v)});`).join('') };
+
+// Pin to the current app-config schema (LATEST_APP_CONFIG_VERSION=13) so the boot
+// skips ConfigurationUpgradeService's v12->v13 migration toast/reload. That migration
+// only strips dataSets/datasetUUID/chartEngine, none of which touch the boolean widget.
+const appV13 = () => { const a = appConfig({ configVersion: 13 }); delete a.dataSets; return a; };
+
+// --- day / default dark theme: full matrix ---
+server.setConfigDocument({ app: appV13(), theme: { themeName: '' }, dashboards: dashboardsFor(scenarios) });
+const dayCtx = await browser.newContext({ viewport: VIEWPORT, deviceScaleFactor: 2 });
+await dayCtx.addInitScript(initScript);
+const dayRows = await runTheme({ ctx: dayCtx, url: server.appUrl, list: scenarios, dir: outDir });
+await dayCtx.close();
+
+// --- config-driven light theme: key repros ---
+dseq = 0;
+server.setConfigDocument({ app: appV13(), theme: { themeName: 'light-theme' }, dashboards: dashboardsFor(lightScenarios) });
+const lightCtx = await browser.newContext({ viewport: VIEWPORT, deviceScaleFactor: 2 });
+await lightCtx.addInitScript(initScript);
+const lightRows = await runTheme({ ctx: lightCtx, url: server.appUrl, list: lightScenarios, dir: outDir });
+await lightCtx.close();
+
+const all = [...dayRows, ...lightRows];
+console.log('\n=== control geometry (ctrlH = shared per-control height in px; MIN_TAP=44) ===');
+console.log('name'.padEnd(30), 'tile'.padEnd(11), 'ctrls', 'ctrlH', 'paintedSum', 'flag');
+for (const r of all) {
+  console.log(String(r.name).padEnd(30), String(r.tile).padEnd(11), String(r.ctrls).padEnd(5), String(r.ctrlH).padEnd(5), String(r.paintedSum).padEnd(10), r.flag);
+}
+
+await browser.close();
+await server.stop();


### PR DESCRIPTION
## Why

Verifying boolean-widget rendering (label fit, OFF-state, the #318 long-label panel-shrink) was framed as needing the on-boat visual session. It doesn't — the perf-harness already renders the real Skip prod bundle headless in Chromium against a mock Signal K server. This adds the missing config surface + a probe so the boolean widget can be judged from real pixels here, off the boat.

This is the harness that machine-reproduced #318 during the #320 fix (renders at 203/91/65px width confirmed the collapse and then the fix). Landing it makes future boolean-widget checks repeatable — including verifying #321 (the cold-boot font-race) without a boat trip.

## What

- **`perf-harness/lib/kip-config.mjs`** — new `booleanControlWidget({ controls, w, h, ... })` factory that emits the persisted `widget-boolean-switch` config shape (`multiChildCtrls` list + matching `paths` keyed by `pathID`; per-control `label`/`type`/`color`/`value`). Pure additive; reuses the file's existing `seq`/`uid`/`node` helpers.
- **`perf-harness/shot-boolean.mjs`** — probe that renders a control-count × label-length × tile-size matrix (single/3/4 controls; short/medium/very-long labels; narrow/x-narrow/large tiles) across the day (dark) and config-driven light themes, screenshots each `widget-boolean-switch` tile to `results/shots/boolean/`, and prints per-control shared height with a 44px tap-target flag (`ok`/`sub-tap`/`SLIVER`/`NO-WIDGET`). Includes the exact #318 repro: a 3–4 control panel with one very-long label alongside short ones.

App-config is pinned to the current schema version to skip the migration toast; night mode is documented as a runtime CSS filter (geometrically inert), so the theme axis is the config-driven light theme.

No app-code changes — `perf-harness/` only, self-contained (its own deps), never touches app builds or CI.

## Verify

```
cd perf-harness && npm install
CHROME_BIN=/usr/bin/chromium node shot-boolean.mjs --public ../public
```
(after a `../public` prod build). Writes screenshots + a geometry table to stdout.

Relates to #318 / #320 / #321.
