### PR TITLE
Handle whole-object Signal K compound leaf values (S2-0 prep)

### DIFF
--- a/src/app/core/services/ais-processing.service.spec.ts
+++ b/src/app/core/services/ais-processing.service.spec.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   AisProcessingService,
   AisVessel,
+  AisSar,
   AisAton,
   AisTrack
 } from './ais-processing.service';
@@ -27,6 +28,7 @@ describe('AisProcessingService applyAisUpdate dispatch', () => {
 
   const VESSEL_CONTEXT = 'vessels.urn:mrn:imo:mmsi:123456789';
   const ATON_CONTEXT = 'atons.urn:mrn:imo:mmsi:987654321';
+  const SAR_CONTEXT = 'sar.urn:mrn:imo:mmsi:111222333';
 
   function makeEvent(fullPath: string, value: unknown): IPathUpdateWithPath {
     return {
@@ -142,6 +144,161 @@ describe('AisProcessingService applyAisUpdate dispatch', () => {
     // Track exists (created on resolve) but position was never set.
     expect(track).toBeDefined();
     expect(track.position).toBeUndefined();
+  });
+
+  it('applies a whole-object position value at the canonical navigation.position path', () => {
+    push(`${VESSEL_CONTEXT}.navigation.position`, { latitude: 48.5, longitude: -123.25 });
+
+    const track = trackByContext(VESSEL_CONTEXT) as AisVessel;
+    expect(track.position?.latitude).toBe(48.5);
+    expect(track.position?.longitude).toBe(-123.25);
+    expect(track.lastPositionAt).toBe(new Date('2026-06-24T00:00:00Z').getTime());
+  });
+
+  it('applies a whole-object design.length value', () => {
+    push(`${VESSEL_CONTEXT}.design.length`, { overall: 42, hull: 40, waterline: 38 });
+
+    const track = trackByContext(VESSEL_CONTEXT) as AisVessel;
+    expect(track.design?.length?.overall).toBe(42);
+    expect(track.design?.length?.hull).toBe(40);
+    expect(track.design?.length?.waterline).toBe(38);
+  });
+
+  it('applies a whole-object design.draft value', () => {
+    push(`${VESSEL_CONTEXT}.design.draft`, { maximum: 2.5, minimum: 1.8, current: 2.1 });
+
+    const track = trackByContext(VESSEL_CONTEXT) as AisVessel;
+    expect(track.design?.draft?.maximum).toBe(2.5);
+    expect(track.design?.draft?.minimum).toBe(1.8);
+    expect(track.design?.draft?.current).toBe(2.1);
+  });
+
+  it('applies a whole-object design.aisShipType value', () => {
+    push(`${VESSEL_CONTEXT}.design.aisShipType`, { id: 36, name: 'Sailing' });
+
+    const track = trackByContext(VESSEL_CONTEXT) as AisVessel;
+    expect(track.design?.aisShipType?.id).toBe(36);
+    expect(track.design?.aisShipType?.name).toBe('Sailing');
+  });
+
+  it('applies a whole-object navigation.closestApproach value', () => {
+    push(`${VESSEL_CONTEXT}.navigation.closestApproach`, { distance: 719.5, timeTo: -768.3 });
+
+    const track = trackByContext(VESSEL_CONTEXT) as AisVessel;
+    expect(track.closestApproach?.distance).toBe(719.5);
+    expect(track.closestApproach?.timeTo).toBe(-768.3);
+  });
+
+  it('flags collision-risk data when a whole closestApproach carries collisionRiskRating', () => {
+    push(`${VESSEL_CONTEXT}.mmsi`, '123456789');
+    push(`${VESSEL_CONTEXT}.navigation.closestApproach`, { distance: 500, timeTo: 300, collisionRiskRating: 0.2 });
+
+    const track = trackByContext(VESSEL_CONTEXT) as AisVessel;
+    expect(track.closestApproach?.collisionRiskRating).toBe(0.2);
+    expect(service.hasCollisionRiskData()).toBe(true);
+  });
+
+  it('merges a whole-object design compound without clobbering sibling design fields', () => {
+    push(`${VESSEL_CONTEXT}.design.beam`, 8);
+    push(`${VESSEL_CONTEXT}.design.length`, { overall: 42 });
+
+    const track = trackByContext(VESSEL_CONTEXT) as AisVessel;
+    expect(track.design?.beam).toBe(8);
+    expect(track.design?.length?.overall).toBe(42);
+  });
+
+  it('does not set whole-object design compounds on a non-vessel (ATON guard holds)', () => {
+    push(`${ATON_CONTEXT}.atonType.name`, 'Buoy 7');
+    push(`${ATON_CONTEXT}.design.length`, { overall: 42 });
+
+    const track = trackByContext(ATON_CONTEXT);
+    expect((track as AisAton).typeName).toBe('Buoy 7');
+    expect((track as unknown as AisVessel).design).toBeUndefined();
+  });
+
+  it('carries altitude on a whole-object position value', () => {
+    push(`${VESSEL_CONTEXT}.navigation.position`, { latitude: 48.5, longitude: -123.25, altitude: 12 });
+
+    const track = trackByContext(VESSEL_CONTEXT) as AisVessel;
+    expect(track.position?.altitude).toBe(12);
+  });
+
+  it('applies whole-object design compounds to a SAR target (isVesselLike admits sar)', () => {
+    push(`${SAR_CONTEXT}.design.length`, { overall: 30 });
+    push(`${SAR_CONTEXT}.navigation.closestApproach`, { distance: 400, timeTo: 120 });
+
+    const track = trackByContext(SAR_CONTEXT) as AisSar;
+    expect(track.type).toBe('sar');
+    expect(track.design?.length?.overall).toBe(30);
+    expect(track.closestApproach?.distance).toBe(400);
+  });
+
+  it('replaces a design compound sub-object wholesale (a later partial clears omitted fields)', () => {
+    push(`${VESSEL_CONTEXT}.design.length`, { overall: 42, hull: 40 });
+    push(`${VESSEL_CONTEXT}.design.length`, { overall: 43 });
+
+    const track = trackByContext(VESSEL_CONTEXT) as AisVessel;
+    expect(track.design?.length?.overall).toBe(43);
+    expect(track.design?.length?.hull).toBeUndefined();
+  });
+
+  it('applies a partial aisShipType (id only) and closestApproach range/bearing whole objects', () => {
+    push(`${VESSEL_CONTEXT}.design.aisShipType`, { id: 37 });
+    push(`${VESSEL_CONTEXT}.navigation.closestApproach`, { range: 800, bearing: 90 });
+
+    const track = trackByContext(VESSEL_CONTEXT) as AisVessel;
+    expect(track.design?.aisShipType?.id).toBe(37);
+    expect(track.design?.aisShipType?.name).toBeUndefined();
+    expect(track.closestApproach?.range).toBe(800);
+    expect(track.closestApproach?.bearing).toBe(90);
+  });
+
+  it('applies design.draft.canoe from a whole-object value', () => {
+    push(`${VESSEL_CONTEXT}.design.draft`, { canoe: 1.2 });
+
+    const track = trackByContext(VESSEL_CONTEXT) as AisVessel;
+    expect(track.design?.draft?.canoe).toBe(1.2);
+  });
+
+  it('does not flag collision-risk data for a whole closestApproach without collisionRiskRating', () => {
+    push(`${VESSEL_CONTEXT}.mmsi`, '123456789');
+    push(`${VESSEL_CONTEXT}.navigation.closestApproach`, { distance: 500, timeTo: 300 });
+
+    const track = trackByContext(VESSEL_CONTEXT) as AisVessel;
+    expect(Object.prototype.hasOwnProperty.call(track.closestApproach ?? {}, 'collisionRiskRating')).toBe(false);
+    expect(service.hasCollisionRiskData()).toBe(false);
+  });
+
+  it('clears a stale collisionRiskRating when a later whole closestApproach omits it', () => {
+    push(`${VESSEL_CONTEXT}.mmsi`, '123456789');
+    push(`${VESSEL_CONTEXT}.navigation.closestApproach`, { distance: 500, timeTo: 300, collisionRiskRating: 0.2 });
+    expect(service.hasCollisionRiskData()).toBe(true);
+
+    push(`${VESSEL_CONTEXT}.navigation.closestApproach`, { distance: 3000, timeTo: 9000 });
+
+    const track = trackByContext(VESSEL_CONTEXT) as AisVessel;
+    expect(track.closestApproach?.collisionRiskRating).toBeUndefined();
+    expect(service.hasCollisionRiskData()).toBe(false);
+  });
+
+  it('treats a null collisionRiskRating as absent, not zero-risk', () => {
+    push(`${VESSEL_CONTEXT}.mmsi`, '123456789');
+    push(`${VESSEL_CONTEXT}.navigation.closestApproach`, { distance: 500, timeTo: 300, collisionRiskRating: null });
+
+    const track = trackByContext(VESSEL_CONTEXT) as AisVessel;
+    expect(track.closestApproach?.collisionRiskRating).toBeUndefined();
+    expect(service.hasCollisionRiskData()).toBe(false);
+  });
+
+  it('ignores a non-object whole-compound value (guard holds, no corruption)', () => {
+    push(`${VESSEL_CONTEXT}.navigation.closestApproach`, { distance: 500 });
+    push(`${VESSEL_CONTEXT}.design.length`, 42);
+    push(`${VESSEL_CONTEXT}.navigation.closestApproach`, 'garbage');
+
+    const track = trackByContext(VESSEL_CONTEXT) as AisVessel;
+    expect(track.design?.length).toBeUndefined();
+    // A non-object value must not replace the prior closestApproach.
+    expect(track.closestApproach?.distance).toBe(500);
   });
 
   it('sets an ATON field gated by isAton (atonType.name)', () => {

--- a/src/app/core/services/ais-processing.service.ts
+++ b/src/app/core/services/ais-processing.service.ts
@@ -548,6 +548,51 @@ export class AisProcessingService {
           track.closestApproach.collisionRiskRating = this.toNumberOrUndefined(update.value);
         }
         break;
+      // Whole-object compound leaves: the delta service emits these SK compound
+      // values whole at their canonical path (navigation.position handled above),
+      // so read the sub-fields off the object. The whole object is the complete
+      // authoritative value, so each sub-object is REPLACED wholesale (like
+      // navigation.position) — an omitted sub-field clears a prior one, which
+      // matters for the present-vs-absent closestApproach.collisionRiskRating
+      // signal. Sibling design leaves (beam, draft, ...) arrive as separate paths
+      // and are preserved by merging at the design level. The dotted child-path
+      // cases above still cover a server that emits the split form.
+      case 'design.length':
+        if (this.isVesselLike(track)) {
+          const length = this.readNumericFields(update.value, ['overall', 'hull', 'waterline']);
+          if (length) {
+            track.design = { ...(track.design ?? {}), length };
+          }
+        }
+        break;
+      case 'design.draft':
+        if (this.isVesselLike(track)) {
+          const draft = this.readNumericFields(update.value, ['maximum', 'minimum', 'current', 'canoe']);
+          if (draft) {
+            track.design = { ...(track.design ?? {}), draft };
+          }
+        }
+        break;
+      case 'design.aisShipType':
+        if (this.isVesselLike(track)) {
+          const value = this.asRecord(update.value);
+          if (value) {
+            const aisShipType: { id?: number; name?: string } = { ...this.readNumericFields(value, ['id']) };
+            const name = this.toStringOrUndefined(value.name);
+            if (name !== undefined) aisShipType.name = name;
+            track.design = { ...(track.design ?? {}), aisShipType };
+          }
+        }
+        break;
+      case 'navigation.closestApproach':
+        if (this.isVesselLike(track)) {
+          const closestApproach = this.readNumericFields(update.value,
+            ['distance', 'timeTo', 'range', 'bearing', 'collisionRiskRating']);
+          if (closestApproach) {
+            track.closestApproach = closestApproach;
+          }
+        }
+        break;
     }
 
     this.updateTargetsSignal();
@@ -794,5 +839,30 @@ export class AisProcessingService {
     if (latitude === undefined || longitude === undefined) return undefined;
     const altitude = this.toNumberOrUndefined((value as { altitude?: unknown }).altitude);
     return { latitude, longitude, altitude };
+  }
+
+  private asRecord(value: unknown): Record<string, unknown> | undefined {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+    return value as Record<string, unknown>;
+  }
+
+  /**
+   * Reads the requested finite-number sub-fields off a whole-object SK value.
+   * Returns undefined for a non-object value (caller preserves prior state);
+   * otherwise a record of only the keys that carry a finite number. A `null`
+   * sub-field (Signal K's "value unavailable") is omitted rather than coerced to
+   * 0, so an absent/unavailable field never reads as a real value.
+   */
+  private readNumericFields(value: unknown, keys: string[]): Record<string, number> | undefined {
+    const record = this.asRecord(value);
+    if (!record) return undefined;
+    const fields: Record<string, number> = {};
+    for (const key of keys) {
+      const raw = record[key];
+      if (raw === null || raw === undefined) continue;
+      const num = this.toNumberOrUndefined(raw);
+      if (num !== undefined) fields[key] = num;
+    }
+    return fields;
   }
 }


### PR DESCRIPTION
## Motivation

Preparatory, additive step for **S2-0 / #21** (canonical whole-value emission). Today `SignalKDeltaService` recursively flattens object-valued Signal K deltas into fabricated dotted child paths (`navigation.position.latitude`, `design.length.overall`, …). The flip removes that flattening so compound leaves arrive **whole** at their canonical SK path. Verified against the live boat's SK model, the AIS-relevant compound leaves are `navigation.position`, `design.length`, `design.draft`, `design.aisShipType`, and `navigation.closestApproach`.

Without a whole-object handler, after the flip AIS dimensions, ship type, and CPA would silently drop (their child-path handlers would never fire again).

## Approach

Add `applyAisUpdate` cases that read the sub-fields off the whole compound object at its canonical path (`navigation.position` was already handled whole via `readPositionValue`). Two small helpers — `asRecord` and `readNumericFields` — keep partial updates from clobbering previously-set sibling fields.

These new cases sit **alongside** the existing dotted child-path cases. Because the delta service still flattens today, the child cases stay live and the new whole-object cases are dead until the flip — so this PR is safe to land on its own and shrinks the S2-0 cutover PR. It lands **before** the flip PR (same merge batch).

## Verification

- New characterization tests drive whole objects through the real stream entry point and assert resulting track state (length/draft/aisShipType/closestApproach, CPA collision-risk detection, sibling-merge, ATON type guard).
- `npm run snc` (strictNullChecks, prod + specs) and `npm run lint` clean; ais-processing spec 30/30 green.

Refs #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)