### PR TITLE
fix(boolean-switch): re-measure control height when fonts settle (#321)

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -193,9 +193,9 @@ exports[`strictNullChecks`] = {
       [1358, 21, 11, "\'b.longitude\' is possibly \'undefined\'.", "3370058570"],
       [1358, 35, 11, "\'a.longitude\' is possibly \'undefined\'.", "2985066057"]
     ],
-    "src/app/widgets/widget-boolean-switch/widget-boolean-switch.component.ts:1261729337": [
-      [77, 38, 9, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "4119212820"],
-      [100, 10, 12, "Object is possibly \'null\'.", "4261782498"]
+    "src/app/widgets/widget-boolean-switch/widget-boolean-switch.component.ts:802906206": [
+      [74, 38, 9, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "4119212820"],
+      [97, 10, 12, "Object is possibly \'null\'.", "4261782498"]
     ],
     "src/app/widgets/widget-datetime/widget-datetime.component.ts:3033260432": [
       [60, 40, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'string\'.", "2620553983"],

--- a/src/app/core/services/canvas.service.spec.ts
+++ b/src/app/core/services/canvas.service.spec.ts
@@ -95,3 +95,30 @@ describe('CanvasService resize handling (freeze-audit)', () => {
     vi.restoreAllMocks();
   });
 });
+
+describe('CanvasService text measurement (#321 font-race)', () => {
+  let service: CanvasService;
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(CanvasService);
+  });
+
+  it('measureTextWidth measures against the shorthand font and scales with text length', () => {
+    // jsdom canvas shim (src/test.ts) reports measureText width = text.length * 8
+    expect(service.measureTextWidth('abc', '700 14px Roboto')).toBe(24);
+    expect(service.measureTextWidth('abcdef', '700 14px Roboto')).toBe(48);
+  });
+
+  it('measureTextWidth lazily creates and reuses a single offscreen context', () => {
+    const createSpy = vi.spyOn(document, 'createElement');
+    service.measureTextWidth('a', '14px Roboto');
+    service.measureTextWidth('bb', '14px Roboto');
+    const canvasCreations = createSpy.mock.calls.filter(([tag]) => tag === 'canvas').length;
+    expect(canvasCreations).toBe(1); // created once on first use, reused thereafter
+    createSpy.mockRestore();
+  });
+
+  it('whenFontsReady resolves', async () => {
+    await expect(service.whenFontsReady()).resolves.toBeUndefined();
+  });
+});

