### PR TITLE
test(perf-harness): render probes to machine-verify #216 + #245 off the boat

### DIFF
--- a/perf-harness/README.md
+++ b/perf-harness/README.md
@@ -92,6 +92,24 @@ that each tile rendered its seeded control count (exits non-zero otherwise). Inv
 with `CHROME_BIN=/usr/bin/chromium node shot-boolean.mjs --public ../public` after a
 `../public` build.
 
+`shot-embed.mjs` boots Skip with and without the `?embed` pre-hash query flag and
+asserts the #216 chromeless contract: the toolbar (`<app-toolbar>`) is present
+normally but unmounted under embed, while all seeded dashboard widgets still render;
+an unknown `?profile` falls back to the default dashboard. Exits non-zero on any
+failure; writes `results/shots/embed/<label>.png`. It verifies the Skip-side embed
+behavior, not rendering inside the actual Freeboard-SK drawer, and covers only the
+profile-fallback (not positive profile-switching, which needs a second seeded slot).
+
+`shot-units.mjs` renders a numeric widget per `convertUnitTo` across a unit spread
+and screenshots the grid to `results/shots/units/units-grid.png` — the #245 display-
+symbol probe (kn, km/h, °C, gal, gal/min, Ω, …). The unit label is canvas-drawn, so
+the machine step boot-asserts only the tile count; **symbol correctness is a human
+eyeball of the screenshot** (each tile is labelled by its measure key). The symbol
+resolution itself is unit-tested in `units.service.spec.ts`.
+
+Both invoke as `CHROME_BIN=/usr/bin/chromium node <probe> --public ../public` after a
+`../public` build.
+
 ## Interpreting the numbers
 
 | Question | Metric | Caveat |

--- a/perf-harness/lib/kip-config.mjs
+++ b/perf-harness/lib/kip-config.mjs
@@ -59,12 +59,12 @@ function node(w, h, x, y, widgetProperties) {
   return { x, y, w, h, id, selector: 'widget-host2', input: { widgetProperties } };
 }
 
