### PR TITLE
refactor(electrical): extract shared config/device normalizers (#4 Stage 1a)

### DIFF
--- a/src/app/widgets/shared/electrical-config.util.spec.ts
+++ b/src/app/widgets/shared/electrical-config.util.spec.ts
@@ -1,0 +1,88 @@
+import {
+  buildIdToDeviceKeysMap,
+  normalizeOptionalString,
+  normalizeStringList,
+  normalizeTrackedDevices
+} from './electrical-config.util';
+
+describe('electrical-config.util', () => {
+  describe('normalizeOptionalString', () => {
+    it('trims a non-empty string', () => {
+      expect(normalizeOptionalString('  house  ')).toBe('house');
+    });
+
+    it('returns null for empty or whitespace-only strings', () => {
+      expect(normalizeOptionalString('')).toBeNull();
+      expect(normalizeOptionalString('   ')).toBeNull();
+    });
+
+    it('returns null for non-string values', () => {
+      expect(normalizeOptionalString(42)).toBeNull();
+      expect(normalizeOptionalString(null)).toBeNull();
+      expect(normalizeOptionalString(undefined)).toBeNull();
+      expect(normalizeOptionalString({})).toBeNull();
+    });
+  });
+
+  describe('normalizeStringList', () => {
+    it('returns an empty array for non-arrays', () => {
+      expect(normalizeStringList(null)).toEqual([]);
+      expect(normalizeStringList('house')).toEqual([]);
+    });
+
+    it('trims, drops empties and non-strings, dedupes, and sorts', () => {
+      expect(normalizeStringList([' b ', 'a', 'b', '', 3, null, 'a'])).toEqual(['a', 'b']);
+    });
+  });
+
+  describe('normalizeTrackedDevices', () => {
+    it('returns an empty array for non-arrays', () => {
+      expect(normalizeTrackedDevices(undefined)).toEqual([]);
+    });
+
+    it('drops items missing id or source and skips non-objects', () => {
+      const result = normalizeTrackedDevices([
+        'plain-string',
+        { id: 'a' },
+        { source: 'x' },
+        { id: 'a', source: 'x' }
+      ]);
+      expect(result).toEqual([{ id: 'a', source: 'x', key: 'a||x' }]);
+    });
+
+    it('synthesizes a key from id and source when key is absent', () => {
+      expect(normalizeTrackedDevices([{ id: 'bat', source: 'n2k' }])).toEqual([
+        { id: 'bat', source: 'n2k', key: 'bat||n2k' }
+      ]);
+    });
+
+    it('honors an explicit key and dedupes by key, sorted', () => {
+      const result = normalizeTrackedDevices([
+        { id: 'b', source: 's', key: 'z' },
+        { id: 'a', source: 's', key: 'a' },
+        { id: 'b', source: 's', key: 'z' }
+      ]);
+      expect(result).toEqual([
+        { id: 'a', source: 's', key: 'a' },
+        { id: 'b', source: 's', key: 'z' }
+      ]);
+    });
+  });
+
+  describe('buildIdToDeviceKeysMap', () => {
+    it('groups device keys under their id', () => {
+      const map = buildIdToDeviceKeysMap([
+        { id: 'a', source: 's1', key: 'a||s1' },
+        { id: 'a', source: 's2', key: 'a||s2' },
+        { id: 'b', source: 's1', key: 'b||s1' }
+      ]);
+      expect(map.get('a')).toEqual(['a||s1', 'a||s2']);
+      expect(map.get('b')).toEqual(['b||s1']);
+      expect(map.size).toBe(2);
+    });
+
+    it('returns an empty map for no devices', () => {
+      expect(buildIdToDeviceKeysMap([]).size).toBe(0);
+    });
+  });
+});

--- a/src/app/widgets/shared/electrical-config.util.ts
+++ b/src/app/widgets/shared/electrical-config.util.ts
@@ -1,0 +1,74 @@
+import type { ElectricalTrackedDevice } from '../../core/interfaces/widgets-interface';
+
+/**
+ * Shared configuration/device normalizers for the electrical widget family
+ * (charger, alternator, inverter, ac, and the parts of solar-charger/bms that
+ * share the object-based device model). Each widget previously carried its own
+ * verbatim copy of these; solar-charger and bms keep their own divergent
+ * `normalizeTrackedDevices`, and ac keeps `normalizeAcTrackedDevices` (a
+ * reserved-aggregate-id guard) — all behaviorally distinct, see #351.
+ */
+
+export function normalizeOptionalString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+export function normalizeStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const ids = new Set<string>();
+  value.forEach(item => {
+    if (typeof item !== 'string') {
+      return;
+    }
+
+    const normalized = item.trim();
+    if (normalized.length > 0) {
+      ids.add(normalized);
+    }
+  });
+
+  return [...ids].sort((left, right) => left.localeCompare(right));
+}
+
+export function normalizeTrackedDevices(value: unknown): ElectricalTrackedDevice[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const devices = new Map<string, ElectricalTrackedDevice>();
+  value.forEach(item => {
+    if (!item || typeof item !== 'object') {
+      return;
+    }
+
+    const candidate = item as { id?: unknown; source?: unknown; key?: unknown };
+    const id = normalizeOptionalString(candidate.id);
+    const source = normalizeOptionalString(candidate.source);
+    if (!id || !source) {
+      return;
+    }
+
+    const key = normalizeOptionalString(candidate.key) ?? `${id}||${source}`;
+    devices.set(key, { id, source, key });
+  });
+
+  return [...devices.values()].sort((left, right) => left.key.localeCompare(right.key));
+}
+
+export function buildIdToDeviceKeysMap(devices: readonly ElectricalTrackedDevice[]): Map<string, string[]> {
+  const map = new Map<string, string[]>();
+  devices.forEach(device => {
+    const existing = map.get(device.id) ?? [];
+    existing.push(device.key);
+    map.set(device.id, existing);
+  });
+  return map;
+}