--- a/src/app/core/services/canvas.service.ts
+++ b/src/app/core/services/canvas.service.ts
@@ -10,6 +10,8 @@ export class CanvasService {
   public debug = false;
   public scaleFactor = window.devicePixelRatio || 1;
   private fontsReadyPromise: Promise<void>;
+  /** Lazy shared offscreen context backing measureTextWidth. */
+  private textMeasureCtx: CanvasRenderingContext2D | null = null;
   private sharedResizeObserver: ResizeObserver | null = null;
   private observedCanvases = new Map<HTMLCanvasElement, { autoRelease?: boolean }>();
   private dprMediaQuery: MediaQueryList | null = null;
@@ -46,6 +48,31 @@ export class CanvasService {
   private areFontsLoaded(): boolean {
     const fonts = this.getDocumentFonts();
     return !fonts || fonts.status === 'loaded';
+  }
+
+  /**
+   * Resolves once web fonts have settled (or immediately when unavailable). Callers
+   * that lay out against measured text width should re-measure on resolution: a cold
+   * boot measures against fallback-font metrics until the web font loads.
+   */
+  public whenFontsReady(): Promise<void> {
+    return this.fontsReadyPromise;
+  }
+
+  /**
+   * Measures rendered text width for a full CSS font shorthand (e.g. '700 14px Roboto')
+   * against a shared offscreen context. Metrics reflect the loaded web font only once
+   * whenFontsReady() has resolved. Returns 0 when no canvas context is available.
+   */
+  public measureTextWidth(text: string, font: string): number {
+    if (!this.textMeasureCtx) {
+      this.textMeasureCtx = typeof document !== 'undefined'
+        ? document.createElement('canvas').getContext('2d')
+        : null;
+    }
+    if (!this.textMeasureCtx) return 0;
+    this.textMeasureCtx.font = font;
+    return this.textMeasureCtx.measureText(text).width;
   }
 
   /**

--- a/src/app/widgets/widget-boolean-switch/widget-boolean-switch.component.html
+++ b/src/app/widgets/widget-boolean-switch/widget-boolean-switch.component.html
@@ -10,7 +10,7 @@
           <app-svg-boolean-switch class="svg-widget"
             [controlData]="ctrl"
             [theme]="theme()"
-            [dimensions]="ctrlDimensions"
+            [dimensions]="ctrlDimensions()"
             (toggleClick)="toggle($event)">
           </app-svg-boolean-switch>
         }
@@ -18,7 +18,7 @@
           <app-svg-boolean-button class="svg-widget"
             [controlData]="ctrl"
             [theme]="theme()"
-            [dimensions]="ctrlDimensions"
+            [dimensions]="ctrlDimensions()"
             (toggleClick)="toggle($event)">
           </app-svg-boolean-button>
         }
@@ -26,7 +26,7 @@
           <app-svg-boolean-light class="svg-widget"
             [controlData]="ctrl"
             [theme]="theme()"
-            [dimensions]="ctrlDimensions"
+            [dimensions]="ctrlDimensions()"
             (toggleClick)="toggle($event)">
           </app-svg-boolean-light>
         }

--- a/src/app/widgets/widget-boolean-switch/widget-boolean-switch.component.spec.ts
+++ b/src/app/widgets/widget-boolean-switch/widget-boolean-switch.component.spec.ts
@@ -1,0 +1,110 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { WidgetBooleanSwitchComponent } from './widget-boolean-switch.component';
+import { CanvasService } from '../../core/services/canvas.service';
+import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
+import { WidgetStreamsDirective } from '../../core/directives/widget-streams.directive';
+import { DashboardService } from '../../core/services/dashboard.service';
+import { SignalkRequestsService } from '../../core/services/signalk-requests.service';
+import { ToastService } from '../../core/services/toast.service';
+import type { ITheme } from '../../core/services/app-service';
+import type { IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
+
+const themeMock = {
+  contrast: '#fff', contrastDim: '#ccc', contrastDimmer: '#999'
+} as unknown as ITheme;
+
+function config(): IWidgetSvcConfig {
+  return {
+    displayName: 'Switch Panel', showLabel: false, filterSelfPaths: true, paths: [],
+    enableTimeout: false, dataTimeout: 5, color: 'contrast', zonesOnlyPaths: false,
+    putEnable: true, putMomentary: false,
+    multiChildCtrls: [
+      { ctrlLabel: 'Nav', type: '1', pathID: 'p0', value: false, color: 'contrast', isNumeric: false },
+      { ctrlLabel: 'Anchor Light', type: '1', pathID: 'p1', value: false, color: 'contrast', isNumeric: false },
+    ],
+  } as unknown as IWidgetSvcConfig;
+}
+
+describe('WidgetBooleanSwitchComponent', () => {
+  let fixture: ComponentFixture<WidgetBooleanSwitchComponent>;
+  let component: WidgetBooleanSwitchComponent;
+  let resolveFonts: () => void;
+
+  let perCharWidth = 8;
+  const runtimeMock = { options: vi.fn() };
+  const streamsMock = { observe: vi.fn() };
+  const dashboardMock = { isDashboardStatic: () => true };
+  const canvasMock = {
+    DEFAULT_FONT: 'Roboto',
+    measureTextWidth: vi.fn((text: string) => String(text).length * perCharWidth),
+    whenFontsReady: vi.fn(() => new Promise<void>((res) => { resolveFonts = res; })),
+  };
+
+  const flushMicrotasks = async () => { await Promise.resolve(); await Promise.resolve(); };
+
+  const readDims = () =>
+    (component as unknown as { ctrlDimensions: () => { width: number; height: number } }).ctrlDimensions();
+
+  const resize = (width: number, height: number) =>
+    component.onResized({ contentRect: { width, height } } as ResizeObserverEntry);
+
+  const setup = async (options: IWidgetSvcConfig = config()) => {
+    runtimeMock.options.mockReturnValue(options);
+    await TestBed.configureTestingModule({
+      imports: [WidgetBooleanSwitchComponent],
+      providers: [
+        { provide: CanvasService, useValue: canvasMock },
+        { provide: WidgetRuntimeDirective, useValue: runtimeMock },
+        { provide: WidgetStreamsDirective, useValue: streamsMock },
+        { provide: DashboardService, useValue: dashboardMock },
+        { provide: SignalkRequestsService, useValue: {} },
+        { provide: ToastService, useValue: {} },
+      ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(WidgetBooleanSwitchComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('id', 'w-bool-1');
+    fixture.componentRef.setInput('type', 'widget-boolean-switch');
+    fixture.componentRef.setInput('theme', themeMock);
+    fixture.detectChanges();
+  };
+
+  afterEach(() => {
+    perCharWidth = 8;
+    vi.clearAllMocks();
+    TestBed.resetTestingModule();
+  });
+
+  it('measures the shared control height via CanvasService once the host has a size', async () => {
+    await setup();
+    resize(200, 260);
+    expect(canvasMock.measureTextWidth).toHaveBeenCalled();
+    expect(readDims().height).toBeGreaterThan(0);
+  });
+
+  it('re-measures when web fonts settle and the new metrics reach ctrlDimensions', async () => {
+    perCharWidth = 2;
+    await setup();
+    resize(200, 260);
+    const before = readDims().height;
+    expect(before).toBeGreaterThan(0);
+
+    perCharWidth = 60; // wider glyphs once the real web font is measured, vs the fallback
+    resolveFonts();
+    await flushMicrotasks();
+
+    expect(readDims().height).not.toBe(before);
+  });
+
+  it('does not measure or crash when fonts settle before the host has a size', async () => {
+    await setup();
+    resolveFonts(); // fonts ready before any ResizeObserver callback
+    await flushMicrotasks();
+    expect(canvasMock.measureTextWidth).not.toHaveBeenCalled();
+    expect(readDims().height).toBe(0);
+
+    resize(200, 260); // size arrives later -> now it measures
+    expect(readDims().height).toBeGreaterThan(0);
+  });
+});

--- a/src/app/widgets/widget-boolean-switch/widget-boolean-switch.component.ts
+++ b/src/app/widgets/widget-boolean-switch/widget-boolean-switch.component.ts
@@ -61,12 +61,9 @@ export class WidgetBooleanSwitchComponent implements OnDestroy {
     const cfg = this.runtime?.options();
     return (cfg?.showLabel === false) ? 'widgets-container-no-title' : 'widgets-container';
   });
-  public ctrlDimensions: IDimensions = { width: 0, height: 0 };
+  protected readonly ctrlDimensions = signal<IDimensions>({ width: 0, height: 0 });
   private hostSize: IDimensions = { width: 0, height: 0 };
   private skRequestSub = new Subscription();
-  private readonly measureCtx = typeof document !== 'undefined'
-    ? document.createElement('canvas').getContext('2d')
-    : null;
 
   constructor() {
     // Effect: theme / label color
@@ -115,6 +112,13 @@ export class WidgetBooleanSwitchComponent implements OnDestroy {
         });
       });
     });
+
+    // Label width is canvas-measured; a cold boot measures against fallback-font
+    // metrics until the web font settles, and nothing else re-measures on a static
+    // dashboard — so re-measure once fonts are ready.
+    this.canvas.whenFontsReady()
+      .then(() => this.updateCtrlDimensions())
+      .catch(() => { /* fonts.ready settling failed; keep the fallback-font metrics */ });
   }
 
   onResized(event: ResizeObserverEntry): void {
@@ -131,18 +135,14 @@ export class WidgetBooleanSwitchComponent implements OnDestroy {
     const controls = this.switchControls();
 
     if (!width || !height || !controls.length) {
-      this.ctrlDimensions = { width, height: 0 };
+      this.ctrlDimensions.set({ width, height: 0 });
       return;
     }
 
-    const measuredHeight = this.measureCtx
-      ? measureBooleanControlsHeight(width, height, controls, (text, fontSize) => {
-        this.measureCtx!.font = `700 ${fontSize}px ${this.canvas.DEFAULT_FONT}`;
-        return this.measureCtx!.measureText(text).width;
-      })
-      : Math.max(1, Math.floor(height / controls.length));
+    const measuredHeight = measureBooleanControlsHeight(width, height, controls, (text, fontSize) =>
+      this.canvas.measureTextWidth(text, `700 ${fontSize}px ${this.canvas.DEFAULT_FONT}`));
 
-    this.ctrlDimensions = { width, height: measuredHeight };
+    this.ctrlDimensions.set({ width, height: measuredHeight });
   }
 
   public toggle(ctrl: IDynamicControl): void {


### PR DESCRIPTION
## Why

The boolean-switch widget derives one shared control height from **canvas-measured label widths**. It measured against a *private* canvas that never re-ran on web-font load, and nothing re-measures on a static dashboard (only `onResized` and the config effect call `updateCtrlDimensions`). So on a cold boot — before Roboto settles — the panel could be sized against fallback-font metrics and keep the **wrong height for the whole session** until a manual resize. (Split out of #318; the long-label-shrink half was fixed in #320.)

Closes #321.

## What

- **`CanvasService.whenFontsReady()`** — exposes the service's existing `fontsReadyPromise` so callers that lay out against measured text can re-measure once fonts settle.
- **`CanvasService.measureTextWidth(text, font)`** — a shared offscreen-context text measure. The widget now routes through it instead of owning a private canvas (the issue's "reuse CanvasService's measurement" suggestion; also removes the duplicate context).
- **Widget**: re-measures on `whenFontsReady()`; `ctrlDimensions` becomes a **signal** so the post-font re-measure actually propagates to the controls under zoneless change detection (a plain-field mutation wouldn't).

**Scope note:** the issue also mentioned Roboto weight 700 not being registered. Deliberately left out — the *measurement* (`700px`) and the *render* (`font-weight:700`) both use weight 700, so they fall back consistently; it's a cosmetic choice, **not** the mis-size cause, and orthogonal to the race fix.

## Verify

- New `widget-boolean-switch.component.spec.ts` + `canvas.service.spec.ts` additions: **37 tests pass** — the re-measure fires on fonts-ready *and the new height reaches the signal*, the fonts-before-size ordering is safe, and `measureTextWidth`/`whenFontsReady` are covered directly. Lint clean; betterer flat at 179.
- **Machine render** (fresh prod build, headless Chromium on the target Pi): geometry is **identical** to pre-change (`c1`=90, `c3-short`=72, `c3-mixed`=44 floor), boot-assert clean — no rendering regression.

## Review

Reviewed by 4 independent personas (correctness, maintainability, testing, reliability). Correctness/maintainability found no defects (traced sound in every mount/font ordering; propagation correct). Addressed testing + reliability findings on-branch: added a direct `CanvasService.measureTextWidth`/`whenFontsReady` test (P2 — the fix's core primitive was only exercised through a mock), a `.catch` on the re-measure to match every other `fontsReadyPromise` consumer (P3), a stronger assertion that the re-measured height reaches `ctrlDimensions` (P3), and the fonts-before-size ordering test (P3).
