### PR TITLE
fix(widget-config): resolve strictNullChecks violations

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -8,31 +8,6 @@ exports[`strictNullChecks`] = {
     "src/app/app.component.ts:3236769020": [
       [123, 19, 25, "Object is possibly \'undefined\'.", "255143637"]
     ],
-    "src/app/widget-config/boolean-control-config/boolean-control-config.component.ts:37806614": [
-      [26, 40, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"],
-      [27, 39, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'number\'.", "2620553983"],
-      [34, 4, 11, "Type \'{ label: string; value: string; }[]\' is not assignable to type \'never[]\'.\\n  Type \'{ label: string; value: string; }\' is not assignable to type \'never\'.", "3027418051"]
-    ],
-    "src/app/widget-config/boolean-multicontrol-options/boolean-multicontrol-options.component.ts:1795746450": [
-      [35, 9, 14, "Type \'null\' is not assignable to type \'UntypedFormGroup\'.", "3522031013"],
-      [37, 10, 26, "Type \'null\' is not assignable to type \'Subscription\'.", "273497119"]
-    ],
-    "src/app/widget-config/dataset-chart-options/dataset-chart-options.component.ts:155376543": [
-      [83, 26, 10, "Argument of type \'ISkPathData | null\' is not assignable to parameter of type \'ISkPathData\'.\\n  Type \'null\' is not assignable to type \'ISkPathData\'.", "384538813"]
-    ],
-    "src/app/widget-config/display-datetime/display-datetime.component.ts:2719976956": [
-      [45, 51, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'FormControl<string>\'.", "2620553983"],
-      [46, 53, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'FormControl<string>\'.", "2620553983"],
-      [49, 10, 22, "Type \'null\' is not assignable to type \'Subscription\'.", "29842089"]
-    ],
-    "src/app/widget-config/paths-options/paths-options.component.ts:2311600985": [
-      [31, 51, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'IAddNewPathObject\'.", "2620553983"],
-      [32, 40, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'string\'.", "2620553983"],
-      [33, 54, 9, "Argument of type \'undefined\' is not assignable to parameter of type \'IDynamicControl[]\'.", "2620553983"],
-      [58, 28, 49, "Object is possibly \'null\'.", "3725617003"],
-      [85, 26, 49, "Object is possibly \'null\'.", "3725617003"],
-      [89, 26, 49, "Object is possibly \'null\'.", "3725617003"]
-    ],
     "src/app/widgets/svg-zone-states/svg-zone-states.component.ts:489168871": [
       [16, 41, 4, "No overload matches this call.\\n  Overload 1 of 5, \'(initialValue: IDynamicControl, opts?: InputOptionsWithoutTransform<IDynamicControl> | undefined): InputSignal<...>\', gave the following error.\\n    Argument of type \'null\' is not assignable to parameter of type \'IDynamicControl\'.\\n  Overload 2 of 5, \'(initialValue: undefined, opts: InputOptionsWithoutTransform<IDynamicControl>): InputSignal<IDynamicControl | undefined>\', gave the following error.\\n    Argument of type \'null\' is not assignable to parameter of type \'undefined\'.", "2087897566"],
       [17, 33, 4, "Argument of type \'null\' is not assignable to parameter of type \'ITheme\'.", "2087897566"],

--- a/src/app/widget-config/boolean-control-config/boolean-control-config.component.ts
+++ b/src/app/widget-config/boolean-control-config/boolean-control-config.component.ts
@@ -24,12 +24,12 @@ export interface IDeleteEventObj {
 export class BooleanControlConfigComponent implements OnInit {
   private app = inject(AppService);
   readonly ctrlFormGroup = input.required<FormGroup<IDynamicControlGroup>>();
-  readonly controlIndex = input<number>(undefined);
-  readonly arrayLength = input<number>(undefined);
+  readonly controlIndex = input.required<number>();
+  readonly arrayLength = input.required<number>();
   public readonly deleteCtrl = output<IDeleteEventObj>();
   public readonly moveUp = output<number>();
   public readonly moveDown = output<number>();
-  protected colors = [];
+  protected colors: { label: string; value: string }[] = [];
 
   ngOnInit(): void {
     this.colors = this.app.configurableThemeColors;

--- a/src/app/widget-config/boolean-multicontrol-options/boolean-multicontrol-options.component.ts
+++ b/src/app/widget-config/boolean-multicontrol-options/boolean-multicontrol-options.component.ts
@@ -33,9 +33,9 @@ export class BooleanMultiControlOptionsComponent implements OnInit, OnDestroy {
   public readonly addPath = output<IAddNewPathObject>();
   public readonly updatePath = output<IDynamicControl[]>();
   public readonly delPath = output<IDeleteEventObj>();
-  public multiFormGroup: UntypedFormGroup = null;
+  public multiFormGroup: UntypedFormGroup | null = null;
   public arrayLength = 0;
-  private multiCtrlArraySubscription: Subscription = null;
+  private multiCtrlArraySubscription: Subscription | null = null;
 
   ngOnInit(): void {
     this.arrayLength = this.multiCtrlArray().length;

--- a/src/app/widget-config/dataset-chart-options/dataset-chart-options.component.ts
+++ b/src/app/widget-config/dataset-chart-options/dataset-chart-options.component.ts
@@ -81,7 +81,9 @@ export class DatasetChartOptionsComponent implements OnInit {
     const currentPath = this.datachartPath()?.value;
     if (currentPath) {
       const pathObject = this.data.getPathObject(currentPath);
-      this.setPathSources(pathObject);
+      if (pathObject) {
+        this.setPathSources(pathObject);
+      }
       this.unitList.set(this.units.getConversionsForPath(currentPath));
     }
     this.setInitFormState();

--- a/src/app/widget-config/display-datetime/display-datetime.component.ts
+++ b/src/app/widget-config/display-datetime/display-datetime.component.ts
@@ -43,11 +43,11 @@ export const getDynamicTimeZones = (): ITzDefinition[] => {
 })
 export class DisplayDatetimeComponent implements OnInit {
   private readonly _destroyRef = inject(DestroyRef);
-  readonly dateFormat = input<FormControl<string>>(undefined);
-  readonly dateTimezone = input<FormControl<string>>(undefined);
+  readonly dateFormat = input.required<FormControl<string>>();
+  readonly dateTimezone = input.required<FormControl<string>>();
   private tz: ITzDefinition[] = [];
   public filteredTZ: Observable<ITzDefinition[]>;
-  private filteredTZSubscription: Subscription = null;
+  private filteredTZSubscription: Subscription | null = null;
 
   constructor() { }
 

--- a/src/app/widget-config/paths-options/paths-options.component.ts
+++ b/src/app/widget-config/paths-options/paths-options.component.ts
@@ -29,9 +29,9 @@ export class PathsOptionsComponent implements OnInit, OnChanges {
   readonly enableTimeout = input.required<UntypedFormControl>();
   readonly dataTimeout = input.required<UntypedFormControl>();
   readonly filterSelfPaths = input.required<UntypedFormControl>();
-  readonly addPathEvent = input<IAddNewPathObject>(undefined);
-  readonly delPathEvent = input<string>(undefined);
-  readonly updatePathEvent = input<IDynamicControl[]>(undefined);
+  readonly addPathEvent = input<IAddNewPathObject>();
+  readonly delPathEvent = input<string>();
+  readonly updatePathEvent = input<IDynamicControl[]>();
 
   protected pathsFormGroup!: UntypedFormArray | UntypedFormGroup;
   protected multiCTRLArray: IDynamicControl[] = [];
@@ -56,7 +56,7 @@ export class PathsOptionsComponent implements OnInit, OnChanges {
   ngOnInit(): void {
     if (this.isArray()) {
       this.pathsFormGroup = this.rootFormGroup.control.get(this.formGroupName()) as UntypedFormArray;
-      this.multiCTRLArray = this.rootFormGroup.control.get('multiChildCtrls').value;
+      this.multiCTRLArray = this.rootFormGroup.control.get('multiChildCtrls')?.value ?? [];
     } else {
       this.pathsFormGroup = this.rootFormGroup.control.get(this.formGroupName()) as UntypedFormGroup;
     }
@@ -83,11 +83,11 @@ export class PathsOptionsComponent implements OnInit, OnChanges {
       })
     );
     this.pathsFormGroup.updateValueAndValidity();
-    this.multiCTRLArray = this.rootFormGroup.control.get('multiChildCtrls').value;
+    this.multiCTRLArray = this.rootFormGroup.control.get('multiChildCtrls')?.value ?? [];
   }
 
   private delPath(): void {
-    this.multiCTRLArray = this.rootFormGroup.control.get('multiChildCtrls').value;
+    this.multiCTRLArray = this.rootFormGroup.control.get('multiChildCtrls')?.value ?? [];
   }
 
   private updatePath(ctrls: IDynamicControl[]): void {


### PR DESCRIPTION
## Why

Part of the strictNullChecks endgame (S2-1, #6). Clears the five widget-config files from the betterer baseline (15 of the remaining errors).

## Approach

Honest typing only — no `!`, no null-laundering casts, no suppressions. Behavior-preserving:

- **boolean-control-config**: `controlIndex`/`arrayLength` → `input.required<number>()` (the sole parent binds both unconditionally in its `@for`, and the spec sets them); `colors` gets an explicit `{label; value}[]` type instead of the `never[]` inferred from `[]`.
- **boolean-multicontrol-options**: `multiFormGroup` / `multiCtrlArraySubscription` widened to `| null` to match their `null` initializers (the subscription is already torn down with `?.unsubscribe()`).
- **display-datetime**: `dateFormat`/`dateTimezone` → `input.required<FormControl<string>>()` (the sole parent binds both inside an `@if` that guards on the config; both getters return concrete `FormControl<string>`); `filteredTZSubscription` → `| null`.
- **paths-options**: the three `ngOnChanges`-only inputs become optional `input<T>()` (read solely via `SimpleChanges`, never by calling the signal); the three `control.get('multiChildCtrls').value` derefs become `?.value ?? []` (behavior-preserving on every reachable path — the control is invariantly present in the array branch).

## Latent bug fixed (flagged)

**dataset-chart-options**: `ngOnInit` passed a possibly-null `getPathObject()` result straight to `setPathSources()`, which does `Object.keys(pathObject.sources)` and **throws when loading a saved config whose path is not currently in the DataService `_skData` map**. Guarded to skip `setPathSources` on null (still setting `unitList`), mirroring the existing null-check in the sibling `changePath()`. Happy path byte-identical; only the currently-crashing path changes (crash → no-op).

## Verification

- `npm run snc`: five files → zero; total 44 → 29 (no new errors).
- `npm run betterer`: regenerated (15 fixed, 29 remaining).
- `npm run lint`: clean. `npm run build:dev`: passes.
- Widget-config specs: 70/70 pass (incl. `root-modal-widget-config`, the display-datetime consumer).
- Multi-persona adversarial review (required-input hazard, latent-bug, adversarial, consumer lenses): zero findings.

> Note: `.betterer.results` will need a regen after any sibling S2-1 PR merges first (content-hash keying); serialize the merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5ipa885FVk3kTiL5b523F