### PR TITLE
refactor(electrical): extract shared apply-path helpers (#4 Stage 1b)

### DIFF
--- a/src/app/widgets/shared/electrical-apply.util.spec.ts
+++ b/src/app/widgets/shared/electrical-apply.util.spec.ts
@@ -1,0 +1,115 @@
+import { States } from '../../core/interfaces/signalk-interfaces';
+import {
+  resolveMostSevereState,
+  setMetricValue,
+  setValue,
+  toBoolean,
+  toStringValue
+} from './electrical-apply.util';
+
+interface TestSnapshot {
+  voltage: number | null;
+  voltageState: States | null;
+}
+
+function snapshot(): TestSnapshot {
+  return { voltage: null, voltageState: null };
+}
+
+describe('electrical-apply.util', () => {
+  describe('setValue', () => {
+    it('writes and returns true when the value changes', () => {
+      const s = snapshot();
+      expect(setValue(s, 'voltage', 12.4)).toBe(true);
+      expect(s.voltage).toBe(12.4);
+    });
+
+    it('returns false and does not write when the value is unchanged (Object.is)', () => {
+      const s = snapshot();
+      s.voltage = 12.4;
+      expect(setValue(s, 'voltage', 12.4)).toBe(false);
+    });
+  });
+
+  describe('setMetricValue', () => {
+    it('writes both fields and returns true when the value changes', () => {
+      const s = snapshot();
+      expect(setMetricValue(s, 'voltage', 'voltageState', 12.4, States.Normal)).toBe(true);
+      expect(s.voltage).toBe(12.4);
+      expect(s.voltageState).toBe(States.Normal);
+    });
+
+    it('returns true when only the state changes', () => {
+      const s = snapshot();
+      s.voltage = 12.4;
+      s.voltageState = States.Normal;
+      expect(setMetricValue(s, 'voltage', 'voltageState', 12.4, States.Alarm)).toBe(true);
+      expect(s.voltageState).toBe(States.Alarm);
+    });
+
+    it('returns true when only the value changes', () => {
+      const s = snapshot();
+      s.voltage = 12.4;
+      s.voltageState = States.Normal;
+      expect(setMetricValue(s, 'voltage', 'voltageState', 15, States.Normal)).toBe(true);
+      expect(s.voltage).toBe(15);
+      expect(s.voltageState).toBe(States.Normal);
+    });
+
+    it('returns false when neither value nor state changes', () => {
+      const s = snapshot();
+      s.voltage = 12.4;
+      s.voltageState = States.Normal;
+      expect(setMetricValue(s, 'voltage', 'voltageState', 12.4, States.Normal)).toBe(false);
+    });
+  });
+
+  describe('toStringValue', () => {
+    it('passes strings through and drops non-strings to null', () => {
+      expect(toStringValue('house')).toBe('house');
+      expect(toStringValue(42)).toBeNull();
+      expect(toStringValue(true)).toBeNull();
+      expect(toStringValue(null)).toBeNull();
+    });
+  });
+
+  describe('toBoolean', () => {
+    it('passes booleans through', () => {
+      expect(toBoolean(true)).toBe(true);
+      expect(toBoolean(false)).toBe(false);
+    });
+
+    it('maps 1/0 numbers', () => {
+      expect(toBoolean(1)).toBe(true);
+      expect(toBoolean(0)).toBe(false);
+      expect(toBoolean(2)).toBeNull();
+    });
+
+    it('maps truthy/falsy string tokens case- and whitespace-insensitively', () => {
+      expect(toBoolean(' TRUE ')).toBe(true);
+      expect(toBoolean('on')).toBe(true);
+      expect(toBoolean('1')).toBe(true);
+      expect(toBoolean('off')).toBe(false);
+      expect(toBoolean('0')).toBe(false);
+      expect(toBoolean('maybe')).toBeNull();
+    });
+
+    it('returns null for unmappable values', () => {
+      expect(toBoolean(null)).toBeNull();
+      expect(toBoolean({})).toBeNull();
+    });
+  });
+
+  describe('resolveMostSevereState', () => {
+    it('applies Alert > Alarm > Warn > Normal priority', () => {
+      expect(resolveMostSevereState(States.Normal, States.Alarm, States.Alert)).toBe(States.Alert);
+      expect(resolveMostSevereState(States.Normal, States.Alarm)).toBe(States.Alarm);
+      expect(resolveMostSevereState(States.Warn, States.Normal)).toBe(States.Warn);
+      expect(resolveMostSevereState(States.Normal, null)).toBe(States.Normal);
+    });
+
+    it('ignores null/undefined and returns null when no known state is present', () => {
+      expect(resolveMostSevereState(null, undefined)).toBeNull();
+    });
+  });
+});

--- a/src/app/widgets/shared/electrical-apply.util.ts
+++ b/src/app/widgets/shared/electrical-apply.util.ts
@@ -1,0 +1,70 @@
+import { States, type TState } from '../../core/interfaces/signalk-interfaces';
+
+/**
+ * Shared value-apply helpers for the electrical widget family: the dirty-check
+ * snapshot writers, the raw-value coercers, and the severity fold used when a
+ * parsed Signal K value is written onto a widget's snapshot. Extracted from the
+ * verbatim copies the charger/alternator/inverter/ac widgets carried.
+ *
+ * solar-charger keeps its own `toStringValue` (which stringifies non-strings)
+ * and `resolveMostSevereState` (rank-based ordering); bms uses a different
+ * write path entirely. Those variants are behaviorally distinct — see #351.
+ */
+
+export function setValue<T, K extends keyof T>(target: T, key: K, nextValue: T[K]): boolean {
+  if (Object.is(target[key], nextValue)) {
+    return false;
+  }
+
+  target[key] = nextValue;
+  return true;
+}
+
+export function setMetricValue<T, K extends keyof T, S extends keyof T>(
+  target: T,
+  key: K,
+  stateKey: S,
+  nextValue: T[K],
+  state: TState | null
+): boolean {
+  const valueChanged = !Object.is(target[key], nextValue);
+  const stateChanged = !Object.is(target[stateKey], state);
+  if (!valueChanged && !stateChanged) {
+    return false;
+  }
+
+  target[key] = nextValue;
+  target[stateKey] = state as T[S];
+  return true;
+}
+
+export function toStringValue(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+export function toBoolean(value: unknown): boolean | null {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'number') {
+    if (value === 1) return true;
+    if (value === 0) return false;
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'true' || normalized === '1' || normalized === 'on') return true;
+    if (normalized === 'false' || normalized === '0' || normalized === 'off') return false;
+  }
+
+  return null;
+}
+
+export function resolveMostSevereState(...states: (TState | null | undefined)[]): TState | null {
+  if (states.some(state => state === States.Alert)) return States.Alert;
+  if (states.some(state => state === States.Alarm)) return States.Alarm;
+  if (states.some(state => state === States.Warn)) return States.Warn;
+  if (states.some(state => state === States.Normal)) return States.Normal;
+  return null;
+}

--- a/src/app/widgets/widget-ac/widget-ac.component.ts
+++ b/src/app/widgets/widget-ac/widget-ac.component.ts
@@ -4,7 +4,7 @@ import { select, type Selection } from 'd3-selection';
 import { DataService, IPathUpdateWithPath } from '../../core/services/data.service';
 import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
 import type { ITheme } from '../../core/services/app-service';