-export function numericWidget({ path = 'self.navigation.speedOverGround', unit = 'knots', sampleTime = 500, miniChart = false } = {}) {
+export function numericWidget({ path = 'self.navigation.speedOverGround', unit = 'knots', sampleTime = 500, miniChart = false, displayName = 'N' } = {}) {
   const uuid = uid('num');
   return (x, y) => node(4, 6, x, y, {
     type: 'widget-numeric', uuid,
     config: {
-      displayName: 'N', filterSelfPaths: true,
+      displayName, filterSelfPaths: true,
       paths: { numericPath: { description: 'Numeric Data', path, source: 'default', pathType: 'number', isPathConfigurable: true, convertUnitTo: unit, sampleTime } },
       numDecimal: 1, showMiniChart: miniChart, color: 'blue', enableTimeout: false, dataTimeout: 5, ignoreZones: false,
     },

--- a/perf-harness/shot-embed.mjs
+++ b/perf-harness/shot-embed.mjs
@@ -1,0 +1,93 @@
+/*
+ * #216 embed-mode render probe. Boots Skip headless with and without the `?embed`
+ * pre-hash query flag and asserts the chromeless contract from E6/#216:
+ *   - Normal boot renders the toolbar (<app-toolbar>) AND the dashboard widgets.
+ *   - `?embed` unmounts the toolbar (the shell's `@if (dashboardVisible() && !embed())`)
+ *     while the dashboard content still renders (read-only chromeless).
+ *   - An unknown `?profile=<name>` boots gracefully (falls back to the user default,
+ *     per the contract) rather than crashing.
+ *
+ *   CHROME_BIN=/usr/bin/chromium node shot-embed.mjs --public ../public
+ *
+ * The embed flag lives in the pre-hash query (EmbedModeService reads window.location.search
+ * once at boot); the app routes with withHashLocation, so the URL is `<appUrl>?embed=1#/page/0`.
+ * Writes results/shots/embed/<label>.png and exits non-zero if any assertion fails.
+ */
+import { chromium } from 'playwright-core';
+import { mkdir } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { startServer } from './lib/server.mjs';
+import { appConfig, numericWidget, buildDashboards, localStorageBundle, serverConfigDocument, initScriptContent } from './lib/kip-config.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CHROME = process.env.CHROME_BIN || '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const arg = (n, d) => { const i = process.argv.indexOf(`--${n}`); return i >= 0 ? process.argv[i + 1] : d; };
+
+const publicDir = arg('public', join(HERE, '..', 'public'));
+const port = Number(arg('port', '4423'));
+const VIEWPORT = { width: 1280, height: 800 };
+
+const server = await startServer({ publicDir, base: '/@halos-org/skip/', port });
+const WIDGETS = [numericWidget(), numericWidget({ unit: 'celsius', path: 'self.environment.water.temperature' })];
+server.setConfigDocument(serverConfigDocument({ dashboards: buildDashboards(WIDGETS) }));
+
+const browser = await chromium.launch({ executablePath: CHROME, headless: true });
+const outDir = join(HERE, 'results', 'shots', 'embed');
+await mkdir(outDir, { recursive: true });
+
+const bundle = localStorageBundle({ origin: server.origin, subscribeAll: false });
+const initScript = { content: initScriptContent(bundle) };
+
+async function probe(label, query) {
+  const ctx = await browser.newContext({ viewport: VIEWPORT, deviceScaleFactor: 1 });
+  await ctx.addInitScript(initScript);
+  const page = await ctx.newPage();
+  const warnings = [];
+  page.on('console', (m) => { if (m.type() === 'warning' || m.type() === 'error') warnings.push(`[${m.type()}] ${m.text()}`); });
+  await page.goto('about:blank');
+  await page.goto(`${server.appUrl}${query}`, { waitUntil: 'load', timeout: 30000 });
+  await page.waitForSelector('widget-numeric', { timeout: 20000 }).catch(() => { /* asserted below */ });
+  await page.waitForTimeout(900); // let the shell + toolbar gate settle
+  const dom = await page.evaluate(() => ({
+    toolbar: !!document.querySelector('app-toolbar'),
+    widgets: document.querySelectorAll('widget-numeric').length,
+  }));
+  await page.screenshot({ path: join(outDir, `${label}.png`) });
+  await ctx.close();
+  return { label, ...dom, warnings };
+}
+
+const rows = [];
+rows.push(await probe('normal', '#/page/0'));
+rows.push(await probe('embed', '?embed=1#/page/0'));
+rows.push(await probe('embed-unknown-profile', '?embed=1&profile=does-not-exist#/page/0'));
+
+await browser.close();
+await server.stop();
+
+const byLabel = Object.fromEntries(rows.map((r) => [r.label, r]));
+console.log('\n=== embed-mode contract (#216) ===');
+console.log('label'.padEnd(24), 'toolbar', 'widgets');
+for (const r of rows) console.log(String(r.label).padEnd(24), String(r.toolbar).padEnd(7), r.widgets);
+
+// Surface any console warnings/errors so a real boot problem is visible (the
+// unknown-profile run legitimately warns about the missing slot).
+for (const r of rows) if (r.warnings.length) { console.log(`\n[${r.label}] console:`); for (const w of r.warnings) console.log('  ' + w); }
+
+// Assertions: toolbar present + ALL seeded widgets rendered normally; toolbar
+// unmounted under embed while all widgets still render (chromeless, not a partial
+// mis-seed); unknown profile falls back to the full default dashboard. Exact count
+// (not >=1) so a dropped widget can't pass — mirrors shot-boolean/shot-units.
+const checks = [
+  ['normal renders the toolbar', byLabel.normal.toolbar === true],
+  [`normal renders all ${WIDGETS.length} dashboard widgets`, byLabel.normal.widgets === WIDGETS.length],
+  ['embed unmounts the toolbar', byLabel.embed.toolbar === false],
+  [`embed still renders all ${WIDGETS.length} dashboard widgets (chromeless, not blank)`, byLabel.embed.widgets === WIDGETS.length],
+  [`embed + unknown profile boots the full default dashboard`, byLabel['embed-unknown-profile'].widgets === WIDGETS.length],
+];
+console.log('');
+let failed = 0;
+for (const [name, ok] of checks) { console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}`); if (!ok) failed++; }
+if (failed) { console.error(`\n${failed} embed assertion(s) failed`); process.exit(1); }
+console.log('\nall embed assertions passed');

--- a/perf-harness/shot-units.mjs
+++ b/perf-harness/shot-units.mjs
@@ -1,0 +1,67 @@
+/*
+ * #245 unit-display-symbol render probe. Renders a numeric widget per convertUnitTo
+ * across a spread of units and screenshots the grid, so the rendered unit labels can
+ * be checked against the display symbols units.service resolves (getUnitDisplaySymbol):
+ * the explicit symbol when one exists (kn, km/h, °C, gal, L, Ω...), else the measure
+ * key (mph, V, psi) — and NEVER the spelled-out description ("Celsius", "Gallons").
+ *
+ *   CHROME_BIN=/usr/bin/chromium node shot-units.mjs --public ../public
+ *
+ * The numeric widget canvas-renders its unit label, so this is a visual check: each
+ * tile's displayName is set to the measure key and the expected symbol is printed
+ * alongside for eyeballing the screenshot. The symbol resolves from convertUnitTo
+ * independent of the (unstreamed) value, so no live data is needed.
+ */
+import { chromium } from 'playwright-core';
+import { mkdir } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { startServer } from './lib/server.mjs';
+import { numericWidget, buildDashboards, localStorageBundle, serverConfigDocument, initScriptContent } from './lib/kip-config.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CHROME = process.env.CHROME_BIN || '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const arg = (n, d) => { const i = process.argv.indexOf(`--${n}`); return i >= 0 ? process.argv[i + 1] : d; };
+
+const publicDir = arg('public', join(HERE, '..', 'public'));
+const port = Number(arg('port', '4424'));
+const VIEWPORT = { width: 1290, height: 900 }; // 12-col grid, 4-wide tiles -> 3 per row
+
+// [measure (convertUnitTo), expected rendered symbol]. Covers the #245 transforms:
+// km/h rename, the gal/L/gal-per-min disambiguation, °C/°F, the ohm glyph, and a few
+// symbol-less units that must fall back to the measure key (not a spelled-out word).
+const UNITS = [
+  ['knots', 'kn'], ['kph', 'km/h'], ['mph', 'mph'],
+  ['celsius', '°C'], ['fahrenheit', '°F'], ['K', 'K'],
+  ['gallon', 'gal'], ['liter', 'L'], ['g/min', 'gal/min'],
+  ['ohm', 'Ω'], ['V', 'V'], ['psi', 'psi'],
+];
+
+const server = await startServer({ publicDir, base: '/@halos-org/skip/', port });
+server.setConfigDocument(serverConfigDocument({
+  dashboards: buildDashboards(UNITS.map(([measure]) => numericWidget({ unit: measure, displayName: measure }))),
+}));
+
+const browser = await chromium.launch({ executablePath: CHROME, headless: true });
+const outDir = join(HERE, 'results', 'shots', 'units');
+await mkdir(outDir, { recursive: true });
+
+const bundle = localStorageBundle({ origin: server.origin, subscribeAll: false });
+const ctx = await browser.newContext({ viewport: VIEWPORT, deviceScaleFactor: 2 });
+await ctx.addInitScript({ content: initScriptContent(bundle) });
+const page = await ctx.newPage();
+await page.goto('about:blank');
+await page.goto(`${server.appUrl}#/page/0`, { waitUntil: 'load', timeout: 30000 });
+await page.waitForSelector('widget-numeric', { timeout: 20000 });
+await page.waitForTimeout(1000); // let all canvases draw
+const count = await page.evaluate(() => document.querySelectorAll('widget-numeric').length);
+await page.screenshot({ path: join(outDir, 'units-grid.png'), fullPage: true });
+await ctx.close();
+await browser.close();
+await server.stop();
+
+console.log(`\n=== #245 unit symbols — expect each tile (labeled by measure) to render its symbol ===`);
+console.log('measure'.padEnd(12), 'expected symbol');
+for (const [measure, symbol] of UNITS) console.log(String(measure).padEnd(12), symbol);
+console.log(`\nrendered ${count}/${UNITS.length} numeric tiles -> results/shots/units/units-grid.png`);
+if (count !== UNITS.length) { console.error(`boot check failed: expected ${UNITS.length} tiles, got ${count}`); process.exit(1); }


### PR DESCRIPTION
## Why

The #257 campaign's Stage 1 is code-complete; the only remaining Stage-1 work is a single on-boat verification session, which **gates all of Stage 2** (Gate B). Two of that session's items are pure *rendering* checks that don't need the boat — this session already proved the boat-verify rendering is machine-runnable here (the #318/#320 boolean work). These probes move #216 and #245 off the boat so session 1 shrinks to what physically needs it (K1 approval, live-RPM/hover feel, the #197 capture).

## What

Two reusable perf-harness probes (perf-harness-only; outside app CI/lint):

- **`shot-embed.mjs` (#216)** — boots Skip with/without the `?embed` pre-hash flag and asserts the chromeless contract: `<app-toolbar>` present normally, **unmounted under embed**, all seeded widgets still render in both, and an unknown `?profile` falls back to the default dashboard (the console output shows the app's fallback warning firing). Exact-count boot-assert; exits non-zero on any failure.
- **`shot-units.mjs` (#245)** — renders a numeric widget per `convertUnitTo` across a unit spread and screenshots the grid; each tile's label resolves to the display symbol (kn, km/h, °C, gal, gal/min, Ω, …), never a spelled-out word.
- `numericWidget` gains a `displayName` param (default `'N'`, existing callers unchanged) so each units tile is labelled by its measure key.

## Verify (run on the target Pi against a current build)

- `shot-embed.mjs` → **all 5 assertions pass**; embed screenshot is cleanly chromeless (no toolbar), content rendered.
- `shot-units.mjs` → **12/12 tiles**, screenshot visually confirms every symbol: `kph→km/h`, `celsius→°C`, `gallon→gal`, `g/min→gal/min`, `ohm→Ω`, plus the measure-key fallbacks (mph, K, V, psi) — no descriptions rendered.

## Coverage limits (honest)

- **#245 symbols are a human eyeball** of the screenshot — the label is canvas-drawn (not DOM), so the machine step asserts only tile count. The symbol-*resolution* logic is already unit-tested in `units.service.spec.ts`; the screenshot backstops the render integration.
- **#216**: verifies the *Skip-side* embed behavior, not rendering inside the real Freeboard-SK drawer (external host). Covers the profile **fallback** path only, not positive profile-switching (needs a second seeded slot). Read-only is proven via toolbar-absence + content-presence, not per-gesture.

Relates to #216, #245, #257 (shrinks the Stage-1-close boat session).