--- a/src/app/widgets/widget-ac/widget-ac.component.ts
+++ b/src/app/widgets/widget-ac/widget-ac.component.ts
@@ -18,6 +18,7 @@ import {
   ELECTRICAL_DIRECT_CARD_VIEWBOX_WIDTH,
   ELECTRICAL_DIRECT_COMPACT_CARD_HEIGHT
 } from '../shared/electrical-card-layout.constants';
+import { normalizeOptionalString, normalizeStringList, buildIdToDeviceKeysMap } from '../shared/electrical-config.util';
 import type { AcDisplayModel, AcSnapshot, AcWidgetConfig, ElectricalCardModeConfig } from './widget-ac.types';
 import { WidgetTitleComponent } from '../../core/components/widget-title/widget-title.component';
 
@@ -322,8 +323,8 @@ export class WidgetAcComponent implements AfterViewInit, OnDestroy {
       }
 
       const candidate = item as { id?: unknown; source?: unknown; key?: unknown };
-      const id = this.normalizeOptionalString(candidate.id);
-      const source = this.normalizeOptionalString(candidate.source);
+      const id = normalizeOptionalString(candidate.id);
+      const source = normalizeOptionalString(candidate.source);
       if (!id || !source) {
         return;
       }
@@ -332,57 +333,30 @@ export class WidgetAcComponent implements AfterViewInit, OnDestroy {
         return;
       }
 
-      const key = this.normalizeOptionalString(candidate.key) ?? `${id}||${source}`;
+      const key = normalizeOptionalString(candidate.key) ?? `${id}||${source}`;
       devices.set(key, { id, source, key });
     });
 
     return [...devices.values()].sort((left, right) => left.key.localeCompare(right.key));
   }
 
-  private buildIdToDeviceKeysMap(): Map<string, string[]> {
-    const map = new Map<string, string[]>();
-    this.trackedDevices().forEach(device => {
-      const existing = map.get(device.id) ?? [];
-      existing.push(device.key);
-      map.set(device.id, existing);
-    });
-    return map;
-  }
-
   private normalizeCardMode(value: unknown): ElectricalCardModeConfig {
     const candidate = (value && typeof value === 'object') ? value as { displayMode?: unknown; metrics?: unknown } : null;
-    const metrics = this.normalizeStringList(candidate?.metrics);
+    const metrics = normalizeStringList(candidate?.metrics);
     return {
       displayMode: candidate?.displayMode === 'compact' ? 'compact' : 'full',
       metrics: metrics.length ? metrics : ['line1Voltage', 'line1Current', 'line1Frequency', 'line2Voltage']
     };
   }
 
