### PR TITLE
refactor(boolean-switch): extract shared dimmer-color resolver

### DIFF
--- a/src/app/widgets/svg-boolean-light/svg-boolean-light.component.ts
+++ b/src/app/widgets/svg-boolean-light/svg-boolean-light.component.ts
@@ -3,6 +3,7 @@ import { ChangeDetectionStrategy } from '@angular/core';
 import type { IDynamicControl, IDimensions } from '../../core/interfaces/widgets-interface';
 import type { ITheme } from '../../core/services/app-service';
 import { BooleanControlLayout, getBooleanControlLayout } from '../widget-boolean-switch/boolean-control-layout.util';
+import { getBooleanControlColors } from '../widget-boolean-switch/boolean-control-colors.util';
 
 
 
@@ -65,52 +66,9 @@ export class SvgBooleanLightComponent implements DoCheck {
   private getColors(color: string): void {
     const theme = this.theme();
     if (!theme) return;
-    switch (color) {
-      case "contrast":
-        this.offColor = theme.contrastDimmer;
-        this.labelColor = theme.contrastDim;
-        this.valueColor = theme.contrast;
-        break;
-      case "blue":
-        this.offColor = theme.blueDimmer;
-        this.labelColor = theme.blueDim;
-        this.valueColor = theme.blue;
-        break;
-      case "green":
-        this.offColor = theme.greenDimmer;
-        this.labelColor = theme.greenDim;
-        this.valueColor = theme.green;
-        break;
-      case "pink":
-        this.offColor = theme.pinkDimmer;
-        this.labelColor = theme.pinkDim;
-        this.valueColor = theme.pink;
-        break;
-      case "orange":
-        this.offColor = theme.orangeDimmer;
-        this.labelColor = theme.orangeDim;
-        this.valueColor = theme.orange;
-        break;
-      case "purple":
-        this.offColor = theme.purpleDimmer;
-        this.labelColor = theme.purpleDim;
-        this.valueColor = theme.purple;
-        break;
-      case "grey":
-        this.offColor = theme.greyDimmer;
-        this.labelColor = theme.greyDim;
-        this.valueColor = theme.grey;
-        break;
-      case "yellow":
-        this.offColor = theme.yellowDimmer;
-        this.labelColor = theme.yellowDim;
-        this.valueColor = theme.yellow;
-        break;
-      default:
-        this.offColor = theme.contrastDimmer;
-        this.labelColor = theme.contrastDim;
-        this.valueColor = theme.contrast;
-        break;
-    }
+    const colors = getBooleanControlColors(theme, color);
+    this.offColor = colors.offColor;
+    this.labelColor = colors.labelColor;
+    this.valueColor = colors.valueColor;
   }
 }

--- a/src/app/widgets/svg-boolean-switch/svg-boolean-switch.component.ts
+++ b/src/app/widgets/svg-boolean-switch/svg-boolean-switch.component.ts
@@ -3,6 +3,7 @@ import type { IDynamicControl, IDimensions } from '../../core/interfaces/widgets
 import type { ITheme } from '../../core/services/app-service';
 import { createSwipeGuard } from '../../core/utils/pointer-swipe-guard.util';
 import { BooleanControlLayout, getBooleanControlLayout } from '../widget-boolean-switch/boolean-control-layout.util';
