### PR TITLE
fix(widgets): resolve strictNullChecks in racing/zone widgets

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -8,29 +8,6 @@ exports[`strictNullChecks`] = {
     "src/app/app.component.ts:3236769020": [
       [123, 19, 25, "Object is possibly \'undefined\'.", "255143637"]
     ],
-    "src/app/widgets/svg-zone-states/svg-zone-states.component.ts:489168871": [
-      [16, 41, 4, "No overload matches this call.\\n  Overload 1 of 5, \'(initialValue: IDynamicControl, opts?: InputOptionsWithoutTransform<IDynamicControl> | undefined): InputSignal<...>\', gave the following error.\\n    Argument of type \'null\' is not assignable to parameter of type \'IDynamicControl\'.\\n  Overload 2 of 5, \'(initialValue: undefined, opts: InputOptionsWithoutTransform<IDynamicControl>): InputSignal<IDynamicControl | undefined>\', gave the following error.\\n    Argument of type \'null\' is not assignable to parameter of type \'undefined\'.", "2087897566"],
-      [17, 33, 4, "Argument of type \'null\' is not assignable to parameter of type \'ITheme\'.", "2087897566"],
-      [21, 41, 4, "Argument of type \'null\' is not assignable to parameter of type \'string\'.", "2087897566"],
-      [22, 41, 4, "Argument of type \'null\' is not assignable to parameter of type \'string\'.", "2087897566"],
-      [23, 42, 4, "Argument of type \'null\' is not assignable to parameter of type \'string\'.", "2087897566"]
-    ],
-    "src/app/widgets/widget-multi-state-switch/widget-multi-state-switch.component.ts:3679063603": [
-      [160, 22, 10, "Object is possibly \'undefined\'.", "3996575854"]
-    ],
-    "src/app/widgets/widget-racer-line/widget-racer-line.component.ts:1630258628": [
-      [176, 10, 13, "Type \'null\' is not assignable to type \'string\'.", "363509612"],
-      [189, 34, 9, "Argument of type \'string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "4119212820"],
-      [340, 4, 6, "Type \'string | null\' is not assignable to type \'string\'.\\n  Type \'null\' is not assignable to type \'string\'.", "2123913871"],
-      [344, 4, 6, "Type \'string | null\' is not assignable to type \'string\'.\\n  Type \'null\' is not assignable to type \'string\'.", "2123913871"],
-      [488, 25, 13, "Argument of type \'number | null\' is not assignable to parameter of type \'number\'.\\n  Type \'null\' is not assignable to type \'number\'.", "2241094794"],
-      [492, 25, 13, "Argument of type \'number | null\' is not assignable to parameter of type \'number\'.\\n  Type \'null\' is not assignable to type \'number\'.", "2926687684"]
-    ],
-    "src/app/widgets/widget-racesteer/widget-racesteer.component.ts:595381304": [
-      [175, 55, 27, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "1820305006"],
-      [215, 29, 1, "Argument of type \'number | null\' is not assignable to parameter of type \'number\'.\\n  Type \'null\' is not assignable to type \'number\'.", "177619"],
-      [336, 100, 27, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "1820305006"]
-    ],
     "src/default-config/config.blank.const.ts:2019243563": [
       [31, 2, 12, "Type \'null\' is not assignable to type \'string\'.", "3195809883"]
     ]

--- a/src/app/widgets/svg-zone-states/svg-zone-states.component.ts
+++ b/src/app/widgets/svg-zone-states/svg-zone-states.component.ts
@@ -14,14 +14,14 @@ import { getColors } from "../../core/utils/themeColors.utils";
 })
 export class SvgZoneStatesComponent {
   // eslint-disable-next-line @angular-eslint/no-input-rename
-  readonly data = input<IDynamicControl>(null, { alias: "controlData" });
-  readonly theme = input<ITheme>(null);
+  readonly data = input.required<IDynamicControl>({ alias: "controlData" });
+  readonly theme = input.required<ITheme | null>();
   readonly dimensions = input.required<IDimensions>();
   readonly toggleClick = output<IDynamicControl>();
 
-  public ctrlLabelColor = signal<string>(null);
-  public ctrlStateColor = signal<string>(null);
-  public messageTxtColor = signal<string>(null);
+  public ctrlLabelColor = signal<string | null>(null);
+  public ctrlStateColor = signal<string | null>(null);
+  public messageTxtColor = signal<string | null>(null);
 
   protected shouldEmergencyBlink = computed(() => {
     const s = (this.data()?.notificationState ?? '').toLowerCase();
@@ -37,6 +37,7 @@ export class SvgZoneStatesComponent {
     effect(() => {
       const data = this.data();
       const theme = this.theme();
+      if (!theme) return;
 
       untracked(() => {
         switch (data.notificationState) {

--- a/src/app/widgets/widget-multi-state-switch/widget-multi-state-switch.component.ts
+++ b/src/app/widgets/widget-multi-state-switch/widget-multi-state-switch.component.ts
@@ -158,7 +158,7 @@ export class WidgetMultiStateSwitchComponent {
   constructor() {
     effect(() => {
       const theme = this.theme();
-      const wdColor = this.cfg().color;
+      const wdColor = this.cfg()?.color;
       if (!theme || !wdColor) return;
       untracked(() => {
         //getColors(cfg.color ?? 'contrast', theme);

--- a/src/app/widgets/widget-racer-line/widget-racer-line.component.ts
+++ b/src/app/widgets/widget-racer-line/widget-racer-line.component.ts
@@ -174,7 +174,7 @@ export class WidgetRacerLineComponent implements AfterViewInit, OnDestroy {
   private maxValueTextHeight = 0;
   private displayLineIndex = 0;
   private lines: string[] = [];
-  private startLineName: string = null;
+  private startLineName: string | null = null;
   protected portBiasValue = signal<string>('');
   protected lineLengthValue = signal<string>('');
   protected stbBiasValue = signal<string>('');
@@ -187,7 +187,7 @@ export class WidgetRacerLineComponent implements AfterViewInit, OnDestroy {
       const theme = this.theme();
       if (!cfg || !theme) return;
       untracked(() => {
-        const palette = getColors(cfg.color, theme);
+        const palette = getColors(cfg.color ?? 'contrast', theme);
         this.labelColor.set(palette.dim);
         this.valueColor = palette.color;
         this.draw();
@@ -337,11 +337,11 @@ export class WidgetRacerLineComponent implements AfterViewInit, OnDestroy {
     this.draw();
   }
 
-  public setLineEnd(end: string): string {
+  public setLineEnd(end: string): string | null {
     return this.signalk.putRequest('navigation.racing.setStartLine', {end, position: 'bow'}, this.id());
   }
 
-  public adjustLineEnd(end: string, delta: number, rotateRadians: number): string {
+  public adjustLineEnd(end: string, delta: number, rotateRadians: number): string | null {
     return this.signalk.putRequest('navigation.racing.setStartLine', {end, delta, rotate: rotateRadians || null}, this.id());
   }
 
@@ -472,7 +472,7 @@ export class WidgetRacerLineComponent implements AfterViewInit, OnDestroy {
     return this.dtsValue.toFixed(cfg?.numDecimal ?? 0);
   }
 
-  private toHHMMSS(totalSeconds: number): string {
+  private toHHMMSS(totalSeconds: number | null): string {
     if (totalSeconds == null || isNaN(totalSeconds)) return '-:--';
     const negative = totalSeconds < 0;
     if (negative) totalSeconds = -totalSeconds;

--- a/src/app/widgets/widget-racesteer/widget-racesteer.component.ts
+++ b/src/app/widgets/widget-racesteer/widget-racesteer.component.ts
@@ -76,7 +76,7 @@ export class WidgetRacesteerComponent implements OnDestroy {
   protected readonly vmgToWaypoint = signal<number | null>(null);
   protected readonly tackTrue = signal(0);
   protected readonly polarSpeedRatio = signal(0);
-  protected readonly targetAngle = signal(0);
+  protected readonly targetAngle = signal<number | null>(0);
   protected readonly optimalWindAngle = signal(0);
   protected readonly targetVMG = signal(0);
   protected readonly VMG = signal(0);
@@ -173,7 +173,7 @@ export class WidgetRacesteerComponent implements OnDestroy {
         if (cfg.windSectorEnable) {
           const heading = this.currentHeading();
           const relative360 = this.addHeading(heading, raw == null ? 0 : raw);
-          this.addHistoricalWindDirection(relative360, cfg.windSectorWindowSeconds);
+          this.addHistoricalWindDirection(relative360, cfg.windSectorWindowSeconds ?? 5);
         }
       }));
     });
@@ -334,7 +334,7 @@ export class WidgetRacesteerComponent implements OnDestroy {
       if (!cfg) return;
       if (cfg.windSectorEnable) {
         if (!this.windSectorSub) {
-          untracked(() => this.windSectorSub = interval(500).subscribe(() => this.historicalCleanup(cfg.windSectorWindowSeconds)));
+          untracked(() => this.windSectorSub = interval(500).subscribe(() => this.historicalCleanup(cfg.windSectorWindowSeconds ?? 5)));
         }
       } else {
         this.windSectorSub?.unsubscribe();


### PR DESCRIPTION
## Why

Part of the strictNullChecks endgame (S2-1, #6). Clears four widgets from the betterer baseline (15 errors).

## Approach

Honest typing only — no `!`, no null-laundering casts, no suppressions. Behavior-preserving:

- **widget-racer-line**: `startLineName` → `string | null`; `getColors('… ?? contrast')`; `setLineEnd`/`adjustLineEnd` return types → `string | null` to match `putRequest()` (all callers are template click handlers that ignore the return); `toHHMMSS` param → `number | null` (its body already guards `totalSeconds == null`).
- **widget-racesteer**: `targetAngle` signal → `number | null` — it is only *set* (from a `number|null` stream) and never *read* in this component, so the type now matches the value it already holds at runtime; `windSectorWindowSeconds` reads with `?? 5` (matching `DEFAULT_CONFIG`, which the runtime merge always applies; `??` preserves an explicit `0`).
- **widget-multi-state-switch**: `cfg()?.color` optional chaining, matching the file's own idiom; the next line already guards `!wdColor`.

## Latent bug fixed (flagged)

**svg-zone-states**: `theme` was typed non-null (`input<ITheme>(null)`) but the parent binds an `ITheme | null` and guards it in its *own* effect. Retyping honestly to `input.required<ITheme | null>()` exposes the effect's unguarded `theme` dereferences (`theme.zoneEmergency`, `getColors(data.color, theme)`, …); added `if (!theme) return` (placed after both signal reads so reactive deps are preserved), converting the current null-theme **crash** into a no-op — mirroring the parent's guard. `data` → `input.required<IDynamicControl>` (always bound in the parent `@for`); the three color signals → `string | null`.

## Verification

- `npm run snc`: four files → zero; total 44 → 29 (no new errors — `svg-racesteer` stays clean).
- `npm run betterer` regenerated. `npm run lint` clean. `npm run build:dev` (strictTemplates) passes.
- Multi-persona adversarial review (cross-file coupling, latent-bug, adversarial, consumer lenses): zero findings.

> **Flip-time follow-up:** `widget-racesteer.targetAngle` (`number | null`) is template-bound to `svg-racesteer`'s `targetAngle = input.required<number>()`. This compiles today only because the app build has strictNullChecks off. When the flip lands (final S2-1 step), `svg-racesteer`'s input must widen to `number | null` and its `targetAngle()/2` derefs (svg-racesteer L518–520) guarded. Tracked for the flip PR.

> Note: `.betterer.results` will need a regen after any sibling S2-1 PR merges first; serialize the merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5ipa885FVk3kTiL5b523F