### PR TITLE
Adopt Signal K unit-preferences as a path's default unit (S2-2, units Phase 1)

### DIFF
--- a/src/app/core/interfaces/signalk-interfaces.ts
+++ b/src/app/core/interfaces/signalk-interfaces.ts
@@ -186,11 +186,27 @@ export interface ISkMetadata {
   properties: object; // Not defined by Kip. Used by GPS and Ship details and other complex data types
   method?: TMethod[];
   displayScale?: ISkDisplayScale
+  /**
+   * Server-supplied display-unit preference (Signal K unit-preferences plugin). Present per path
+   * when the plugin is installed; absent otherwise. `targetUnit`/`symbol` are the plugin's unit key
+   * and abbreviation; `formula`/`inverseFormula` are math.js expressions (SI <-> target) reserved for
+   * a later phase — Skip currently maps `targetUnit` onto its own conversion engine.
+   */
+  displayUnits?: ISkDisplayUnits;
   alertMethod?: TMethod[];
   warnMethod?: TMethod[];
   alarmMethod?: TMethod[];
   emergencyMethod?: TMethod[];
   zones?: ISkZone[];
+}
+
+export interface ISkDisplayUnits {
+  category?: string;
+  targetUnit?: string;
+  symbol?: string;
+  formula?: string;
+  inverseFormula?: string;
+  displayFormat?: string;
 }
 
 export interface ISkPossibleValue {

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -1,7 +1,7 @@
 import { DestroyRef, inject, Injectable, OnDestroy } from '@angular/core';
 import { Observable, BehaviorSubject, ReplaySubject, Subject, map, combineLatest, interval, filter, Subscription } from 'rxjs';
 import { ISkPathData, IPathValueData, IPathMetaData, IMeta, IPathUpdateEvent } from "../interfaces/app-interfaces";
-import { ISignalKDataValueUpdate, ISkMetadata, ISignalKNotification, States, TState } from '../interfaces/signalk-interfaces'
+import { ISignalKDataValueUpdate, ISkMetadata, ISkDisplayUnits, ISignalKNotification, States, TState } from '../interfaces/signalk-interfaces'
 import { SignalKDeltaService } from './signalk-delta.service';
 import { cloneDeep, merge } from 'lodash-es';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -851,6 +851,15 @@ export class DataService implements OnDestroy {
 
   public getPathUnitType(path: string): string | null {
     return this._skData.get(path)?.meta?.units || null;
+  }
+
+  /**
+   * Server-supplied display-unit preference for a path (Signal K unit-preferences plugin), captured
+   * off the existing sendMeta=all stream. Returns undefined when the plugin is absent or the path
+   * carries no displayUnits meta.
+   */
+  public getPathDisplayUnits(path: string): ISkDisplayUnits | undefined {
+    return this._skData.get(path)?.meta?.displayUnits;
   }
 
   /**

--- a/src/app/core/services/units.service.spec.ts
+++ b/src/app/core/services/units.service.spec.ts
@@ -59,4 +59,101 @@ describe('UnitsService', () => {
       expect(service.getUnitDisplaySymbol('')).toBe('');
     });
   });
+
+  describe('getConversionsForPath server displayUnits (#246 Phase 1)', () => {
+    // Build a UnitsService whose DataService reports a path's SI unit + optional server displayUnits.
+    function setupWithData(
+      defaults: IUnitDefaults,
+      pathUnitType: string | null,
+      displayUnits?: { targetUnit?: string },
+    ): UnitsService {
+      TestBed.resetTestingModule();
+      unitDefaults = signal<IUnitDefaults>(defaults);
+      const settingsStub: Partial<SettingsService> = { unitDefaults };
+      const dataStub: Partial<DataService> = {
+        getPathUnitType: () => pathUnitType,
+        getPathDisplayUnits: () => displayUnits,
+      };
+      TestBed.configureTestingModule({
+        providers: [
+          UnitsService,
+          { provide: SettingsService, useValue: settingsStub },
+          { provide: DataService, useValue: dataStub },
+        ],
+      });
+      return TestBed.inject(UnitsService);
+    }
+
+    it("prefers the server targetUnit (aliased to a Skip measure) over the group default", () => {
+      const service = setupWithData({ Speed: 'mph' }, 'm/s', { targetUnit: 'kn' });
+      // Server 'kn' maps to Skip 'knots' and wins over the user's per-group default 'mph'.
+      expect(service.getConversionsForPath('self.navigation.speedOverGround').base).toBe('knots');
+    });
+
+    it('uses a server targetUnit that already equals a Skip measure directly (mbar)', () => {
+      const service = setupWithData({ Pressure: 'psi' }, 'Pa', { targetUnit: 'mbar' });
+      expect(service.getConversionsForPath('self.environment.outside.pressure').base).toBe('mbar');
+    });
+
+    it('falls back to the group default when the path has no server displayUnits', () => {
+      const service = setupWithData({ Speed: 'mph' }, 'm/s', undefined);
+      expect(service.getConversionsForPath('self.navigation.speedOverGround').base).toBe('mph');
+    });
+
+    it('falls back to the group default when the server targetUnit is not honourable for the group', () => {
+      const service = setupWithData({ Speed: 'mph' }, 'm/s', { targetUnit: 'furlong-per-fortnight' });
+      expect(service.getConversionsForPath('self.navigation.speedOverGround').base).toBe('mph');
+    });
+
+    it('resolves the ambiguous C alias to celsius for a temperature path (not Charge Coulomb)', () => {
+      const service = setupWithData({ Temperature: 'K' }, 'K', { targetUnit: 'C' });
+      expect(service.getConversionsForPath('self.environment.water.temperature').base).toBe('celsius');
+    });
+
+    it('does not mis-apply the C->celsius alias on a Charge path (celsius not in group -> fall back)', () => {
+      // A charge path's SI unit is 'C' (Coulomb); a stray targetUnit 'C' must not become celsius.
+      const service = setupWithData({ Charge: 'Ah' }, 'C', { targetUnit: 'C' });
+      expect(service.getConversionsForPath('self.electrical.batteries.house.capacity').base).toBe('Ah');
+    });
+
+    it('maps every non-identity server target through to a valid group measure', () => {
+      // The exact aliased VALUES are load-bearing (the group guard matches them literally).
+      expect(setupWithData({}, 'm', { targetUnit: 'naut-mile' }).getConversionsForPath('self.navigation.trip.log').base).toBe('nm');
+      expect(setupWithData({}, 'rad', { targetUnit: 'degree' }).getConversionsForPath('self.navigation.headingTrue').base).toBe('deg');
+      expect(setupWithData({}, 's', { targetUnit: 'hour' }).getConversionsForPath('self.navigation.trip.timeElapsed').base).toBe('Hours');
+    });
+
+    it('keeps the label-matches-conversion invariant for every aliased category (symbol + working conversion)', () => {
+      // Empty defaults, so the server value is the SOLE base source — proves the invariant holds
+      // across the alias set, not just for one measure.
+      const cases: { unit: string; target: string; measure: string }[] = [
+        { unit: 'm/s', target: 'kn', measure: 'knots' },
+        { unit: 'K', target: 'C', measure: 'celsius' },
+        { unit: 'm', target: 'naut-mile', measure: 'nm' },
+        { unit: 'rad', target: 'degree', measure: 'deg' },
+        { unit: 's', target: 'hour', measure: 'Hours' },
+        { unit: 'Pa', target: 'mbar', measure: 'mbar' },
+      ];
+      for (const c of cases) {
+        const service = setupWithData({}, c.unit, { targetUnit: c.target });
+        const base = service.getConversionsForPath('self.some.path').base;
+        expect(base, `target ${c.target}`).toBe(c.measure);
+        // The one base drives BOTH a non-empty symbol AND a finite conversion.
+        expect(service.getUnitDisplaySymbol(base), `symbol for ${base}`).not.toBe('');
+        expect(Number.isFinite(service.convertToUnit(base, 1) as number), `conversion for ${base}`).toBe(true);
+      }
+    });
+
+    it('every conversion-list measure has a working conversion (a group-valid server base is never value-less)', () => {
+      // Underpins the group-membership guard: because every measure converts, resolving a server
+      // target to any group-valid measure guarantees a real value + matching symbol. Fails loudly if
+      // a future measure is added to the table without a conversion function.
+      const service = setup({});
+      for (const group of service.getConversions()) {
+        for (const unit of group.units) {
+          expect(service.convertToUnit(unit.measure, 1), `measure ${unit.measure}`).not.toBeNull();
+        }
+      }
+    });
+  });
 });

--- a/src/app/core/services/units.service.ts
+++ b/src/app/core/services/units.service.ts
@@ -98,6 +98,23 @@ export interface ISkUnitProperties {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type UnitConverter = (v: any) => any;
 
+/**
+ * Maps a Signal K unit-preferences `displayUnits.targetUnit` string onto Skip's internal conversion
+ * measure key, for the cases where the two differ. Keys are the strings the plugin actually EMITS in
+ * `meta.displayUnits.targetUnit` (verified from live path meta — e.g. temperature emits the bare `C`,
+ * time emits `hour`), NOT the plugin's internal preset/definition keys. Server targets that already
+ * equal a Skip measure (A, V, W, J, mbar, liter, percent, rpm, Ah, deg/s, ...) need no entry — an
+ * unmapped target is used as-is and, when it is not a resolvable conversion for the path's group,
+ * the caller degrades gracefully to Skip's own default. Extend as other presets/units are adopted.
+ */
+const SERVER_TARGET_UNIT_ALIASES: Record<string, string> = {
+  kn: 'knots',
+  'naut-mile': 'nm',
+  degree: 'deg',
+  hour: 'Hours',
+  C: 'celsius',
+};
+
 @Injectable()
 
 export class UnitsService {
@@ -715,12 +732,38 @@ export class UnitsService {
       });
 
       if (groupList.length > 0) {
-        return { base: defaultUnit, conversions: groupList };
+        const serverDefault = this.resolveServerDefaultMeasure(path, groupList);
+        return { base: serverDefault ?? defaultUnit, conversions: groupList };
       }
 
       console.log("[Units Service] Unit type: " + pathUnitType + ", found for path: " + path + "\nbut Kip does not support it.");
       return { base: UNITLESS, conversions: this._conversionList };
     }
+  }
+
+  /** Map a server displayUnits.targetUnit onto a Skip conversion measure key (identity when no alias). */
+  private mapServerTargetToMeasure(targetUnit: string): string {
+    return SERVER_TARGET_UNIT_ALIASES[targetUnit] ?? targetUnit;
+  }
+
+  /**
+   * The server's preferred display measure for a path (Signal K unit-preferences plugin), used as the
+   * default conversion target when present. Returns a measure only when the server's targetUnit maps
+   * to a Skip measure that is valid for the path's own conversion group — so the resolved measure
+   * drives BOTH the conversion and the label from one source (the "label matches conversion"
+   * invariant). Undefined when there is no server preference or it is not honourable (unit-less path,
+   * or an unmapped/unsupported target), in which case the caller falls back to Skip's group default.
+   * Per-widget overrides are unaffected: this only supplies the default a fresh path selection seeds.
+   */
+  private resolveServerDefaultMeasure(path: string, groupList: IUnitGroup[]): string | undefined {
+    const targetUnit = this.data.getPathDisplayUnits(path)?.targetUnit;
+    if (!targetUnit) return undefined;
+    const measure = this.mapServerTargetToMeasure(targetUnit);
+    // Honour the server preference only when the mapped measure is a member of the path's group.
+    // Every conversion-list measure has a conversion function (pinned by a table-integrity test), so a
+    // group-valid measure is guaranteed to drive both a real conversion and a matching symbol — the
+    // label-matches-conversion invariant. Anything else degrades gracefully to Skip's group default.
+    return groupList.some(group => group.units.some(unit => unit.measure === measure)) ? measure : undefined;
   }
 
 }


