### PR TITLE
fix(types): resolve strictNullChecks in widget-config (#6, S2-1 cluster 2)

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -106,20 +106,10 @@ exports[`strictNullChecks`] = {
     "src/app/widget-config/dataset-chart-options/dataset-chart-options.component.ts:155376543": [
       [83, 26, 10, "Argument of type \'ISkPathData | null\' is not assignable to parameter of type \'ISkPathData\'.\\n  Type \'null\' is not assignable to type \'ISkPathData\'.", "384538813"]
     ],
-    "src/app/widget-config/display-chart-options/display-chart-options.component.ts:2641875525": [
-      [48, 4, 11, "Type \'{ label: string; value: string; }[]\' is not assignable to type \'never[]\'.\\n  Type \'{ label: string; value: string; }\' is not assignable to type \'never\'.", "3027418051"]
-    ],
     "src/app/widget-config/display-datetime/display-datetime.component.ts:2719976956": [
       [45, 51, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'FormControl<string>\'.", "2620553983"],
       [46, 53, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'FormControl<string>\'.", "2620553983"],
       [49, 10, 22, "Type \'null\' is not assignable to type \'Subscription\'.", "29842089"]
-    ],
-    "src/app/widget-config/electrical-family-setup/electrical-family-setup.component.ts:4115844403": [
-      [60, 48, 28, "Object is possibly \'undefined\'.", "758680035"],
-      [114, 4, 20, "Object is possibly \'undefined\'.", "2522653710"],
-      [115, 4, 20, "Object is possibly \'undefined\'.", "2522653710"],
-      [119, 4, 20, "Object is possibly \'undefined\'.", "2522653710"],
-      [120, 4, 20, "Object is possibly \'undefined\'.", "2522653710"]
     ],
     "src/app/widget-config/paths-options/paths-options.component.ts:2311600985": [
       [31, 51, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'IAddNewPathObject\'.", "2620553983"],
@@ -128,16 +118,6 @@ exports[`strictNullChecks`] = {
       [58, 28, 49, "Object is possibly \'null\'.", "3725617003"],
       [85, 26, 49, "Object is possibly \'null\'.", "3725617003"],
       [89, 26, 49, "Object is possibly \'null\'.", "3725617003"]
-    ],
-    "src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.ts:3462626181": [
-      [85, 4, 11, "Type \'{ label: string; value: string; }[]\' is not assignable to type \'never[]\'.\\n  Type \'{ label: string; value: string; }\' is not assignable to type \'never\'.", "3027418051"]
-    ],
-    "src/app/widget-config/solar-charger-setup/solar-charger-setup.component.ts:3993417046": [
-      [47, 48, 28, "Object is possibly \'undefined\'.", "758680035"],
-      [151, 4, 20, "Object is possibly \'undefined\'.", "2522653710"],
-      [152, 4, 20, "Object is possibly \'undefined\'.", "2522653710"],
-      [156, 4, 20, "Object is possibly \'undefined\'.", "2522653710"],
-      [157, 4, 20, "Object is possibly \'undefined\'.", "2522653710"]
     ],
     "src/app/widgets/svg-racesteer/svg-racesteer.component.ts:3776013780": [
       [36, 46, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"],

--- a/src/app/widget-config/display-chart-options/display-chart-options.component.ts
+++ b/src/app/widget-config/display-chart-options/display-chart-options.component.ts
@@ -43,7 +43,7 @@ export class DisplayChartOptionsComponent implements OnInit {
 
   readonly numDecimal = input.required<FormControl<number>>();
   readonly color = input.required<FormControl<string>>();
-  protected colors = [];
+  protected colors: { label: string; value: string }[] = [];
 
   ngOnInit(): void {
     this.colors = this.app.configurableThemeColors;

--- a/src/app/widget-config/electrical-family-setup/electrical-family-setup.component.ts
+++ b/src/app/widget-config/electrical-family-setup/electrical-family-setup.component.ts
@@ -58,7 +58,7 @@ export class ElectricalFamilySetupComponent implements OnInit, OnDestroy {
 
     return this.discoveredIds().map(id => ({ value: id, label: id }));
   });
-  protected readonly hasGroups = computed(() => this.groupsFormArray?.length > 0);
+  protected readonly hasGroups = computed(() => (this.groupsFormArray?.length ?? 0) > 0);
   protected readonly supportsGroups = computed(() => !!this.groupsFormArray);
 
   private discoveryToken?: PathDiscoveryToken;
@@ -104,6 +104,10 @@ export class ElectricalFamilySetupComponent implements OnInit, OnDestroy {
   }
 
   protected addGroup(): void {
+    const groupsFormArray = this.groupsFormArray;
+    if (!groupsFormArray) {
+      return;
+    }
     const slug = this.setupLabel().toLowerCase().replace(/\s+/g, '-');
     const nextGroup: ElectricalGroupConfig = {
       id: `${slug}-group-${Date.now()}`,
@@ -112,13 +116,17 @@ export class ElectricalFamilySetupComponent implements OnInit, OnDestroy {
       connectionMode: 'parallel'
     };
 
-    this.groupsFormArray.push(this.createGroup(nextGroup));
-    this.groupsFormArray.markAsDirty();
+    groupsFormArray.push(this.createGroup(nextGroup));
+    groupsFormArray.markAsDirty();
   }
 
   protected removeGroup(index: number): void {
-    this.groupsFormArray.removeAt(index);
-    this.groupsFormArray.markAsDirty();
+    const groupsFormArray = this.groupsFormArray;
+    if (!groupsFormArray) {
+      return;
+    }
+    groupsFormArray.removeAt(index);
+    groupsFormArray.markAsDirty();
   }
 
   protected compareTrackedDevice(

--- a/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.ts
+++ b/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.ts
@@ -63,7 +63,7 @@ export class RootModalWidgetConfigComponent implements OnInit {
   public addPathEvent: IAddNewPathObject;
   public delPathEvent: string;
   public updatePathEvent: IDynamicControl[];
-  public colors = [];
+  public colors: { label: string; value: string }[] = [];
   protected readonly saveDisabled = signal(true);
 
   ngOnInit() {

--- a/src/app/widget-config/solar-charger-setup/solar-charger-setup.component.ts
+++ b/src/app/widget-config/solar-charger-setup/solar-charger-setup.component.ts
@@ -45,7 +45,7 @@ export class SolarChargerSetupComponent implements OnInit, OnDestroy {
   protected readonly discoveredSolarIds = signal<string[]>([]);
   protected readonly discoveredTrackedDevices = signal<ElectricalTrackedDevice[]>([]);
   protected readonly selectedTrackedDeviceIds = signal<string[]>([]);
-  protected readonly hasGroups = computed(() => this.groupsFormArray?.length > 0);
+  protected readonly hasGroups = computed(() => (this.groupsFormArray?.length ?? 0) > 0);
   protected readonly supportsGroups = computed(() => !!this.groupsFormArray);
   protected readonly optionIds = computed(() => {
     const selected = this.selectedTrackedDeviceIds();
@@ -142,6 +142,10 @@ export class SolarChargerSetupComponent implements OnInit, OnDestroy {
   }
 
   protected addGroup(): void {
+    const groupsFormArray = this.groupsFormArray;
+    if (!groupsFormArray) {
+      return;
+    }
     const next: ElectricalGroupConfig = {
       id: `solar-bank-${Date.now()}`,
       name: 'New Group',
@@ -149,13 +153,17 @@ export class SolarChargerSetupComponent implements OnInit, OnDestroy {
       connectionMode: 'parallel'
     };
 
-    this.groupsFormArray.push(this.createGroup(next));
-    this.groupsFormArray.markAsDirty();
+    groupsFormArray.push(this.createGroup(next));
+    groupsFormArray.markAsDirty();
   }
 
   protected removeGroup(index: number): void {
-    this.groupsFormArray.removeAt(index);
-    this.groupsFormArray.markAsDirty();
+    const groupsFormArray = this.groupsFormArray;
+    if (!groupsFormArray) {
+      return;
+    }
+    groupsFormArray.removeAt(index);
+    groupsFormArray.markAsDirty();
   }
 
   private createGroup(group: ElectricalGroupConfig): UntypedFormGroup {


### PR DESCRIPTION
## Why

S2-1 (#6 strictNullChecks endgame) — the `src/app/widget-config` cluster. A **quality-over-coverage** pass: fully fix the files whose errors resolve cleanly and behavior-preservingly; **leave the delicate ones untouched and flag them** rather than force a cast that could hide a bug.

## Fully fixed (4 files, baseline 179 → 167)

- **`display-chart-options` + `root-modal-widget-config`**: `colors = []` (inferred `never[]`) → `colors: { label: string; value: string }[] = []`, matching `AppService.configurableThemeColors`. Pure type annotation.
- **`electrical-family-setup` + `solar-charger-setup`**: `hasGroups` → `(this.groupsFormArray?.length ?? 0) > 0` (behaviorally identical — `undefined > 0` and `0 > 0` are both `false`); `addGroup`/`removeGroup` narrow via a local-const guard. The guard is unreachable in practice — both are only invoked from controls inside `@if (supportsGroups())` (= `!!groupsFormArray`) — so behavior is preserved; the guard exists only for the compiler to narrow (a `!`/cast is forbidden by the migration convention).

## Deferred / flagged (left untouched — the important part)

- **`dataset-chart-options`** — flagging surfaced a **real latent bug**: `ngOnInit` passes a possibly-null `getPathObject()` into `setPathSources()` (which derefs it), while the sibling `changePath()` guards `=== null`. A saved chart path with no current data crashes on open. Filed as **#329** (the fix is a behavior change, so it belongs outside this pure-type cluster).
- **`boolean-control-config`, `display-datetime`** — clean fix needs converting `input<T>(undefined)` to `input.required<T>()`, a public input-contract change; `display-datetime` is also #25 typed-forms territory.
- **`boolean-multicontrol-options`** — `convertUnitTo: null` fails because `IWidgetPath.convertUnitTo?: string` omits the `null` its own JSDoc documents as the sentinel; the honest fix widens the shared core interface (#25-adjacent, could ripple).
- **`paths-options`** — excluded (overlaps #25, already partly retyped by H7).

These remain in #6's backlog for careful individual treatment.

## Verify

`npm run snc`: the 4 fixed files clean, total **179 → 167** (−12), no new errors. `.betterer.results` regenerated. `npm run lint` clean. The 4 modified components' specs: **4 files / 28 tests pass**. CI runs the full suite.

**Merge note:** touches `.betterer.results`, so it serializes with #328 — merge #328 first, then this rebases + regenerates onto the new baseline. #6, S2-1 cluster 2.
