### PR TITLE
Canonical whole-value emission: stop flattening compound Signal K leaves (S2-0)

### DIFF
--- a/perf-harness/lib/kip-config.mjs
+++ b/perf-harness/lib/kip-config.mjs
@@ -8,7 +8,7 @@
  *
  * Three distinct version spaces (all from src/app/core/constants/config-versions.const.ts):
  *  - applicationData URL path segment 11 (REMOTE_CONFIG_FILE_VERSION)
- *  - app.configVersion 13 (LATEST_APP_CONFIG_VERSION)
+ *  - app.configVersion 14 (LATEST_APP_CONFIG_VERSION)
  *  - connectionConfig.configVersion 13 (CONNECTION_CONFIG_VERSION)
  */
 export const SELF_URN = 'vessels.urn:mrn:signalk:uuid:11111111-1111-4111-8111-111111111111';
@@ -30,11 +30,12 @@ const DEFAULT_NOTIF = {
 };
 
 export function appConfig(extra = {}) {
-  // configVersion 13 with no dataSets field: a genuine post-v12->v13 config, so the
-  // boot skips ConfigurationUpgradeService's migration toast/reload (which is what
-  // strips dataSets/datasetUUID/chartEngine) inside the measurement window.
+  // configVersion at LATEST (14): a genuine current config, so the boot skips
+  // ConfigurationUpgradeService's migration toast/reload entirely inside the
+  // measurement window. Bump this in lockstep with LATEST_APP_CONFIG_VERSION, or
+  // the boot triggers an upgrade+reload and the boot-assert fails.
   return {
-    configVersion: 13, autoNightMode: false, redNightMode: false, nightModeBrightness: 0.27,
+    configVersion: 14, autoNightMode: false, redNightMode: false, nightModeBrightness: 0.27,
     widgetHistoryDisabled: false, unitDefaults: DEFAULT_UNITS,
     notificationConfig: DEFAULT_NOTIF, browserTabTitle: 'Skip', ...extra,
   };

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -453,6 +453,11 @@ describe('AppComponent — embed read-only invariants (#216 E6)', () => {
     expect(runUpgradeSpy).toHaveBeenCalledWith(12);
   });
 
+  it('runs the config migration in the full app for an upgradeable v13 config (the S2-0 gate)', async () => {
+    const { runUpgradeSpy } = await render({ embed: false, configUpgrade: true, configVersion: 13 });
+    expect(runUpgradeSpy).toHaveBeenCalledWith(13);
+  });
+
   it('does NOT show the missing-shared-config create prompt under embed', async () => {
     const { toast, bootstrapIssue$ } = await render({ embed: true });
     toast.show.mockClear();

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -100,7 +100,7 @@ export class AppComponent implements AfterViewInit, OnDestroy {
       if (this.settings.configUpgrade()) {
         const liveVersion = this.settings.getConfigVersion();
 
-        if (liveVersion === 11 || liveVersion === 12) {
+        if (liveVersion === 11 || liveVersion === 12 || liveVersion === 13) {
           this.upgrade.runUpgrade(liveVersion);
         }
 

--- a/src/app/core/constants/config-versions.const.ts
+++ b/src/app/core/constants/config-versions.const.ts
@@ -21,7 +21,7 @@ export const REMOTE_CONFIG_FILE_VERSION = 11;
  * its legacy transforms pin their own MIGRATION_OUTPUT_VERSION so that bumping this constant
  * cannot silently re-label old migration output as current — add a chained migration instead.
  */
-export const LATEST_APP_CONFIG_VERSION = 13;
+export const LATEST_APP_CONFIG_VERSION = 14;
 
 /**
  * Per-device connectionConfig schema version (its own version space, decoupled from the app config

--- a/src/app/core/directives/widget-streams.directive.spec.ts
+++ b/src/app/core/directives/widget-streams.directive.spec.ts
@@ -168,6 +168,58 @@ describe('WidgetStreamsDirective', () => {
         subj.next({ data: { value: 'B', timestamp: new Date() }, state: 'normal' } as IPathUpdate);
     });
 
+    it('extracts the configured sub-field from a whole compound-object value', () => {
+        const cfg = makeCfg({ path: 'navigation.position', source: null, pathType: 'number', sampleTime: 50 });
+        directive.setStreamsConfig(cfg);
+
+        const received: unknown[] = [];
+        directive.observe('p', u => received.push(u?.data?.value), 'latitude');
+
+        const subj = dataSvc.subjects.get('navigation.position|default')!;
+        subj.next({ data: { value: { latitude: 48.5, longitude: -123.25 }, timestamp: new Date() }, state: 'normal' } as IPathUpdate);
+
+        expect(received).toEqual([48.5]);
+    });
+
+    it('applies unit conversion to the extracted sub-field (extraction precedes conversion)', () => {
+        const cfg = makeCfg({ path: 'navigation.attitude', source: null, pathType: 'number', convertUnitTo: 'x10', sampleTime: 50 });
+        directive.setStreamsConfig(cfg);
+
+        const received: unknown[] = [];
+        directive.observe('p', u => received.push(u?.data?.value), 'roll');
+
+        const subj = dataSvc.subjects.get('navigation.attitude|default')!;
+        subj.next({ data: { value: { roll: 0.2, pitch: 0.1 }, timestamp: new Date() }, state: 'normal' } as IPathUpdate);
+
+        expect(received).toEqual([2]); // 0.2 extracted first, then the x10 conversion applied
+    });
+
+    it('passes a scalar value straight through when a sub-field is configured (customised scalar path stays working)', () => {
+        const cfg = makeCfg({ path: 'steering.rudderAngle', source: null, pathType: 'number', sampleTime: 50 });
+        directive.setStreamsConfig(cfg);
+
+        const received: unknown[] = [];
+        directive.observe('p', u => received.push(u?.data?.value), 'roll');
+
+        const subj = dataSvc.subjects.get('steering.rudderAngle|default')!;
+        subj.next({ data: { value: 0.42, timestamp: new Date() }, state: 'normal' } as IPathUpdate);
+
+        expect(received).toEqual([0.42]);
+    });
+
+    it('emits null for a missing sub-field of a compound value', () => {
+        const cfg = makeCfg({ path: 'navigation.position', source: null, pathType: 'number', sampleTime: 50 });
+        directive.setStreamsConfig(cfg);
+
+        const received: unknown[] = [];
+        directive.observe('p', u => received.push(u?.data?.value), 'altitude');
+
+        const subj = dataSvc.subjects.get('navigation.position|default')!;
+        subj.next({ data: { value: { latitude: 48.5, longitude: -123.25 }, timestamp: new Date() }, state: 'normal' } as IPathUpdate);
+
+        expect(received).toEqual([null]);
+    });
+
     it('resubscribes to DataService when source changes', async () => {
         const cfg1 = makeCfg({ path: 'env.switch', source: null, pathType: 'string', sampleTime: 50 });
         directive.setStreamsConfig(cfg1);

--- a/src/app/core/directives/widget-streams.directive.ts
+++ b/src/app/core/directives/widget-streams.directive.ts
@@ -38,7 +38,7 @@ export class WidgetStreamsDirective implements OnDestroy {
   private readonly destroyRef = inject(DestroyRef);
   // Base raw observables per logical path key
   private streams: Map<string, Observable<IPathUpdate>> | undefined;
-  private registrations: { pathName: string; next: (value: IPathUpdate) => void }[] = [];
+  private registrations: { pathName: string; next: (value: IPathUpdate) => void; subField?: string }[] = [];
   // Active subscriptions per path (so we can surgically unsubscribe changed/removed paths)
   private subscriptions = new Map<string, { sub: Subscription; signature: string }>();
   // Track identity of the cached base observable (path + normalized source) per path key
@@ -98,8 +98,22 @@ export class WidgetStreamsDirective implements OnDestroy {
     this.baseReleases.clear();
   }
 
+  /**
+   * Extract a named sub-field from a whole compound-object value, so a numeric widget can read one
+   * field (e.g. `latitude`) of a Signal K compound leaf (e.g. `navigation.position`) that the server
+   * emits whole. A non-object value (a path pointed at a scalar) passes straight through, and a
+   * missing sub-field yields null — so the extraction never breaks a scalar path and slots into the
+   * pipeline BEFORE unit conversion, keeping convertUnitTo working on the extracted number.
+   */
+  private extractSubField(update: IPathUpdate, subField: string): IPathUpdate {
+    const value = update.data.value;
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) return update;
+    const extracted = (value as Record<string, unknown>)[subField] ?? null;
+    return { data: { value: extracted, timestamp: update.data.timestamp }, state: update.state } as IPathUpdate;
+  }
+
   /** Create (or reuse) base observable, assemble pipeline, and subscribe with diff-aware replacement. */
-  private buildAndSubscribe(pathName: string, next: (value: IPathUpdate) => void, cfg: IWidgetSvcConfig, pathCfg: { path: string; pathType: string; sampleTime?: number; convertUnitTo?: string; source?: string; suppressBootstrapNull?: boolean }): void {
+  private buildAndSubscribe(pathName: string, next: (value: IPathUpdate) => void, cfg: IWidgetSvcConfig, pathCfg: { path: string; pathType: string; sampleTime?: number; convertUnitTo?: string; source?: string; suppressBootstrapNull?: boolean }, subField?: string): void {
     const normalizedPath = this.normalizePath(pathCfg.path);
     if (!normalizedPath) {
       const existing = this.subscriptions.get(pathName);
@@ -142,6 +156,11 @@ export class WidgetStreamsDirective implements OnDestroy {
     const toUnit = (val: number) => convert ? this.unitsService.convertToUnit(convert, val) : val;
 
     let data$: Observable<IPathUpdate> = base$;
+    if (subField) {
+      // Extract the widget's sub-field from the whole compound value first, so bootstrap-null
+      // suppression, sampling and unit conversion all operate on the extracted number.
+      data$ = data$.pipe(map(x => this.extractSubField(x, subField)));
+    }
     if (suppressBootstrapNull) {
       // Drop only the LEADING (bootstrap) null values. Once a real value has been seen, let
       // everything through - including a later null produced by a TTL timeout. The flag is
@@ -312,7 +331,7 @@ export class WidgetStreamsDirective implements OnDestroy {
         // Defer base observable creation/refresh to buildAndSubscribe(), which
         // will reuse the cached base when base identity (path+source) is unchanged.
         const reg = this.registrations.find(r => r.pathName === p);
-        if (reg) this.buildAndSubscribe(p, reg.next, cfg, normalizedCfg);
+        if (reg) this.buildAndSubscribe(p, reg.next, cfg, normalizedCfg, reg.subField);
       }
     }
   }
@@ -362,13 +381,18 @@ export class WidgetStreamsDirective implements OnDestroy {
    *
    * @param pathName Logical path key from widget config (config.paths[pathName])
    * @param next Callback for processed updates (unit conversion + sampling applied)
+   * @param subField Optional sub-field key to read out of a whole compound-object value (e.g.
+   *   'latitude' when the path is the canonical compound leaf 'navigation.position'). The widget
+   *   owns this — it is extracted before unit conversion; a scalar value passes through unchanged.
    */
-  public observe(pathName: string, next: (value: IPathUpdate) => void): void {
-    // Capture previous callback before replacing registration
-    const prevReg = this.registrations.find(r => r.pathName === pathName)?.next;
+  public observe(pathName: string, next: (value: IPathUpdate) => void, subField?: string): void {
+    // Capture previous registration before replacing it (callback + sub-field)
+    const prev = this.registrations.find(r => r.pathName === pathName);
+    const prevReg = prev?.next;
+    const prevSubField = prev?.subField;
     // Replace any existing registration for this path (one callback per path)
     this.registrations = this.registrations.filter(r => r.pathName !== pathName);
-    this.registrations.push({ pathName, next });
+    this.registrations.push({ pathName, next, subField });
 
     const cfg = this._streamsConfig();
     if (!cfg || !cfg.paths?.[pathName]) {
@@ -403,10 +427,11 @@ export class WidgetStreamsDirective implements OnDestroy {
     const normalizedCfg = { ...pathCfg, path: normalizedPath };
     const sig = this.computePathSignature(normalizedCfg);
     const existing = this.subscriptions.get(pathName);
-    // If signature unchanged but callback changed, rebuild to swap observer; otherwise keep
-    if (existing && existing.signature === sig && prevReg === next) return;
+    // If signature unchanged and neither the callback nor the sub-field changed, keep as-is;
+    // otherwise rebuild to swap the observer / sub-field extraction.
+    if (existing && existing.signature === sig && prevReg === next && prevSubField === subField) return;
 
-    this.buildAndSubscribe(pathName, next, cfg, normalizedCfg);
+    this.buildAndSubscribe(pathName, next, cfg, normalizedCfg, subField);
   }
 
   /**

--- a/src/app/core/services/configuration-upgrade.service.spec.ts
+++ b/src/app/core/services/configuration-upgrade.service.spec.ts
@@ -195,24 +195,21 @@ describe('ConfigurationUpgradeService', () => {
         expect(mockStorage.setConfig).not.toHaveBeenCalled();
     });
 
-    it('v13 upgrade rewrites compound sub-field widget paths to the whole canonical path and stamps v14', async () => {
+    it('v13 upgrade rewrites sub-field-aware widget paths, sets isPathConfigurable:false, reconciles auto-history, and stamps v14', async () => {
         mockStorage.listConfigs.mockResolvedValueOnce([{ scope: 'user', name: 'default' }]);
         mockStorage.getConfig.mockResolvedValue({
             app: { configVersion: 13 },
             theme: { themeName: '' },
             dashboards: [
                 { id: 'd0', configuration: [
-                    // Record form of paths (typical widget): position sub-fields, attitude sub-field, and a genuine scalar leaf.
-                    { input: { widgetProperties: { config: { paths: {
-                        longPath: { path: 'self.navigation.position.longitude', pathType: 'number' },
-                        latPath: { path: 'self.navigation.position.latitude', pathType: 'number' },
-                        angle: { path: 'self.navigation.attitude.roll', pathType: 'number' },
-                        speed: { path: 'self.navigation.speedOverGround', pathType: 'number' }
+                    { input: { widgetProperties: { type: 'widget-position', config: { paths: {
+                        longPath: { path: 'self.navigation.position.longitude', pathType: 'number', isPathConfigurable: true },
+                        latPath: { path: 'self.navigation.position.latitude', pathType: 'number', isPathConfigurable: true }
                     } } } } },
-                    // Array form of paths (multi-control widget) + a nested compound (autopilot nextPoint position).
-                    { input: { widgetProperties: { config: { paths: [
-                        { path: 'self.navigation.courseGreatCircle.nextPoint.position.latitude', pathType: 'number' }
-                    ] } } } }
+                    { input: { widgetProperties: { type: 'widget-horizon', config: { supportAutomaticHistoricalSeries: true, paths: {
+                        gaugePitchPath: { path: 'self.navigation.attitude.pitch', pathType: 'number', isPathConfigurable: true },
+                        gaugeRollPath: { path: 'self.navigation.attitude.roll', pathType: 'number', isPathConfigurable: true }
+                    } } } } }
                 ] }
             ]
         });
@@ -221,14 +218,61 @@ describe('ConfigurationUpgradeService', () => {
 
         const written = mockStorage.setConfig.mock.calls.at(-1)![2];
         expect(written.app.configVersion).toBe(14);
-        const recordPaths = written.dashboards[0].configuration[0].input.widgetProperties.config.paths;
-        expect(recordPaths.longPath.path).toBe('self.navigation.position');
-        expect(recordPaths.latPath.path).toBe('self.navigation.position');
-        expect(recordPaths.angle.path).toBe('self.navigation.attitude');
-        // A genuine scalar leaf must be left untouched.
-        expect(recordPaths.speed.path).toBe('self.navigation.speedOverGround');
-        const arrayPaths = written.dashboards[0].configuration[1].input.widgetProperties.config.paths;
-        expect(arrayPaths[0].path).toBe('self.navigation.courseGreatCircle.nextPoint.position');
+        const pos = written.dashboards[0].configuration[0].input.widgetProperties.config.paths;
+        expect(pos.longPath.path).toBe('self.navigation.position');
+        expect(pos.latPath.path).toBe('self.navigation.position');
+        // The stale stored true would otherwise override the new isPathConfigurable:false default.
+        expect(pos.longPath.isPathConfigurable).toBe(false);
+        expect(pos.latPath.isPathConfigurable).toBe(false);
+        const horizon = written.dashboards[0].configuration[1].input.widgetProperties.config;
+        expect(horizon.paths.gaugePitchPath.path).toBe('self.navigation.attitude');
+        expect(horizon.paths.gaugeRollPath.path).toBe('self.navigation.attitude');
+        // Charting a compound sub-field is deferred (#345): auto-history reconciled off.
+        expect(horizon.supportAutomaticHistoricalSeries).toBe(false);
+    });
+
+    it('v13 upgrade leaves a GENERIC widget pointed at a compound sub-field untouched (no whole-object readout)', async () => {
+        mockStorage.listConfigs.mockResolvedValueOnce([{ scope: 'user', name: 'default' }]);
+        mockStorage.getConfig.mockResolvedValue({
+            app: { configVersion: 13 },
+            theme: { themeName: '' },
+            dashboards: [
+                { id: 'd0', configuration: [
+                    { input: { widgetProperties: { type: 'widget-numeric', config: { paths: {
+                        numericPath: { path: 'self.navigation.attitude.pitch', pathType: 'number', isPathConfigurable: true }
+                    } } } } }
+                ] }
+            ]
+        });
+
+        await service.runUpgrade(13);
+
+        const written = mockStorage.setConfig.mock.calls.at(-1)![2];
+        expect(written.app.configVersion).toBe(14); // still stamped current
+        const numeric = written.dashboards[0].configuration[0].input.widgetProperties.config.paths.numericPath;
+        expect(numeric.path).toBe('self.navigation.attitude.pitch'); // path left on the inert child (clean no-data), not collapsed
+        expect(numeric.isPathConfigurable).toBe(true);
+    });
+
+    it('v13 upgrade handles the array form of paths on a sub-field-aware widget', async () => {
+        mockStorage.listConfigs.mockResolvedValueOnce([{ scope: 'user', name: 'default' }]);
+        mockStorage.getConfig.mockResolvedValue({
+            app: { configVersion: 13 },
+            theme: { themeName: '' },
+            dashboards: [
+                { id: 'd0', configuration: [
+                    { input: { widgetProperties: { type: 'widget-position', config: { paths: [
+                        { path: 'self.navigation.position.latitude', pathType: 'number', isPathConfigurable: true }
+                    ] } } } }
+                ] }
+            ]
+        });
+
+        await service.runUpgrade(13);
+
+        const written = mockStorage.setConfig.mock.calls.at(-1)![2];
+        expect(written.dashboards[0].configuration[0].input.widgetProperties.config.paths[0].path)
+            .toBe('self.navigation.position');
     });
 
     it('v13 upgrade skips a slot that is not at version 13 (no re-stamp)', async () => {
@@ -251,7 +295,7 @@ describe('ConfigurationUpgradeService', () => {
             theme: { themeName: '' },
             dashboards: [
                 { id: 'd0', configuration: [
-                    { input: { widgetProperties: { config: { paths: {
+                    { input: { widgetProperties: { type: 'widget-heel-gauge', config: { paths: {
                         angle: { path: 'self.navigation.attitude', pathType: 'number' }
                     } } } } }
                 ] }

--- a/src/app/core/services/configuration-upgrade.service.spec.ts
+++ b/src/app/core/services/configuration-upgrade.service.spec.ts
@@ -195,6 +195,76 @@ describe('ConfigurationUpgradeService', () => {
         expect(mockStorage.setConfig).not.toHaveBeenCalled();
     });
 
+    it('v13 upgrade rewrites compound sub-field widget paths to the whole canonical path and stamps v14', async () => {
+        mockStorage.listConfigs.mockResolvedValueOnce([{ scope: 'user', name: 'default' }]);
+        mockStorage.getConfig.mockResolvedValue({
+            app: { configVersion: 13 },
+            theme: { themeName: '' },
+            dashboards: [
+                { id: 'd0', configuration: [
+                    // Record form of paths (typical widget): position sub-fields, attitude sub-field, and a genuine scalar leaf.
+                    { input: { widgetProperties: { config: { paths: {
+                        longPath: { path: 'self.navigation.position.longitude', pathType: 'number' },
+                        latPath: { path: 'self.navigation.position.latitude', pathType: 'number' },
+                        angle: { path: 'self.navigation.attitude.roll', pathType: 'number' },
+                        speed: { path: 'self.navigation.speedOverGround', pathType: 'number' }
+                    } } } } },
+                    // Array form of paths (multi-control widget) + a nested compound (autopilot nextPoint position).
+                    { input: { widgetProperties: { config: { paths: [
+                        { path: 'self.navigation.courseGreatCircle.nextPoint.position.latitude', pathType: 'number' }
+                    ] } } } }
+                ] }
+            ]
+        });
+
+        await service.runUpgrade(13);
+
+        const written = mockStorage.setConfig.mock.calls.at(-1)![2];
+        expect(written.app.configVersion).toBe(14);
+        const recordPaths = written.dashboards[0].configuration[0].input.widgetProperties.config.paths;
+        expect(recordPaths.longPath.path).toBe('self.navigation.position');
+        expect(recordPaths.latPath.path).toBe('self.navigation.position');
+        expect(recordPaths.angle.path).toBe('self.navigation.attitude');
+        // A genuine scalar leaf must be left untouched.
+        expect(recordPaths.speed.path).toBe('self.navigation.speedOverGround');
+        const arrayPaths = written.dashboards[0].configuration[1].input.widgetProperties.config.paths;
+        expect(arrayPaths[0].path).toBe('self.navigation.courseGreatCircle.nextPoint.position');
+    });
+
+    it('v13 upgrade skips a slot that is not at version 13 (no re-stamp)', async () => {
+        mockStorage.listConfigs.mockResolvedValueOnce([{ scope: 'user', name: 'default' }]);
+        mockStorage.getConfig.mockResolvedValue({
+            app: { configVersion: 14 },
+            theme: { themeName: '' },
+            dashboards: []
+        });
+
+        await service.runUpgrade(13);
+
+        expect(mockStorage.setConfig).not.toHaveBeenCalled();
+    });
+
+    it('v13 upgrade is idempotent — a path already at the compound level is not re-trimmed', async () => {
+        mockStorage.listConfigs.mockResolvedValueOnce([{ scope: 'user', name: 'default' }]);
+        mockStorage.getConfig.mockResolvedValue({
+            app: { configVersion: 13 },
+            theme: { themeName: '' },
+            dashboards: [
+                { id: 'd0', configuration: [
+                    { input: { widgetProperties: { config: { paths: {
+                        angle: { path: 'self.navigation.attitude', pathType: 'number' }
+                    } } } } }
+                ] }
+            ]
+        });
+
+        await service.runUpgrade(13);
+
+        const written = mockStorage.setConfig.mock.calls.at(-1)![2];
+        expect(written.dashboards[0].configuration[0].input.widgetProperties.config.paths.angle.path)
+            .toBe('self.navigation.attitude');
+    });
+
     it('startFresh retires BOTH global and user legacy configs via an awaited write before resetting', async () => {
         mockStorage.initConfig = null; // remote (Signal K) path
         mockStorage.listConfigs.mockResolvedValueOnce([

--- a/src/app/core/services/configuration-upgrade.service.ts
+++ b/src/app/core/services/configuration-upgrade.service.ts
@@ -32,6 +32,14 @@ const COMPOUND_SUBFIELD_PATH_SUFFIXES = [
   '.attitude.roll', '.attitude.pitch', '.attitude.yaw',
 ];
 
+// Only the predefined widgets that were adapted to read a compound sub-field off the whole value are
+// rewritten. A generic widget (numeric, gauge, ...) a user pointed at a compound sub-field has no
+// sub-field accessor, so rewriting its path to the whole leaf would render a raw object — worse than
+// leaving it on the now-inert child path (which shows a clean no-data placeholder). Charting a
+// compound sub-field is deferred to #345. Autopilot's Next-WPT position is an internal widget config,
+// not a stored path, so it is not listed here.
+const SUBFIELD_WIDGET_TYPES = new Set(['widget-position', 'widget-heel-gauge', 'widget-horizon']);
+
 // NOTE: This service encapsulates the app-config upgrades — the legacy migration (remote file
 // version 9 / app-config version 10) and the v11 remote upgrade — each stamping the upgraded
 // config with MIGRATION_OUTPUT_VERSION.
@@ -537,10 +545,13 @@ export class ConfigurationUpgradeService {
 
   /**
    * v13 -> v14 (SK-02 / #21): the delta parser no longer flattens compound Signal K leaves into
-   * fabricated dotted child paths. Rewrite every stored widget path that points at a sub-field of a
-   * known compound leaf (`navigation.position.*`, `navigation.attitude.*`, and their nested
-   * occurrences) to the whole canonical path — the affected widgets read the sub-field off the whole
-   * value. Idempotent: a path already at the compound level matches no suffix and is left untouched.
+   * fabricated dotted child paths. For the predefined widgets that were adapted to read a sub-field
+   * off the whole value (SUBFIELD_WIDGET_TYPES only), rewrite each stored path pointing at a
+   * sub-field of a known compound leaf (`navigation.position.*`, `navigation.attitude.*`) to the
+   * whole canonical path, and reconcile the fields whose new defaults a stale stored value would
+   * otherwise override (`isPathConfigurable` -> false; heel/horizon auto-history -> off). A generic
+   * widget is deliberately left untouched (see SUBFIELD_WIDGET_TYPES). Idempotent: a path already at
+   * the compound level matches no suffix.
    */
   private upgradeConfigV13toV14(config: IConfig): IConfig | null {
     try {
@@ -555,18 +566,27 @@ export class ConfigurationUpgradeService {
         for (const dash of config.dashboards) {
           if (!dash || !Array.isArray(dash.configuration)) continue;
           for (const widget of dash.configuration) {
-            const cfg = (widget as { input?: { widgetProperties?: { config?: { paths?: unknown } } } })
-              ?.input?.widgetProperties?.config;
+            const wp = (widget as { input?: { widgetProperties?: {
+              type?: unknown;
+              config?: { paths?: unknown; supportAutomaticHistoricalSeries?: boolean };
+            } } })?.input?.widgetProperties;
+            if (!wp || typeof wp.type !== 'string' || !SUBFIELD_WIDGET_TYPES.has(wp.type)) continue;
+            const type = wp.type;
+            const cfg = wp.config;
             const paths = cfg?.paths;
-            if (!paths || typeof paths !== 'object') continue;
-            // paths is either a Record<string, IWidgetPath> or an IWidgetPath[]; Object.values covers both.
-            for (const pathCfg of Object.values(paths as Record<string, { path?: unknown }>)) {
-              if (!pathCfg || typeof pathCfg.path !== 'string') continue;
-              const suffix = COMPOUND_SUBFIELD_PATH_SUFFIXES.find(s => (pathCfg.path as string).endsWith(s));
-              if (suffix) {
-                pathCfg.path = (pathCfg.path as string).slice(0, (pathCfg.path as string).lastIndexOf('.'));
-                rewritten++;
+            if (paths && typeof paths === 'object') {
+              // paths is either a Record<string, IWidgetPath> or an IWidgetPath[]; Object.values covers both.
+              for (const pathCfg of Object.values(paths as Record<string, { path?: unknown; isPathConfigurable?: boolean }>)) {
+                if (!pathCfg || typeof pathCfg.path !== 'string') continue;
+                if (COMPOUND_SUBFIELD_PATH_SUFFIXES.some(s => (pathCfg.path as string).endsWith(s))) {
+                  pathCfg.path = (pathCfg.path as string).slice(0, (pathCfg.path as string).lastIndexOf('.'));
+                  pathCfg.isPathConfigurable = false;
+                  rewritten++;
+                }
               }
+            }
+            if (cfg && (type === 'widget-heel-gauge' || type === 'widget-horizon')) {
+              cfg.supportAutomaticHistoricalSeries = false;
             }
           }
         }

--- a/src/app/core/services/configuration-upgrade.service.ts
+++ b/src/app/core/services/configuration-upgrade.service.ts
@@ -20,6 +20,18 @@ const MIGRATION_OUTPUT_VERSION = 12;
 // config instead of relabeling it as current.
 const V13_MIGRATION_OUTPUT_VERSION = 13;
 
+// The v13 -> v14 transform output. Pinned to a fixed 14 for the same reason as the constants above.
+const V14_MIGRATION_OUTPUT_VERSION = 14;
+
+// SK-02 / #21: the delta parser stopped fabricating dotted child paths for compound leaves, so a
+// stored widget path pointing at a sub-field of one of these leaves must be rewritten to the whole
+// canonical path (the widgets read the sub-field off the whole value). Matched by suffix so a nested
+// compound (e.g. courseGreatCircle.nextPoint.position) is covered as well as the top-level leaf.
+const COMPOUND_SUBFIELD_PATH_SUFFIXES = [
+  '.position.latitude', '.position.longitude', '.position.altitude',
+  '.attitude.roll', '.attitude.pitch', '.attitude.yaw',
+];
+
 // NOTE: This service encapsulates the app-config upgrades — the legacy migration (remote file
 // version 9 / app-config version 10) and the v11 remote upgrade — each stamping the upgraded
 // config with MIGRATION_OUTPUT_VERSION.
@@ -192,6 +204,30 @@ export class ConfigurationUpgradeService {
         this.upgrading.set(false);
       }
 
+    } else if (version === 13) {
+      // Remote (Signal K) configs. v13 slots live in the same active file version as v11/v12.
+      try {
+        const configsList: Config[] = await this._storage.listConfigs(REMOTE_CONFIG_FILE_VERSION);
+
+        for (const item of configsList) {
+          try {
+            const config = await this._storage.getConfig(item.scope, item.name, REMOTE_CONFIG_FILE_VERSION);
+            this.pushMsg(`[Upgrade] ${item.scope}/${item.name} -> v${V14_MIGRATION_OUTPUT_VERSION}.`);
+            const migratedConfig = this.migrateOneAppVersion(config, 13);
+            if (!migratedConfig) continue; // skip if not a v13 slot
+
+            await this._storage.setConfig(item.scope, item.name, migratedConfig);
+          } catch (error) {
+            this.pushError(`[Upgrade] Error upgrading ${item.scope}/${item.name}: ${(error as Error).message}`);
+          }
+        }
+        this.pushMsg(`[Upgrade] Reloading app to finalize upgrade...`);
+        setTimeout(() => this._settings.reloadApp(), 1500);
+      } catch (error) {
+        this.pushError('Error fetching configuration data. Aborting upgrade. Details: ' + (error as Error).message);
+        this.upgrading.set(false);
+      }
+
     } else {
       // LocalStorage upgrade path for config version 10
       const localStorageConfig: v10IConfig = {
@@ -320,6 +356,7 @@ export class ConfigurationUpgradeService {
     switch (fromVersion) {
       case 11: return this.upgradeConfig(config);
       case 12: return this.upgradeConfigV12toV13(config);
+      case 13: return this.upgradeConfigV13toV14(config);
       default: return null;
     }
   }
@@ -494,6 +531,54 @@ export class ConfigurationUpgradeService {
       return { app: appConfig, theme: config.theme, dashboards: config.dashboards };
     } catch (error) {
       this.pushError(`[Upgrade Service] Error upgrading v12->v13: ${(error as Error).message}`);
+      return null;
+    }
+  }
+
+  /**
+   * v13 -> v14 (SK-02 / #21): the delta parser no longer flattens compound Signal K leaves into
+   * fabricated dotted child paths. Rewrite every stored widget path that points at a sub-field of a
+   * known compound leaf (`navigation.position.*`, `navigation.attitude.*`, and their nested
+   * occurrences) to the whole canonical path — the affected widgets read the sub-field off the whole
+   * value. Idempotent: a path already at the compound level matches no suffix and is left untouched.
+   */
+  private upgradeConfigV13toV14(config: IConfig): IConfig | null {
+    try {
+      const appConfig = config.app;
+      if (!appConfig || appConfig.configVersion !== 13) {
+        this.pushError(`[Upgrade Service] Config version ${appConfig?.configVersion} is not an upgradable v13 config. Skipping...`);
+        return null;
+      }
+
+      let rewritten = 0;
+      if (Array.isArray(config.dashboards)) {
+        for (const dash of config.dashboards) {
+          if (!dash || !Array.isArray(dash.configuration)) continue;
+          for (const widget of dash.configuration) {
+            const cfg = (widget as { input?: { widgetProperties?: { config?: { paths?: unknown } } } })
+              ?.input?.widgetProperties?.config;
+            const paths = cfg?.paths;
+            if (!paths || typeof paths !== 'object') continue;
+            // paths is either a Record<string, IWidgetPath> or an IWidgetPath[]; Object.values covers both.
+            for (const pathCfg of Object.values(paths as Record<string, { path?: unknown }>)) {
+              if (!pathCfg || typeof pathCfg.path !== 'string') continue;
+              const suffix = COMPOUND_SUBFIELD_PATH_SUFFIXES.find(s => (pathCfg.path as string).endsWith(s));
+              if (suffix) {
+                pathCfg.path = (pathCfg.path as string).slice(0, (pathCfg.path as string).lastIndexOf('.'));
+                rewritten++;
+              }
+            }
+          }
+        }
+      }
+      if (rewritten) {
+        this.pushMsg(`[Upgrade] Rewrote ${rewritten} compound sub-field path(s) to their canonical whole path.`);
+      }
+
+      appConfig.configVersion = V14_MIGRATION_OUTPUT_VERSION;
+      return { app: appConfig, theme: config.theme, dashboards: config.dashboards };
+    } catch (error) {
+      this.pushError(`[Upgrade Service] Error upgrading v13->v14: ${(error as Error).message}`);
       return null;
     }
   }

--- a/src/app/core/services/profile.service.spec.ts
+++ b/src/app/core/services/profile.service.spec.ts
@@ -5,10 +5,11 @@ import { StorageService } from './storage.service';
 import { SettingsService } from './settings.service';
 import { ConfigurationUpgradeService } from './configuration-upgrade.service';
 import { IConfig } from '../interfaces/app-settings.interfaces';
+import { LATEST_APP_CONFIG_VERSION } from '../constants/config-versions.const';
 import { DefaultDashboard } from '../../../default-config/config.blank.dashboard';
 
 const cfg = (theme = 'x'): IConfig => ({
-  app: { configVersion: 13 } as IConfig['app'],
+  app: { configVersion: LATEST_APP_CONFIG_VERSION } as IConfig['app'],
   theme: { themeName: theme },
   dashboards: [{ id: 'd' }]
 });
@@ -159,7 +160,7 @@ describe('ProfileService', () => {
       const migrated = await service.importProfile('imported', older);
       expect(migrated).toBe(true);
       const written = storage.setConfig.mock.calls.at(-1)?.[2] as IConfig;
-      expect(written.app?.configVersion).toBe(13);
+      expect(written.app?.configVersion).toBe(LATEST_APP_CONFIG_VERSION);
       expect(settings.setActiveProfile).not.toHaveBeenCalled();
     });
 

--- a/src/app/core/services/signalk-delta.service.spec.ts
+++ b/src/app/core/services/signalk-delta.service.spec.ts
@@ -175,19 +175,18 @@ describe('SignalKDeltaService', () => {
       ]);
     });
 
-    it('recursively flattens a nested object into synthetic dotted child paths', () => {
-      // Pins current behaviour (finding SK-02 / #21): KIP fabricates child paths absent from the SK spec.
+    it('emits an object value whole at its canonical path (no child-path fabrication)', () => {
+      // SK-02 / #21: compound leaves emit whole; the delta service no longer fabricates dotted child paths.
       const { service } = setup();
       const out = collectData(service);
-      parse(service, { context: CTX, updates: [update([{ path: 'navigation.position', value: { latitude: 48.1, longitude: -4.5 } }], { $source: 'gps.1' })] });
-      expect(out.map(v => [v.path, v.value])).toEqual([
-        ['navigation.position.latitude', 48.1],
-        ['navigation.position.longitude', -4.5],
+      const value = { latitude: 48.1, longitude: -4.5 };
+      parse(service, { context: CTX, updates: [update([{ path: 'navigation.position', value }], { $source: 'gps.1' })] });
+      expect(out).toEqual([
+        { context: CTX, path: 'navigation.position', source: 'gps.1', timestamp: TS, value },
       ]);
-      expect(out.every(v => v.source === 'gps.1' && v.timestamp === TS)).toBe(true);
     });
 
-    it('leaves paths in DO_NOT_FLATTEN_PATHS (displays.*) as a single whole-object value', () => {
+    it('emits a nested-object value whole (no recursive flattening)', () => {
       const { service } = setup();
       const out = collectData(service);
       const value = { layout: { rows: 2 }, name: 'main' };
@@ -197,25 +196,25 @@ describe('SignalKDeltaService', () => {
       ]);
     });
 
-    it('falls back to a single-level split when nesting exceeds the depth limit', () => {
-      // Deeper than maxDepth (3): canFlattenCompletely fails, so only the top level is split and the nested value is kept whole.
+    it('emits a deeply nested object whole (no depth-based splitting)', () => {
       const { service } = setup();
       const out = collectData(service);
-      parse(service, { context: CTX, updates: [update([{ path: 'foo.bar', value: { a: { b: { c: { d: 1 } } } } }])] });
+      const value = { a: { b: { c: { d: 1 } } } };
+      parse(service, { context: CTX, updates: [update([{ path: 'foo.bar', value }])] });
       expect(out).toEqual([
-        { context: CTX, path: 'foo.bar.a', source: 'src.1', timestamp: TS, value: { b: { c: { d: 1 } } } },
+        { context: CTX, path: 'foo.bar', source: 'src.1', timestamp: TS, value },
       ]);
     });
 
-    it('falls back to a single-level split when an object exceeds the size limit', () => {
-      // More than maxObjectSize (20) keys: canFlattenCompletely fails, so the object is split one level deep.
+    it('emits a large object whole (no size-based splitting)', () => {
       const { service } = setup();
       const out = collectData(service);
       const wide: Record<string, number> = {};
       for (let i = 0; i < 21; i++) { wide[`k${i}`] = i; }
       parse(service, { context: CTX, updates: [update([{ path: 'wide.obj', value: wide }])] });
-      expect(out).toHaveLength(21);
-      expect(out[0]).toEqual({ context: CTX, path: 'wide.obj.k0', source: 'src.1', timestamp: TS, value: 0 });
+      expect(out).toEqual([
+        { context: CTX, path: 'wide.obj', source: 'src.1', timestamp: TS, value: wide },
+      ]);
     });
 
     it('routes notifications.* items to the notifications stream, not the data stream', () => {
@@ -238,17 +237,19 @@ describe('SignalKDeltaService', () => {
       expect(out[0].context).toBe(foreign);
     });
 
-    it('expands metadata carrying a properties map into per-property emissions', () => {
+    it('emits metadata carrying a properties map whole at the canonical path', () => {
+      // SK-02 / #21: meta mirrors whole-value emission — the per-sub-field properties map stays nested
+      // rather than being fanned out to fabricated child paths.
       const { service } = setup();
       const out: IMeta[] = [];
       service.subscribeMetadataUpdates().subscribe(v => out.push(v));
       const latMeta = { units: 'rad', description: 'Latitude' };
       const lonMeta = { units: 'rad', description: 'Longitude' };
-      const meta = [skMeta('navigation.position', { description: 'Position', properties: { latitude: latMeta, longitude: lonMeta } })];
+      const value = { description: 'Position', properties: { latitude: latMeta, longitude: lonMeta } };
+      const meta = [skMeta('navigation.position', value)];
       parse(service, { context: CTX, updates: [update([], { meta })] });
       expect(out).toEqual([
-        { context: CTX, path: 'navigation.position.latitude', meta: latMeta },
-        { context: CTX, path: 'navigation.position.longitude', meta: lonMeta },
+        { context: CTX, path: 'navigation.position', meta: value },
       ]);
     });
 
@@ -285,49 +286,23 @@ describe('SignalKDeltaService', () => {
       expect(setServerInfo).toHaveBeenCalledWith('sk', '2.0.0', ['main', 'master']);
     });
 
-    it('drops an empty object value entirely — no emissions (latent data loss)', () => {
-      // canFlattenCompletely({}) is true, flattenObjectValue({}) returns [], so nothing is emitted.
+    it('emits an empty object value whole (fixes the former silent-drop data loss)', () => {
+      // Previously canFlattenCompletely({}) was true and flattenObjectValue({}) returned [], dropping data.
       const { service } = setup();
       const out = collectData(service);
       parse(service, { context: CTX, updates: [update([{ path: 'some.path', value: {} }])] });
-      expect(out).toEqual([]);
-    });
-
-    it('flattens an array value into indexed child paths', () => {
-      const { service } = setup();
-      const out = collectData(service);
-      parse(service, { context: CTX, updates: [update([{ path: 'foo.list', value: [10, 20] }])] });
-      expect(out.map(v => [v.path, v.value])).toEqual([
-        ['foo.list.0', 10],
-        ['foo.list.1', 20],
+      expect(out).toEqual([
+        { context: CTX, path: 'some.path', source: 'src.1', timestamp: TS, value: {} },
       ]);
     });
 
-    it('fully flattens nesting whose values sit at depth 2 (inside the depth limit)', () => {
+    it('emits an array value whole (no index-explosion into numeric child paths)', () => {
       const { service } = setup();
       const out = collectData(service);
-      parse(service, { context: CTX, updates: [update([{ path: 'x', value: { a: { b: 1 } } }])] });
-      expect(out.map(v => [v.path, v.value])).toEqual([['x.a.b', 1]]);
-    });
-
-    it('falls back to single-level split once a value sits at depth 3 (the exact cutoff)', () => {
-      // The depth guard fires at currentDepth >= maxDepth (3) before the scalar check, so a value at depth 3 fails.
-      const { service } = setup();
-      const out = collectData(service);
-      parse(service, { context: CTX, updates: [update([{ path: 'x', value: { a: { b: { c: 1 } } } }])] });
+      const value = [10, 20];
+      parse(service, { context: CTX, updates: [update([{ path: 'foo.list', value }])] });
       expect(out).toEqual([
-        { context: CTX, path: 'x.a', source: 'src.1', timestamp: TS, value: { b: { c: 1 } } },
-      ]);
-    });
-
-    it('skips flattening for any path CONTAINING "displays." (substring, not prefix)', () => {
-      // DO_NOT_FLATTEN_PATHS is matched with .includes(), so the guard triggers mid-path too.
-      const { service } = setup();
-      const out = collectData(service);
-      const value = { a: 1, b: 2 };
-      parse(service, { context: CTX, updates: [update([{ path: 'foo.displays.bar', value }])] });
-      expect(out).toEqual([
-        { context: CTX, path: 'foo.displays.bar', source: 'src.1', timestamp: TS, value },
+        { context: CTX, path: 'foo.list', source: 'src.1', timestamp: TS, value },
       ]);
     });
 

--- a/src/app/core/services/signalk-delta.service.ts
+++ b/src/app/core/services/signalk-delta.service.ts
@@ -86,16 +86,6 @@ export class SignalKDeltaService implements OnDestroy {
   private auth = inject(AuthenticationService);
   private connectionStateMachine = inject(ConnectionStateMachine);
 
-  // Object flattening configuration - conservative settings for performance
-  private readonly FLATTEN_CONFIG = {
-    maxDepth: 3,        // Object recursive depth limit
-    maxObjectSize: 20,  // Object number of property limit
-    enableFlattening: true // Enable or disable recursive flattening of objects
-  };
-  private readonly DO_NOT_FLATTEN_PATHS = [  // StartWith paths fragment to exclude from flattening
-    'displays.',
-  ];
-
   constructor() {
     // Register WebSocket retry callback with ConnectionStateMachine
     this.connectionStateMachine.setWebSocketRetryCallback(() => {
@@ -385,108 +375,23 @@ export class SignalKDeltaService implements OnDestroy {
               }
               return;
             }
-            if ((typeof(item.value) == 'object') && (item.value !== null)) {
-              if (this.DO_NOT_FLATTEN_PATHS.some(sub_string => item.path.includes(sub_string))) {
-                // Skip flattening, treat as a single value
-                const dataPath: IPathValueData = {
-                  context: context,
-                  path: item.path,
-                  source: update.$source,
-                  timestamp: update.timestamp,
-                  value: item.value,
-                };
-                this._skValue$.next(dataPath);
-              } else if (this.FLATTEN_CONFIG.enableFlattening &&
-                this.canFlattenCompletely(item.value, this.FLATTEN_CONFIG.maxDepth, this.FLATTEN_CONFIG.maxObjectSize)) {
-                // Perform recursive flattening
-                const flattenedItems = this.flattenObjectValue(item.value, item.path);
-                flattenedItems.forEach(flatItem => {
-                  const dataPath: IPathValueData = {
-                    context: context,
-                    path: flatItem.path,
-                    source: update.$source,
-                    timestamp: update.timestamp,
-                    value: flatItem.value,
-                  };
-                  this._skValue$.next(dataPath);
-                });
-              } else {
-                // Fall back to single-level flattening for objects that exceed limits
-                Object.keys(item.value).forEach(key => {
-                  const dataPath: IPathValueData = {
-                    context: context,
-                    path: `${item.path}.${key}`,
-                    source: update.$source,
-                    timestamp: update.timestamp,
-                    value: item.value[key],
-                  };
-                  this._skValue$.next(dataPath);
-                });
-              }
-            } else {
-              // It's a Primitive type or a null value
-              const dataPath: IPathValueData = {
-                context: context,
-                path: item.path,
-                source: update.$source,
-                timestamp: update.timestamp,
-                value: item.value,
-              };
-              this._skValue$.next(dataPath);
-            }
+            // Emit every value whole at its canonical Signal K path. Object and array values are
+            // no longer flattened into fabricated dotted child paths (SK-02 / #21) — consumers that
+            // need a single sub-field of a compound leaf read it off the whole value. This also
+            // stops the array index-explosion and the size/depth-dependent non-determinism, and
+            // fixes the empty-object ({}) case that previously emitted nothing.
+            const dataPath: IPathValueData = {
+              context: context,
+              path: item.path,
+              source: update.$source,
+              timestamp: update.timestamp,
+              value: item.value,
+            };
+            this._skValue$.next(dataPath);
           }
         });
       }
     });
-  }
-
-  /**
-   * Validates if an object can be completely flattened within configured limits.
-   * Uses all-or-nothing approach to prevent partial flattening.
-   */
-  private canFlattenCompletely(obj: unknown, maxDepth: number, maxSize: number, currentDepth = 0): boolean {
-    if (currentDepth >= maxDepth) {
-      return false;
-    }
-
-    if (typeof obj !== 'object' || obj === null) {
-      return true;
-    }
-
-    const keys = Object.keys(obj);
-    if (keys.length > maxSize) {
-      return false;
-    }
-
-    // Check all nested objects recursively
-    for (const key of keys) {
-      if (!this.canFlattenCompletely((obj as Record<string, unknown>)[key], maxDepth, maxSize, currentDepth + 1)) {
-        return false;
-      }
-    }
-
-    return true;
-  }
-
-  /**
-   * Recursively flattens an object into an array of path-value pairs.
-   * Only called after validation confirms complete flattening is possible.
-   */
-  private flattenObjectValue(obj: unknown, basePath: string, currentDepth = 0): {path: string, value: unknown}[] {
-    const results: {path: string, value: unknown}[] = [];
-
-    if (typeof obj !== 'object' || obj === null || currentDepth >= this.FLATTEN_CONFIG.maxDepth) {
-      return [{ path: basePath, value: obj }];
-    }
-
-    const keys = Object.keys(obj);
-    for (const key of keys) {
-      const newPath = basePath ? `${basePath}.${key}` : key;
-      const nestedResults = this.flattenObjectValue((obj as Record<string, unknown>)[key], newPath, currentDepth + 1);
-      results.push(...nestedResults);
-    }
-
-    return results;
   }
 
   private parseSkMeta(metadata: ISignalKMeta, context: string | undefined) {
@@ -498,21 +403,14 @@ export class SignalKDeltaService implements OnDestroy {
       console.warn("[Delta Service] Dropping metadata update without a path:", metadata);
       return;
     }
-    if (metadata.value.properties != null) {
-      Object.keys(metadata.value.properties).forEach(key => {
-        this._skMetadata$.next({
-          context: context,
-          path: `${metadata.path}.${key}`,
-          meta: metadata.value.properties[key],
-        });
-      });
-    } else {
-      this._skMetadata$.next({
-        context: context,
-        path: metadata.path,
-        meta: metadata.value,
-      });
-    }
+    // Emit meta whole at its canonical path, mirroring whole-value emission (SK-02 / #21). A
+    // compound leaf's per-sub-field meta stays nested in metadata.value.properties rather than
+    // being fanned out to fabricated child paths, so value and meta stay coherent.
+    this._skMetadata$.next({
+      context: context,
+      path: metadata.path,
+      meta: metadata.value,
+    });
   }
 
   // WebSocket Stream Status observable

--- a/src/app/widgets/widget-autopilot/widget-autopilot.component.ts
+++ b/src/app/widgets/widget-autopilot/widget-autopilot.component.ts
@@ -439,10 +439,10 @@ export class WidgetAutopilotComponent implements OnInit, OnDestroy {
       paths: {
         "longPath": {
           description: "Longitude",
-          path: "self.navigation.courseGreatCircle.nextPoint.position.longitude",
+          path: "self.navigation.courseGreatCircle.nextPoint.position",
           source: "default",
           pathType: "number",
-          isPathConfigurable: true,
+          isPathConfigurable: false,
           convertUnitTo: "longitudeMin",
           showPathSkUnitsFilter: true,
           pathSkUnitsFilter: null,
@@ -450,10 +450,10 @@ export class WidgetAutopilotComponent implements OnInit, OnDestroy {
         },
         "latPath": {
           description: "Latitude",
-          path: "self.navigation.courseGreatCircle.nextPoint.position.latitude",
+          path: "self.navigation.courseGreatCircle.nextPoint.position",
           source: "default",
           pathType: "number",
-          isPathConfigurable: true,
+          isPathConfigurable: false,
           convertUnitTo: "latitudeMin",
           showPathSkUnitsFilter: true,
           pathSkUnitsFilter: null,

--- a/src/app/widgets/widget-heel-gauge/widget-heel-gauge.component.spec.ts
+++ b/src/app/widgets/widget-heel-gauge/widget-heel-gauge.component.spec.ts
@@ -7,10 +7,12 @@ import { WidgetStreamsDirective } from '../../core/directives/widget-streams.dir
 describe('WidgetHeelGaugeComponent', () => {
   let fixture: ComponentFixture<WidgetHeelGaugeComponent>;
   let component: WidgetHeelGaugeComponent;
+  let observeCalls: { pathName: string; subField?: string }[];
   let originalGetTotalLength: ((this: SVGElement) => number) | undefined;
   let originalGetPointAtLength: ((this: SVGElement, distance: number) => DOMPoint) | undefined;
 
   beforeEach(async () => {
+    observeCalls = [];
     originalGetTotalLength = (SVGElement.prototype as SVGElement & { getTotalLength?: () => number }).getTotalLength;
     originalGetPointAtLength = (SVGElement.prototype as SVGElement & { getPointAtLength?: (distance: number) => DOMPoint }).getPointAtLength;
 
@@ -30,6 +32,7 @@ describe('WidgetHeelGaugeComponent', () => {
               gauge: { sideLabel: true },
               paths: {
                 angle: {
+                  path: 'self.navigation.attitude',
                   sampleTime: 1000,
                 },
               },
@@ -42,7 +45,9 @@ describe('WidgetHeelGaugeComponent', () => {
         {
           provide: WidgetStreamsDirective,
           useValue: {
-            observe: () => undefined,
+            observe: (pathName: string, _next: unknown, subField?: string) => {
+              observeCalls.push({ pathName, subField });
+            },
           },
         },
       ],
@@ -76,5 +81,11 @@ describe('WidgetHeelGaugeComponent', () => {
 
     expect(component).toBeTruthy();
     expect(fixture.nativeElement.textContent).toContain('Heel');
+  });
+
+  it('observes the whole navigation.attitude leaf and extracts the roll sub-field', () => {
+    fixture.detectChanges();
+
+    expect(observeCalls).toContainEqual({ pathName: 'angle', subField: 'roll' });
   });
 });

--- a/src/app/widgets/widget-heel-gauge/widget-heel-gauge.component.ts
+++ b/src/app/widgets/widget-heel-gauge/widget-heel-gauge.component.ts
@@ -71,16 +71,16 @@ export class WidgetHeelGaugeComponent implements AfterViewInit {
 
   // Static Host2 default config (parity with legacy defaultConfig)
   public static readonly DEFAULT_CONFIG: IWidgetSvcConfig = {
-    supportAutomaticHistoricalSeries: true,
+    supportAutomaticHistoricalSeries: false,
     displayName: 'Heel',
     filterSelfPaths: true,
     paths: {
       angle: {
-        description: 'Heel / Roll / Other Angle',
-        path: 'self.navigation.attitude.roll',
+        description: 'Heel / Roll Angle',
+        path: 'self.navigation.attitude',
         source: 'default',
         pathType: 'number',
-        isPathConfigurable: true,
+        isPathConfigurable: false,
         convertUnitTo: 'deg',
         sampleTime: 1000,
         pathRequired: true
@@ -105,7 +105,8 @@ export class WidgetHeelGaugeComponent implements AfterViewInit {
       if (!cfg) return;
       const angleCfg = cfg.paths?.['angle'];
       if (!angleCfg?.path) return; // nothing to observe if path empty
-      // Establish observation outside reactive tracking of angle updates
+      // Establish observation outside reactive tracking of angle updates. The path is the whole
+      // navigation.attitude compound leaf; the widget reads its 'roll' sub-field.
       untracked(() => this.streams.observe('angle', pkt => {
         const raw = (pkt?.data?.value as number | undefined);
         if (raw == null) {
@@ -114,7 +115,7 @@ export class WidgetHeelGaugeComponent implements AfterViewInit {
         }
         const inv = cfg.gauge?.invertAngle ? -raw : raw;
         this.angleDeg.set(inv);
-      }));
+      }, 'roll'));
     });
 
     // Theme + color config effect

--- a/src/app/widgets/widget-horizon/widget-horizon.component.spec.ts
+++ b/src/app/widgets/widget-horizon/widget-horizon.component.spec.ts
@@ -51,3 +51,38 @@ describe('WidgetHorizonComponent frame visibility', () => {
     expect(c.frameVisibleView()).toBe(false);
   });
 });
+
+describe('WidgetHorizonComponent sub-field extraction', () => {
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('observes the whole navigation.attitude leaf and extracts pitch and roll', () => {
+    const calls: { pathName: string; subField?: string }[] = [];
+    const options = signal<IWidgetSvcConfig | undefined>({
+      gauge: { type: 'horizon' },
+      paths: {
+        gaugePitchPath: { path: 'self.navigation.attitude', sampleTime: 1000 },
+        gaugeRollPath: { path: 'self.navigation.attitude', sampleTime: 1000 },
+      },
+    } as unknown as IWidgetSvcConfig);
+    TestBed.configureTestingModule({
+      imports: [WidgetHorizonComponent],
+      providers: [
+        { provide: WidgetRuntimeDirective, useValue: { options } },
+        {
+          provide: WidgetStreamsDirective,
+          useValue: {
+            observe: (pathName: string, _next: unknown, subField?: string) => calls.push({ pathName, subField }),
+          },
+        },
+      ],
+    });
+    const fixture = TestBed.createComponent(WidgetHorizonComponent);
+    fixture.componentRef.setInput('id', 'test-horizon');
+    fixture.componentRef.setInput('type', 'widget-horizon');
+    fixture.componentRef.setInput('theme', null);
+    fixture.detectChanges();
+
+    expect(calls).toContainEqual({ pathName: 'gaugePitchPath', subField: 'pitch' });
+    expect(calls).toContainEqual({ pathName: 'gaugeRollPath', subField: 'roll' });
+  });
+});

--- a/src/app/widgets/widget-horizon/widget-horizon.component.ts
+++ b/src/app/widgets/widget-horizon/widget-horizon.component.ts
@@ -60,17 +60,17 @@ export class WidgetHorizonComponent implements AfterViewInit, OnDestroy {
 
   // Static default config (legacy parity + displayName)
   public static readonly DEFAULT_CONFIG: IWidgetSvcConfig = {
-    supportAutomaticHistoricalSeries: true,
+    supportAutomaticHistoricalSeries: false,
     displayName: 'Horizon',
     filterSelfPaths: true,
     paths: {
       gaugePitchPath: {
         description: 'Attitude Pitch Data',
-        path: 'self.navigation.attitude.pitch',
+        path: 'self.navigation.attitude',
         source: 'default',
         pathType: 'number',
         pathRequired: false,
-        isPathConfigurable: true,
+        isPathConfigurable: false,
         showPathSkUnitsFilter: false,
         pathSkUnitsFilter: 'rad',
         convertUnitTo: 'deg',
@@ -78,11 +78,11 @@ export class WidgetHorizonComponent implements AfterViewInit, OnDestroy {
       },
       gaugeRollPath: {
         description: 'Attitude Roll Data',
-        path: 'self.navigation.attitude.roll',
+        path: 'self.navigation.attitude',
         source: 'default',
         pathType: 'number',
         pathRequired: false,
-        isPathConfigurable: true,
+        isPathConfigurable: false,
         showPathSkUnitsFilter: false,
         pathSkUnitsFilter: 'rad',
         convertUnitTo: 'deg',
@@ -134,7 +134,7 @@ export class WidgetHorizonComponent implements AfterViewInit, OnDestroy {
           const inv = cfg.gauge?.invertPitch ? -v : v;
           try { this.gauge.setPitchAnimated(inv); } catch { /* ignore */ }
         }
-      }));
+      }, 'pitch'));
     });
 
     // Observe roll path
@@ -149,7 +149,7 @@ export class WidgetHorizonComponent implements AfterViewInit, OnDestroy {
           const inv = cfg.gauge?.invertRoll ? -v : v;
           try { this.gauge.setRollAnimated(inv); } catch { /* ignore */ }
         }
-      }));
+      }, 'roll'));
     });
 
     // Config structural effect (independent from size changes)

--- a/src/app/widgets/widget-position/widget-position.component.ts
+++ b/src/app/widgets/widget-position/widget-position.component.ts
@@ -56,10 +56,10 @@ export class WidgetPositionComponent implements AfterViewInit, OnDestroy {
     paths: {
       longPath: {
         description: 'Longitude',
-        path: 'self.navigation.position.longitude',
+        path: 'self.navigation.position',
         source: 'default',
         pathType: 'number',
-        isPathConfigurable: true,
+        isPathConfigurable: false,
         convertUnitTo: 'longitudeMin',
         showPathSkUnitsFilter: true,
         pathSkUnitsFilter: null,
@@ -67,10 +67,10 @@ export class WidgetPositionComponent implements AfterViewInit, OnDestroy {
       },
       latPath: {
         description: 'Latitude',
-        path: 'self.navigation.position.latitude',
+        path: 'self.navigation.position',
         source: 'default',
         pathType: 'number',
-        isPathConfigurable: true,
+        isPathConfigurable: false,
         convertUnitTo: 'latitudeMin',
         showPathSkUnitsFilter: true,
         pathSkUnitsFilter: null,
@@ -109,7 +109,7 @@ export class WidgetPositionComponent implements AfterViewInit, OnDestroy {
         else this.longPos = String(val);
         this.calculateFontSizeAndPositions();
         this.draw();
-      }));
+      }, 'longitude'));
     });
 
     // Observe latitude path
@@ -124,7 +124,7 @@ export class WidgetPositionComponent implements AfterViewInit, OnDestroy {
         else this.latPos = String(val);
         this.calculateFontSizeAndPositions();
         this.draw();
-      }));
+      }, 'latitude'));
     });
   }
 

--- a/src/assets/kip-dashboard-schema.json
+++ b/src/assets/kip-dashboard-schema.json
@@ -541,7 +541,7 @@
   },
   "meta": {
     "configFileVersion": 11,
-    "configVersion": 13,
+    "configVersion": 14,
     "kipVersion": "4.8.0",
     "schemaVersion": 1
   },
@@ -1435,16 +1435,16 @@
         "paths": {
           "angle": {
             "convertUnitTo": "deg",
-            "description": "Heel / Roll / Other Angle",
-            "isPathConfigurable": true,
-            "path": "self.navigation.attitude.roll",
+            "description": "Heel / Roll Angle",
+            "isPathConfigurable": false,
+            "path": "self.navigation.attitude",
             "pathRequired": true,
             "pathType": "number",
             "sampleTime": 1000,
             "source": "default"
           }
         },
-        "supportAutomaticHistoricalSeries": true
+        "supportAutomaticHistoricalSeries": false
       },
       "defaultHeight": 6,
       "defaultWidth": 4,
@@ -1456,10 +1456,10 @@
       "pathSlots": [
         {
           "defaultConvertUnitTo": "deg",
-          "defaultPath": "self.navigation.attitude.roll",
-          "description": "Heel / Roll / Other Angle",
+          "defaultPath": "self.navigation.attitude",
+          "description": "Heel / Roll Angle",
           "expectedSkUnit": null,
-          "isPathConfigurable": true,
+          "isPathConfigurable": false,
           "pathRequired": true,
           "pathType": "number",
           "sampleTime": 1000,
@@ -1508,8 +1508,8 @@
           "gaugePitchPath": {
             "convertUnitTo": "deg",
             "description": "Attitude Pitch Data",
-            "isPathConfigurable": true,
-            "path": "self.navigation.attitude.pitch",
+            "isPathConfigurable": false,
+            "path": "self.navigation.attitude",
             "pathRequired": false,
             "pathSkUnitsFilter": "rad",
             "pathType": "number",
@@ -1520,8 +1520,8 @@
           "gaugeRollPath": {
             "convertUnitTo": "deg",
             "description": "Attitude Roll Data",
-            "isPathConfigurable": true,
-            "path": "self.navigation.attitude.roll",
+            "isPathConfigurable": false,
+            "path": "self.navigation.attitude",
             "pathRequired": false,
             "pathSkUnitsFilter": "rad",
             "pathType": "number",
@@ -1530,7 +1530,7 @@
             "source": "default"
           }
         },
-        "supportAutomaticHistoricalSeries": true
+        "supportAutomaticHistoricalSeries": false
       },
       "defaultHeight": 6,
       "defaultWidth": 4,
@@ -1542,10 +1542,10 @@
       "pathSlots": [
         {
           "defaultConvertUnitTo": "deg",
-          "defaultPath": "self.navigation.attitude.pitch",
+          "defaultPath": "self.navigation.attitude",
           "description": "Attitude Pitch Data",
           "expectedSkUnit": "rad",
-          "isPathConfigurable": true,
+          "isPathConfigurable": false,
           "pathRequired": false,
           "pathType": "number",
           "sampleTime": 1000,
@@ -1554,10 +1554,10 @@
         },
         {
           "defaultConvertUnitTo": "deg",
-          "defaultPath": "self.navigation.attitude.roll",
+          "defaultPath": "self.navigation.attitude",
           "description": "Attitude Roll Data",
           "expectedSkUnit": "rad",
-          "isPathConfigurable": true,
+          "isPathConfigurable": false,
           "pathRequired": false,
           "pathType": "number",
           "sampleTime": 1000,
@@ -1757,8 +1757,8 @@
           "latPath": {
             "convertUnitTo": "latitudeMin",
             "description": "Latitude",
-            "isPathConfigurable": true,
-            "path": "self.navigation.position.latitude",
+            "isPathConfigurable": false,
+            "path": "self.navigation.position",
             "pathSkUnitsFilter": null,
             "pathType": "number",
             "sampleTime": 500,
@@ -1768,8 +1768,8 @@
           "longPath": {
             "convertUnitTo": "longitudeMin",
             "description": "Longitude",
-            "isPathConfigurable": true,
-            "path": "self.navigation.position.longitude",
+            "isPathConfigurable": false,
+            "path": "self.navigation.position",
             "pathSkUnitsFilter": null,
             "pathType": "number",
             "sampleTime": 500,
@@ -1789,10 +1789,10 @@
       "pathSlots": [
         {
           "defaultConvertUnitTo": "longitudeMin",
-          "defaultPath": "self.navigation.position.longitude",
+          "defaultPath": "self.navigation.position",
           "description": "Longitude",
           "expectedSkUnit": null,
-          "isPathConfigurable": true,
+          "isPathConfigurable": false,
           "pathRequired": false,
           "pathType": "number",
           "sampleTime": 500,
@@ -1801,10 +1801,10 @@
         },
         {
           "defaultConvertUnitTo": "latitudeMin",
-          "defaultPath": "self.navigation.position.latitude",
+          "defaultPath": "self.navigation.position",
           "description": "Latitude",
           "expectedSkUnit": null,
-          "isPathConfigurable": true,
+          "isPathConfigurable": false,
           "pathRequired": false,
           "pathType": "number",
           "sampleTime": 500,

--- a/src/default-config/config.blank.dashboard.ts
+++ b/src/default-config/config.blank.dashboard.ts
@@ -1302,16 +1302,16 @@ export const DefaultDashboard: Dashboard[] = [
             "type": "widget-heel-gauge",
             "uuid": "84f7b83c-2fd9-4de6-88e8-a032a18048cd",
             "config": {
-              "supportAutomaticHistoricalSeries": true,
+              "supportAutomaticHistoricalSeries": false,
               "displayName": "Heel",
               "filterSelfPaths": true,
               "paths": {
                 "angle": {
-                  "description": "Heel / Roll / Other Angle",
-                  "path": "self.navigation.attitude.roll",
+                  "description": "Heel / Roll Angle",
+                  "path": "self.navigation.attitude",
                   "source": "default",
                   "pathType": "number",
-                  "isPathConfigurable": true,
+                  "isPathConfigurable": false,
                   "convertUnitTo": "deg",
                   "sampleTime": 1000,
                   "pathRequired": true
@@ -1345,17 +1345,17 @@ export const DefaultDashboard: Dashboard[] = [
             "type": "widget-horizon",
             "uuid": "119f2f65-e9f9-4c1d-ae93-2ac9ad12b313",
             "config": {
-              "supportAutomaticHistoricalSeries": true,
+              "supportAutomaticHistoricalSeries": false,
               "displayName": "Horizon",
               "filterSelfPaths": true,
               "paths": {
                 "gaugePitchPath": {
                   "description": "Attitude Pitch Data",
-                  "path": "self.navigation.attitude.pitch",
+                  "path": "self.navigation.attitude",
                   "source": "default",
                   "pathType": "number",
                   "pathRequired": false,
-                  "isPathConfigurable": true,
+                  "isPathConfigurable": false,
                   "showPathSkUnitsFilter": false,
                   "pathSkUnitsFilter": "rad",
                   "convertUnitTo": "deg",
@@ -1363,11 +1363,11 @@ export const DefaultDashboard: Dashboard[] = [
                 },
                 "gaugeRollPath": {
                   "description": "Attitude Roll Data",
-                  "path": "self.navigation.attitude.roll",
+                  "path": "self.navigation.attitude",
                   "source": "default",
                   "pathType": "number",
                   "pathRequired": false,
-                  "isPathConfigurable": true,
+                  "isPathConfigurable": false,
                   "showPathSkUnitsFilter": false,
                   "pathSkUnitsFilter": "rad",
                   "convertUnitTo": "deg",
@@ -1407,10 +1407,10 @@ export const DefaultDashboard: Dashboard[] = [
               "paths": {
                 "longPath": {
                   "description": "Longitude",
-                  "path": "self.navigation.position.longitude",
+                  "path": "self.navigation.position",
                   "source": "default",
                   "pathType": "number",
-                  "isPathConfigurable": true,
+                  "isPathConfigurable": false,
                   "convertUnitTo": "longitudeMin",
                   "showPathSkUnitsFilter": true,
                   "pathSkUnitsFilter": null,
@@ -1418,10 +1418,10 @@ export const DefaultDashboard: Dashboard[] = [
                 },
                 "latPath": {
                   "description": "Latitude",
-                  "path": "self.navigation.position.latitude",
+                  "path": "self.navigation.position",
                   "source": "default",
                   "pathType": "number",
-                  "isPathConfigurable": true,
+                  "isPathConfigurable": false,
                   "convertUnitTo": "latitudeMin",
                   "showPathSkUnitsFilter": true,
                   "pathSkUnitsFilter": null,


### PR DESCRIPTION
Closes #21. Stacked on #344 (base branch `fix/ais-whole-object-values`) — merge #344 first, then retarget this to `main`.

## Motivation

`SignalKDeltaService` recursively flattened object/array values into fabricated dotted child paths (`navigation.position.latitude`, `navigation.attitude.roll`, …) that don't exist in the SK spec. The path set was non-deterministic (size/depth heuristics), arrays exploded into `path.0`/`path.1` (no `Array.isArray` guard), and an empty `{}` value silently emitted nothing. Path pickers surfaced fabricated paths and canonical subscriptions (`navigation.position`) received no data.

## Approach

Emit every value **whole** at its canonical SK path; meta likewise (`parseSkMeta` stops fanning `properties` into child meta paths). Verified against the live boat, the only consumers of compound sub-fields are four predefined widgets — so rather than a generic accessor, each reads its own sub-field:

- **`WidgetStreamsDirective.observe(pathName, next, subField?)`** extracts one field from the whole compound value at the single raw-value entry point, **before** unit conversion (so `convertUnitTo`, incl. position's `longitudeMin` formatting, keeps working). A scalar value passes straight through; the sub-field stays out of the base key so widgets sharing a path share one registration.
- **widget-position / heel-gauge / horizon / autopilot Next-WPT** point at the whole compound leaf and pass their sub-field. Those sub-field paths are `isPathConfigurable:false` (a numeric widget can't pick an object-typed path).
- **Config migration v13→v14** rewrites stored sub-field widget paths to the whole canonical path (idempotent; both `Record` and array `paths` forms; nested `nextPoint.position` too). Validated against the boat's actual stored config.
- Default dashboard + regenerated MCP widget schema updated to match.

The **generic sub-field accessor** approach (a config-schema field + path-picker UI + units/charts/history cascade) was explored and rejected as over-engineering for four widgets (rationale on #21). **Charting** a compound sub-field is deferred to #345 (nothing on the boat or in defaults charts one; heel-gauge/horizon `supportAutomaticHistoricalSeries` turned off to avoid an object-typed history query).

## Verification

- Full CI gate green (`lint` → `snc` → `test:headless` → `test:plugin` → `test:mcp-schema`): 1360+ tests.
- Re-pinned delta characterization suite (whole-value + whole-meta emission, array-whole, empty-`{}`-whole data-loss fix); new streams sub-field extraction tests (extract-before-convert, scalar passthrough, missing-field→null); new v13→v14 migration tests (Record + array forms, nested compound, genuine-leaf-untouched, idempotency).
- Migration transform validated against the boat's real stored config (all 5 sub-field paths rewrite correctly).
- **Pending pre-merge:** on-boat visual verification that position/heel/horizon render live and a v13 config upgrades cleanly (batched boat session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)