### PR TITLE
fix(widget-ais-radar): resolve strictNullChecks violations

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -40,20 +40,6 @@ exports[`strictNullChecks`] = {
       [22, 41, 4, "Argument of type \'null\' is not assignable to parameter of type \'string\'.", "2087897566"],
       [23, 42, 4, "Argument of type \'null\' is not assignable to parameter of type \'string\'.", "2087897566"]
     ],
-    "src/app/widgets/widget-ais-radar/widget-ais-radar.component.ts:3930432924": [
-      [416, 34, 9, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "4119212820"],
-      [543, 29, 17, "Object is possibly \'undefined\'.", "671087258"],
-      [738, 49, 14, "Argument of type \'Position | undefined\' is not assignable to parameter of type \'Position\'.\\n  Type \'undefined\' is not assignable to type \'Position\'.", "3448801501"],
-      [739, 56, 14, "Argument of type \'Position | undefined\' is not assignable to parameter of type \'Position\'.\\n  Type \'undefined\' is not assignable to type \'Position\'.", "3448801501"],
-      [762, 8, 6, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "2141063537"],
-      [774, 8, 6, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "2141063537"],
-      [1355, 17, 10, "\'a.latitude\' is possibly \'undefined\'.", "3625974138"],
-      [1356, 17, 10, "\'b.latitude\' is possibly \'undefined\'.", "3132265881"],
-      [1357, 18, 10, "\'b.latitude\' is possibly \'undefined\'.", "3132265881"],
-      [1357, 31, 10, "\'a.latitude\' is possibly \'undefined\'.", "3625974138"],
-      [1358, 21, 11, "\'b.longitude\' is possibly \'undefined\'.", "3370058570"],
-      [1358, 35, 11, "\'a.longitude\' is possibly \'undefined\'.", "2985066057"]
-    ],
     "src/app/widgets/widget-multi-state-switch/widget-multi-state-switch.component.ts:3679063603": [
       [160, 22, 10, "Object is possibly \'undefined\'.", "3996575854"]
     ],

--- a/src/app/widgets/widget-ais-radar/widget-ais-radar.component.ts
+++ b/src/app/widgets/widget-ais-radar/widget-ais-radar.component.ts
@@ -46,7 +46,7 @@ interface RenderTarget {
   x: number;
   y: number;
   heading: number;
-  status: string;
+  status: string | undefined;
   aisClass: string | undefined;
   type: string;
   iconHref: string | null;
@@ -414,7 +414,7 @@ export class WidgetAisRadarComponent implements AfterViewInit, OnDestroy {
     // Rings/labels only change with data (size/range/theme/showSelf), never
     // with rotation — rebuild them only on a data change.
     if (dataChanged) {
-      const ringColor = getColors(cfg.color, theme).dim;
+      const ringColor = getColors(cfg.color ?? 'contrast', theme).dim;
       this.renderRings(ringCount, rangeNm, radius, maxRingRadius, viewRotation, scale, radarCfg.showSelf ?? true, ownShipRotation, ringColor);
     }
 
@@ -467,7 +467,7 @@ export class WidgetAisRadarComponent implements AfterViewInit, OnDestroy {
     ownShipRotation: number,
     ringColor: string
   ): void {
-    if (!this.ringsLayer) return;
+    if (!this.ringsLayer || !this.ownShipLayer) return;
 
     const ringKey = `${rangeNm.toFixed(3)}|${radius.toFixed(3)}|${maxRadius.toFixed(3)}|${ringCount}`;
     if (!this.ringCache || this.ringCache.key !== ringKey) {
@@ -724,7 +724,7 @@ export class WidgetAisRadarComponent implements AfterViewInit, OnDestroy {
       }
     }
 
-    const candidates = tracks.filter(track => {
+    const candidates = tracks.filter((track): track is AisTrack & { position: Position } => {
       if (track.ais.status === 'remove') return false;
       if (track.ais.status === 'lost' && !showLost) return false;
       if (track.ais.status === 'unconfirmed' && !showUnconfirmed) return false;
@@ -1158,7 +1158,7 @@ export class WidgetAisRadarComponent implements AfterViewInit, OnDestroy {
     ].join('|');
   }
 
-  private buildClassName(target: { status: string; type: string; aisClass: string | undefined; navState: string | undefined; id: string }): string {
+  private buildClassName(target: { status: string | undefined; type: string; aisClass: string | undefined; navState: string | undefined; id: string }): string {
     const classes = [
       `status-${target.status}`,
       `type-${target.type}`,
@@ -1353,10 +1353,15 @@ export class WidgetAisRadarComponent implements AfterViewInit, OnDestroy {
 
   private distanceNm(a: Position, b: Position): number {
     const R = 6371e3; // meters
-    const phi1 = a.latitude * Math.PI / 180;
-    const phi2 = b.latitude * Math.PI / 180;
-    const dPhi = (b.latitude - a.latitude) * Math.PI / 180;
-    const dLambda = (b.longitude - a.longitude) * Math.PI / 180;
+    const { latitude: lat1, longitude: lon1 } = a;
+    const { latitude: lat2, longitude: lon2 } = b;
+    if (lat1 === undefined || lon1 === undefined || lat2 === undefined || lon2 === undefined) {
+      return NaN;
+    }
+    const phi1 = lat1 * Math.PI / 180;
+    const phi2 = lat2 * Math.PI / 180;
+    const dPhi = (lat2 - lat1) * Math.PI / 180;
+    const dLambda = (lon2 - lon1) * Math.PI / 180;
 
     const sinDP = Math.sin(dPhi / 2);
     const sinDL = Math.sin(dLambda / 2);


### PR DESCRIPTION
## Why

Part of the strictNullChecks endgame (S2-1, #6). `widget-ais-radar` was the single largest remaining file in the betterer baseline — 12 of 44 errors. Clearing it drops the baseline to 32 errors across 11 files.

## Approach

Honest typing only — no `!`, no null-laundering casts, no suppressions. Every change is behavior-preserving:

- **`getColors(cfg.color ?? 'contrast', …)`** — `getColors` already folds an unknown/undefined key to `'contrast'` (see `themeColors.utils.ts`), so the fallback is a runtime no-op and matches the convention used across the widget family.
- **`renderRings` guards `ownShipLayer` alongside `ringsLayer`** — both layers are created together in the same setup, so the added condition never changes control flow; it just narrows the field for its single later use.
- **`candidates` filter uses a typed predicate** (`track is AisTrack & { position: Position }`) — matches the existing predicate-filter idiom in the same method; the filter body already proves `position` is a valid `Position`, so `buildTargets` no longer needs to re-assert it.
- **`RenderTarget.status` / `buildClassName` param widened to `string | undefined`** — mirrors the nullable `ais.status` source. The field is write-only apart from the `status-${status}` className, whose output is unchanged (`undefined` still renders `status-undefined`).
- **`distanceNm` guards undefined coordinates and returns `NaN`** — identical to the prior `undefined`-arithmetic `NaN` propagation; callers already guarantee valid positions via the typed predicate.

## Verification

- `npm run snc`: file goes to zero errors; total 44 → 32 (no new errors elsewhere).
- `npm run betterer`: baseline regenerated — "12 fixed issues, 32 remaining".
- `npm run lint`: clean.
- Component spec: 8/8 pass.
- Multi-persona adversarial review (correctness, adversarial, type-soundness, data-flow/consumer lenses): zero findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5ipa885FVk3kTiL5b523F