### PR DESCRIPTION
Phase 1 of #246. Follow-up scope tracked in #347.

## Motivation

Skip owns its entire unit story client-side (a hand-authored conversion table + per-user group defaults). Signal K's `signalk-units-preference` plugin (installed and active on the boat, preset `nautical-metric`) publishes a per-path `displayUnits` preference in path meta. This lets a path default to the **boat-wide** server preference instead of each client configuring units separately.

## What this does (Phase 1)

- Types `ISkMetadata.displayUnits` (`{category, targetUnit, symbol, formula, inverseFormula, displayFormat}`) — the data already arrives via the existing `sendMeta=all` stream and is deep-merged into `_skData[path].meta`; it was just untyped/unread. Adds `DataService.getPathDisplayUnits(path)`.
- `UnitsService.getConversionsForPath(path).base` now prefers the server's `displayUnits.targetUnit` over the per-group `unitDefaults`, so a **freshly-configured** path defaults to the server preference.

## Design choices

- **Route the server `targetUnit` through Skip's own resolver, not its raw `symbol`.** The boat's preset spells some symbols out (`hour`, `liter`) — exactly what #245 fixed — so adopting the server symbol verbatim would regress label consistency. Mapping `targetUnit`→Skip measure yields Skip's clean symbol.
- **Single-source invariant preserved.** Label (`getUnitDisplaySymbol`) and conversion (`convertToUnit`) still both key off one measure, so "the label provably matches the applied conversion" holds — the server preference is honoured only when its `targetUnit` maps to a measure valid for the path's group.
- **Graceful degradation.** Absent plugin, unit-less path (e.g. `navigation.position`), or an unmapped/unsupported target → falls back to Skip's own default. Not gated on any deployment's plugin state.
- **Per-widget `convertUnitTo` overrides untouched** — a stored value still wins; the server only supplies the default. Their retirement (making the server apply live everywhere), formula eval, and the electrical-family temperature seam are **Phase 2 (#347)**.

## Verification

- Full CI gate green (`lint`→`snc`→`test:headless`→`test:plugin`→`test:mcp-schema`).
- New `UnitsService` tests: server target preempts the group default; direct-match (`mbar`) and alias (`kn`→`knots`, `C`→`celsius`) mapping; the `C`→`celsius` alias does **not** mis-apply on a Charge path (group guard); fallback when absent/unmappable; and the label-matches-conversion invariant (resolved base has both a symbol and a working conversion).
- Grounded against the live boat's `displayUnits` vocabulary (15 categories).

🤖 Generated with [Claude Code](https://claude.com/claude-code)