### PR TITLE
fix(perf-harness): seed configVersion 13 to skip the migration reload (#323)

### DIFF
--- a/perf-harness/lib/kip-config.mjs
+++ b/perf-harness/lib/kip-config.mjs
@@ -8,7 +8,7 @@
  *
  * Three distinct version spaces (all from src/app/core/constants/config-versions.const.ts):
  *  - applicationData URL path segment 11 (REMOTE_CONFIG_FILE_VERSION)
- *  - app.configVersion 12 (LATEST_APP_CONFIG_VERSION)
+ *  - app.configVersion 13 (LATEST_APP_CONFIG_VERSION)
  *  - connectionConfig.configVersion 13 (CONNECTION_CONFIG_VERSION)
  */
 export const SELF_URN = 'vessels.urn:mrn:signalk:uuid:11111111-1111-4111-8111-111111111111';
@@ -30,9 +30,12 @@ const DEFAULT_NOTIF = {
 };
 
 export function appConfig(extra = {}) {
+  // configVersion 13 with no dataSets field: a genuine post-v12->v13 config, so the
+  // boot skips ConfigurationUpgradeService's migration toast/reload (which is what
+  // strips dataSets/datasetUUID/chartEngine) inside the measurement window.
   return {
-    configVersion: 12, autoNightMode: false, redNightMode: false, nightModeBrightness: 0.27,
-    widgetHistoryDisabled: false, dataSets: [], unitDefaults: DEFAULT_UNITS,
+    configVersion: 13, autoNightMode: false, redNightMode: false, nightModeBrightness: 0.27,
+    widgetHistoryDisabled: false, unitDefaults: DEFAULT_UNITS,
     notificationConfig: DEFAULT_NOTIF, browserTabTitle: 'Skip', ...extra,
   };
 }

--- a/perf-harness/lib/kip-config.mjs
+++ b/perf-harness/lib/kip-config.mjs
@@ -160,6 +160,16 @@ export function localStorageBundle({ origin, subscribeAll }) {
   return { 'skip.connectionConfig': JSON.stringify(cc) };
 }
 
+/**
+ * Playwright addInitScript body: sets the boot-time test flag, then seeds the
+ * localStorageBundle() keys before the app script runs. Pass the object from
+ * localStorageBundle().
+ */
+export function initScriptContent(bundle) {
+  return `window.__KIP_TEST__=true;` +
+    Object.entries(bundle).map(([k, v]) => `localStorage.setItem(${JSON.stringify(k)}, ${JSON.stringify(v)});`).join('');
+}
+
 /** Full IConfig document the mock serves from applicationData/user/skip/<ver>/default. */
 export function serverConfigDocument({ dashboards, app = appConfig() }) {
   return { app, theme: { themeName: '' }, dashboards };

--- a/perf-harness/run.mjs
+++ b/perf-harness/run.mjs
@@ -19,7 +19,7 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { buildBranch, WORKTREES } from './lib/build-serve.mjs';
 import { startServer } from './lib/server.mjs';
-import { localStorageBundle, serverConfigDocument } from './lib/kip-config.mjs';
+import { localStorageBundle, serverConfigDocument, initScriptContent } from './lib/kip-config.mjs';
 import { scenarios as ALL } from './scenarios.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -124,9 +124,7 @@ async function main() {
       const dashboards = s.dashboards();
       server.setConfigDocument(serverConfigDocument({ dashboards }));
       const bundle = localStorageBundle({ origin: server.origin, subscribeAll: s.subscribeAll });
-      const injector = `window.__KIP_TEST__ = true;` +
-        Object.entries(bundle).map(([k, v]) => `localStorage.setItem(${JSON.stringify(k)}, ${JSON.stringify(v)});`).join('');
-      await ctx.addInitScript({ content: injector });
+      await ctx.addInitScript({ content: initScriptContent(bundle) });
       const page = await ctx.newPage();
       const cdp = await ctx.newCDPSession(page);
       await cdp.send('Emulation.setCPUThrottlingRate', { rate: THROTTLE });

--- a/perf-harness/screenshot.mjs
+++ b/perf-harness/screenshot.mjs
@@ -9,7 +9,7 @@ import { mkdir } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { startServer } from './lib/server.mjs';
-import { aisRadarWidget, buildDashboards, localStorageBundle, serverConfigDocument } from './lib/kip-config.mjs';
+import { aisRadarWidget, buildDashboards, localStorageBundle, serverConfigDocument, initScriptContent } from './lib/kip-config.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const CHROME = process.env.CHROME_BIN || '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
@@ -39,7 +39,7 @@ const browser = await chromium.launch({ executablePath: CHROME, headless: true }
 const ctx = await browser.newContext({ viewport: { width: 900, height: 900 }, deviceScaleFactor: 2 });
 await ctx.route('https://www.gstatic.com/generate_204', (route) => route.fulfill({ status: 204, body: '' }));
 const bundle = localStorageBundle({ origin: server.origin, subscribeAll: true });
-await ctx.addInitScript({ content: `window.__KIP_TEST__=true;` + Object.entries(bundle).map(([k, v]) => `localStorage.setItem(${JSON.stringify(k)}, ${JSON.stringify(v)});`).join('') });
+await ctx.addInitScript({ content: initScriptContent(bundle) });
 const page = await ctx.newPage();
 
 server.setControl({ streaming: true, staticScene: { ownShip: own, targets } });

--- a/perf-harness/shot-boolean.mjs
+++ b/perf-harness/shot-boolean.mjs
@@ -18,7 +18,7 @@ import { mkdir } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { startServer } from './lib/server.mjs';
-import { appConfig, booleanControlWidget, localStorageBundle } from './lib/kip-config.mjs';
+import { appConfig, booleanControlWidget, localStorageBundle, initScriptContent } from './lib/kip-config.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const CHROME = process.env.CHROME_BIN || '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
@@ -154,7 +154,7 @@ const outDir = join(HERE, 'results', 'shots', 'boolean');
 await mkdir(outDir, { recursive: true });
 
 const bundle = localStorageBundle({ origin: server.origin, subscribeAll: false });
-const initScript = { content: `window.__KIP_TEST__=true;` + Object.entries(bundle).map(([k, v]) => `localStorage.setItem(${JSON.stringify(k)}, ${JSON.stringify(v)});`).join('') };
+const initScript = { content: initScriptContent(bundle) };
 
 // --- day / default dark theme: full matrix ---
 server.setConfigDocument({ app: appConfig(), theme: { themeName: '' }, dashboards: dashboardsFor(scenarios) });

--- a/perf-harness/shot-boolean.mjs
+++ b/perf-harness/shot-boolean.mjs
@@ -156,13 +156,8 @@ await mkdir(outDir, { recursive: true });
 const bundle = localStorageBundle({ origin: server.origin, subscribeAll: false });
 const initScript = { content: `window.__KIP_TEST__=true;` + Object.entries(bundle).map(([k, v]) => `localStorage.setItem(${JSON.stringify(k)}, ${JSON.stringify(v)});`).join('') };
 
-// Pin to the current app-config schema (LATEST_APP_CONFIG_VERSION=13) so the boot
-// skips ConfigurationUpgradeService's v12->v13 migration toast/reload. That migration
-// only strips dataSets/datasetUUID/chartEngine, none of which touch the boolean widget.
-const appV13 = () => { const a = appConfig({ configVersion: 13 }); delete a.dataSets; return a; };
-
 // --- day / default dark theme: full matrix ---
-server.setConfigDocument({ app: appV13(), theme: { themeName: '' }, dashboards: dashboardsFor(scenarios) });
+server.setConfigDocument({ app: appConfig(), theme: { themeName: '' }, dashboards: dashboardsFor(scenarios) });
 const dayCtx = await browser.newContext({ viewport: VIEWPORT, deviceScaleFactor: 2 });
 await dayCtx.addInitScript(initScript);
 const dayRows = await runTheme({ ctx: dayCtx, url: server.appUrl, list: scenarios, dir: outDir });
@@ -170,7 +165,7 @@ await dayCtx.close();
 
 // --- config-driven light theme: key repros ---
 dseq = 0;
-server.setConfigDocument({ app: appV13(), theme: { themeName: 'light-theme' }, dashboards: dashboardsFor(lightScenarios) });
+server.setConfigDocument({ app: appConfig(), theme: { themeName: 'light-theme' }, dashboards: dashboardsFor(lightScenarios) });
 const lightCtx = await browser.newContext({ viewport: VIEWPORT, deviceScaleFactor: 2 });
 await lightCtx.addInitScript(initScript);
 const lightRows = await runTheme({ ctx: lightCtx, url: server.appUrl, list: lightScenarios, dir: outDir });


### PR DESCRIPTION
## Why

The perf-harness `appConfig()` default seeded `configVersion: 12`, but the app's `LATEST_APP_CONFIG_VERSION` is **13**. Every probe using the default (`run.mjs`, `screenshot.mjs`) therefore booted into `ConfigurationUpgradeService`'s v12→v13 migration (toast + reload) *inside its measurement window*, polluting the freeze/render numbers. `shot-boolean.mjs` worked around it locally with an `appV13()` override.

Closes #323.

## What

- **`appConfig()`** now seeds `configVersion: 13` and drops `dataSets: []` — a genuine post-v12→v13 config has no `dataSets` (the migration strips it), so the app boots without running the migration. Header comment corrected 12→13 (the other two version numbers already matched the const file).
- **`shot-boolean.mjs`**: removed the now-redundant `appV13()` workaround; uses `appConfig()` directly.
- **DRY** (2nd commit): the triplicated `window.__KIP_TEST__` + `localStorage.setItem` init-script is extracted to a shared `initScriptContent(bundle)` helper, used by `run.mjs`, `screenshot.mjs`, and `shot-boolean.mjs`.

perf-harness-only — no app-code changes, outside app CI/lint.

## Verify

All three probes boot-assert clean at v13 (a mis-seeded config would fail the boot check), run twice — after the primary fix and again after the DRY refactor:
- `shot-boolean.mjs` → exit 0, 20 tiles `ok`.
- `screenshot.mjs` → exit 0, AIS radar rendered.
- `run.mjs --scenarios resize-storm` → exit 0, **boot-asserts 28/28** (this is the key regression check — it seeds the default `appConfig()` via `serverConfigDocument`).

## Review

Correctness-reviewed against app source: confirmed the app skips migration at `configVersion === 13`, the v12→v13 transform strips exactly `dataSets`/`datasetUUID`/`chartEngine`, `IAppConfig`/`DefaultAppConfig` omit `dataSets`, and **no app code reads `app.dataSets`** — so removing it can't misbehave at boot. `initScriptContent` is byte-equivalent to the three inline injectors it replaces (the only difference, run.mjs's `= true` spacing, is inert — readers test truthiness only). No findings.
