### PR TITLE
fix(types): resolve strictNullChecks in core/components (#6, S2-1 cluster 3)

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -44,55 +44,6 @@ exports[`strictNullChecks`] = {
       [743, 8, 15, "\'_gridstack.grid\' is possibly \'undefined\'.", "3391422426"],
       [752, 4, 22, "Object is possibly \'undefined\'.", "2187394131"]
     ],
-    "src/app/core/components/dashboards-editor/dashboards-editor.component.ts:976168273": [
-      [80, 39, 40, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "1983996063"],
-      [94, 6, 4, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "2087876002"],
-      [140, 17, 13, "\'currentActive\' is possibly \'null\'.", "194687392"],
-      [140, 56, 13, "\'currentActive\' is possibly \'null\'.", "194687392"],
-      [142, 44, 13, "\'currentActive\' is possibly \'null\'.", "194687392"],
-      [143, 17, 13, "\'currentActive\' is possibly \'null\'.", "194687392"],
-      [143, 56, 13, "\'currentActive\' is possibly \'null\'.", "194687392"],
-      [145, 44, 13, "\'currentActive\' is possibly \'null\'.", "194687392"]
-    ],
-    "src/app/core/components/data-inspector-row/data-inspector-row.component.ts:3525188709": [
-      [25, 34, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'string\'.", "2620553983"],
-      [34, 4, 10, "Type \'IConversionPathList\' is not assignable to type \'null\'.", "4013178488"],
-      [35, 24, 10, "Object is possibly \'null\'.", "4013178488"]
-    ],
-    "src/app/core/components/data-inspector/data-inspector.component.ts:2942185648": [
-      [71, 4, 20, "Type \'Signal<BreakpointState | undefined>\' is not assignable to type \'Signal<BreakpointState>\'.\\n  Type \'Signal<BreakpointState | undefined>\' is not assignable to type \'() => BreakpointState\'.\\n    Type \'BreakpointState | undefined\' is not assignable to type \'BreakpointState\'.\\n      Type \'undefined\' is not assignable to type \'BreakpointState\'.", "1507091964"]
-    ],
-    "src/app/core/components/options/notifications/notifications.component.ts:3253454142": [
-      [41, 4, 20, "Type \'Signal<BreakpointState | undefined>\' is not assignable to type \'Signal<BreakpointState>\'.\\n  Type \'Signal<BreakpointState | undefined>\' is not assignable to type \'() => BreakpointState\'.\\n    Type \'BreakpointState | undefined\' is not assignable to type \'BreakpointState\'.\\n      Type \'undefined\' is not assignable to type \'BreakpointState\'.", "1507091964"],
-      [47, 4, 24, "Object is possibly \'undefined\'.", "2222700196"],
-      [54, 6, 17, "Object is possibly \'undefined\'.", "2944426029"],
-      [55, 6, 17, "Object is possibly \'undefined\'.", "27783321"]
-    ],
-    "src/app/core/components/options/signalk/signalk.component.ts:2801402843": [
-      [102, 10, 6, "Type \'null\' is not assignable to type \'Chart<keyof ChartTypeRegistry, (number | [number, number] | Point | BubbleDataPoint | null)[], unknown>\'.", "3491622934"],
-      [111, 45, 20, "Object is possibly \'undefined\'.", "235433357"],
-      [172, 28, 20, "Object is possibly \'undefined\'.", "235433357"],
-      [172, 28, 51, "Argument of type \'CanvasRenderingContext2D | null\' is not assignable to parameter of type \'ChartItem\'.\\n  Type \'null\' is not assignable to type \'ChartItem\'.", "38422540"]
-    ],
-    "src/app/core/components/options/units/units.component.ts:2220224509": [
-      [36, 19, 4, "Argument of type \'IUnit\' is not assignable to parameter of type \'never\'.", "2087995779"]
-    ],
-    "src/app/core/components/settings/settings.component.ts:794917258": [
-      [23, 45, 23, "Object is possibly \'undefined\'.", "214257314"],
-      [24, 46, 24, "Object is possibly \'undefined\'.", "3441589046"]
-    ],
-    "src/app/core/components/widget-embedded/widget-embedded.component.ts:3928020917": [
-      [114, 4, 13, "Type \'Type<WidgetViewComponentBase> | undefined\' is not assignable to type \'Type<WidgetViewComponentBase>\'.\\n  Type \'undefined\' is not assignable to type \'Type<WidgetViewComponentBase>\'.", "2689238020"]
-    ],
-    "src/app/core/components/widget-host2/widget-host2.component.ts:4255652117": [
-      [134, 4, 13, "Type \'Type<WidgetViewComponentBase> | undefined\' is not assignable to type \'Type<WidgetViewComponentBase>\'.\\n  Type \'undefined\' is not assignable to type \'Type<WidgetViewComponentBase>\'.", "2689238020"],
-      [250, 32, 9, "Type \'null\' cannot be used as an index type.", "2171020380"]
-    ],
-    "src/app/core/components/widget-title/widget-title.component.ts:2551944470": [
-      [25, 4, 14, "Type \'CanvasRenderingContext2D | null\' is not assignable to type \'CanvasRenderingContext2D\'.\\n  Type \'null\' is not assignable to type \'CanvasRenderingContext2D\'.", "912271434"],
-      [54, 4, 14, "Type \'null\' is not assignable to type \'CanvasRenderingContext2D\'.", "912271434"],
-      [55, 4, 18, "Type \'null\' is not assignable to type \'HTMLCanvasElement\'.", "1193423419"]
-    ],
     "src/app/widget-config/boolean-control-config/boolean-control-config.component.ts:37806614": [
       [26, 40, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"],
       [27, 39, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"],

--- a/src/app/core/components/dashboards-editor/dashboards-editor.component.ts
+++ b/src/app/core/components/dashboards-editor/dashboards-editor.component.ts
@@ -92,7 +92,7 @@ export class DashboardsEditorComponent {
     const dashboard = this._dashboard.dashboards()[itemIndex];
     this._dialog.openDashboardPageEditorDialog({
       title: 'Page Options',
-      name: dashboard.name,
+      name: dashboard.name ?? '',
       icon: dashboard.icon || 'dashboard-dashboard',
       confirmBtnText: 'Save',
       cancelBtnText: 'Cancel'
@@ -102,7 +102,7 @@ export class DashboardsEditorComponent {
     });
   }
 
-  private duplicateDashboard(itemIndex: number, currentName: string): void {
+  private duplicateDashboard(itemIndex: number, currentName: string | undefined): void {
     const originalDashboard = this._dashboard.dashboards()[itemIndex];
     this._dialog.openDashboardPageEditorDialog({
       title: 'Duplicate Page',
@@ -138,10 +138,10 @@ export class DashboardsEditorComponent {
       if (currentActive === event.previousIndex) {
         // Active item was moved to new position
         this._dashboard.activeDashboard.set(event.currentIndex);
-      } else if (currentActive > event.previousIndex && currentActive <= event.currentIndex) {
+      } else if (currentActive !== null && currentActive > event.previousIndex && currentActive <= event.currentIndex) {
         // Active item shifted down due to move
         this._dashboard.activeDashboard.set(currentActive - 1);
-      } else if (currentActive < event.previousIndex && currentActive >= event.currentIndex) {
+      } else if (currentActive !== null && currentActive < event.previousIndex && currentActive >= event.currentIndex) {
         // Active item shifted up due to move
         this._dashboard.activeDashboard.set(currentActive + 1);
       }

--- a/src/app/core/components/data-inspector-row/data-inspector-row.component.ts
+++ b/src/app/core/components/data-inspector-row/data-inspector-row.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, ViewEncapsulation, input, inject, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
 import { MatDialog, MatDialogRef, MAT_DIALOG_DATA, MatDialogTitle, MatDialogContent, MatDialogActions, MatDialogClose } from '@angular/material/dialog';
 
-import { UnitsService } from '../../services/units.service';
+import { UnitsService, IConversionPathList } from '../../services/units.service';
 import { MatCell } from '@angular/material/table';
 import { MatButtonModule } from '@angular/material/button';
 import { MatOptgroup, MatOption } from '@angular/material/core';
@@ -23,17 +23,18 @@ export class DataInspectorRowComponent implements OnInit {
   private _dialog = inject(MatDialog);
   private readonly cdr = inject(ChangeDetectorRef);
   readonly path = input.required<string>();
-  readonly source = input<string>(undefined);
+  readonly source = input<string | undefined>(undefined);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   readonly pathValue = input<any>(undefined);
   readonly type = input.required<string>();
 
-  units = null;
+  units: IConversionPathList | null = null;
   selectedUnit = "unitless"
 
   ngOnInit() {
-    this.units = this._units.getConversionsForPath(this.path());
-    this.selectedUnit = this.units.base;
+    const conversions = this._units.getConversionsForPath(this.path());
+    this.units = conversions;
+    this.selectedUnit = conversions.base;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/app/core/components/data-inspector/data-inspector.component.ts
+++ b/src/app/core/components/data-inspector/data-inspector.component.ts
@@ -69,7 +69,7 @@ export class DataInspectorComponent implements AfterViewInit, OnDestroy {
       }
     });
 
-    this.isPhonePortrait = toSignal(this._responsive.observe(Breakpoints.HandsetPortrait));
+    this.isPhonePortrait = toSignal(this._responsive.observe(Breakpoints.HandsetPortrait), { requireSync: true });
 
     effect(() => {
       if (this.isPhonePortrait().matches) {

--- a/src/app/core/components/options/notifications/notifications.component.ts
+++ b/src/app/core/components/options/notifications/notifications.component.ts
@@ -32,14 +32,14 @@ export class SettingsNotificationsComponent {
   private settings = inject(SettingsService);
   private _responsive = inject(BreakpointObserver);
   protected isPhonePortrait: Signal<BreakpointState>;
-  readonly notificationsForm = viewChild<NgForm>('notificationsForm');
-  readonly statePanel = viewChild<MatExpansionPanel>('statePanel');
-  readonly soundPanel = viewChild<MatExpansionPanel>('soundPanel');
+  readonly notificationsForm = viewChild.required<NgForm>('notificationsForm');
+  readonly statePanel = viewChild.required<MatExpansionPanel>('statePanel');
+  readonly soundPanel = viewChild.required<MatExpansionPanel>('soundPanel');
   public notificationConfig: INotificationConfig;
   public notificationDisabledExpandPanel = false;
 
   constructor() {
-    this.isPhonePortrait = toSignal(this._responsive.observe(Breakpoints.HandsetPortrait));
+    this.isPhonePortrait = toSignal(this._responsive.observe(Breakpoints.HandsetPortrait), { requireSync: true });
     this.notificationConfig = cloneDeep(this.settings.getNotificationConfig());
   }
 

--- a/src/app/core/components/options/signalk/signalk.component.ts
+++ b/src/app/core/components/options/signalk/signalk.component.ts
@@ -100,7 +100,7 @@ export class SettingsSignalkComponent implements OnInit, AfterViewInit, OnDestro
   });
 
 
-  private _chart: Chart = null;
+  private _chart: Chart | null = null;
   private textColor: string; // Store the computed text color for chart styling
 
   ngOnInit() {
@@ -109,19 +109,23 @@ export class SettingsSignalkComponent implements OnInit, AfterViewInit, OnDestro
   }
 
   ngAfterViewInit(): void {
-    this.textColor = window.getComputedStyle(this.activityGraph().nativeElement).color;
+    const canvas = this.activityGraph()?.nativeElement;
+    if (!canvas) return;
+    this.textColor = window.getComputedStyle(canvas).color;
     this._chart?.destroy();
-    this.startChart();
+    this.startChart(canvas);
 
     // Get real-time WebSocket Delta update statistics for chart
     this.DataService.getSignalkDeltaUpdateStatistics().pipe(
       takeUntilDestroyed(this.destroyRef)
     ).subscribe((update: IDeltaUpdate) => {
-      this._chart.data.datasets[0].data.push({ x: update.timestamp, y: update.value });
-      if (this._chart.data.datasets[0].data.length > 10) {
-        this._chart.data.datasets[0].data.shift();
+      const chart = this._chart;
+      if (!chart) return;
+      chart.data.datasets[0].data.push({ x: update.timestamp, y: update.value });
+      if (chart.data.datasets[0].data.length > 10) {
+        chart.data.datasets[0].data.shift();
       }
-      this._chart?.update("none");
+      chart.update("none");
     });
   }
 
@@ -169,8 +173,10 @@ export class SettingsSignalkComponent implements OnInit, AfterViewInit, OnDestro
    * Initializes the Chart.js line chart for displaying WebSocket delta statistics.
    * Creates a time-series chart showing data update frequency over time.
    */
-  private startChart() {
-    this._chart = new Chart(this.activityGraph().nativeElement.getContext('2d'), {
+  private startChart(canvas: HTMLCanvasElement) {
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    this._chart = new Chart(ctx, {
       type: 'line',
       data: {
         datasets: [

--- a/src/app/core/components/options/units/units.component.ts
+++ b/src/app/core/components/options/units/units.component.ts
@@ -31,7 +31,7 @@ export class SettingsUnitsComponent implements OnInit {
 
     for (const groupRaw of unitGroupsRaw) {
       if (groupRaw.group === "Position") continue; // Skip the iteration when key is "Position" as it's not a valid unit group as-is. We need to use position Objects instead. Then we can set format properly.
-      const units = [];
+      const units: IUnit[] = [];
 
       for (const unit of groupRaw.units) {
         units.push(unit);

--- a/src/app/core/components/settings/settings.component.ts
+++ b/src/app/core/components/settings/settings.component.ts
@@ -19,8 +19,8 @@ export class SettingsComponent {
   private readonly _router = inject(Router);
   protected readonly app = inject(AppService);
   private readonly _responsive = inject(BreakpointObserver);
-  private readonly _isPhonePortrait = toSignal(this._responsive.observe(Breakpoints.HandsetPortrait));
-  private readonly _isPhoneLandscape = toSignal(this._responsive.observe(Breakpoints.HandsetLandscape));
+  private readonly _isPhonePortrait = toSignal(this._responsive.observe(Breakpoints.HandsetPortrait), { requireSync: true });
+  private readonly _isPhoneLandscape = toSignal(this._responsive.observe(Breakpoints.HandsetLandscape), { requireSync: true });
   protected isPhonePortrait = computed(() => this._isPhonePortrait().matches);
   protected isPhoneLandscape = computed(() => this._isPhoneLandscape().matches);
 

--- a/src/app/core/components/widget-embedded/widget-embedded.component.ts
+++ b/src/app/core/components/widget-embedded/widget-embedded.component.ts
@@ -88,7 +88,7 @@ export class WidgetEmbeddedComponent implements OnInit, OnDestroy {
   // True when the widget's lazy chunk could not be resolved, so the template shows a retry affordance.
   protected readonly loadFailed = signal(false);
   private childRef: ComponentRef<WidgetViewComponentBase>;
-  private compType: Type<WidgetViewComponentBase>
+  private compType: Type<WidgetViewComponentBase> | undefined
   private _destroyed = false;
 
   constructor() {

--- a/src/app/core/components/widget-host2/widget-host2.component.ts
+++ b/src/app/core/components/widget-host2/widget-host2.component.ts
@@ -76,7 +76,7 @@ export class WidgetHost2Component extends BaseWidget implements OnInit, OnDestro
   // instead of a silent blank tile.
   protected readonly loadFailed = signal(false);
   private childRef: ComponentRef<WidgetViewComponentBase> | null = null;
-  private compType: Type<WidgetViewComponentBase>
+  private compType: Type<WidgetViewComponentBase> | undefined
   private _hasInitialized = false;
   private _destroyed = false;
   private readonly openOverlays = new Set<TOverlayGate>();
@@ -248,7 +248,7 @@ export class WidgetHost2Component extends BaseWidget implements OnInit, OnDestro
     try {
       const dashboards = this.dashboard.dashboards();
       const activeIdx = this.dashboard.activeDashboard();
-      const dash = dashboards?.[activeIdx];
+      const dash = activeIdx == null ? undefined : dashboards?.[activeIdx];
       type NodeWithConfig = NgGridStackWidget & {
         input?: { widgetProperties?: { config?: IWidgetSvcConfig } };
         widgetProperties?: { config?: IWidgetSvcConfig };

--- a/src/app/core/components/widget-title/widget-title.component.ts
+++ b/src/app/core/components/widget-title/widget-title.component.ts
@@ -12,8 +12,8 @@ export class WidgetTitleComponent implements AfterViewInit, OnChanges, OnDestroy
   protected color = input.required<string>();
   protected canvasRef = viewChild.required<ElementRef<HTMLCanvasElement>>('canvas');
   private canvas = inject(CanvasService);
-  private canvasElement: HTMLCanvasElement;
-  private canvasCtx: CanvasRenderingContext2D;
+  private canvasElement: HTMLCanvasElement | null = null;
+  private canvasCtx: CanvasRenderingContext2D | null = null;
   private isReady = false;
   private cssWidth = 0;
   private cssHeight = 0;
@@ -45,12 +45,12 @@ export class WidgetTitleComponent implements AfterViewInit, OnChanges, OnDestroy
   }
 
   protected drawTitle() {
-    if (!this.isReady) return;
+    if (!this.isReady || !this.canvasCtx) return;
     this.canvas.drawTitle(this.canvasCtx, this.text(), this.color(), 'normal', this.cssWidth, this.cssHeight);
   }
 
   ngOnDestroy(): void {
-    try { this.canvas.unregisterCanvas(this.canvasElement); }
+    try { if (this.canvasElement) this.canvas.unregisterCanvas(this.canvasElement); }
     catch { /* ignore */ }
     this.canvasCtx = null;
     this.canvasElement = null;


### PR DESCRIPTION
## Why

S2-1 (#6 strictNullChecks endgame) — the `src/app/core/components` cluster (10 files; **`dashboard.component.ts` deliberately excluded** — its ~35 gridstack-null errors get separate careful handling). All 10 fully fixed, **179 → 150** (−29).

## What (all behavior-preserving; no `!`, no `as`, no suppressions)

- **`toSignal(BreakpointObserver.observe(...))` → `{ requireSync: true }`** (data-inspector, notifications, settings ×2): types the signal as non-`undefined`. **Honest caveat:** this is behavior-*adjacent*, not a pure type change — `requireSync` removes the (never-observable) initial `undefined` tick and would throw NG0601 if `observe()` ever failed to emit synchronously. Verified sound: CDK `observe()` emits synchronously (`combineLatest` of `startWith`-seeded queries via `concat(take(1),…)`) in browser, SSR, and the jsdom shim, so it never throws; and the old code already relied on that same sync guarantee (it would have `.matches`-derefed `undefined` otherwise). Net: identical behavior for every reachable input; a *shift in failure timing*, not new fragility.
- **`viewChild<T>()` → `viewChild.required<T>()`** (notifications ×3): the three refs are unconditional in the template and read only in post-view-init user handlers, so `.required` always resolves.
- **`colors: never[]` → typed annotation** (units accumulator); **`_chart`/`canvasCtx`/`canvasElement` → `| null`** with guards matching the pre-existing no-op paths (`CanvasService.drawTitle`/`unregisterCanvas` already early-return on null); **`compType | undefined`** (type-only, every read already guarded); **`drop()` `currentActive !== null`** guards (protective — non-null at drop time via the first `NavigationEnd`).

## Review

Reviewed by **correctness + adversarial** personas (this cluster earned the extra scrutiny for its construction-time-throw surface). **Both returned zero findings** after tracing each invariant — CDK's synchronous-emit contract, the unconditional viewChild refs, and the `activeDashboard` non-null-at-drop ordering. Residuals noted transparently (the `requireSync` CDK-contract dependency; the `drop()` guards being protective dead-code today).

## Verify

`npm run snc`: 10 files clean, **179 → 150**, no new errors. `.betterer.results` regenerated. `npm run lint` clean. 9 of 10 components have specs — **all 9 pass, 37 tests** (the specs `detectChanges()`, exercising the `requireSync` construction path). CI runs the full suite.

**Merge note:** touches `.betterer.results` — serializes with #328 and #330 (merge in sequence, rebase + regen each). #6, S2-1 cluster 3.