+import { getBooleanControlColors } from '../widget-boolean-switch/boolean-control-colors.util';
 
 @Component({
     selector: 'app-svg-boolean-switch',
@@ -85,52 +86,9 @@ export class SvgBooleanSwitchComponent implements DoCheck {
   private getColors(color: string): void {
     const theme = this.theme();
     if (!theme) return;
-    switch (color) {
-      case "contrast":
-        this.offColor = theme.contrastDimmer;
-        this.labelColor = theme.contrastDim;
-        this.valueColor = theme.contrast;
-        break;
-      case "blue":
-        this.offColor = theme.blueDimmer;
-        this.labelColor = theme.blueDim;
-        this.valueColor = theme.blue;
-        break;
-      case "green":
-        this.offColor = theme.greenDimmer;
-        this.labelColor = theme.greenDim;
-        this.valueColor = theme.green;
-        break;
-      case "pink":
-        this.offColor = theme.pinkDimmer;
-        this.labelColor = theme.pinkDim;
-        this.valueColor = theme.pink;
-        break;
-      case "orange":
-        this.offColor = theme.orangeDimmer;
-        this.labelColor = theme.orangeDim;
-        this.valueColor = theme.orange;
-        break;
-      case "purple":
-        this.offColor = theme.purpleDimmer;
-        this.labelColor = theme.purpleDim;
-        this.valueColor = theme.purple;
-        break;
-      case "grey":
-        this.offColor = theme.greyDimmer;
-        this.labelColor = theme.greyDim;
-        this.valueColor = theme.grey;
-        break;
-      case "yellow":
-        this.offColor = theme.yellowDimmer;
-        this.labelColor = theme.yellowDim;
-        this.valueColor = theme.yellow;
-        break;
-      default:
-        this.offColor = theme.contrastDimmer;
-        this.labelColor = theme.contrastDim;
-        this.valueColor = theme.contrast;
-        break;
-    }
+    const colors = getBooleanControlColors(theme, color);
+    this.offColor = colors.offColor;
+    this.labelColor = colors.labelColor;
+    this.valueColor = colors.valueColor;
   }
 }

--- a/src/app/widgets/widget-boolean-switch/boolean-control-colors.util.spec.ts
+++ b/src/app/widgets/widget-boolean-switch/boolean-control-colors.util.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import type { ITheme } from '../../core/services/app-service';
+import { getBooleanControlColors } from './boolean-control-colors.util';
+
+const NAMED_COLORS = ['contrast', 'blue', 'green', 'pink', 'orange', 'purple', 'grey', 'yellow'] as const;
+
+function makeTheme(): ITheme {
+  const theme: Record<string, string> = {};
+  for (const color of NAMED_COLORS) {
+    theme[color] = color;
+    theme[`${color}Dim`] = `${color}Dim`;
+    theme[`${color}Dimmer`] = `${color}Dimmer`;
+  }
+  return theme as unknown as ITheme;
+}
+
+describe('boolean-control-colors util', () => {
+  const theme = makeTheme();
+  const contrastTriple = { offColor: 'contrastDimmer', labelColor: 'contrastDim', valueColor: 'contrast' };
+
+  it.each([...NAMED_COLORS])('resolves the %s triple from its dimmer/dim/base theme keys', (color) => {
+    expect(getBooleanControlColors(theme, color)).toEqual({
+      offColor: `${color}Dimmer`,
+      labelColor: `${color}Dim`,
+      valueColor: color,
+    });
+  });
+
+  it('falls back to the contrast triple for an unknown color name', () => {
+    expect(getBooleanControlColors(theme, 'chartreuse')).toEqual(contrastTriple);
+    expect(getBooleanControlColors(theme, '')).toEqual(contrastTriple);
+  });
+
+  it('resolves an unknown color identically to the contrast case', () => {
+    expect(getBooleanControlColors(theme, 'chartreuse')).toEqual(getBooleanControlColors(theme, 'contrast'));
+  });
+});

--- a/src/app/widgets/widget-boolean-switch/boolean-control-colors.util.ts
+++ b/src/app/widgets/widget-boolean-switch/boolean-control-colors.util.ts
@@ -1,0 +1,34 @@
+import type { ITheme } from '../../core/services/app-service';
+
+export interface BooleanControlColors {
+  offColor: string;
+  labelColor: string;
+  valueColor: string;
+}
+
+/**
+ * Resolves a boolean control's OFF/label/value colors from a named theme color.
+ * Shared by the switch and light SVG controls; an unknown name falls back to the
+ * contrast triple (the `default` case).
+ */
+export function getBooleanControlColors(theme: ITheme, colorName: string): BooleanControlColors {
+  switch (colorName) {
+    case 'blue':
+      return { offColor: theme.blueDimmer, labelColor: theme.blueDim, valueColor: theme.blue };
+    case 'green':
+      return { offColor: theme.greenDimmer, labelColor: theme.greenDim, valueColor: theme.green };
+    case 'pink':
+      return { offColor: theme.pinkDimmer, labelColor: theme.pinkDim, valueColor: theme.pink };
+    case 'orange':
+      return { offColor: theme.orangeDimmer, labelColor: theme.orangeDim, valueColor: theme.orange };
+    case 'purple':
+      return { offColor: theme.purpleDimmer, labelColor: theme.purpleDim, valueColor: theme.purple };
+    case 'grey':
+      return { offColor: theme.greyDimmer, labelColor: theme.greyDim, valueColor: theme.grey };
+    case 'yellow':
+      return { offColor: theme.yellowDimmer, labelColor: theme.yellowDim, valueColor: theme.yellow };
+    case 'contrast':
+    default:
+      return { offColor: theme.contrastDimmer, labelColor: theme.contrastDim, valueColor: theme.contrast };
+  }
+}


### PR DESCRIPTION
## Why

`SvgBooleanSwitchComponent.getColors` and `SvgBooleanLightComponent.getColors` were byte-for-byte identical — a pure `(theme, colorName) → {offColor, labelColor, valueColor}` lookup over 8 named colors + a contrast fallback. The duplication is partly pre-existing but grew in #316 (the OFF-state port added the `offColor` line to all 9 cases in **both** files — 18 duplicated lines). Adding a theme color or changing the dimmer mapping meant editing two identical blocks in lockstep, and they could drift silently.

Closes #319.

## What

- New `boolean-control-colors.util.ts` (colocated with `boolean-control-layout.util.ts`): exports `interface BooleanControlColors` and pure `getBooleanControlColors(theme, colorName)`. Names mirror the sibling `BooleanControlLayout` / `getBooleanControlLayout` convention.
- `svg-boolean-switch` and `svg-boolean-light` `getColors` now delegate to it (guard + resolver + three assignments); public surface, field types (`string | null`), and `ngDoCheck` call sites unchanged.
- `SvgBooleanButtonComponent` left untouched — its `labelColorEnabled` / `labelColorDisabled` mapping is asymmetric and genuinely different.
- New `boolean-control-colors.util.spec.ts` pins all 8 named-color triples + the unknown→contrast fallback.

Pure, zero-behavior-change refactor: the color mapping is byte-identical to the two originals (both `contrast` and `default` resolve to the contrast triple).

## Verify

- `ng test` (switch/light components + both util specs): **31 passed**.
- `npm run lint`: clean. `npm run betterer:ci`: strictNullChecks **179, unchanged**.

## Review

Reviewed by 3 independent persona reviewers (correctness, testing, maintainability). Correctness confirmed the two originals were byte-identical and every case is preserved; testing confirmed the util spec's fake-theme (value == key) catches any transposed field and the component specs still exercise delegation. Maintainability's one P3 — names/interface should mirror the sibling util (`getBooleanControlLayout`) and `DimmerColors` misnamed the triple (only `offColor` is the *Dimmer*) — was **addressed on-branch** (renamed to `BooleanControlColors` / `getBooleanControlColors`).
