### PR TITLE
fix(core): resolve final strictNullChecks errors (app + connection URL)

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -3,13 +3,3 @@
 // If this file contains merge conflicts, use `betterer merge` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //
-exports[`strictNullChecks`] = {
-  value: `{
-    "src/app/app.component.ts:3236769020": [
-      [123, 19, 25, "Object is possibly \'undefined\'.", "255143637"]
-    ],
-    "src/default-config/config.blank.const.ts:2019243563": [
-      [31, 2, 12, "Type \'null\' is not assignable to type \'string\'.", "3195809883"]
-    ]
-  }`
-};

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -120,8 +120,9 @@ export class AppComponent implements AfterViewInit, OnDestroy {
 
     effect(() => {
       const msg = this.upgrade.messages();
-      if (this.upgrade.upgrading() && msg.length && this.upgradeMessagesRef()) {
-        const ul = this.upgradeMessagesRef().nativeElement;
+      const messagesEl = this.upgradeMessagesRef();
+      if (this.upgrade.upgrading() && msg.length && messagesEl) {
+        const ul = messagesEl.nativeElement;
         ul.scrollTop = ul.scrollHeight;
       }
     });

--- a/src/app/core/components/options/signalk/signalk.component.ts
+++ b/src/app/core/components/options/signalk/signalk.component.ts
@@ -143,7 +143,7 @@ export class SettingsSignalkComponent implements OnInit, AfterViewInit, OnDestro
       console.log('[Settings-SignalK] Validating Signal K server before connecting...');
 
       // Step 1: Validate the URL before proceeding
-      await this.signalKConnectionService.validateSignalKUrl(this.connectionConfig.signalKUrl);
+      await this.signalKConnectionService.validateSignalKUrl(this.connectionConfig.signalKUrl ?? '');
 
       console.log('[Settings-SignalK] Validation successful - proceeding with connection');
 

--- a/src/app/core/interfaces/app-settings.interfaces.ts
+++ b/src/app/core/interfaces/app-settings.interfaces.ts
@@ -4,7 +4,7 @@ import { Dashboard } from './../services/dashboard.service';
 export interface IConnectionConfig {
   configVersion: number;
   kipUUID: string;
-  signalKUrl: string;
+  signalKUrl: string | null;
   proxyEnabled: boolean;
   signalKSubscribeAll: boolean;
   sharedConfigName: string;

--- a/src/app/core/services/settings.service.ts
+++ b/src/app/core/services/settings.service.ts
@@ -129,7 +129,7 @@ export class SettingsService {
         break;
     }
 
-    this.signalkUrl = {url: config.signalKUrl, new: false};
+    this.signalkUrl = {url: config.signalKUrl ?? '', new: false};
     this.proxyEnabled = config.proxyEnabled;
     this.signalKSubscribeAll = config.signalKSubscribeAll;
     this.sharedConfigName = config.sharedConfigName;
@@ -299,7 +299,7 @@ export class SettingsService {
     this.proxyEnabled = value.proxyEnabled;
     this.signalKSubscribeAll = value.signalKSubscribeAll;
     if (this.signalkUrl) {
-      this.signalkUrl.url = value.signalKUrl;
+      this.signalkUrl.url = value.signalKUrl ?? '';
     }
     this.saveConnectionConfigToLocalStorage();
   }


### PR DESCRIPTION
## Why

The last two strictNullChecks errors of the S2-1 endgame (#6), both in core files. With this merged the betterer baseline reaches **zero**, unblocking the flip.

## Approach

Honest typing only — no `!`, no null-laundering casts, no suppressions. `x ?? ''` is real runtime defaulting, not a cast.

- **app.component**: the upgrade-messages scroll effect read the `upgradeMessagesRef()` viewChild signal twice (guard + `.nativeElement`), so the guard's narrowing didn't carry to the second read. Hoisted a single read into a local; runtime-identical (both reads were in the same effect run).
- **connection URL cascade**: `DefaultConnectionConfig.signalKUrl` is a deliberate **null sentinel** — `app-initNetwork` distinguishes it via `!== null` to fall back to origin auto-discovery — so `IConnectionConfig.signalKUrl` is honestly widened to `string | null`. The three string sinks that consume it coalesce with `?? ''`: `settings.service` `loadConnectionConfig` and `setConnectionConfig`, and `signalk.component`'s `validateSignalKUrl` argument. `ISignalKUrl.url` is **kept as `string`** to contain the cascade — no ripple into `signalk-connection.service`.

## Behavior preservation

All three `?? ''` sites are proven never-null at runtime (every persisted connection config is written through `?? ''` or the origin overwrite), and their downstream consumers already treat `null`/`''` identically (`if (!skUrl.url)`, `?? ''`, `||`), so the coalesce never fires. `app-initNetwork:128`'s `!== null` sentinel semantics are preserved by the field widening.

## Verification

- `npm run snc`: **42 → 42 in this worktree with only widget-cluster files remaining; zero errors in any core file touched** (net −1 for config.blank, zero new anywhere — cascade fully contained). A cascade-mapping pass confirmed there is no missed sink (it caught a third one, `signalk.component.ts:146`, now handled).
- `npm run betterer` regenerated. `npm run lint` clean.
- `npm run build:dev` (strictTemplates) + core specs (app.component, settings.service, signalk.component): 79/79 pass.
- Multi-persona adversarial review (cascade-completeness, behavior-preservation, adversarial, serialization/migration lenses): in progress; synthesis to follow.

> Note: `.betterer.results` will need a regen after the sibling S2-1 PRs (#337/#338/#339) merge first — this PR should land **last** in the serialized sequence, taking the baseline to zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5ipa885FVk3kTiL5b523F