-import { States, TState } from '../../core/interfaces/signalk-interfaces';
+import { TState } from '../../core/interfaces/signalk-interfaces';
 import type { ElectricalTrackedDevice, IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
 import { UnitsService } from '../../core/services/units.service';
 import { getColors, resolveZoneAwareColor } from '../../core/utils/themeColors.utils';
@@ -19,6 +19,7 @@ import {
   ELECTRICAL_DIRECT_COMPACT_CARD_HEIGHT
 } from '../shared/electrical-card-layout.constants';
 import { normalizeOptionalString, normalizeStringList, buildIdToDeviceKeysMap } from '../shared/electrical-config.util';
+import { setValue, setMetricValue, toStringValue, resolveMostSevereState } from '../shared/electrical-apply.util';
 import type { AcDisplayModel, AcSnapshot, AcWidgetConfig, ElectricalCardModeConfig } from './widget-ac.types';
 import { WidgetTitleComponent } from '../../core/components/widget-title/widget-title.component';
 
@@ -148,7 +149,7 @@ export class WidgetAcComponent implements AfterViewInit, OnDestroy {
     for (const bus of buses) {
       const modelKey = bus.deviceKey ?? bus.id;
       const showSource = !!bus.source && duplicateIds.has(bus.id);
-      const aggregateState = this.resolveMostSevereState(
+      const aggregateState = resolveMostSevereState(
         bus.line1VoltageState ?? null,
         bus.line1CurrentState ?? null,
         bus.line2VoltageState ?? null,
@@ -157,12 +158,12 @@ export class WidgetAcComponent implements AfterViewInit, OnDestroy {
         bus.line3CurrentState ?? null,
         bus.modeState ?? null
       );
-      const primaryState = this.resolveMostSevereState(
+      const primaryState = resolveMostSevereState(
         bus.line1VoltageState ?? null,
         bus.line1CurrentState ?? null,
         bus.line1FrequencyState ?? null
       );
-      const secondaryState = this.resolveMostSevereState(
+      const secondaryState = resolveMostSevereState(
         bus.line2VoltageState ?? null,
         bus.line2CurrentState ?? null,
         bus.line3VoltageState ?? null,
@@ -482,52 +483,30 @@ export class WidgetAcComponent implements AfterViewInit, OnDestroy {
     }
 
     switch (normalizedKey) {
-      case 'name': return this.setValue(snapshot, 'name', this.toStringValue(value));
-      case 'location': return this.setValue(snapshot, 'location', this.toStringValue(value));
-      case 'associatedBus': return this.setValue(snapshot, 'associatedBus', this.toStringValue(value));
-      case 'mode': return this.setMetricValue(snapshot, 'mode', 'modeState', this.toStringValue(value), state);
+      case 'name': return setValue(snapshot, 'name', toStringValue(value));
+      case 'location': return setValue(snapshot, 'location', toStringValue(value));
+      case 'associatedBus': return setValue(snapshot, 'associatedBus', toStringValue(value));
+      case 'mode': return setMetricValue(snapshot, 'mode', 'modeState', toStringValue(value), state);
       // Backward-compatible flat AC keys map to line 1 when source data is single-phase per id.
-      case 'voltage': return this.setMetricValue(snapshot, 'line1Voltage', 'line1VoltageState', this.toNumber(value, 'V'), state);
-      case 'current': return this.setMetricValue(snapshot, 'line1Current', 'line1CurrentState', this.toNumber(value, 'A'), state);
-      case 'frequency': return this.setMetricValue(snapshot, 'line1Frequency', 'line1FrequencyState', this.toNumber(value, 'Hz'), state);
-      case 'line1.voltage': return this.setMetricValue(snapshot, 'line1Voltage', 'line1VoltageState', this.toNumber(value, 'V'), state);
-      case 'line1.current': return this.setMetricValue(snapshot, 'line1Current', 'line1CurrentState', this.toNumber(value, 'A'), state);
-      case 'line1.frequency': return this.setMetricValue(snapshot, 'line1Frequency', 'line1FrequencyState', this.toNumber(value, 'Hz'), state);
-      case 'line1.realPower': return this.setMetricValue(snapshot, 'power', 'line1CurrentState', this.toNumber(value, 'W'), state);
-      case 'line2.voltage': return this.setMetricValue(snapshot, 'line2Voltage', 'line2VoltageState', this.toNumber(value, 'V'), state);
-      case 'line2.current': return this.setMetricValue(snapshot, 'line2Current', 'line2CurrentState', this.toNumber(value, 'A'), state);
-      case 'line2.frequency': return this.setMetricValue(snapshot, 'line2Frequency', 'line2FrequencyState', this.toNumber(value, 'Hz'), state);
-      case 'line2.realPower': return this.setMetricValue(snapshot, 'power', 'line2CurrentState', this.toNumber(value, 'W'), state);
-      case 'line3.voltage': return this.setMetricValue(snapshot, 'line3Voltage', 'line3VoltageState', this.toNumber(value, 'V'), state);
-      case 'line3.current': return this.setMetricValue(snapshot, 'line3Current', 'line3CurrentState', this.toNumber(value, 'A'), state);
-      case 'line3.frequency': return this.setMetricValue(snapshot, 'line3Frequency', 'line3FrequencyState', this.toNumber(value, 'Hz'), state);
-      case 'line3.realPower': return this.setMetricValue(snapshot, 'power', 'line3CurrentState', this.toNumber(value, 'W'), state);
-      case 'power': return this.setMetricValue(snapshot, 'power', 'line1CurrentState', this.toNumber(value, 'W'), state);
+      case 'voltage': return setMetricValue(snapshot, 'line1Voltage', 'line1VoltageState', this.toNumber(value, 'V'), state);
+      case 'current': return setMetricValue(snapshot, 'line1Current', 'line1CurrentState', this.toNumber(value, 'A'), state);
+      case 'frequency': return setMetricValue(snapshot, 'line1Frequency', 'line1FrequencyState', this.toNumber(value, 'Hz'), state);
+      case 'line1.voltage': return setMetricValue(snapshot, 'line1Voltage', 'line1VoltageState', this.toNumber(value, 'V'), state);
+      case 'line1.current': return setMetricValue(snapshot, 'line1Current', 'line1CurrentState', this.toNumber(value, 'A'), state);
+      case 'line1.frequency': return setMetricValue(snapshot, 'line1Frequency', 'line1FrequencyState', this.toNumber(value, 'Hz'), state);
+      case 'line1.realPower': return setMetricValue(snapshot, 'power', 'line1CurrentState', this.toNumber(value, 'W'), state);
+      case 'line2.voltage': return setMetricValue(snapshot, 'line2Voltage', 'line2VoltageState', this.toNumber(value, 'V'), state);
+      case 'line2.current': return setMetricValue(snapshot, 'line2Current', 'line2CurrentState', this.toNumber(value, 'A'), state);
+      case 'line2.frequency': return setMetricValue(snapshot, 'line2Frequency', 'line2FrequencyState', this.toNumber(value, 'Hz'), state);
+      case 'line2.realPower': return setMetricValue(snapshot, 'power', 'line2CurrentState', this.toNumber(value, 'W'), state);
+      case 'line3.voltage': return setMetricValue(snapshot, 'line3Voltage', 'line3VoltageState', this.toNumber(value, 'V'), state);
+      case 'line3.current': return setMetricValue(snapshot, 'line3Current', 'line3CurrentState', this.toNumber(value, 'A'), state);
+      case 'line3.frequency': return setMetricValue(snapshot, 'line3Frequency', 'line3FrequencyState', this.toNumber(value, 'Hz'), state);
+      case 'line3.realPower': return setMetricValue(snapshot, 'power', 'line3CurrentState', this.toNumber(value, 'W'), state);
+      case 'power': return setMetricValue(snapshot, 'power', 'line1CurrentState', this.toNumber(value, 'W'), state);
       default:
         return false;
     }
-  }
-
-  private setValue<K extends keyof AcSnapshot>(target: AcSnapshot, key: K, nextValue: AcSnapshot[K]): boolean {
-    if (Object.is(target[key], nextValue)) return false;
-    target[key] = nextValue;
-    return true;
-  }
-
-  private setMetricValue<K extends keyof AcSnapshot, S extends keyof AcSnapshot>(
-    target: AcSnapshot,
-    key: K,
-    stateKey: S,
-    nextValue: AcSnapshot[K],
-    state: TState | null
-  ): boolean {
-    const valueChanged = !Object.is(target[key], nextValue);
-    const stateChanged = !Object.is(target[stateKey], state);
-    if (!valueChanged && !stateChanged) return false;
-
-    target[key] = nextValue;
-    target[stateKey] = state as AcSnapshot[S];
-    return true;
   }
 
   private requestRender(snapshot?: AcRenderSnapshot): void {
@@ -692,18 +671,6 @@ export class WidgetAcComponent implements AfterViewInit, OnDestroy {
   private formatValue(value: number | null | undefined, unit: string): string {
     if (value == null || Number.isNaN(value)) return '-';
     return `${value.toFixed(1)} ${unit}`;
-  }
-
-  private toStringValue(value: unknown): string | null {
-    return typeof value === 'string' ? value : null;
-  }
-
-  private resolveMostSevereState(...states: (TState | null | undefined)[]): TState | null {
-    if (states.some(state => state === States.Alert)) return States.Alert;
-    if (states.some(state => state === States.Alarm)) return States.Alarm;
-    if (states.some(state => state === States.Warn)) return States.Warn;
-    if (states.some(state => state === States.Normal)) return States.Normal;
-    return null;
   }
 
   private toNumber(value: unknown, unitHint: string): number | null {

--- a/src/app/widgets/widget-alternator/widget-alternator.component.ts
+++ b/src/app/widgets/widget-alternator/widget-alternator.component.ts
@@ -4,7 +4,7 @@ import { select, type Selection } from 'd3-selection';
 import { DataService, IPathUpdateWithPath } from '../../core/services/data.service';
 import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
 import type { ITheme } from '../../core/services/app-service';
-import { States, TState } from '../../core/interfaces/signalk-interfaces';
+import { TState } from '../../core/interfaces/signalk-interfaces';
 import type { ElectricalTrackedDevice, IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
 import { UnitsService } from '../../core/services/units.service';
 import { getColors, resolveZoneAwareColor } from '../../core/utils/themeColors.utils';
@@ -21,6 +21,7 @@ import {
 import type { AlternatorDisplayModel, AlternatorSnapshot, AlternatorWidgetConfig, ElectricalCardModeConfig } from './widget-alternator.types';
 import { WidgetTitleComponent } from '../../core/components/widget-title/widget-title.component';
 import { normalizeOptionalString, normalizeStringList, normalizeTrackedDevices, buildIdToDeviceKeysMap } from '../shared/electrical-config.util';
+import { setValue, setMetricValue, toStringValue, resolveMostSevereState } from '../shared/electrical-apply.util';
 
 function escapeRegex(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -151,7 +152,7 @@ export class WidgetAlternatorComponent implements AfterViewInit, OnDestroy {
     for (const alternator of alternators) {
       const modelKey = alternator.deviceKey ?? alternator.id;
       const showSource = !!alternator.source && duplicateIds.has(alternator.id);
-      const aggregateState = this.resolveMostSevereState(
+      const aggregateState = resolveMostSevereState(
         alternator.powerState ?? null,
         alternator.currentState ?? null,
         alternator.voltageState ?? null,
@@ -161,8 +162,8 @@ export class WidgetAlternatorComponent implements AfterViewInit, OnDestroy {
         alternator.fieldDriveState ?? null,
         alternator.regulatorTemperatureState ?? null
       );
-      const primaryState = this.resolveMostSevereState(alternator.voltageState ?? null, alternator.currentState ?? null);
-      const secondaryState = this.resolveMostSevereState(
+      const primaryState = resolveMostSevereState(alternator.voltageState ?? null, alternator.currentState ?? null);
+      const secondaryState = resolveMostSevereState(
         alternator.powerState ?? null,
         alternator.revolutionsState ?? null,
         alternator.temperatureState ?? null,
@@ -182,7 +183,7 @@ export class WidgetAlternatorComponent implements AfterViewInit, OnDestroy {
         stateBarColor: resolveZoneAwareColor(aggregateState, widgetColors?.dim ?? 'var(--skip-contrast-color)', theme, ignoreZones),
         titleTextColor: resolveZoneAwareColor(aggregateState, 'var(--skip-contrast-color)', theme, ignoreZones),
         metaTextColor: resolveZoneAwareColor(
-          this.resolveMostSevereState(alternator.chargingModeState ?? null, alternator.fieldDriveState ?? null),
+          resolveMostSevereState(alternator.chargingModeState ?? null, alternator.fieldDriveState ?? null),
           'var(--skip-contrast-dim-color)',
           theme,
           ignoreZones
@@ -448,7 +449,7 @@ export class WidgetAlternatorComponent implements AfterViewInit, OnDestroy {
           }
 
           if (next.rawPower == null) {
-            next.powerState = this.resolveMostSevereState(next.voltageState ?? null, next.currentState ?? null);
+            next.powerState = resolveMostSevereState(next.voltageState ?? null, next.currentState ?? null);
           }
 
           if (!changed) {
@@ -476,62 +477,35 @@ export class WidgetAlternatorComponent implements AfterViewInit, OnDestroy {
   private applyValue(snapshot: AlternatorSnapshot, key: string, value: unknown, state: TState | null): boolean {
     switch (key) {
       case 'name':
-        return this.setValue(snapshot, 'name', this.toStringValue(value));
+        return setValue(snapshot, 'name', toStringValue(value));
       case 'location':
-        return this.setValue(snapshot, 'location', this.toStringValue(value));
+        return setValue(snapshot, 'location', toStringValue(value));
       case 'associatedBus':
-        return this.setValue(snapshot, 'associatedBus', this.toStringValue(value));
+        return setValue(snapshot, 'associatedBus', toStringValue(value));
       case 'chargingMode':
-        return this.setMetricValue(snapshot, 'chargingMode', 'chargingModeState', this.toStringValue(value), state);
+        return setMetricValue(snapshot, 'chargingMode', 'chargingModeState', toStringValue(value), state);
       case 'voltage':
-        return this.setMetricValue(snapshot, 'voltage', 'voltageState', this.toNumber(value, 'V'), state);
+        return setMetricValue(snapshot, 'voltage', 'voltageState', this.toNumber(value, 'V'), state);
       case 'current':
-        return this.setMetricValue(snapshot, 'current', 'currentState', this.toNumber(value, 'A'), state);
+        return setMetricValue(snapshot, 'current', 'currentState', this.toNumber(value, 'A'), state);
       case 'power':
       case 'realPower':
-        return this.setMetricValue(snapshot, 'rawPower', 'powerState', this.toNumber(value, 'W'), state);
+        return setMetricValue(snapshot, 'rawPower', 'powerState', this.toNumber(value, 'W'), state);
       case 'temperature':
-        return this.setMetricValue(snapshot, 'temperature', 'temperatureState', this.toNumber(value, this.units.getDefaults().Temperature), state);
+        return setMetricValue(snapshot, 'temperature', 'temperatureState', this.toNumber(value, this.units.getDefaults().Temperature), state);
       case 'revolutions':
-        return this.setMetricValue(snapshot, 'revolutions', 'revolutionsState', this.toNumber(value, 'Hz'), state);
+        return setMetricValue(snapshot, 'revolutions', 'revolutionsState', this.toNumber(value, 'Hz'), state);
       case 'fieldDrive':
-        return this.setMetricValue(snapshot, 'fieldDrive', 'fieldDriveState', this.toNumber(value, '%'), state);
+        return setMetricValue(snapshot, 'fieldDrive', 'fieldDriveState', this.toNumber(value, '%'), state);
       case 'regulatorTemperature':
-        return this.setMetricValue(snapshot, 'regulatorTemperature', 'regulatorTemperatureState', this.toNumber(value, this.units.getDefaults().Temperature), state);
+        return setMetricValue(snapshot, 'regulatorTemperature', 'regulatorTemperatureState', this.toNumber(value, this.units.getDefaults().Temperature), state);
       case 'setpointVoltage':
-        return this.setMetricValue(snapshot, 'setpointVoltage', 'setpointVoltageState', this.toNumber(value, 'V'), state);
+        return setMetricValue(snapshot, 'setpointVoltage', 'setpointVoltageState', this.toNumber(value, 'V'), state);
       case 'setpointCurrent':
-        return this.setMetricValue(snapshot, 'setpointCurrent', 'setpointCurrentState', this.toNumber(value, 'A'), state);
+        return setMetricValue(snapshot, 'setpointCurrent', 'setpointCurrentState', this.toNumber(value, 'A'), state);
       default:
         return false;
     }
-  }
-
-  private setValue<K extends keyof AlternatorSnapshot>(target: AlternatorSnapshot, key: K, nextValue: AlternatorSnapshot[K]): boolean {
-    if (Object.is(target[key], nextValue)) {
-      return false;
-    }
-
-    target[key] = nextValue;
-    return true;
-  }
-
-  private setMetricValue<K extends keyof AlternatorSnapshot, S extends keyof AlternatorSnapshot>(
-    target: AlternatorSnapshot,
-    key: K,
-    stateKey: S,
-    nextValue: AlternatorSnapshot[K],
-    state: TState | null
-  ): boolean {
-    const valueChanged = !Object.is(target[key], nextValue);
-    const stateChanged = !Object.is(target[stateKey], state);
-    if (!valueChanged && !stateChanged) {
-      return false;
-    }
-
-    target[key] = nextValue;
-    target[stateKey] = state as AlternatorSnapshot[S];
-    return true;
   }
 
   private requestRender(snapshot?: AlternatorRenderSnapshot): void {
@@ -765,18 +739,6 @@ export class WidgetAlternatorComponent implements AfterViewInit, OnDestroy {
     }
 
     return `${value.toFixed(0)} %`;
-  }
-
-  private toStringValue(value: unknown): string | null {
-    return typeof value === 'string' ? value : null;
-  }
-
-  private resolveMostSevereState(...states: (TState | null | undefined)[]): TState | null {
-    if (states.some(state => state === States.Alert)) return States.Alert;
-    if (states.some(state => state === States.Alarm)) return States.Alarm;
-    if (states.some(state => state === States.Warn)) return States.Warn;
-    if (states.some(state => state === States.Normal)) return States.Normal;
-    return null;
   }
 
   private toNumber(value: unknown, unitHint: string): number | null {

--- a/src/app/widgets/widget-charger/widget-charger.component.ts
+++ b/src/app/widgets/widget-charger/widget-charger.component.ts
@@ -3,7 +3,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { select, type Selection } from 'd3-selection';
 import { DataService, IPathUpdateWithPath } from '../../core/services/data.service';
 import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
-import { States, TState } from '../../core/interfaces/signalk-interfaces';
+import { TState } from '../../core/interfaces/signalk-interfaces';
 import { UnitsService } from '../../core/services/units.service';
 import { getColors } from '../../core/utils/themeColors.utils';
 import { getElectricalWidgetFamilyDescriptor } from '../../core/contracts/electrical-widget-family.contract';
@@ -13,6 +13,7 @@ import type { ITheme } from '../../core/services/app-service';
 import type { ChargerDisplayModel, ChargerSnapshot } from './widget-charger.types';
 import { ELECTRICAL_DIRECT_CARD_COMPACT_LAYOUT, ELECTRICAL_DIRECT_CARD_FULL_LAYOUT, ELECTRICAL_DIRECT_CARD_GAP, ELECTRICAL_DIRECT_CARD_HEIGHT, ELECTRICAL_DIRECT_CARD_VIEWBOX_WIDTH, ELECTRICAL_DIRECT_COMPACT_CARD_HEIGHT } from '../shared/electrical-card-layout.constants';
 import { normalizeOptionalString, normalizeTrackedDevices, buildIdToDeviceKeysMap } from '../shared/electrical-config.util';
+import { setValue, setMetricValue, toStringValue, toBoolean, resolveMostSevereState } from '../shared/electrical-apply.util';
 import { WidgetTitleComponent } from '../../core/components/widget-title/widget-title.component';
 
 interface ChargerRenderSnapshot {
@@ -397,7 +398,7 @@ export class WidgetChargerComponent implements AfterViewInit, OnDestroy {
           }
 
           if (next.rawPower == null) {
-            next.powerState = this.resolveMostSevereState(next.voltageState ?? null, next.currentState ?? null);
+            next.powerState = resolveMostSevereState(next.voltageState ?? null, next.currentState ?? null);
           }
 
           if (!changed) {
@@ -435,93 +436,62 @@ export class WidgetChargerComponent implements AfterViewInit, OnDestroy {
   private applyValue(snapshot: ChargerSnapshot, key: string, value: unknown, state: TState | null): boolean {
     switch (key) {
       case 'name':
-        return this.setValue(snapshot, 'name', this.toStringValue(value));
+        return setValue(snapshot, 'name', toStringValue(value));
       case 'location':
-        return this.setValue(snapshot, 'location', this.toStringValue(value));
+        return setValue(snapshot, 'location', toStringValue(value));
       case 'associatedBus':
-        return this.setValue(snapshot, 'associatedBus', this.toStringValue(value));
+        return setValue(snapshot, 'associatedBus', toStringValue(value));
       case 'state':
-        return this.setMetricValue(snapshot, 'state', 'stateState', this.toStringValue(value), state);
+        return setMetricValue(snapshot, 'state', 'stateState', toStringValue(value), state);
       case 'offReason':
-        return this.setMetricValue(snapshot, 'offReason', 'offReasonState', this.toStringValue(value), state);
+        return setMetricValue(snapshot, 'offReason', 'offReasonState', toStringValue(value), state);
       case 'error':
-        return this.setMetricValue(snapshot, 'error', 'errorState', this.toStringValue(value), state);
+        return setMetricValue(snapshot, 'error', 'errorState', toStringValue(value), state);
       case 'mode':
-        return this.setMetricValue(snapshot, 'mode', 'modeState', this.toStringValue(value), state);
+        return setMetricValue(snapshot, 'mode', 'modeState', toStringValue(value), state);
       case 'modeState':
-        return this.setMetricValue(snapshot, 'mode', 'modeState', this.toStringValue(value), state);
+        return setMetricValue(snapshot, 'mode', 'modeState', toStringValue(value), state);
       case 'modeNumber':
-        return this.setMetricValue(snapshot, 'modeNumber', 'modeNumberState', this.toNumber(value, ''), state);
+        return setMetricValue(snapshot, 'modeNumber', 'modeNumberState', this.toNumber(value, ''), state);
       case 'chargingMode':
-        return this.setMetricValue(snapshot, 'chargingMode', 'chargingModeState', this.toStringValue(value), state);
+        return setMetricValue(snapshot, 'chargingMode', 'chargingModeState', toStringValue(value), state);
       case 'chargingModeNumber':
-        return this.setMetricValue(snapshot, 'chargingModeNumber', 'chargingModeNumberState', this.toNumber(value, ''), state);
+        return setMetricValue(snapshot, 'chargingModeNumber', 'chargingModeNumberState', this.toNumber(value, ''), state);
       case 'output.voltage': {
         const nextVoltage = this.toNumber(value, 'V');
-        const outputChanged = this.setMetricValue(snapshot, 'outputVoltage', 'outputVoltageState', nextVoltage, state);
-        const voltageChanged = this.setMetricValue(snapshot, 'voltage', 'voltageState', nextVoltage, state);
+        const outputChanged = setMetricValue(snapshot, 'outputVoltage', 'outputVoltageState', nextVoltage, state);
+        const voltageChanged = setMetricValue(snapshot, 'voltage', 'voltageState', nextVoltage, state);
         return outputChanged || voltageChanged;
       }
       case 'input.voltage':
-        return this.setMetricValue(snapshot, 'inputVoltage', 'inputVoltageState', this.toNumber(value, 'V'), state);
+        return setMetricValue(snapshot, 'inputVoltage', 'inputVoltageState', this.toNumber(value, 'V'), state);
       case 'voltage':
-        return this.setMetricValue(snapshot, 'voltage', 'voltageState', this.toNumber(value, 'V'), state);
+        return setMetricValue(snapshot, 'voltage', 'voltageState', this.toNumber(value, 'V'), state);
       case 'current':
-        return this.setMetricValue(snapshot, 'current', 'currentState', this.toNumber(value, 'A'), state);
+        return setMetricValue(snapshot, 'current', 'currentState', this.toNumber(value, 'A'), state);
       case 'power':
-        return this.setMetricValue(snapshot, 'rawPower', 'powerState', this.toNumber(value, 'W'), state);
+        return setMetricValue(snapshot, 'rawPower', 'powerState', this.toNumber(value, 'W'), state);
       case 'temperature':
-        return this.setMetricValue(snapshot, 'temperature', 'temperatureState', this.toNumber(value, this.units.getDefaults().Temperature), state);
+        return setMetricValue(snapshot, 'temperature', 'temperatureState', this.toNumber(value, this.units.getDefaults().Temperature), state);
       case 'leds.absorption':
-        return this.setMetricValue(snapshot, 'ledsAbsorption', 'ledsAbsorptionState', this.toBoolean(value), state);
+        return setMetricValue(snapshot, 'ledsAbsorption', 'ledsAbsorptionState', toBoolean(value), state);
       case 'leds.bulk':
-        return this.setMetricValue(snapshot, 'ledsBulk', 'ledsBulkState', this.toBoolean(value), state);
+        return setMetricValue(snapshot, 'ledsBulk', 'ledsBulkState', toBoolean(value), state);
       case 'leds.float':
-        return this.setMetricValue(snapshot, 'ledsFloat', 'ledsFloatState', this.toBoolean(value), state);
+        return setMetricValue(snapshot, 'ledsFloat', 'ledsFloatState', toBoolean(value), state);
       case 'leds.inverter':
-        return this.setMetricValue(snapshot, 'ledsInverter', 'ledsInverterState', this.toBoolean(value), state);
+        return setMetricValue(snapshot, 'ledsInverter', 'ledsInverterState', toBoolean(value), state);
       case 'leds.lowBattery':
-        return this.setMetricValue(snapshot, 'ledsLowBattery', 'ledsLowBatteryState', this.toBoolean(value), state);
+        return setMetricValue(snapshot, 'ledsLowBattery', 'ledsLowBatteryState', toBoolean(value), state);
       case 'leds.mains':
-        return this.setMetricValue(snapshot, 'ledsMains', 'ledsMainsState', this.toBoolean(value), state);
+        return setMetricValue(snapshot, 'ledsMains', 'ledsMainsState', toBoolean(value), state);
       case 'leds.overload':
-        return this.setMetricValue(snapshot, 'ledsOverload', 'ledsOverloadState', this.toBoolean(value), state);
+        return setMetricValue(snapshot, 'ledsOverload', 'ledsOverloadState', toBoolean(value), state);
       case 'leds.temperature':
-        return this.setMetricValue(snapshot, 'ledsTemperature', 'ledsTemperatureState', this.toBoolean(value), state);
+        return setMetricValue(snapshot, 'ledsTemperature', 'ledsTemperatureState', toBoolean(value), state);
       default:
         return false;
     }
-  }
-
-  private setValue<K extends keyof ChargerSnapshot>(
-    target: ChargerSnapshot,
-    key: K,
-    nextValue: ChargerSnapshot[K]
-  ): boolean {
-    if (Object.is(target[key], nextValue)) {
-      return false;
-    }
-
-    target[key] = nextValue;
-    return true;
-  }
-
-  private setMetricValue<K extends keyof ChargerSnapshot, S extends keyof ChargerSnapshot>(
-    target: ChargerSnapshot,
-    key: K,
-    stateKey: S,
-    nextValue: ChargerSnapshot[K],
-    state: TState | null
-  ): boolean {
-    const valueChanged = !Object.is(target[key], nextValue);
-    const stateChanged = !Object.is(target[stateKey], state);
-    if (!valueChanged && !stateChanged) {
-      return false;
-    }
-
-    target[key] = nextValue;
-    target[stateKey] = state as ChargerSnapshot[S];
-    return true;
   }
 
   private requestRender(snapshot?: ChargerRenderSnapshot): void {
@@ -864,37 +834,6 @@ export class WidgetChargerComponent implements AfterViewInit, OnDestroy {
     }
 
     return `${value.toFixed(0)}`;
-  }
-
-  private toStringValue(value: unknown): string | null {
-    return typeof value === 'string' ? value : null;
-  }
-
-  private toBoolean(value: unknown): boolean | null {
-    if (typeof value === 'boolean') {
-      return value;
-    }
-
-    if (typeof value === 'number') {
-      if (value === 1) return true;
-      if (value === 0) return false;
-    }
-
-    if (typeof value === 'string') {
-      const normalized = value.trim().toLowerCase();
-      if (normalized === 'true' || normalized === '1' || normalized === 'on') return true;
-      if (normalized === 'false' || normalized === '0' || normalized === 'off') return false;
-    }
-
-    return null;
-  }
-
-  private resolveMostSevereState(...states: (TState | null | undefined)[]): TState | null {
-    if (states.some(state => state === States.Alert)) return States.Alert;
-    if (states.some(state => state === States.Alarm)) return States.Alarm;
-    if (states.some(state => state === States.Warn)) return States.Warn;
-    if (states.some(state => state === States.Normal)) return States.Normal;
-    return null;
   }
 
   private toNumber(value: unknown, unitHint: string): number | null {

--- a/src/app/widgets/widget-inverter/widget-inverter.component.ts
+++ b/src/app/widgets/widget-inverter/widget-inverter.component.ts
@@ -4,7 +4,7 @@ import { select, type Selection } from 'd3-selection';
 import { DataService, IPathUpdateWithPath } from '../../core/services/data.service';
 import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
 import type { ITheme } from '../../core/services/app-service';
-import { States, TState } from '../../core/interfaces/signalk-interfaces';
+import { TState } from '../../core/interfaces/signalk-interfaces';
 import type { ElectricalTrackedDevice, IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
 import { UnitsService } from '../../core/services/units.service';
 import { getColors, resolveZoneAwareColor } from '../../core/utils/themeColors.utils';
@@ -21,6 +21,7 @@ import {
 import type { InverterDisplayModel, InverterSnapshot, InverterWidgetConfig, ElectricalCardModeConfig } from './widget-inverter.types';
 import { WidgetTitleComponent } from '../../core/components/widget-title/widget-title.component';
 import { normalizeOptionalString, normalizeStringList, normalizeTrackedDevices, buildIdToDeviceKeysMap } from '../shared/electrical-config.util';
+import { setValue, setMetricValue, toStringValue, toBoolean, resolveMostSevereState } from '../shared/electrical-apply.util';
 
 function escapeRegex(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -151,7 +152,7 @@ export class WidgetInverterComponent implements AfterViewInit, OnDestroy {
     for (const inverter of inverters) {
       const modelKey = inverter.deviceKey ?? inverter.id;
       const showSource = !!inverter.source && duplicateIds.has(inverter.id);
-      const aggregateState = this.resolveMostSevereState(
+      const aggregateState = resolveMostSevereState(
         inverter.dcVoltageState ?? null,
         inverter.dcCurrentState ?? null,
         inverter.acVoltageState ?? null,
@@ -160,8 +161,8 @@ export class WidgetInverterComponent implements AfterViewInit, OnDestroy {
         inverter.temperatureState ?? null,
         inverter.inverterModeState ?? null
       );
-      const primaryState = this.resolveMostSevereState(inverter.dcVoltageState ?? null, inverter.dcCurrentState ?? null);
-      const secondaryState = this.resolveMostSevereState(inverter.acVoltageState ?? null, inverter.acCurrentState ?? null, inverter.acFrequencyState ?? null);
+      const primaryState = resolveMostSevereState(inverter.dcVoltageState ?? null, inverter.dcCurrentState ?? null);
+      const secondaryState = resolveMostSevereState(inverter.acVoltageState ?? null, inverter.acCurrentState ?? null, inverter.acFrequencyState ?? null);
       const [metricsLineOne, metricsLineTwo] = this.buildMetricRows(inverter);
 
       models[modelKey] = {
@@ -398,7 +399,7 @@ export class WidgetInverterComponent implements AfterViewInit, OnDestroy {
           if (next.dcVoltage != null && next.dcCurrent != null) {
             const derived = next.dcVoltage * next.dcCurrent;
             next.dcPower = Number.isFinite(derived) ? derived : null;
-            next.dcPowerState = this.resolveMostSevereState(next.dcVoltageState ?? null, next.dcCurrentState ?? null);
+            next.dcPowerState = resolveMostSevereState(next.dcVoltageState ?? null, next.dcCurrentState ?? null);
           } else {
             next.dcPower = null;
             next.dcPowerState = null;
@@ -421,50 +422,33 @@ export class WidgetInverterComponent implements AfterViewInit, OnDestroy {
 
   private applyValue(snapshot: InverterSnapshot, key: string, value: unknown, state: TState | null): boolean {
     switch (key) {
-      case 'name': return this.setValue(snapshot, 'name', this.toStringValue(value));
-      case 'location': return this.setValue(snapshot, 'location', this.toStringValue(value));
-      case 'associatedBus': return this.setValue(snapshot, 'associatedBus', this.toStringValue(value));
-      case 'dc.voltage': return this.setMetricValue(snapshot, 'dcVoltage', 'dcVoltageState', this.toNumber(value, 'V'), state);
-      case 'dc.current': return this.setMetricValue(snapshot, 'dcCurrent', 'dcCurrentState', this.toNumber(value, 'A'), state);
-      case 'acin.voltage': return this.setMetricValue(snapshot, 'acInVoltage', 'acInVoltageState', this.toNumber(value, 'V'), state);
-      case 'acin.current': return this.setMetricValue(snapshot, 'acInCurrent', 'acInCurrentState', this.toNumber(value, 'A'), state);
-      case 'acin.frequency': return this.setMetricValue(snapshot, 'acInFrequency', 'acInFrequencyState', this.toNumber(value, 'Hz'), state);
-      case 'acin.power': return this.setMetricValue(snapshot, 'acInPower', 'acInPowerState', this.toNumber(value, 'W'), state);
-      case 'acin.1.currentLimit': return this.setMetricValue(snapshot, 'acIn1CurrentLimit', 'acIn1CurrentLimitState', this.toNumber(value, 'A'), state);
-      case 'acin.currentLimit': return this.setMetricValue(snapshot, 'acInCurrentLimit', 'acInCurrentLimitState', this.toNumber(value, 'A'), state);
-      case 'acState.acIn1Available': return this.setMetricValue(snapshot, 'acIn1Available', 'acIn1AvailableState', this.toBoolean(value), state);
-      case 'acState.ignoreAcIn1.state': return this.setMetricValue(snapshot, 'ignoreAcIn1', 'ignoreAcIn1State', this.toBoolean(value), state);
-      case 'ac.voltage': return this.setMetricValue(snapshot, 'acVoltage', 'acVoltageState', this.toNumber(value, 'V'), state);
-      case 'ac.current': return this.setMetricValue(snapshot, 'acCurrent', 'acCurrentState', this.toNumber(value, 'A'), state);
-      case 'ac.frequency': return this.setMetricValue(snapshot, 'acFrequency', 'acFrequencyState', this.toNumber(value, 'Hz'), state);
-      case 'acout.voltage': return this.setMetricValue(snapshot, 'acOutVoltage', 'acOutVoltageState', this.toNumber(value, 'V'), state);
-      case 'acout.current': return this.setMetricValue(snapshot, 'acOutCurrent', 'acOutCurrentState', this.toNumber(value, 'A'), state);
-      case 'acout.frequency': return this.setMetricValue(snapshot, 'acOutFrequency', 'acOutFrequencyState', this.toNumber(value, 'Hz'), state);
-      case 'acout.power': return this.setMetricValue(snapshot, 'acOutPower', 'acOutPowerState', this.toNumber(value, 'W'), state);
-      case 'inverterMode': return this.setMetricValue(snapshot, 'inverterMode', 'inverterModeState', this.toStringValue(value), state);
-      case 'inverterModeNumber': return this.setMetricValue(snapshot, 'inverterModeNumber', 'inverterModeNumberState', this.toNumber(value, ''), state);
-      case 'preferRenewableEnergy': return this.setMetricValue(snapshot, 'preferRenewableEnergy', 'preferRenewableEnergyState', this.toBoolean(value), state);
-      case 'preferRenewableEnergyActive': return this.setMetricValue(snapshot, 'preferRenewableEnergyActive', 'preferRenewableEnergyActiveState', this.toBoolean(value), state);
-      case 'temperature': return this.setMetricValue(snapshot, 'temperature', 'temperatureState', this.toNumber(value, this.units.getDefaults().Temperature), state);
+      case 'name': return setValue(snapshot, 'name', toStringValue(value));
+      case 'location': return setValue(snapshot, 'location', toStringValue(value));
+      case 'associatedBus': return setValue(snapshot, 'associatedBus', toStringValue(value));
+      case 'dc.voltage': return setMetricValue(snapshot, 'dcVoltage', 'dcVoltageState', this.toNumber(value, 'V'), state);
+      case 'dc.current': return setMetricValue(snapshot, 'dcCurrent', 'dcCurrentState', this.toNumber(value, 'A'), state);
+      case 'acin.voltage': return setMetricValue(snapshot, 'acInVoltage', 'acInVoltageState', this.toNumber(value, 'V'), state);
+      case 'acin.current': return setMetricValue(snapshot, 'acInCurrent', 'acInCurrentState', this.toNumber(value, 'A'), state);
+      case 'acin.frequency': return setMetricValue(snapshot, 'acInFrequency', 'acInFrequencyState', this.toNumber(value, 'Hz'), state);
+      case 'acin.power': return setMetricValue(snapshot, 'acInPower', 'acInPowerState', this.toNumber(value, 'W'), state);
+      case 'acin.1.currentLimit': return setMetricValue(snapshot, 'acIn1CurrentLimit', 'acIn1CurrentLimitState', this.toNumber(value, 'A'), state);
+      case 'acin.currentLimit': return setMetricValue(snapshot, 'acInCurrentLimit', 'acInCurrentLimitState', this.toNumber(value, 'A'), state);
+      case 'acState.acIn1Available': return setMetricValue(snapshot, 'acIn1Available', 'acIn1AvailableState', toBoolean(value), state);
+      case 'acState.ignoreAcIn1.state': return setMetricValue(snapshot, 'ignoreAcIn1', 'ignoreAcIn1State', toBoolean(value), state);
+      case 'ac.voltage': return setMetricValue(snapshot, 'acVoltage', 'acVoltageState', this.toNumber(value, 'V'), state);
+      case 'ac.current': return setMetricValue(snapshot, 'acCurrent', 'acCurrentState', this.toNumber(value, 'A'), state);
+      case 'ac.frequency': return setMetricValue(snapshot, 'acFrequency', 'acFrequencyState', this.toNumber(value, 'Hz'), state);
+      case 'acout.voltage': return setMetricValue(snapshot, 'acOutVoltage', 'acOutVoltageState', this.toNumber(value, 'V'), state);
+      case 'acout.current': return setMetricValue(snapshot, 'acOutCurrent', 'acOutCurrentState', this.toNumber(value, 'A'), state);
+      case 'acout.frequency': return setMetricValue(snapshot, 'acOutFrequency', 'acOutFrequencyState', this.toNumber(value, 'Hz'), state);
+      case 'acout.power': return setMetricValue(snapshot, 'acOutPower', 'acOutPowerState', this.toNumber(value, 'W'), state);
+      case 'inverterMode': return setMetricValue(snapshot, 'inverterMode', 'inverterModeState', toStringValue(value), state);
+      case 'inverterModeNumber': return setMetricValue(snapshot, 'inverterModeNumber', 'inverterModeNumberState', this.toNumber(value, ''), state);
+      case 'preferRenewableEnergy': return setMetricValue(snapshot, 'preferRenewableEnergy', 'preferRenewableEnergyState', toBoolean(value), state);
+      case 'preferRenewableEnergyActive': return setMetricValue(snapshot, 'preferRenewableEnergyActive', 'preferRenewableEnergyActiveState', toBoolean(value), state);
+      case 'temperature': return setMetricValue(snapshot, 'temperature', 'temperatureState', this.toNumber(value, this.units.getDefaults().Temperature), state);
       default: return false;
     }
-  }
-
-  private setValue<K extends keyof InverterSnapshot>(target: InverterSnapshot, key: K, nextValue: InverterSnapshot[K]): boolean {
-    if (Object.is(target[key], nextValue)) return false;
-    target[key] = nextValue;
-    return true;
-  }
-
-  private setMetricValue<K extends keyof InverterSnapshot, S extends keyof InverterSnapshot>(
-    target: InverterSnapshot, key: K, stateKey: S, nextValue: InverterSnapshot[K], state: TState | null
-  ): boolean {
-    const valueChanged = !Object.is(target[key], nextValue);
-    const stateChanged = !Object.is(target[stateKey], state);
-    if (!valueChanged && !stateChanged) return false;
-    target[key] = nextValue;
-    target[stateKey] = state as InverterSnapshot[S];
-    return true;
   }
 
   private requestRender(snapshot?: InverterRenderSnapshot): void {
@@ -638,18 +622,6 @@ export class WidgetInverterComponent implements AfterViewInit, OnDestroy {
     return `${value.toFixed(1)} ${this.units.getUnitDisplaySymbol(this.units.getDefaults().Temperature)}`;
   }
 
-  private toStringValue(value: unknown): string | null {
-    return typeof value === 'string' ? value : null;
-  }
-
-  private resolveMostSevereState(...states: (TState | null | undefined)[]): TState | null {
-    if (states.some(s => s === States.Alert)) return States.Alert;
-    if (states.some(s => s === States.Alarm)) return States.Alarm;
-    if (states.some(s => s === States.Warn)) return States.Warn;
-    if (states.some(s => s === States.Normal)) return States.Normal;
-    return null;
-  }
-
   private toNumber(value: unknown, unitHint: string): number | null {
     if (value == null || typeof value === 'boolean') return null;
     const rawNumber = typeof value === 'number' ? value : Number(value);
@@ -658,22 +630,4 @@ export class WidgetInverterComponent implements AfterViewInit, OnDestroy {
     return typeof converted === 'number' && Number.isFinite(converted) ? converted : null;
   }
 
-  private toBoolean(value: unknown): boolean | null {
-    if (typeof value === 'boolean') {
-      return value;
-    }
-
-    if (typeof value === 'number') {
-      if (value === 1) return true;
-      if (value === 0) return false;
-    }
-
-    if (typeof value === 'string') {
-      const normalized = value.trim().toLowerCase();
-      if (normalized === 'true' || normalized === '1' || normalized === 'on') return true;
-      if (normalized === 'false' || normalized === '0' || normalized === 'off') return false;
-    }
-
-    return null;
-  }
 }

--- a/src/app/widgets/widget-solar-charger/widget-solar-charger.component.ts
+++ b/src/app/widgets/widget-solar-charger/widget-solar-charger.component.ts
@@ -13,6 +13,7 @@ import { getElectricalWidgetFamilyDescriptor } from '../../core/contracts/electr
 import type { ElectricalCardDisplayMode } from '../../core/contracts/electrical-topology-card.contract';
 import { ELECTRICAL_DIRECT_CARD_GAP, ELECTRICAL_DIRECT_CARD_HEIGHT, ELECTRICAL_DIRECT_CARD_VIEWBOX_WIDTH, ELECTRICAL_DIRECT_CARD_FULL_LAYOUT } from '../shared/electrical-card-layout.constants';
 import { normalizeOptionalString, normalizeStringList } from '../shared/electrical-config.util';
+import { setValue } from '../shared/electrical-apply.util';
 import { WidgetTitleComponent } from '../../core/components/widget-title/widget-title.component';
 
 interface SolarRenderSnapshot {
@@ -591,9 +592,9 @@ export class WidgetSolarChargerComponent implements AfterViewInit, OnDestroy {
 
   private applyChargerValue(charger: SolarChargerSnapshot, key: string, value: unknown, state: TState | null): boolean {
     switch (key) {
-      case 'name': return this.setValue(charger, 'name', this.toStringValue(value));
-      case 'location': return this.setValue(charger, 'location', this.toStringValue(value));
-      case 'associatedBus': return this.setValue(charger, 'associatedBus', this.toStringValue(value));
+      case 'name': return setValue(charger, 'name', this.toStringValue(value));
+      case 'location': return setValue(charger, 'location', this.toStringValue(value));
+      case 'associatedBus': return setValue(charger, 'associatedBus', this.toStringValue(value));
       case 'voltage': {
         const nextValue = this.toNumber(value, 'V');
         const stateChanged = !Object.is(charger.voltageState ?? null, state ?? null);
@@ -619,12 +620,12 @@ export class WidgetSolarChargerComponent implements AfterViewInit, OnDestroy {
         charger.temperatureState = state;
         return true;
       }
-      case 'chargingAlgorithm': return this.setValue(charger, 'chargingAlgorithm', this.toStringValue(value));
-      case 'chargerRole': return this.setValue(charger, 'chargerRole', this.toStringValue(value));
-      case 'chargingMode': return this.setValue(charger, 'chargingMode', this.toStringValue(value));
-      case 'setpointVoltage': return this.setValue(charger, 'setpointVoltage', this.toNumber(value, 'V'));
-      case 'setpointCurrent': return this.setValue(charger, 'setpointCurrent', this.toNumber(value, 'A'));
-      case 'controllerMode': return this.setValue(charger, 'controllerMode', this.toStringValue(value));
+      case 'chargingAlgorithm': return setValue(charger, 'chargingAlgorithm', this.toStringValue(value));
+      case 'chargerRole': return setValue(charger, 'chargerRole', this.toStringValue(value));
+      case 'chargingMode': return setValue(charger, 'chargingMode', this.toStringValue(value));
+      case 'setpointVoltage': return setValue(charger, 'setpointVoltage', this.toNumber(value, 'V'));
+      case 'setpointCurrent': return setValue(charger, 'setpointCurrent', this.toNumber(value, 'A'));
+      case 'controllerMode': return setValue(charger, 'controllerMode', this.toStringValue(value));
       case 'panelVoltage': {
         const nextValue = this.toNumber(value, 'V');
         const stateChanged = !Object.is(charger.panelVoltageState ?? null, state ?? null);
@@ -649,8 +650,8 @@ export class WidgetSolarChargerComponent implements AfterViewInit, OnDestroy {
         charger.panelPowerState = state;
         return true;
       }
-      case 'yieldToday': return this.setValue(charger, 'yieldToday', this.toNumber(value, 'kWh'));
-      case 'yieldYesterday': return this.setValue(charger, 'yieldYesterday', this.toNumber(value, 'kWh'));
+      case 'yieldToday': return setValue(charger, 'yieldToday', this.toNumber(value, 'kWh'));
+      case 'yieldYesterday': return setValue(charger, 'yieldYesterday', this.toNumber(value, 'kWh'));
       case 'panelTemperature': {
         const nextValue = this.toNumber(value, this.units.getDefaults().Temperature);
         const stateChanged = !Object.is(charger.panelTemperatureState ?? null, state ?? null);
@@ -662,7 +663,7 @@ export class WidgetSolarChargerComponent implements AfterViewInit, OnDestroy {
       case 'load':
       case 'loadState':
       case 'load.state':
-        return this.setValue(charger, 'load', value as string | number | boolean | null);
+        return setValue(charger, 'load', value as string | number | boolean | null);
       case 'loadCurrent': {
         const nextValue = this.toNumber(value, 'A');
         const stateChanged = !Object.is(charger.loadCurrentState ?? null, state ?? null);
@@ -678,13 +679,7 @@ export class WidgetSolarChargerComponent implements AfterViewInit, OnDestroy {
 
   private setPowerPathValue(charger: SolarChargerSnapshot, key: 'rawBatteryPower' | 'rawPanelPower', value: unknown): boolean {
     const parsedValue = this.toNumber(value, 'W');
-    return this.setValue(charger, key, parsedValue);
-  }
-
-  private setValue<K extends keyof SolarChargerSnapshot>(snapshot: SolarChargerSnapshot, key: K, value: SolarChargerSnapshot[K]): boolean {
-    if (Object.is(snapshot[key], value)) return false;
-    snapshot[key] = value;
-    return true;
+    return setValue(charger, key, parsedValue);
   }
 
   private resolvePowerValue(pathPower: number | null | undefined, voltage: number | null | undefined, current: number | null | undefined): number | undefined {


### PR DESCRIPTION
## Why

Stage 1b of the #4 electrical extraction — the second surgical slice: the value-apply helpers the charger/alternator/inverter/ac quad carried verbatim. **Stacked on #352 (Stage 1a); review/merge #352 first.**

## What

Adds `src/app/widgets/shared/electrical-apply.util.ts` (with a spec) and migrates the call sites:

- `setValue` / `setMetricValue` — the `Object.is` dirty-check snapshot writers, now generic over the snapshot type (`<T, K extends keyof T>`), so all five adopters share one implementation.
- `toStringValue`, `toBoolean` — pure value coercers.
- `resolveMostSevereState` — the Alert > Alarm > Warn > Normal severity fold.

## What is deliberately *not* merged

- **solar-charger** adopts only `setValue`. Its `toStringValue` **stringifies** non-strings (quad returns `null`) and its `resolveMostSevereState` uses a **rank-based** ordering with extra states — both behaviorally distinct, kept private, tracked in #351 (divergence #4 added there).
- **bms** uses a different write path and is untouched.
- `toNumber` (units-dependent) and `escapeRegex` (path-regex construction) stay in the widgets — they belong with Stage 2's ingest engine, not this stateless slice.

## Verification

`npm run snc` + `npm run lint` clean; the six electrical widget specs + the new apply-util spec (99 tests) pass locally; solar's divergent bodies confirmed byte-unchanged. Net ~183 lines removed (~420 across Stage 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