-  private normalizeStringList(value: unknown): string[] {
-    if (!Array.isArray(value)) return [];
-    const ids = new Set<string>();
-    value.forEach(item => {
-      if (typeof item !== 'string') return;
-      const normalized = item.trim();
-      if (normalized.length > 0) ids.add(normalized);
-    });
-    return [...ids].sort((a, b) => a.localeCompare(b));
-  }
-
   private normalizeOptionsById(value: unknown): AcWidgetConfig['optionsById'] {
     if (!value || typeof value !== 'object') return {};
     const next: AcWidgetConfig['optionsById'] = {};
     Object.entries(value as Record<string, unknown>).forEach(([id]) => {
-      const normalizedId = this.normalizeOptionalString(id);
+      const normalizedId = normalizeOptionalString(id);
       if (normalizedId) next[normalizedId] = {};
     });
     return next;
-  }
-
-  private normalizeOptionalString(value: unknown): string | null {
-    if (typeof value !== 'string') return null;
-    const normalized = value.trim();
-    return normalized.length > 0 ? normalized : null;
   }
 
   private enqueuePathUpdate(update: IPathUpdateWithPath, fromInitial = false): void {
@@ -416,7 +390,7 @@ export class WidgetAcComponent implements AfterViewInit, OnDestroy {
     const uniqueIds = new Set(updates.map(item => item.id));
     uniqueIds.forEach(id => this.trackDiscoveredBus(id));
 
-    const idToKeys = this.buildIdToDeviceKeysMap();
+    const idToKeys = buildIdToDeviceKeysMap(this.trackedDevices());
 
     this.busesByKey.update(current => {
       let next = current;

--- a/src/app/widgets/widget-alternator/widget-alternator.component.ts
+++ b/src/app/widgets/widget-alternator/widget-alternator.component.ts
@@ -20,6 +20,7 @@ import {
 } from '../shared/electrical-card-layout.constants';
 import type { AlternatorDisplayModel, AlternatorSnapshot, AlternatorWidgetConfig, ElectricalCardModeConfig } from './widget-alternator.types';
 import { WidgetTitleComponent } from '../../core/components/widget-title/widget-title.component';
+import { normalizeOptionalString, normalizeStringList, normalizeTrackedDevices, buildIdToDeviceKeysMap } from '../shared/electrical-config.util';
 
 function escapeRegex(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -324,45 +325,10 @@ export class WidgetAlternatorComponent implements AfterViewInit, OnDestroy {
     );
 
     return {
-      trackedDevices: this.normalizeTrackedDevices(alternator?.trackedDevices),
+      trackedDevices: normalizeTrackedDevices(alternator?.trackedDevices),
       optionsById,
       cardMode: this.normalizeCardMode(alternator?.cardMode)
     };
-  }
-
-  private normalizeTrackedDevices(value: unknown): ElectricalTrackedDevice[] {
-    if (!Array.isArray(value)) {
-      return [];
-    }
-
-    const devices = new Map<string, ElectricalTrackedDevice>();
-    value.forEach(item => {
-      if (!item || typeof item !== 'object') {
-        return;
-      }
-
-      const candidate = item as { id?: unknown; source?: unknown; key?: unknown };
-      const id = this.normalizeOptionalString(candidate.id);
-      const source = this.normalizeOptionalString(candidate.source);
-      if (!id || !source) {
-        return;
-      }
-
-      const key = this.normalizeOptionalString(candidate.key) ?? `${id}||${source}`;
-      devices.set(key, { id, source, key });
-    });
-
-    return [...devices.values()].sort((left, right) => left.key.localeCompare(right.key));
-  }
-
-  private buildIdToDeviceKeysMap(): Map<string, string[]> {
-    const map = new Map<string, string[]>();
-    this.trackedDevices().forEach(device => {
-      const existing = map.get(device.id) ?? [];
-      existing.push(device.key);
-      map.set(device.id, existing);
-    });
-    return map;
   }
 
   private normalizeCardMode(value: unknown): ElectricalCardModeConfig {
@@ -374,31 +340,11 @@ export class WidgetAlternatorComponent implements AfterViewInit, OnDestroy {
       };
     }
 
-    const metrics = this.normalizeStringList(candidate?.metrics);
+    const metrics = normalizeStringList(candidate?.metrics);
     return {
       displayMode: candidate?.displayMode === 'compact' ? 'compact' : 'full',
       metrics: metrics.length ? metrics : ['voltage', 'current', 'power', 'revolutions']
     };
-  }
-
-  private normalizeStringList(value: unknown): string[] {
-    if (!Array.isArray(value)) {
-      return [];
-    }
-
-    const ids = new Set<string>();
-    value.forEach(item => {
-      if (typeof item !== 'string') {
-        return;
-      }
-
-      const normalized = item.trim();
-      if (normalized.length > 0) {
-        ids.add(normalized);
-      }
-    });
-
-    return [...ids].sort((left, right) => left.localeCompare(right));
   }
 
   private normalizeOptionsById(value: unknown): AlternatorWidgetConfig['optionsById'] {
@@ -408,7 +354,7 @@ export class WidgetAlternatorComponent implements AfterViewInit, OnDestroy {
 
     const next: AlternatorWidgetConfig['optionsById'] = {};
     Object.entries(value as Record<string, unknown>).forEach(([id]) => {
-      const normalizedId = this.normalizeOptionalString(id);
+      const normalizedId = normalizeOptionalString(id);
       if (!normalizedId) {
         return;
       }
@@ -417,15 +363,6 @@ export class WidgetAlternatorComponent implements AfterViewInit, OnDestroy {
     });
 
     return next;
-  }
-
-  private normalizeOptionalString(value: unknown): string | null {
-    if (typeof value !== 'string') {
-      return null;
-    }
-
-    const normalized = value.trim();
-    return normalized.length > 0 ? normalized : null;
   }
 
   private enqueuePathUpdate(update: IPathUpdateWithPath, fromInitial = false): void {
@@ -476,7 +413,7 @@ export class WidgetAlternatorComponent implements AfterViewInit, OnDestroy {
     const uniqueIds = new Set(updates.map(update => update.id));
     uniqueIds.forEach(id => this.trackDiscoveredAlternator(id));
 
-    const idToKeys = this.buildIdToDeviceKeysMap();
+    const idToKeys = buildIdToDeviceKeysMap(this.trackedDevices());
 
     this.alternatorsByKey.update(current => {
       let nextState = current;

--- a/src/app/widgets/widget-bms/widget-bms.component.ts
+++ b/src/app/widgets/widget-bms/widget-bms.component.ts
@@ -15,6 +15,7 @@ import type { BmsBankDisplayModel, BmsBankSummary, BmsBatteryDisplayModel, BmsBa
 import type { ElectricalCardDisplayMode } from '../../core/contracts/electrical-topology-card.contract';
 import type { ITheme } from '../../core/services/app-service';
 import { ELECTRICAL_DIRECT_CARD_HEIGHT, ELECTRICAL_DIRECT_CARD_FULL_LAYOUT, ELECTRICAL_DIRECT_CARD_VIEWBOX_WIDTH } from '../shared/electrical-card-layout.constants';
+import { normalizeOptionalString, normalizeStringList } from '../shared/electrical-config.util';
 import { WidgetTitleComponent } from '../../core/components/widget-title/widget-title.component';
 
 interface BmsRenderBank extends BmsBankSummary {
@@ -436,31 +437,11 @@ export class WidgetBmsComponent implements AfterViewInit, OnDestroy {
       ? value as { displayMode?: unknown; metrics?: unknown }
       : null;
 
-    const metrics = this.normalizeStringList(cardMode?.metrics);
+    const metrics = normalizeStringList(cardMode?.metrics);
     return {
       displayMode: cardMode?.displayMode === 'compact' ? 'compact' : 'full',
       metrics
     };
-  }
-
-  private normalizeStringList(value: unknown): string[] {
-    if (!Array.isArray(value)) {
-      return [];
-    }
-
-    const ids = new Set<string>();
-    value.forEach(item => {
-      if (typeof item !== 'string') {
-        return;
-      }
-
-      const normalized = item.trim();
-      if (normalized.length > 0) {
-        ids.add(normalized);
-      }
-    });
-
-    return [...ids].sort((left, right) => left.localeCompare(right));
   }
 
   private normalizeBanksFromGroups(groups: unknown): BmsBankConfig[] {
@@ -470,9 +451,9 @@ export class WidgetBmsComponent implements AfterViewInit, OnDestroy {
 
     return groups
       .map(group => {
-        const id = this.normalizeOptionalString((group as { id?: unknown })?.id) ?? `bank-${Date.now()}`;
-        const name = this.normalizeOptionalString((group as { name?: unknown })?.name) ?? id;
-        const memberIds = this.normalizeStringList((group as { memberIds?: unknown })?.memberIds);
+        const id = normalizeOptionalString((group as { id?: unknown })?.id) ?? `bank-${Date.now()}`;
+        const name = normalizeOptionalString((group as { name?: unknown })?.name) ?? id;
+        const memberIds = normalizeStringList((group as { memberIds?: unknown })?.memberIds);
         return {
           id,
           name,
@@ -490,9 +471,9 @@ export class WidgetBmsComponent implements AfterViewInit, OnDestroy {
 
     return banks
       .map(bank => {
-        const id = this.normalizeOptionalString((bank as { id?: unknown })?.id) ?? `bank-${Date.now()}`;
-        const name = this.normalizeOptionalString((bank as { name?: unknown })?.name) ?? id;
-        const batteryIds = this.normalizeStringList((bank as { batteryIds?: unknown })?.batteryIds);
+        const id = normalizeOptionalString((bank as { id?: unknown })?.id) ?? `bank-${Date.now()}`;
+        const name = normalizeOptionalString((bank as { name?: unknown })?.name) ?? id;
+        const batteryIds = normalizeStringList((bank as { batteryIds?: unknown })?.batteryIds);
         return {
           id,
           name,
@@ -501,15 +482,6 @@ export class WidgetBmsComponent implements AfterViewInit, OnDestroy {
         };
       })
       .filter(bank => bank.id.length > 0);
-  }
-
-  private normalizeOptionalString(value: unknown): string | null {
-    if (typeof value !== 'string') {
-      return null;
-    }
-
-    const normalized = value.trim();
-    return normalized.length > 0 ? normalized : null;
   }
 
   private normalizeConnectionMode(mode: unknown): BmsBankConnectionMode {

--- a/src/app/widgets/widget-charger/widget-charger.component.ts
+++ b/src/app/widgets/widget-charger/widget-charger.component.ts
@@ -12,6 +12,7 @@ import type { ElectricalTrackedDevice, IWidgetSvcConfig } from '../../core/inter
 import type { ITheme } from '../../core/services/app-service';
 import type { ChargerDisplayModel, ChargerSnapshot } from './widget-charger.types';
 import { ELECTRICAL_DIRECT_CARD_COMPACT_LAYOUT, ELECTRICAL_DIRECT_CARD_FULL_LAYOUT, ELECTRICAL_DIRECT_CARD_GAP, ELECTRICAL_DIRECT_CARD_HEIGHT, ELECTRICAL_DIRECT_CARD_VIEWBOX_WIDTH, ELECTRICAL_DIRECT_COMPACT_CARD_HEIGHT } from '../shared/electrical-card-layout.constants';
+import { normalizeOptionalString, normalizeTrackedDevices, buildIdToDeviceKeysMap } from '../shared/electrical-config.util';
 import { WidgetTitleComponent } from '../../core/components/widget-title/widget-title.component';
 
 interface ChargerRenderSnapshot {
@@ -251,44 +252,9 @@ export class WidgetChargerComponent implements AfterViewInit, OnDestroy {
   }
 
   private applyConfig(cfg: IWidgetSvcConfig): void {
-    const trackedDevices = this.normalizeTrackedDevices(cfg.charger?.trackedDevices);
+    const trackedDevices = normalizeTrackedDevices(cfg.charger?.trackedDevices);
     this.trackedDevices.set(trackedDevices);
     this.reprojectSnapshotsToDeviceKeys(trackedDevices);
-  }
-
-  private normalizeTrackedDevices(value: unknown): ElectricalTrackedDevice[] {
-    if (!Array.isArray(value)) {
-      return [];
-    }
-
-    const devices = new Map<string, ElectricalTrackedDevice>();
-    value.forEach(item => {
-      if (!item || typeof item !== 'object') {
-        return;
-      }
-
-      const candidate = item as { id?: unknown; source?: unknown; key?: unknown };
-      const id = this.normalizeOptionalString(candidate.id);
-      const source = this.normalizeOptionalString(candidate.source);
-      if (!id || !source) {
-        return;
-      }
-
-      const key = this.normalizeOptionalString(candidate.key) ?? `${id}||${source}`;
-      devices.set(key, { id, source, key });
-    });
-
-    return [...devices.values()].sort((left, right) => left.key.localeCompare(right.key));
-  }
-
-  private buildIdToDeviceKeysMap(): Map<string, string[]> {
-    const map = new Map<string, string[]>();
-    this.trackedDevices().forEach(device => {
-      const existing = map.get(device.id) ?? [];
-      existing.push(device.key);
-      map.set(device.id, existing);
-    });
-    return map;
   }
 
   private reprojectSnapshotsToDeviceKeys(devices: ElectricalTrackedDevice[]): void {
@@ -329,15 +295,6 @@ export class WidgetChargerComponent implements AfterViewInit, OnDestroy {
 
       return changed ? next : current;
     });
-  }
-
-  private normalizeOptionalString(value: unknown): string | null {
-    if (typeof value !== 'string') {
-      return null;
-    }
-
-    const normalized = value.trim();
-    return normalized.length > 0 ? normalized : null;
   }
 
   private enqueuePathUpdate(update: IPathUpdateWithPath, fromInitial = false): void {
@@ -392,7 +349,7 @@ export class WidgetChargerComponent implements AfterViewInit, OnDestroy {
     const uniqueIds = new Set(updates.map(update => update.id));
     uniqueIds.forEach(id => this.trackDiscoveredCharger(id));
 
-    const idToKeys = this.buildIdToDeviceKeysMap();
+    const idToKeys = buildIdToDeviceKeysMap(this.trackedDevices());
     const trackedDevicesByKey = new Map<string, ElectricalTrackedDevice>();
     this.trackedDevices().forEach(device => trackedDevicesByKey.set(device.key, device));
 
@@ -457,12 +414,12 @@ export class WidgetChargerComponent implements AfterViewInit, OnDestroy {
   }
 
   private extractUpdateSource(update: IPathUpdateWithPath): string | null {
-    const sourceFromUpdate = this.normalizeOptionalString((update as { source?: unknown }).source);
+    const sourceFromUpdate = normalizeOptionalString((update as { source?: unknown }).source);
     if (sourceFromUpdate) {
       return sourceFromUpdate;
     }
 
-    const sourceFromData = this.normalizeOptionalString((update.update?.data as { source?: unknown } | undefined)?.source);
+    const sourceFromData = normalizeOptionalString((update.update?.data as { source?: unknown } | undefined)?.source);
     return sourceFromData ?? null;
   }
 

--- a/src/app/widgets/widget-inverter/widget-inverter.component.ts
+++ b/src/app/widgets/widget-inverter/widget-inverter.component.ts
@@ -20,6 +20,7 @@ import {
 } from '../shared/electrical-card-layout.constants';
 import type { InverterDisplayModel, InverterSnapshot, InverterWidgetConfig, ElectricalCardModeConfig } from './widget-inverter.types';
 import { WidgetTitleComponent } from '../../core/components/widget-title/widget-title.component';
+import { normalizeOptionalString, normalizeStringList, normalizeTrackedDevices, buildIdToDeviceKeysMap } from '../shared/electrical-config.util';
 
 function escapeRegex(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -306,81 +307,29 @@ export class WidgetInverterComponent implements AfterViewInit, OnDestroy {
   private resolveInverterConfig(cfg: IWidgetSvcConfig): InverterWidgetConfig {
     const inverter = cfg.inverter;
     return {
-      trackedDevices: this.normalizeTrackedDevices(inverter?.trackedDevices),
+      trackedDevices: normalizeTrackedDevices(inverter?.trackedDevices),
       optionsById: this.normalizeOptionsById(inverter?.optionsById),
       cardMode: this.normalizeCardMode(inverter?.cardMode)
     };
   }
 
-  private normalizeTrackedDevices(value: unknown): ElectricalTrackedDevice[] {
-    if (!Array.isArray(value)) {
-      return [];
-    }
-
-    const devices = new Map<string, ElectricalTrackedDevice>();
-    value.forEach(item => {
-      if (!item || typeof item !== 'object') {
-        return;
-      }
-
-      const candidate = item as { id?: unknown; source?: unknown; key?: unknown };
-      const id = this.normalizeOptionalString(candidate.id);
-      const source = this.normalizeOptionalString(candidate.source);
-      if (!id || !source) {
-        return;
-      }
-
-      const key = this.normalizeOptionalString(candidate.key) ?? `${id}||${source}`;
-      devices.set(key, { id, source, key });
-    });
-
-    return [...devices.values()].sort((left, right) => left.key.localeCompare(right.key));
-  }
-
-  private buildIdToDeviceKeysMap(): Map<string, string[]> {
-    const map = new Map<string, string[]>();
-    this.trackedDevices().forEach(device => {
-      const existing = map.get(device.id) ?? [];
-      existing.push(device.key);
-      map.set(device.id, existing);
-    });
-    return map;
-  }
-
   private normalizeCardMode(value: unknown): ElectricalCardModeConfig {
     const candidate = (value && typeof value === 'object') ? value as { displayMode?: unknown; metrics?: unknown } : null;
-    const metrics = this.normalizeStringList(candidate?.metrics);
+    const metrics = normalizeStringList(candidate?.metrics);
     return {
       displayMode: candidate?.displayMode === 'compact' ? 'compact' : 'full',
       metrics: metrics.length ? metrics : ['dcVoltage', 'dcCurrent', 'acVoltage', 'acFrequency']
     };
   }
 
-  private normalizeStringList(value: unknown): string[] {
-    if (!Array.isArray(value)) return [];
-    const ids = new Set<string>();
-    value.forEach(item => {
-      if (typeof item !== 'string') return;
-      const normalized = item.trim();
-      if (normalized.length > 0) ids.add(normalized);
-    });
-    return [...ids].sort((a, b) => a.localeCompare(b));
-  }
-
   private normalizeOptionsById(value: unknown): InverterWidgetConfig['optionsById'] {
     if (!value || typeof value !== 'object') return {};
     const next: InverterWidgetConfig['optionsById'] = {};
     Object.entries(value as Record<string, unknown>).forEach(([id]) => {
-      const normalizedId = this.normalizeOptionalString(id);
+      const normalizedId = normalizeOptionalString(id);
       if (normalizedId) next[normalizedId] = {};
     });
     return next;
-  }
-
-  private normalizeOptionalString(value: unknown): string | null {
-    if (typeof value !== 'string') return null;
-    const normalized = value.trim();
-    return normalized.length > 0 ? normalized : null;
   }
 
   private enqueuePathUpdate(update: IPathUpdateWithPath, fromInitial = false): void {
@@ -421,7 +370,7 @@ export class WidgetInverterComponent implements AfterViewInit, OnDestroy {
     const uniqueIds = new Set(updates.map(update => update.id));
     uniqueIds.forEach(id => this.trackDiscoveredInverter(id));
 
-    const idToKeys = this.buildIdToDeviceKeysMap();
+    const idToKeys = buildIdToDeviceKeysMap(this.trackedDevices());
 
     this.invertersByKey.update(current => {
       let nextState = current;

--- a/src/app/widgets/widget-solar-charger/widget-solar-charger.component.ts
+++ b/src/app/widgets/widget-solar-charger/widget-solar-charger.component.ts
@@ -12,6 +12,7 @@ import type { ElectricalCardModeConfig, ElectricalTrackedDevice, SolarChargerDis
 import { getElectricalWidgetFamilyDescriptor } from '../../core/contracts/electrical-widget-family.contract';
 import type { ElectricalCardDisplayMode } from '../../core/contracts/electrical-topology-card.contract';
 import { ELECTRICAL_DIRECT_CARD_GAP, ELECTRICAL_DIRECT_CARD_HEIGHT, ELECTRICAL_DIRECT_CARD_VIEWBOX_WIDTH, ELECTRICAL_DIRECT_CARD_FULL_LAYOUT } from '../shared/electrical-card-layout.constants';
+import { normalizeOptionalString, normalizeStringList } from '../shared/electrical-config.util';
 import { WidgetTitleComponent } from '../../core/components/widget-title/widget-title.component';
 
 interface SolarRenderSnapshot {
@@ -425,31 +426,11 @@ export class WidgetSolarChargerComponent implements AfterViewInit, OnDestroy {
       ? value as { displayMode?: unknown; metrics?: unknown }
       : null;
 
-    const metrics = this.normalizeStringList(cardMode?.metrics);
+    const metrics = normalizeStringList(cardMode?.metrics);
     return {
       displayMode: cardMode?.displayMode === 'compact' ? 'compact' : 'full',
       metrics: metrics.length ? metrics : ['panelVoltage', 'panelCurrent', 'voltage', 'current']
     };
-  }
-
-  private normalizeStringList(value: unknown): string[] {
-    if (!Array.isArray(value)) {
-      return [];
-    }
-
-    const ids = new Set<string>();
-    value.forEach(item => {
-      if (typeof item !== 'string') {
-        return;
-      }
-
-      const normalized = item.trim();
-      if (normalized.length > 0) {
-        ids.add(normalized);
-      }
-    });
-
-    return [...ids].sort((left, right) => left.localeCompare(right));
   }
 
   private normalizeOptionsById(value: unknown): Record<string, SolarOptionConfig> {
@@ -461,7 +442,7 @@ export class WidgetSolarChargerComponent implements AfterViewInit, OnDestroy {
     const next: Record<string, SolarOptionConfig> = {};
 
     entries.forEach(([id, rawOption]) => {
-      const normalizedId = this.normalizeOptionalString(id);
+      const normalizedId = normalizeOptionalString(id);
       if (!normalizedId) {
         return;
       }
@@ -475,15 +456,6 @@ export class WidgetSolarChargerComponent implements AfterViewInit, OnDestroy {
     });
 
     return next;
-  }
-
-  private normalizeOptionalString(value: unknown): string | null {
-    if (typeof value !== 'string') {
-      return null;
-    }
-
-    const normalized = value.trim();
-    return normalized.length > 0 ? normalized : null;
   }
 
   private enqueuePathUpdate(update: IPathUpdateWithPath, fromInitial = false): void {


### PR DESCRIPTION
## Why

The six electrical widgets (bms, solar-charger, charger, alternator, inverter, ac) share a well-designed model layer but never had their behavioral layer extracted — each carries verbatim copies of the same config/device-tracking normalizers, maintained in lockstep. This is the first surgical slice of the #4 extraction (Stage 1a): the genuinely byte-identical config normalizers.

## What

Adds `src/app/widgets/shared/electrical-config.util.ts` (with a focused spec) exporting four pure functions, and migrates each widget to import them, deleting its local copy:

- `normalizeOptionalString` (was in all 6)
- `normalizeStringList` (5)
- `normalizeTrackedDevices` (the charger/alternator/inverter triplet)
- `buildIdToDeviceKeysMap` (the charger/alternator/inverter/ac quad; now takes the devices array as a parameter instead of reading component state)

## What is deliberately *not* merged

Verifying byte-identity surfaced that the "identical across all 6" framing was inflated: **solar-charger** and **bms** carry behaviorally-distinct `normalizeTrackedDevices` variants (string-item tolerance, `Partial`-cast tracking), and **ac** has `normalizeAcTrackedDevices` (a reserved-aggregate-id guard). These are left untouched — merging them would change behavior. The divergences (severity ordering, number coercion, device parsing) are documented in #351 for separate triage; this PR stays strictly behavior-preserving.

## Verification

`npm run snc` + `npm run lint` clean; the six electrical widget specs (87 tests) and the new util spec (11 tests) all pass locally. Net ~240 lines removed.

Stage 1a of #4. Follow-ups: Stage 1b (apply-path helpers), Stage 2 (ingest engine), Stage 3 (d3 draw).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
