### PR TITLE
fix(types): resolve strictNullChecks in core/utils (#6, S2-1 cluster 1)

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -93,15 +93,6 @@ exports[`strictNullChecks`] = {
       [54, 4, 14, "Type \'null\' is not assignable to type \'CanvasRenderingContext2D\'.", "912271434"],
       [55, 4, 18, "Type \'null\' is not assignable to type \'HTMLCanvasElement\'.", "1193423419"]
     ],
-    "src/app/core/utils/dataScales.util.ts:2208923770": [
-      [54, 6, 12, "Type \'null\' is not assignable to type \'number\'.", "2083421902"]
-    ],
-    "src/app/core/utils/zones-highlight.utils.ts:1634660371": [
-      [42, 8, 5, "Type \'null\' is not assignable to type \'number\'.", "173263814"],
-      [43, 8, 5, "Type \'null\' is not assignable to type \'number\'.", "183473191"],
-      [72, 6, 5, "Type \'number | null\' is not assignable to type \'number\'.\\n  Type \'null\' is not assignable to type \'number\'.", "173263814"],
-      [78, 6, 5, "Type \'number | null\' is not assignable to type \'number\'.\\n  Type \'null\' is not assignable to type \'number\'.", "183473191"]
-    ],
     "src/app/widget-config/boolean-control-config/boolean-control-config.component.ts:37806614": [
       [26, 40, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"],
       [27, 39, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"],

--- a/src/app/core/utils/dataScales.util.ts
+++ b/src/app/core/utils/dataScales.util.ts
@@ -52,7 +52,7 @@ export function adjustLinearScaleAndMajorTicks(minValue: number, maxValue: numbe
 function calcNiceNumber(range: number, round: boolean): number {
   const exponent = Math.floor(Math.log10(range));   // exponent of range
   const fraction = range / Math.pow(10, exponent);  // fractional part of range
-  let niceFraction: number = null;                  // nice, rounded fraction
+  let niceFraction: number;                         // nice, rounded fraction
 
   if (round) {
       if (1.5 > fraction) {

--- a/src/app/core/utils/zones-highlight.utils.ts
+++ b/src/app/core/utils/zones-highlight.utils.ts
@@ -40,8 +40,8 @@ export function getHighlights(zones: ISkZone[], theme: ITheme, convertUnitTo: st
   // Sort zones based on lower value
   const sortedZones = [...zones].sort((a, b) => (a.lower ?? -Infinity) - (b.lower ?? -Infinity));
   for (const zone of sortedZones) {
-    let lower: number = null;
-    let upper: number = null;
+    let lower: number | null;
+    let upper: number | null;
 
     let color: string;
     switch (zone.state) {
@@ -79,8 +79,8 @@ export function getHighlights(zones: ISkZone[], theme: ITheme, convertUnitTo: st
       upper = unitsService.convertToUnit(convertUnitTo, zone.upper);
     }
 
-    // If unit conversion fails, skip this zone.
-    if (!Number.isFinite(lower) || !Number.isFinite(upper)) {
+    // If unit conversion fails (null) or is non-finite, skip this zone.
+    if (lower == null || upper == null || !Number.isFinite(lower) || !Number.isFinite(upper)) {
       continue;
     }
 


### PR DESCRIPTION
## Why

Opens **S2-1 (#6 strictNullChecks endgame)** — the first directory-cluster sub-PR of the migration that drives the betterer baseline to zero and flips `strictNullChecks` in the app tsconfig. Cluster: `src/app/core/utils` (2 pure helper files, 5 issues). Establishes the per-cluster flow (fix → `snc` clean → betterer regen).

## What

- **`dataScales.util.ts`** `calcNiceNumber`: drop the dead `= null` initializer on `niceFraction`. Both `round` and `!round` paths are complete if/elif/elif/else chains that assign a number before the `return`, so TS definite-assignment covers it — no cast, no suppression, no behavior change.
- **`zones-highlight.utils.ts`** `getHighlights`: type `lower`/`upper` as `number | null` (what `unitsService.convertToUnit` actually returns) and add explicit `== null` checks to the existing skip-guard so TS narrows to `number` for the rest of the loop. **Behavior-preserving:** `Number.isFinite(null)` is already `false`, so a null conversion already hit `continue` — the `== null` clause only adds the type narrowing, not a runtime change.

## Verify

- `npm run snc`: both files clean; total **179 → 174** (−5), no new errors introduced elsewhere.
- `.betterer.results` regenerated (both file blocks removed). `npm run lint` clean. No specs exist for these pure helpers or their gauge consumers; CI runs the full vitest suite per the S2-1 convention.

First of the S2-1 cluster series (#6).
