### PR TITLE
refactor(electrical): extract ingest scheduler + topology store, adopt trio (#4 Stage 2a)

### DIFF
--- a/src/app/widgets/shared/electrical-ingest-scheduler.spec.ts
+++ b/src/app/widgets/shared/electrical-ingest-scheduler.spec.ts
@@ -1,0 +1,170 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Subject } from 'rxjs';
+import type { DestroyRef } from '@angular/core';
+import { States } from '../../core/interfaces/signalk-interfaces';
+import { ElectricalIngestScheduler } from './electrical-ingest-scheduler';
+import type { DataService, IPathUpdateWithPath } from '../../core/services/data.service';
+
+interface TestEntry {
+  id: string;
+  key: string;
+  value: unknown;
+}
+
+interface TestSnapshot {
+  tag: string;
+}
+
+const makeUpdate = (path: string, value: unknown): IPathUpdateWithPath => ({
+  path,
+  update: {
+    data: { value, timestamp: new Date('2026-01-01T00:00:00.000Z') },
+    state: States.Normal
+  }
+});
+
+const parseUpdate = (update: IPathUpdateWithPath): { key: string; entry: TestEntry } | null => {
+  const match = update.path.match(/\.([^.]+)\.([^.]+)$/);
+  if (!match) return null;
+  return {
+    key: `${match[1]}::${match[2]}`,
+    entry: { id: match[1], key: match[2], value: update.update?.data?.value ?? null }
+  };
+};
+
+const makeDestroyRef = (): { ref: DestroyRef; destroy: () => void } => {
+  const callbacks: (() => void)[] = [];
+  const ref = { onDestroy: (cb: () => void) => { callbacks.push(cb); return () => undefined; } } as unknown as DestroyRef;
+  return { ref, destroy: () => callbacks.slice().forEach(cb => cb()) };
+};
+
+interface Harness {
+  scheduler: ElectricalIngestScheduler<TestEntry, TestSnapshot>;
+  onFlush: ReturnType<typeof vi.fn>;
+  draw: ReturnType<typeof vi.fn>;
+  live: Subject<IPathUpdateWithPath>;
+  destroy: () => void;
+  setReady: (ready: boolean) => void;
+}
+
+const setup = (initial: IPathUpdateWithPath[] = []): Harness => {
+  const live = new Subject<IPathUpdateWithPath>();
+  const data = {
+    subscribePathTreeWithInitial: vi.fn().mockReturnValue({ initial, live$: live.asObservable() })
+  } as unknown as DataService;
+  const { ref, destroy } = makeDestroyRef();
+  const onFlush = vi.fn();
+  const draw = vi.fn();
+  let ready = true;
+
+  const scheduler = new ElectricalIngestScheduler<TestEntry, TestSnapshot>({
+    data,
+    destroyRef: ref,
+    rootPattern: 'self.electrical.x.*',
+    batchWindowMs: 500,
+    parseUpdate,
+    onFlush,
+    resolveRenderSnapshot: explicit => (ready ? (explicit ?? { tag: 'default' }) : null),
+    draw
+  });
+
+  return { scheduler, onFlush, draw, live, destroy, setReady: value => { ready = value; } };
+};
+
+describe('ElectricalIngestScheduler', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('drains the initial tree synchronously in one flush with no timer', () => {
+    vi.useFakeTimers();
+    const { onFlush } = setup([
+      makeUpdate('self.electrical.x.a1.voltage', 12),
+      makeUpdate('self.electrical.x.a1.current', 3)
+    ]);
+
+    expect(onFlush).toHaveBeenCalledTimes(1);
+    expect(onFlush.mock.calls[0][0]).toEqual([
+      { id: 'a1', key: 'voltage', value: 12 },
+      { id: 'a1', key: 'current', value: 3 }
+    ]);
+  });
+
+  it('flushes the first live update immediately, then batches subsequent ones at the window', async () => {
+    vi.useFakeTimers();
+    const { onFlush, live } = setup();
+    expect(onFlush).not.toHaveBeenCalled();
+
+    live.next(makeUpdate('self.electrical.x.a1.voltage', 12));
+    expect(onFlush).toHaveBeenCalledTimes(1); // immediate, no advance
+
+    live.next(makeUpdate('self.electrical.x.a1.current', 3));
+    await vi.advanceTimersByTimeAsync(499);
+    expect(onFlush).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(onFlush).toHaveBeenCalledTimes(2);
+  });
+
+  it('coalesces same-key updates within the window, keeping the last value', async () => {
+    vi.useFakeTimers();
+    const { onFlush, live } = setup([makeUpdate('self.electrical.x.a1.name', 'n')]); // initial drain arms initialPaintDone
+    onFlush.mockClear();
+
+    live.next(makeUpdate('self.electrical.x.a1.voltage', 10));
+    live.next(makeUpdate('self.electrical.x.a1.voltage', 20));
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(onFlush).toHaveBeenCalledTimes(1);
+    expect(onFlush.mock.calls[0][0]).toEqual([{ id: 'a1', key: 'voltage', value: 20 }]);
+  });
+
+  it('coalesces render requests into one frame carrying the last snapshot', async () => {
+    vi.useFakeTimers();
+    const { scheduler, draw } = setup();
+
+    scheduler.requestRender({ tag: 'a' });
+    scheduler.requestRender({ tag: 'b' });
+    expect(draw).not.toHaveBeenCalled(); // frame pending
+
+    await vi.runAllTimersAsync();
+    expect(draw).toHaveBeenCalledTimes(1);
+    expect(draw).toHaveBeenCalledWith({ tag: 'b' });
+  });
+
+  it('schedules no frame when the widget is not ready', async () => {
+    vi.useFakeTimers();
+    const { scheduler, draw, setReady } = setup();
+    setReady(false);
+
+    scheduler.requestRender({ tag: 'a' });
+    await vi.runAllTimersAsync();
+    expect(draw).not.toHaveBeenCalled();
+  });
+
+  it('on teardown cancels the pending batch timer and render frame', async () => {
+    vi.useFakeTimers();
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+    const cancelFrameSpy = vi.spyOn(globalThis, 'cancelAnimationFrame');
+    const { scheduler, onFlush, draw, live, destroy } = setup([makeUpdate('self.electrical.x.a1.name', 'n')]);
+    onFlush.mockClear();
+
+    live.next(makeUpdate('self.electrical.x.a1.voltage', 10)); // arms the 500ms batch timer
+    scheduler.requestRender({ tag: 'a' }); // arms a render frame
+
+    destroy();
+
+    // Prove teardown actually cancels both — not merely that the callbacks no-op afterwards.
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    expect(cancelFrameSpy).toHaveBeenCalled();
+
+    await vi.runAllTimersAsync();
+    expect(onFlush).not.toHaveBeenCalled();
+    expect(draw).not.toHaveBeenCalled();
+
+    live.next(makeUpdate('self.electrical.x.a1.current', 3)); // stream torn down
+    await vi.advanceTimersByTimeAsync(500);
+    expect(onFlush).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/widgets/shared/electrical-ingest-scheduler.ts
+++ b/src/app/widgets/shared/electrical-ingest-scheduler.ts
@@ -1,0 +1,138 @@
+import { DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import type { DataService, IPathUpdateWithPath } from '../../core/services/data.service';
+
+/**
+ * Universal ingest/render scheduler shared by the electrical widget family.
+ *
+ * Owns the timing machinery that every electrical widget duplicated verbatim:
+ * the de-duping pending-update buffer, the coalescing batch timer with the
+ * initial-paint synchronous drain and first-live-immediate-flush fast path,
+ * the single-flight requestAnimationFrame scheduler, the path-tree subscription
+ * lifecycle, and teardown. It owns *when* work happens, never *what* — parsing,
+ * store mutation, snapshot resolution, and drawing are injected seams, so the
+ * scheduler is behaviorally indifferent to the widget's snapshot shape.
+ */
+export interface ElectricalIngestConfig<TEntry, TRender> {
+  data: DataService;
+  destroyRef: DestroyRef;
+  /** Path prefix passed to subscribePathTreeWithInitial. */
+  rootPattern: string;
+  /** Source bucket for the subscription (default 'default'). */
+  source?: string;
+  /** Coalescing window in milliseconds. */
+  batchWindowMs: number;
+  /** Parse an update into a de-dup buffer key + entry, or null to drop it. */
+  parseUpdate: (update: IPathUpdateWithPath) => { key: string; entry: TEntry } | null;
+  /** Process a drained batch of buffered entries (the store layer). */
+  onFlush: (entries: TEntry[]) => void;
+  /**
+   * Resolve the snapshot to draw for a render request: apply the widget's
+   * readiness guard and return the explicit snapshot, a freshly built default,
+   * or null when the widget is not ready to render.
+   */
+  resolveRenderSnapshot: (explicit?: TRender) => TRender | null;
+  /** Draw a resolved snapshot. */
+  draw: (snapshot: TRender) => void;
+}
+
+export class ElectricalIngestScheduler<TEntry, TRender> {
+  private readonly pending = new Map<string, TEntry>();
+  private batchTimerId: number | null = null;
+  private initialPaintDone = false;
+  private frameId: number | null = null;
+  private pendingRender: TRender | null = null;
+
+  constructor(private readonly cfg: ElectricalIngestConfig<TEntry, TRender>) {
+    const tree = cfg.source !== undefined
+      ? cfg.data.subscribePathTreeWithInitial(cfg.rootPattern, cfg.source)
+      : cfg.data.subscribePathTreeWithInitial(cfg.rootPattern);
+
+    if (tree.initial.length) {
+      for (const update of tree.initial) {
+        this.enqueue(update, true);
+      }
+      this.flush();
+      this.initialPaintDone = true;
+    }
+
+    tree.live$
+      .pipe(takeUntilDestroyed(cfg.destroyRef))
+      .subscribe(update => this.enqueue(update, false));
+
+    cfg.destroyRef.onDestroy(() => this.teardown());
+  }
+
+  /** Schedule a coalesced render frame; last snapshot wins, one frame in flight. */
+  requestRender(explicit?: TRender): void {
+    const snapshot = this.cfg.resolveRenderSnapshot(explicit);
+    if (snapshot == null) {
+      return;
+    }
+
+    this.pendingRender = snapshot;
+    if (this.frameId !== null) {
+      return;
+    }
+
+    this.frameId = requestAnimationFrame(() => {
+      this.frameId = null;
+      const next = this.pendingRender;
+      this.pendingRender = null;
+      if (next == null) {
+        return;
+      }
+      this.cfg.draw(next);
+    });
+  }
+
+  private enqueue(update: IPathUpdateWithPath, fromInitial: boolean): void {
+    const parsed = this.cfg.parseUpdate(update);
+    if (!parsed) {
+      return;
+    }
+
+    this.pending.set(parsed.key, parsed.entry);
+
+    if (fromInitial) {
+      return;
+    }
+
+    if (!this.initialPaintDone) {
+      this.initialPaintDone = true;
+      this.flush();
+      return;
+    }
+
+    if (this.batchTimerId !== null) {
+      return;
+    }
+
+    this.batchTimerId = window.setTimeout(() => {
+      this.batchTimerId = null;
+      this.flush();
+    }, this.cfg.batchWindowMs);
+  }
+
+  private flush(): void {
+    if (!this.pending.size) {
+      return;
+    }
+
+    const entries = Array.from(this.pending.values());
+    this.pending.clear();
+    this.cfg.onFlush(entries);
+  }
+
+  private teardown(): void {
+    if (this.batchTimerId !== null) {
+      clearTimeout(this.batchTimerId);
+      this.batchTimerId = null;
+    }
+    if (this.frameId !== null) {
+      cancelAnimationFrame(this.frameId);
+      this.frameId = null;
+    }
+    this.pendingRender = null;
+  }
+}

--- a/src/app/widgets/shared/electrical-topology-store.spec.ts
+++ b/src/app/widgets/shared/electrical-topology-store.spec.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import type { IElectricalTopologySnapshotCore } from '../../core/contracts/electrical-topology-card.contract';
+import type { ElectricalTrackedDevice } from '../../core/interfaces/widgets-interface';
+import {
+  ElectricalTopologyStore,
+  type ElectricalTopologyConfig,
+  type ElectricalTopologyEntry
+} from './electrical-topology-store';
+
+type Snapshot = IElectricalTopologySnapshotCore;
+
+const config: ElectricalTopologyConfig<Snapshot> = {
+  createSnapshot: seed => ({ id: seed.id, source: seed.source, deviceKey: seed.deviceKey }),
+  applyValue: (snapshot, key, value) => {
+    const bag = snapshot as unknown as Record<string, unknown>;
+    if (Object.is(bag[key], value)) {
+      return false;
+    }
+    bag[key] = value;
+    return true;
+  },
+  derive: snapshot => {
+    if (snapshot.voltage != null && snapshot.current != null) {
+      snapshot.power = snapshot.voltage * snapshot.current;
+    }
+  }
+};
+
+const entry = (id: string, key: string, value: unknown): ElectricalTopologyEntry => ({ id, key, value, state: null });
+const device = (id: string, source: string): ElectricalTrackedDevice => ({ id, source, key: `${id}||${source}` });
+
+describe('ElectricalTopologyStore', () => {
+  it('stores discovered snapshots by id and exposes them as visible', () => {
+    const store = new ElectricalTopologyStore(config);
+    store.processBatch([entry('a1', 'voltage', 12)]);
+
+    expect(store.store()['a1']?.voltage).toBe(12);
+    expect(store.discoveredIds()).toEqual(['a1']);
+    expect(store.visibleKeys()).toEqual(['a1']);
+    expect(store.visibleSnapshots()).toHaveLength(1);
+  });
+
+  it('runs the derive hook over the fully-applied draft when V and I arrive in one batch', () => {
+    const store = new ElectricalTopologyStore(config);
+    store.processBatch([entry('a1', 'voltage', 14), entry('a1', 'current', 3)]);
+
+    expect(store.store()['a1']?.power).toBe(42);
+  });
+
+  it('does not commit when applyValue reports no change', () => {
+    const store = new ElectricalTopologyStore(config);
+    store.processBatch([entry('a1', 'voltage', 12)]);
+    const before = store.store();
+
+    store.processBatch([entry('a1', 'voltage', 12)]); // same value
+    expect(store.store()).toBe(before);
+  });
+
+  it('reprojects id-arrived-before-config snapshots onto device keys and drops the stale plain-id', () => {
+    const store = new ElectricalTopologyStore(config);
+    store.processBatch([entry('a1', 'voltage', 12)]); // arrives before config, keyed by plain id
+    expect(store.store()['a1']).toBeDefined();
+
+    store.applyConfig([device('a1', 'n2k')]);
+
+    expect(store.store()['a1||n2k']).toBeDefined();
+    expect(store.store()['a1||n2k']?.voltage).toBe(12);
+    expect(store.store()['a1']).toBeUndefined();
+    expect(store.visibleKeys()).toEqual(['a1||n2k']);
+  });
+
+  it('selects tracked keys when tracked, else discovered ids', () => {
+    const store = new ElectricalTopologyStore(config);
+    store.processBatch([entry('b2', 'voltage', 1), entry('a1', 'voltage', 2)]);
+    expect(store.visibleKeys()).toEqual(['a1', 'b2']); // discovered, sorted
+
+    store.applyConfig([device('a1', 'n2k')]);
+    expect(store.visibleKeys()).toEqual(['a1||n2k']); // tracked order
+  });
+
+  it('fans one id out to all its tracked device keys, seeding source and deviceKey', () => {
+    const store = new ElectricalTopologyStore(config);
+    store.applyConfig([device('a1', 'n2k'), device('a1', 'victron')]);
+    store.processBatch([entry('a1', 'voltage', 12)]);
+
+    const map = store.store();
+    expect(map['a1||n2k']?.voltage).toBe(12);
+    expect(map['a1||victron']?.voltage).toBe(12);
+    expect(map['a1||n2k']?.source).toBe('n2k');
+    expect(map['a1||n2k']?.deviceKey).toBe('a1||n2k');
+    expect(map['a1||victron']?.source).toBe('victron');
+    expect(store.visibleKeys()).toEqual(['a1||n2k', 'a1||victron']);
+  });
+});

--- a/src/app/widgets/shared/electrical-topology-store.ts
+++ b/src/app/widgets/shared/electrical-topology-store.ts
@@ -1,0 +1,163 @@
+import { computed, signal } from '@angular/core';
+import type { TState } from '../../core/interfaces/signalk-interfaces';
+import type { ElectricalTrackedDevice } from '../../core/interfaces/widgets-interface';
+import type { IElectricalTopologySnapshotCore } from '../../core/contracts/electrical-topology-card.contract';
+import { buildIdToDeviceKeysMap } from './electrical-config.util';
+
+/** One de-duped, parsed path update handed to the store from the ingest scheduler. */
+export interface ElectricalTopologyEntry {
+  id: string;
+  key: string;
+  value: unknown;
+  state: TState | null;
+}
+
+export interface ElectricalTopologyConfig<TSnapshot extends IElectricalTopologySnapshotCore> {
+  /** Create a fresh snapshot for a newly seen device key. */
+  createSnapshot: (seed: { id: string; source: string | null; deviceKey: string | undefined }) => TSnapshot;
+  /** Apply one parsed value to the draft snapshot; return whether a field actually changed. */
+  applyValue: (snapshot: TSnapshot, key: string, value: unknown, state: TState | null) => boolean;
+  /** Optional per-changed-key derivation (e.g. power = V*I) run after a value applies. */
+  derive?: (snapshot: TSnapshot) => void;
+}
+
+/**
+ * Source-blind keyed-snapshot store shared by the electrical widget family
+ * (alternator, inverter, ac, solar). Owns the by-key snapshot store, the
+ * discovered-id and tracked-device signals, the batch-apply flush body,
+ * reproject (re-key id-arrived-before-config snapshots onto configured device
+ * keys), and the tracked-else-discovered visible selection. Per-widget metric
+ * mapping and derivation are injected seams. Charger's source-qualified variant
+ * and bms's id-only store compose their own paths (Stage 2b/2d).
+ */
+export class ElectricalTopologyStore<TSnapshot extends IElectricalTopologySnapshotCore> {
+  private readonly _store = signal<Record<string, TSnapshot>>({});
+  private readonly _discoveredIds = signal<string[]>([]);
+  private readonly _trackedDevices = signal<ElectricalTrackedDevice[]>([]);
+
+  readonly store = this._store.asReadonly();
+  readonly discoveredIds = this._discoveredIds.asReadonly();
+  readonly trackedDevices = this._trackedDevices.asReadonly();
+
+  readonly visibleKeys = computed<string[]>(() => {
+    const tracked = this._trackedDevices();
+    if (tracked.length) {
+      return tracked.map(device => device.key);
+    }
+
+    const map = this._store();
+    const ids = new Set(this._discoveredIds());
+    return Object.keys(map)
+      .filter(key => {
+        const snapshot = map[key];
+        return !!snapshot && ids.has(snapshot.id);
+      })
+      .sort((left, right) => left.localeCompare(right));
+  });
+
+  readonly visibleSnapshots = computed<TSnapshot[]>(() => {
+    const keys = this.visibleKeys();
+    const map = this._store();
+    return keys.map(key => map[key]).filter((snapshot): snapshot is TSnapshot => !!snapshot);
+  });
+
+  constructor(private readonly cfg: ElectricalTopologyConfig<TSnapshot>) {}
+
+  /** Apply resolved config: set the tracked devices and reproject existing snapshots. */
+  applyConfig(devices: ElectricalTrackedDevice[]): void {
+    this._trackedDevices.set(devices);
+    this.reproject(devices);
+  }
+
+  /** Process a drained batch of entries into the store. */
+  processBatch(entries: ElectricalTopologyEntry[]): void {
+    const uniqueIds = new Set(entries.map(entry => entry.id));
+    uniqueIds.forEach(id => this.trackDiscovered(id));
+
+    const idToKeys = buildIdToDeviceKeysMap(this._trackedDevices());
+
+    this._store.update(current => {
+      let next = current;
+      let changed = false;
+
+      for (const entry of entries) {
+        const keysForId = idToKeys.get(entry.id);
+        const targetKeys: string[] = keysForId?.length ? keysForId : [entry.id];
+
+        for (const deviceKey of targetKeys) {
+          const isTracked = !!keysForId?.length;
+          const trackedDevice = isTracked ? this._trackedDevices().find(device => device.key === deviceKey) : null;
+          const existing = next[deviceKey]
+            ?? this.cfg.createSnapshot({ id: entry.id, source: trackedDevice?.source ?? null, deviceKey: isTracked ? deviceKey : undefined });
+          const snapshot = { ...existing };
+
+          const fieldChanged = this.cfg.applyValue(snapshot, entry.key, entry.value, entry.state);
+          if (!fieldChanged) {
+            continue;
+          }
+
+          this.cfg.derive?.(snapshot);
+
+          if (!changed) {
+            next = { ...next };
+            changed = true;
+          }
+          next[deviceKey] = snapshot;
+        }
+      }
+
+      return changed ? next : current;
+    });
+  }
+
+  private reproject(devices: ElectricalTrackedDevice[]): void {
+    if (!devices.length) {
+      return;
+    }
+
+    const idToKeys = new Map<string, string[]>();
+    devices.forEach(device => {
+      const existing = idToKeys.get(device.id) ?? [];
+      existing.push(device.key);
+      idToKeys.set(device.id, existing);
+    });
+
+    this._store.update(current => {
+      let next = current;
+      let changed = false;
+
+      idToKeys.forEach((keys, id) => {
+        const sourceSnapshot = current[id];
+        if (!sourceSnapshot) {
+          return;
+        }
+
+        for (const deviceKey of keys) {
+          if (current[deviceKey]) {
+            continue;
+          }
+          const trackedDevice = devices.find(device => device.key === deviceKey);
+          if (!changed) {
+            next = { ...current };
+            changed = true;
+          }
+          next[deviceKey] = { ...sourceSnapshot, source: trackedDevice?.source ?? null, deviceKey };
+        }
+
+        if (changed && next[id]?.deviceKey === undefined) {
+          delete next[id];
+        }
+      });
+
+      return changed ? next : current;
+    });
+  }
+
+  private trackDiscovered(id: string): void {
+    const ids = this._discoveredIds();
+    if (ids.includes(id)) {
+      return;
+    }
+    this._discoveredIds.set([...ids, id].sort((left, right) => left.localeCompare(right)));
+  }
+}

--- a/src/app/widgets/widget-ac/widget-ac.component.ts
+++ b/src/app/widgets/widget-ac/widget-ac.component.ts
@@ -1,7 +1,6 @@
-import { AfterViewInit, ChangeDetectionStrategy, Component, DestroyRef, ElementRef, OnDestroy, computed, effect, inject, input, signal, untracked, viewChild } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { AfterViewInit, ChangeDetectionStrategy, Component, DestroyRef, ElementRef, computed, effect, inject, input, signal, untracked, viewChild } from '@angular/core';
 import { select, type Selection } from 'd3-selection';
-import { DataService, IPathUpdateWithPath } from '../../core/services/data.service';
+import { DataService } from '../../core/services/data.service';
 import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
 import type { ITheme } from '../../core/services/app-service';
 import { TState } from '../../core/interfaces/signalk-interfaces';
@@ -18,8 +17,10 @@ import {
   ELECTRICAL_DIRECT_CARD_VIEWBOX_WIDTH,
   ELECTRICAL_DIRECT_COMPACT_CARD_HEIGHT
 } from '../shared/electrical-card-layout.constants';
-import { normalizeOptionalString, normalizeStringList, buildIdToDeviceKeysMap } from '../shared/electrical-config.util';
+import { normalizeOptionalString, normalizeStringList } from '../shared/electrical-config.util';
 import { setValue, setMetricValue, toStringValue, resolveMostSevereState } from '../shared/electrical-apply.util';
+import { ElectricalIngestScheduler } from '../shared/electrical-ingest-scheduler';
+import { ElectricalTopologyStore, type ElectricalTopologyEntry } from '../shared/electrical-topology-store';
 import type { AcDisplayModel, AcSnapshot, AcWidgetConfig, ElectricalCardModeConfig } from './widget-ac.types';
 import { WidgetTitleComponent } from '../../core/components/widget-title/widget-title.component';
 
@@ -36,7 +37,7 @@ interface AcRenderSnapshot {
   imports: [WidgetTitleComponent],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class WidgetAcComponent implements AfterViewInit, OnDestroy {
+export class WidgetAcComponent implements AfterViewInit {
   private static readonly AC_DESCRIPTOR = getElectricalWidgetFamilyDescriptor('widget-ac');
   private static readonly SELF_ROOT_PATH = (() => {
     const root = WidgetAcComponent.AC_DESCRIPTOR?.selfRootPath;
@@ -75,39 +76,53 @@ export class WidgetAcComponent implements AfterViewInit, OnDestroy {
   private svg?: Selection<SVGSVGElement, unknown, null, undefined>;
   private layer?: Selection<SVGGElement, unknown, null, undefined>;
 
-  private readonly pendingPathUpdates = new Map<string, { id: string; key: string; value: unknown; state: TState | null }>();
-  private pathBatchTimerId: ReturnType<typeof setTimeout> | null = null;
-  private initialPathPaintDone = false;
-  private renderFrameId: number | null = null;
-  private pendingRenderSnapshot: AcRenderSnapshot | null = null;
+  private readonly store = new ElectricalTopologyStore<AcSnapshot>({
+    createSnapshot: seed => ({ id: seed.id, source: seed.source, deviceKey: seed.deviceKey }),
+    applyValue: (snapshot, key, value, state) => this.applyValue(snapshot, key, value, state)
+  });
 
-  protected readonly discoveredBusIds = signal<string[]>([]);
-  protected readonly trackedDevices = signal<ElectricalTrackedDevice[]>([]);
+  private readonly scheduler = new ElectricalIngestScheduler<ElectricalTopologyEntry, AcRenderSnapshot>({
+    data: this.data,
+    destroyRef: this.destroyRef,
+    rootPattern: WidgetAcComponent.ROOT_PATTERN,
+    batchWindowMs: WidgetAcComponent.PATH_BATCH_WINDOW_MS,
+    parseUpdate: update => {
+      const parsed = this.parsePath(update.path);
+      if (!parsed) return null;
+      return {
+        key: `${parsed.id}::${parsed.key}`,
+        entry: {
+          id: parsed.id,
+          key: parsed.key,
+          value: update.update?.data?.value ?? null,
+          state: update.update?.state ?? null
+        }
+      };
+    },
+    onFlush: entries => this.store.processBatch(entries),
+    resolveRenderSnapshot: explicit => {
+      const widgetColors = this.widgetColors();
+      if (!this.svg || !widgetColors) return null;
+      return explicit ?? {
+        buses: this.visibleBuses(),
+        displayModels: this.displayModels(),
+        widgetColors
+      };
+    },
+    draw: snapshot => this.render(snapshot)
+  });
+
   protected readonly optionsById = signal<AcWidgetConfig['optionsById']>({});
   protected readonly cardMode = signal<ElectricalCardModeConfig>({
     displayMode: 'full',
     metrics: ['line1Voltage', 'line1Current', 'line1Frequency', 'line2Voltage']
   });
-  protected readonly busesByKey = signal<Record<string, AcSnapshot>>({});
 
-  protected readonly visibleBusKeys = computed(() => {
-    const tracked = this.trackedDevices();
-    if (tracked.length) return tracked.map(device => device.key);
-    const map = this.busesByKey();
-    const ids = new Set(this.discoveredBusIds());
-    return Object.keys(map)
-      .filter(key => {
-        const snapshot = map[key];
-        return !!snapshot && ids.has(snapshot.id);
-      })
-      .sort((left, right) => left.localeCompare(right));
-  });
-
-  protected readonly visibleBuses = computed<AcSnapshot[]>(() => {
-    const keys = this.visibleBusKeys();
-    const map = this.busesByKey();
-    return keys.map(key => map[key]).filter((item): item is AcSnapshot => !!item);
-  });
+  protected readonly busesByKey = this.store.store;
+  protected readonly discoveredBusIds = this.store.discoveredIds;
+  protected readonly trackedDevices = this.store.trackedDevices;
+  protected readonly visibleBusKeys = this.store.visibleKeys;
+  protected readonly visibleBuses = this.store.visibleSnapshots;
 
   protected readonly hasBuses = computed(() => this.visibleBuses().length > 0);
   protected readonly activeDisplayMode = computed<ElectricalCardDisplayMode>(() => this.renderMode() ?? this.cardMode().displayMode ?? 'full');
@@ -203,49 +218,13 @@ export class WidgetAcComponent implements AfterViewInit, OnDestroy {
       const buses = this.visibleBuses();
       const widgetColors = this.widgetColors();
       if (!this.svg || !widgetColors) return;
-      this.requestRender({ buses, displayModels: models, widgetColors });
+      this.scheduler.requestRender({ buses, displayModels: models, widgetColors });
     });
-
-    const acTrees = [
-      this.data.subscribePathTreeWithInitial(WidgetAcComponent.ROOT_PATTERN)
-    ];
-
-    let hasInitialUpdates = false;
-    for (const tree of acTrees) {
-      if (!tree.initial.length) continue;
-      hasInitialUpdates = true;
-      for (const update of tree.initial) {
-        this.enqueuePathUpdate(update, true);
-      }
-    }
-
-    if (hasInitialUpdates) {
-      this.flushPendingPathUpdates();
-      this.initialPathPaintDone = true;
-    }
-
-    for (const tree of acTrees) {
-      tree.live$
-        .pipe(takeUntilDestroyed(this.destroyRef))
-        .subscribe(update => this.enqueuePathUpdate(update));
-    }
   }
 
   ngAfterViewInit(): void {
     this.initializeSvg();
-    this.requestRender();
-  }
-
-  ngOnDestroy(): void {
-    if (this.pathBatchTimerId !== null) {
-      clearTimeout(this.pathBatchTimerId);
-      this.pathBatchTimerId = null;
-    }
-    if (this.renderFrameId !== null) {
-      cancelAnimationFrame(this.renderFrameId);
-      this.renderFrameId = null;
-    }
-    this.pendingRenderSnapshot = null;
+    this.scheduler.requestRender();
   }
 
   private initializeSvg(): void {
@@ -260,47 +239,9 @@ export class WidgetAcComponent implements AfterViewInit, OnDestroy {
 
   private applyConfig(cfg: IWidgetSvcConfig): void {
     const acCfg = this.resolveAcConfig(cfg);
-    this.trackedDevices.set(acCfg.trackedDevices ?? []);
-    this.reprojectSnapshotsToDeviceKeys(acCfg.trackedDevices ?? []);
+    this.store.applyConfig(acCfg.trackedDevices ?? []);
     this.optionsById.set(acCfg.optionsById);
     this.cardMode.set(this.normalizeCardMode(acCfg.cardMode));
-  }
-
-  private reprojectSnapshotsToDeviceKeys(devices: ElectricalTrackedDevice[]): void {
-    if (!devices.length) return;
-
-    const idToKeys = new Map<string, string[]>();
-    devices.forEach(device => {
-      const existing = idToKeys.get(device.id) ?? [];
-      existing.push(device.key);
-      idToKeys.set(device.id, existing);
-    });
-
-    this.busesByKey.update(current => {
-      let next = current;
-      let changed = false;
-
-      idToKeys.forEach((keys, id) => {
-        const sourceSnapshot = current[id];
-        if (!sourceSnapshot) return;
-
-        for (const deviceKey of keys) {
-          if (current[deviceKey]) continue;
-          const trackedDevice = devices.find(device => device.key === deviceKey);
-          if (!changed) {
-            next = { ...current };
-            changed = true;
-          }
-          next[deviceKey] = { ...sourceSnapshot, source: trackedDevice?.source ?? null, deviceKey };
-        }
-
-        if (changed && next[id]?.deviceKey === undefined) {
-          delete next[id];
-        }
-      });
-
-      return changed ? next : current;
-    });
   }
 
   private resolveAcConfig(cfg: IWidgetSvcConfig): AcWidgetConfig {
@@ -360,72 +301,6 @@ export class WidgetAcComponent implements AfterViewInit, OnDestroy {
     return next;
   }
 
-  private enqueuePathUpdate(update: IPathUpdateWithPath, fromInitial = false): void {
-    const parsed = this.parsePath(update.path);
-    if (!parsed) return;
-
-    const value = update.update?.data?.value ?? null;
-    const state = update.update?.state ?? null;
-    this.pendingPathUpdates.set(`${parsed.id}::${parsed.key}`, { id: parsed.id, key: parsed.key, value, state });
-
-    if (fromInitial) return;
-    if (!this.initialPathPaintDone) {
-      this.initialPathPaintDone = true;
-      this.flushPendingPathUpdates();
-      return;
-    }
-
-    if (this.pathBatchTimerId !== null) return;
-    this.pathBatchTimerId = setTimeout(() => {
-      this.pathBatchTimerId = null;
-      this.flushPendingPathUpdates();
-    }, WidgetAcComponent.PATH_BATCH_WINDOW_MS);
-  }
-
-  private flushPendingPathUpdates(): void {
-    if (!this.pendingPathUpdates.size) return;
-
-    const updates = Array.from(this.pendingPathUpdates.values());
-    this.pendingPathUpdates.clear();
-
-    const uniqueIds = new Set(updates.map(item => item.id));
-    uniqueIds.forEach(id => this.trackDiscoveredBus(id));
-
-    const idToKeys = buildIdToDeviceKeysMap(this.trackedDevices());
-
-    this.busesByKey.update(current => {
-      let next = current;
-      let changed = false;
-
-      for (const update of updates) {
-        const keysForId = idToKeys.get(update.id);
-        const targetKeys: string[] = keysForId?.length ? keysForId : [update.id];
-
-        for (const deviceKey of targetKeys) {
-          const isTracked = !!(keysForId?.length);
-          const trackedDevice = isTracked ? this.trackedDevices().find(device => device.key === deviceKey) : null;
-          const existing = next[deviceKey] ?? {
-            id: update.id,
-            source: trackedDevice?.source ?? null,
-            deviceKey: isTracked ? deviceKey : undefined
-          };
-          const snapshot = { ...existing } as AcSnapshot;
-          const fieldChanged = this.applyValue(snapshot, update.key, update.value, update.state);
-
-          if (!fieldChanged) continue;
-
-          if (!changed) {
-            next = { ...next };
-            changed = true;
-          }
-          next[deviceKey] = snapshot;
-        }
-      }
-
-      return changed ? next : current;
-    });
-  }
-
   private parsePath(path: string): { id: string; key: string } | null {
     if (!path.startsWith(WidgetAcComponent.ROOT_PREFIX)) return null;
 
@@ -470,12 +345,6 @@ export class WidgetAcComponent implements AfterViewInit, OnDestroy {
     return null;
   }
 
-  private trackDiscoveredBus(id: string): void {
-    const ids = this.discoveredBusIds();
-    if (ids.includes(id)) return;
-    this.discoveredBusIds.set([...ids, id].sort((a, b) => a.localeCompare(b)));
-  }
-
   private applyValue(snapshot: AcSnapshot, key: string, value: unknown, state: TState | null): boolean {
     const normalizedKey = this.normalizeMetricKey(key);
     if (!normalizedKey) {
@@ -507,27 +376,6 @@ export class WidgetAcComponent implements AfterViewInit, OnDestroy {
       default:
         return false;
     }
-  }
-
-  private requestRender(snapshot?: AcRenderSnapshot): void {
-    const widgetColors = this.widgetColors();
-    if (!this.svg || !widgetColors) return;
-
-    this.pendingRenderSnapshot = snapshot ?? {
-      buses: this.visibleBuses(),
-      displayModels: this.displayModels(),
-      widgetColors
-    };
-
-    if (this.renderFrameId !== null) return;
-
-    this.renderFrameId = requestAnimationFrame(() => {
-      this.renderFrameId = null;
-      const nextSnapshot = this.pendingRenderSnapshot;
-      this.pendingRenderSnapshot = null;
-      if (!nextSnapshot) return;
-      this.render(nextSnapshot);
-    });
   }
 
   private render(snapshot: AcRenderSnapshot): void {

--- a/src/app/widgets/widget-alternator/widget-alternator.component.ts
+++ b/src/app/widgets/widget-alternator/widget-alternator.component.ts
@@ -1,11 +1,10 @@
-import { AfterViewInit, ChangeDetectionStrategy, Component, DestroyRef, ElementRef, OnDestroy, computed, effect, inject, input, signal, untracked, viewChild } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { AfterViewInit, ChangeDetectionStrategy, Component, DestroyRef, ElementRef, computed, effect, inject, input, signal, untracked, viewChild } from '@angular/core';
 import { select, type Selection } from 'd3-selection';
-import { DataService, IPathUpdateWithPath } from '../../core/services/data.service';
+import { DataService } from '../../core/services/data.service';
 import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
 import type { ITheme } from '../../core/services/app-service';
 import { TState } from '../../core/interfaces/signalk-interfaces';
-import type { ElectricalTrackedDevice, IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
+import type { IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
 import { UnitsService } from '../../core/services/units.service';
 import { getColors, resolveZoneAwareColor } from '../../core/utils/themeColors.utils';
 import { getElectricalWidgetFamilyDescriptor } from '../../core/contracts/electrical-widget-family.contract';
@@ -20,8 +19,10 @@ import {
 } from '../shared/electrical-card-layout.constants';
 import type { AlternatorDisplayModel, AlternatorSnapshot, AlternatorWidgetConfig, ElectricalCardModeConfig } from './widget-alternator.types';
 import { WidgetTitleComponent } from '../../core/components/widget-title/widget-title.component';
-import { normalizeOptionalString, normalizeStringList, normalizeTrackedDevices, buildIdToDeviceKeysMap } from '../shared/electrical-config.util';
+import { normalizeOptionalString, normalizeStringList, normalizeTrackedDevices } from '../shared/electrical-config.util';
 import { setValue, setMetricValue, toStringValue, resolveMostSevereState } from '../shared/electrical-apply.util';
+import { ElectricalIngestScheduler } from '../shared/electrical-ingest-scheduler';
+import { ElectricalTopologyStore, type ElectricalTopologyEntry } from '../shared/electrical-topology-store';
 
 function escapeRegex(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -40,7 +41,7 @@ interface AlternatorRenderSnapshot {
   imports: [WidgetTitleComponent],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class WidgetAlternatorComponent implements AfterViewInit, OnDestroy {
+export class WidgetAlternatorComponent implements AfterViewInit {
   private static readonly ALTERNATOR_DESCRIPTOR = getElectricalWidgetFamilyDescriptor('widget-alternator');
   private static readonly SELF_ROOT_PATH = (() => {
     const root = WidgetAlternatorComponent.ALTERNATOR_DESCRIPTOR?.selfRootPath;
@@ -78,39 +79,54 @@ export class WidgetAlternatorComponent implements AfterViewInit, OnDestroy {
   private svg?: Selection<SVGSVGElement, unknown, null, undefined>;
   private layer?: Selection<SVGGElement, unknown, null, undefined>;
 
-  private readonly pendingPathUpdates = new Map<string, { id: string; key: string; value: unknown; state: TState | null }>();
-  private pathBatchTimerId: number | null = null;
-  private initialPathPaintDone = false;
-  private renderFrameId: number | null = null;
-  private pendingRenderSnapshot: AlternatorRenderSnapshot | null = null;
+  private readonly store = new ElectricalTopologyStore<AlternatorSnapshot>({
+    createSnapshot: seed => ({ id: seed.id, source: seed.source, deviceKey: seed.deviceKey }),
+    applyValue: (snapshot, key, value, state) => this.applyValue(snapshot, key, value, state),
+    derive: snapshot => this.derivePower(snapshot)
+  });
 
-  protected readonly discoveredAlternatorIds = signal<string[]>([]);
-  protected readonly trackedDevices = signal<ElectricalTrackedDevice[]>([]);
+  private readonly scheduler = new ElectricalIngestScheduler<ElectricalTopologyEntry, AlternatorRenderSnapshot>({
+    data: this.data,
+    destroyRef: this.destroyRef,
+    rootPattern: WidgetAlternatorComponent.ROOT_PATTERN,
+    batchWindowMs: WidgetAlternatorComponent.PATH_BATCH_WINDOW_MS,
+    parseUpdate: update => {
+      const parsed = this.parsePath(update.path);
+      if (!parsed) return null;
+      return {
+        key: `${parsed.id}::${parsed.key}`,
+        entry: {
+          id: parsed.id,
+          key: parsed.key,
+          value: update.update?.data?.value ?? null,
+          state: update.update?.state ?? null
+        }
+      };
+    },
+    onFlush: entries => this.store.processBatch(entries),
+    resolveRenderSnapshot: explicit => {
+      const widgetColors = this.widgetColors();
+      if (!this.svg || !widgetColors) return null;
+      return explicit ?? {
+        alternators: this.visibleAlternators(),
+        displayModels: this.displayModels(),
+        widgetColors
+      };
+    },
+    draw: snapshot => this.render(snapshot)
+  });
+
   protected readonly optionsById = signal<AlternatorWidgetConfig['optionsById']>({});
   protected readonly cardMode = signal<ElectricalCardModeConfig>({
     displayMode: 'full',
     metrics: ['voltage', 'current', 'power', 'revolutions']
   });
-  protected readonly alternatorsByKey = signal<Record<string, AlternatorSnapshot>>({});
 
-  protected readonly visibleAlternatorKeys = computed(() => {
-    const tracked = this.trackedDevices();
-    if (tracked.length) return tracked.map(device => device.key);
-    const map = this.alternatorsByKey();
-    const ids = new Set(this.discoveredAlternatorIds());
-    return Object.keys(map)
-      .filter(key => {
-        const snapshot = map[key];
-        return !!snapshot && ids.has(snapshot.id);
-      })
-      .sort((left, right) => left.localeCompare(right));
-  });
-
-  protected readonly visibleAlternators = computed<AlternatorSnapshot[]>(() => {
-    const keys = this.visibleAlternatorKeys();
-    const map = this.alternatorsByKey();
-    return keys.map(key => map[key]).filter((item): item is AlternatorSnapshot => !!item);
-  });
+  protected readonly alternatorsByKey = this.store.store;
+  protected readonly discoveredAlternatorIds = this.store.discoveredIds;
+  protected readonly trackedDevices = this.store.trackedDevices;
+  protected readonly visibleAlternatorKeys = this.store.visibleKeys;
+  protected readonly visibleAlternators = this.store.visibleSnapshots;
 
   protected readonly hasAlternators = computed(() => this.visibleAlternators().length > 0);
   protected readonly activeDisplayMode = computed<ElectricalCardDisplayMode>(() => this.renderMode() ?? this.cardMode().displayMode ?? 'full');
@@ -211,55 +227,13 @@ export class WidgetAlternatorComponent implements AfterViewInit, OnDestroy {
       const alternators = this.visibleAlternators();
       const widgetColors = this.widgetColors();
       if (!this.svg || !widgetColors) return;
-      this.requestRender({ alternators, displayModels: models, widgetColors });
+      this.scheduler.requestRender({ alternators, displayModels: models, widgetColors });
     });
-
-    const alternatorTrees = [
-      this.data.subscribePathTreeWithInitial(WidgetAlternatorComponent.ROOT_PATTERN)
-    ];
-
-    let hasInitialUpdates = false;
-    for (const tree of alternatorTrees) {
-      if (!tree.initial.length) {
-        continue;
-      }
-      hasInitialUpdates = true;
-      for (const update of tree.initial) {
-        this.enqueuePathUpdate(update, true);
-      }
-    }
-
-    if (hasInitialUpdates) {
-      this.flushPendingPathUpdates();
-      this.initialPathPaintDone = true;
-    }
-
-    for (const tree of alternatorTrees) {
-      tree.live$
-        .pipe(takeUntilDestroyed(this.destroyRef))
-        .subscribe(update => {
-          this.enqueuePathUpdate(update);
-        });
-    }
   }
 
   ngAfterViewInit(): void {
     this.initializeSvg();
-    this.requestRender();
-  }
-
-  ngOnDestroy(): void {
-    if (this.pathBatchTimerId !== null) {
-      clearTimeout(this.pathBatchTimerId);
-      this.pathBatchTimerId = null;
-    }
-
-    if (this.renderFrameId !== null) {
-      cancelAnimationFrame(this.renderFrameId);
-      this.renderFrameId = null;
-    }
-
-    this.pendingRenderSnapshot = null;
+    this.scheduler.requestRender();
   }
 
   private initializeSvg(): void {
@@ -275,47 +249,9 @@ export class WidgetAlternatorComponent implements AfterViewInit, OnDestroy {
 
   private applyConfig(cfg: IWidgetSvcConfig): void {
     const alternatorCfg = this.resolveAlternatorConfig(cfg);
-    this.trackedDevices.set(alternatorCfg.trackedDevices ?? []);
-    this.reprojectSnapshotsToDeviceKeys(alternatorCfg.trackedDevices ?? []);
+    this.store.applyConfig(alternatorCfg.trackedDevices ?? []);
     this.optionsById.set(alternatorCfg.optionsById);
     this.cardMode.set(this.normalizeCardMode(alternatorCfg.cardMode));
-  }
-
-  private reprojectSnapshotsToDeviceKeys(devices: ElectricalTrackedDevice[]): void {
-    if (!devices.length) return;
-
-    const idToKeys = new Map<string, string[]>();
-    devices.forEach(device => {
-      const existing = idToKeys.get(device.id) ?? [];
-      existing.push(device.key);
-      idToKeys.set(device.id, existing);
-    });
-
-    this.alternatorsByKey.update(current => {
-      let next = current;
-      let changed = false;
-
-      idToKeys.forEach((keys, id) => {
-        const sourceSnapshot = current[id];
-        if (!sourceSnapshot) return;
-
-        for (const deviceKey of keys) {
-          if (current[deviceKey]) continue;
-          const trackedDevice = devices.find(device => device.key === deviceKey);
-          if (!changed) {
-            next = { ...current };
-            changed = true;
-          }
-          next[deviceKey] = { ...sourceSnapshot, source: trackedDevice?.source ?? null, deviceKey };
-        }
-
-        if (changed && next[id]?.deviceKey === undefined) {
-          delete next[id];
-        }
-      });
-
-      return changed ? next : current;
-    });
   }
 
   private resolveAlternatorConfig(cfg: IWidgetSvcConfig): AlternatorWidgetConfig {
@@ -366,112 +302,10 @@ export class WidgetAlternatorComponent implements AfterViewInit, OnDestroy {
     return next;
   }
 
-  private enqueuePathUpdate(update: IPathUpdateWithPath, fromInitial = false): void {
-    const parsed = this.parsePath(update.path);
-    if (!parsed) {
-      return;
-    }
-
-    const value = update.update?.data?.value ?? null;
-    const state = update.update?.state ?? null;
-    const updateKey = `${parsed.id}::${parsed.key}`;
-    this.pendingPathUpdates.set(updateKey, { id: parsed.id, key: parsed.key, value, state });
-
-    if (fromInitial) {
-      return;
-    }
-
-    if (!this.initialPathPaintDone) {
-      this.initialPathPaintDone = true;
-      this.flushPendingPathUpdates();
-      return;
-    }
-
-    if (this.pathBatchTimerId !== null) {
-      return;
-    }
-
-    this.pathBatchTimerId = window.setTimeout(() => {
-      this.pathBatchTimerId = null;
-      this.flushPendingPathUpdates();
-    }, WidgetAlternatorComponent.PATH_BATCH_WINDOW_MS);
-  }
-
   private parsePath(path: string): { id: string; key: string } | null {
     const match = path.match(WidgetAlternatorComponent.PATH_REGEX);
     if (!match) return null;
     return { id: match[1], key: match[2] };
-  }
-
-  private flushPendingPathUpdates(): void {
-    if (!this.pendingPathUpdates.size) {
-      return;
-    }
-
-    const updates = Array.from(this.pendingPathUpdates.values());
-    this.pendingPathUpdates.clear();
-
-    const uniqueIds = new Set(updates.map(update => update.id));
-    uniqueIds.forEach(id => this.trackDiscoveredAlternator(id));
-
-    const idToKeys = buildIdToDeviceKeysMap(this.trackedDevices());
-
-    this.alternatorsByKey.update(current => {
-      let nextState = current;
-      let changed = false;
-
-      for (const update of updates) {
-        const keysForId = idToKeys.get(update.id);
-        const targetKeys: string[] = keysForId?.length ? keysForId : [update.id];
-
-        for (const deviceKey of targetKeys) {
-          const isTracked = !!(keysForId?.length);
-          const trackedDevice = isTracked ? this.trackedDevices().find(device => device.key === deviceKey) : null;
-          const existing = nextState[deviceKey] ?? {
-            id: update.id,
-            source: trackedDevice?.source ?? null,
-            deviceKey: isTracked ? deviceKey : undefined
-          };
-          const next = { ...existing } as AlternatorSnapshot;
-          const fieldChanged = this.applyValue(next, update.key, update.value, update.state);
-
-          if (!fieldChanged) {
-            continue;
-          }
-
-          const derivedPower = next.rawPower != null
-            ? next.rawPower
-            : (next.voltage != null && next.current != null ? next.voltage * next.current : null);
-          if (derivedPower != null) {
-            next.power = Number.isFinite(derivedPower) ? derivedPower : null;
-          } else {
-            next.power = null;
-          }
-
-          if (next.rawPower == null) {
-            next.powerState = resolveMostSevereState(next.voltageState ?? null, next.currentState ?? null);
-          }
-
-          if (!changed) {
-            nextState = { ...nextState };
-            changed = true;
-          }
-
-          nextState[deviceKey] = next;
-        }
-      }
-
-      return changed ? nextState : current;
-    });
-  }
-
-  private trackDiscoveredAlternator(id: string): void {
-    const ids = this.discoveredAlternatorIds();
-    if (ids.includes(id)) {
-      return;
-    }
-
-    this.discoveredAlternatorIds.set([...ids, id].sort((left, right) => left.localeCompare(right)));
   }
 
   private applyValue(snapshot: AlternatorSnapshot, key: string, value: unknown, state: TState | null): boolean {
@@ -508,31 +342,19 @@ export class WidgetAlternatorComponent implements AfterViewInit, OnDestroy {
     }
   }
 
-  private requestRender(snapshot?: AlternatorRenderSnapshot): void {
-    const widgetColors = this.widgetColors();
-    if (!this.svg || !widgetColors) {
-      return;
+  private derivePower(snapshot: AlternatorSnapshot): void {
+    const derivedPower = snapshot.rawPower != null
+      ? snapshot.rawPower
+      : (snapshot.voltage != null && snapshot.current != null ? snapshot.voltage * snapshot.current : null);
+    if (derivedPower != null) {
+      snapshot.power = Number.isFinite(derivedPower) ? derivedPower : null;
+    } else {
+      snapshot.power = null;
     }
 
-    this.pendingRenderSnapshot = snapshot ?? {
-      alternators: this.visibleAlternators(),
-      displayModels: this.displayModels(),
-      widgetColors
-    };
-    if (this.renderFrameId !== null) {
-      return;
+    if (snapshot.rawPower == null) {
+      snapshot.powerState = resolveMostSevereState(snapshot.voltageState ?? null, snapshot.currentState ?? null);
     }
-
-    this.renderFrameId = requestAnimationFrame(() => {
-      this.renderFrameId = null;
-      const nextSnapshot = this.pendingRenderSnapshot;
-      this.pendingRenderSnapshot = null;
-      if (!nextSnapshot) {
-        return;
-      }
-
-      this.render(nextSnapshot);
-    });
   }
 
   private render(snapshot: AlternatorRenderSnapshot): void {

--- a/src/app/widgets/widget-inverter/widget-inverter.component.ts
+++ b/src/app/widgets/widget-inverter/widget-inverter.component.ts
@@ -1,11 +1,10 @@
-import { AfterViewInit, ChangeDetectionStrategy, Component, DestroyRef, ElementRef, OnDestroy, computed, effect, inject, input, signal, untracked, viewChild } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { AfterViewInit, ChangeDetectionStrategy, Component, DestroyRef, ElementRef, computed, effect, inject, input, signal, untracked, viewChild } from '@angular/core';
 import { select, type Selection } from 'd3-selection';
-import { DataService, IPathUpdateWithPath } from '../../core/services/data.service';
+import { DataService } from '../../core/services/data.service';
 import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
 import type { ITheme } from '../../core/services/app-service';
 import { TState } from '../../core/interfaces/signalk-interfaces';
-import type { ElectricalTrackedDevice, IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
+import type { IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
 import { UnitsService } from '../../core/services/units.service';
 import { getColors, resolveZoneAwareColor } from '../../core/utils/themeColors.utils';
 import { getElectricalWidgetFamilyDescriptor } from '../../core/contracts/electrical-widget-family.contract';
@@ -20,8 +19,10 @@ import {
 } from '../shared/electrical-card-layout.constants';
 import type { InverterDisplayModel, InverterSnapshot, InverterWidgetConfig, ElectricalCardModeConfig } from './widget-inverter.types';
 import { WidgetTitleComponent } from '../../core/components/widget-title/widget-title.component';
-import { normalizeOptionalString, normalizeStringList, normalizeTrackedDevices, buildIdToDeviceKeysMap } from '../shared/electrical-config.util';
+import { normalizeOptionalString, normalizeStringList, normalizeTrackedDevices } from '../shared/electrical-config.util';
 import { setValue, setMetricValue, toStringValue, toBoolean, resolveMostSevereState } from '../shared/electrical-apply.util';
+import { ElectricalIngestScheduler } from '../shared/electrical-ingest-scheduler';
+import { ElectricalTopologyStore, type ElectricalTopologyEntry } from '../shared/electrical-topology-store';
 
 function escapeRegex(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -40,7 +41,7 @@ interface InverterRenderSnapshot {
   imports: [WidgetTitleComponent],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class WidgetInverterComponent implements AfterViewInit, OnDestroy {
+export class WidgetInverterComponent implements AfterViewInit {
   private static readonly INVERTER_DESCRIPTOR = getElectricalWidgetFamilyDescriptor('widget-inverter');
   private static readonly SELF_ROOT_PATH = (() => {
     const root = WidgetInverterComponent.INVERTER_DESCRIPTOR?.selfRootPath;
@@ -78,38 +79,54 @@ export class WidgetInverterComponent implements AfterViewInit, OnDestroy {
   private svg?: Selection<SVGSVGElement, unknown, null, undefined>;
   private layer?: Selection<SVGGElement, unknown, null, undefined>;
 
-  private readonly pendingPathUpdates = new Map<string, { id: string; key: string; value: unknown; state: TState | null }>();
-  private pathBatchTimerId: number | null = null;
-  private initialPathPaintDone = false;
-  private renderFrameId: number | null = null;
-  private pendingRenderSnapshot: InverterRenderSnapshot | null = null;
+  private readonly store = new ElectricalTopologyStore<InverterSnapshot>({
+    createSnapshot: seed => ({ id: seed.id, source: seed.source, deviceKey: seed.deviceKey }),
+    applyValue: (snapshot, key, value, state) => this.applyValue(snapshot, key, value, state),
+    derive: snapshot => this.deriveDcPower(snapshot)
+  });
 
-  protected readonly discoveredInverterIds = signal<string[]>([]);
-  protected readonly trackedDevices = signal<ElectricalTrackedDevice[]>([]);
+  private readonly scheduler = new ElectricalIngestScheduler<ElectricalTopologyEntry, InverterRenderSnapshot>({
+    data: this.data,
+    destroyRef: this.destroyRef,
+    rootPattern: WidgetInverterComponent.ROOT_PATTERN,
+    batchWindowMs: WidgetInverterComponent.PATH_BATCH_WINDOW_MS,
+    parseUpdate: update => {
+      const parsed = this.parsePath(update.path);
+      if (!parsed) return null;
+      return {
+        key: `${parsed.id}::${parsed.key}`,
+        entry: {
+          id: parsed.id,
+          key: parsed.key,
+          value: update.update?.data?.value ?? null,
+          state: update.update?.state ?? null
+        }
+      };
+    },
+    onFlush: entries => this.store.processBatch(entries),
+    resolveRenderSnapshot: explicit => {
+      const widgetColors = this.widgetColors();
+      if (!this.svg || !widgetColors) return null;
+      return explicit ?? {
+        inverters: this.visibleInverters(),
+        displayModels: this.displayModels(),
+        widgetColors
+      };
+    },
+    draw: snapshot => this.render(snapshot)
+  });
+
   protected readonly optionsById = signal<InverterWidgetConfig['optionsById']>({});
   protected readonly cardMode = signal<ElectricalCardModeConfig>({
     displayMode: 'full',
     metrics: ['dcVoltage', 'dcCurrent', 'acVoltage', 'acFrequency']
   });
-  protected readonly invertersByKey = signal<Record<string, InverterSnapshot>>({});
 
-  protected readonly visibleInverterKeys = computed(() => {
-    const tracked = this.trackedDevices();
-    if (tracked.length) return tracked.map(d => d.key);
-    // No tracking: return every key in invertersByKey that belongs to a discovered id
-    // (keys may be plain ids or deviceKeys depending on whether tracking was ever configured)
-    const map = this.invertersByKey();
-    const ids = new Set(this.discoveredInverterIds());
-    return Object.keys(map)
-      .filter(key => { const s = map[key]; return !!s && ids.has(s.id); })
-      .sort((a, b) => a.localeCompare(b));
-  });
-
-  protected readonly visibleInverters = computed<InverterSnapshot[]>(() => {
-    const keys = this.visibleInverterKeys();
-    const map = this.invertersByKey();
-    return keys.map(key => map[key]).filter((item): item is InverterSnapshot => !!item);
-  });
+  protected readonly invertersByKey = this.store.store;
+  protected readonly discoveredInverterIds = this.store.discoveredIds;
+  protected readonly trackedDevices = this.store.trackedDevices;
+  protected readonly visibleInverterKeys = this.store.visibleKeys;
+  protected readonly visibleInverters = this.store.visibleSnapshots;
 
   protected readonly hasInverters = computed(() => this.visibleInverters().length > 0);
   protected readonly activeDisplayMode = computed<ElectricalCardDisplayMode>(() => this.renderMode() ?? this.cardMode().displayMode ?? 'full');
@@ -199,52 +216,13 @@ export class WidgetInverterComponent implements AfterViewInit, OnDestroy {
       const inverters = this.visibleInverters();
       const widgetColors = this.widgetColors();
       if (!this.svg || !widgetColors) return;
-      this.requestRender({ inverters, displayModels: models, widgetColors });
+      this.scheduler.requestRender({ inverters, displayModels: models, widgetColors });
     });
-
-    const inverterTrees = [
-      this.data.subscribePathTreeWithInitial(WidgetInverterComponent.ROOT_PATTERN)
-    ];
-
-    let hasInitialUpdates = false;
-    for (const tree of inverterTrees) {
-      if (!tree.initial.length) {
-        continue;
-      }
-
-      hasInitialUpdates = true;
-      for (const update of tree.initial) {
-        this.enqueuePathUpdate(update, true);
-      }
-    }
-
-    if (hasInitialUpdates) {
-      this.flushPendingPathUpdates();
-      this.initialPathPaintDone = true;
-    }
-
-    for (const tree of inverterTrees) {
-      tree.live$
-        .pipe(takeUntilDestroyed(this.destroyRef))
-        .subscribe(update => this.enqueuePathUpdate(update));
-    }
   }
 
   ngAfterViewInit(): void {
     this.initializeSvg();
-    this.requestRender();
-  }
-
-  ngOnDestroy(): void {
-    if (this.pathBatchTimerId !== null) {
-      clearTimeout(this.pathBatchTimerId);
-      this.pathBatchTimerId = null;
-    }
-    if (this.renderFrameId !== null) {
-      cancelAnimationFrame(this.renderFrameId);
-      this.renderFrameId = null;
-    }
-    this.pendingRenderSnapshot = null;
+    this.scheduler.requestRender();
   }
 
   private initializeSvg(): void {
@@ -259,50 +237,9 @@ export class WidgetInverterComponent implements AfterViewInit, OnDestroy {
 
   private applyConfig(cfg: IWidgetSvcConfig): void {
     const inverterCfg = this.resolveInverterConfig(cfg);
-    this.trackedDevices.set(inverterCfg.trackedDevices ?? []);
-    this.reprojectSnapshotsToDeviceKeys(inverterCfg.trackedDevices ?? []);
+    this.store.applyConfig(inverterCfg.trackedDevices ?? []);
     this.optionsById.set(inverterCfg.optionsById);
     this.cardMode.set(this.normalizeCardMode(inverterCfg.cardMode));
-  }
-
-  /**
-   * Re-projects any id-keyed snapshots already in `invertersByKey` to their
-   * proper deviceKey entries when tracked devices are configured after the fact
-   * (e.g., initial path data arrives before the config effect fires).
-   */
-  private reprojectSnapshotsToDeviceKeys(devices: ElectricalTrackedDevice[]): void {
-    if (!devices.length) return;
-
-    const idToKeys = new Map<string, string[]>();
-    devices.forEach(d => {
-      const existing = idToKeys.get(d.id) ?? [];
-      existing.push(d.key);
-      idToKeys.set(d.id, existing);
-    });
-
-    this.invertersByKey.update(current => {
-      let next = current;
-      let changed = false;
-
-      idToKeys.forEach((keys, id) => {
-        const sourceSnapshot = current[id];
-        if (!sourceSnapshot) return;
-
-        for (const deviceKey of keys) {
-          if (current[deviceKey]) continue; // already keyed — don't overwrite live data
-          const trackedDevice = devices.find(d => d.key === deviceKey);
-          if (!changed) { next = { ...current }; changed = true; }
-          next[deviceKey] = { ...sourceSnapshot, source: trackedDevice?.source ?? null, deviceKey };
-        }
-
-        // Remove the stale plain-id entry now that deviceKey entries exist
-        if (changed && next[id]?.deviceKey === undefined) {
-          delete next[id];
-        }
-      });
-
-      return changed ? next : current;
-    });
   }
 
   private resolveInverterConfig(cfg: IWidgetSvcConfig): InverterWidgetConfig {
@@ -333,91 +270,10 @@ export class WidgetInverterComponent implements AfterViewInit, OnDestroy {
     return next;
   }
 
-  private enqueuePathUpdate(update: IPathUpdateWithPath, fromInitial = false): void {
-    const parsed = this.parsePath(update.path);
-    if (!parsed) return;
-
-    const value = update.update?.data?.value ?? null;
-    const state = update.update?.state ?? null;
-    this.pendingPathUpdates.set(`${parsed.id}::${parsed.key}`, { id: parsed.id, key: parsed.key, value, state });
-
-    if (fromInitial) return;
-
-    if (!this.initialPathPaintDone) {
-      this.initialPathPaintDone = true;
-      this.flushPendingPathUpdates();
-      return;
-    }
-
-    if (this.pathBatchTimerId !== null) return;
-
-    this.pathBatchTimerId = window.setTimeout(() => {
-      this.pathBatchTimerId = null;
-      this.flushPendingPathUpdates();
-    }, WidgetInverterComponent.PATH_BATCH_WINDOW_MS);
-  }
-
   private parsePath(path: string): { id: string; key: string } | null {
     const match = path.match(WidgetInverterComponent.PATH_REGEX);
     if (!match) return null;
     return { id: match[1], key: match[2] };
-  }
-
-  private flushPendingPathUpdates(): void {
-    if (!this.pendingPathUpdates.size) return;
-    const updates = Array.from(this.pendingPathUpdates.values());
-    this.pendingPathUpdates.clear();
-
-    const uniqueIds = new Set(updates.map(update => update.id));
-    uniqueIds.forEach(id => this.trackDiscoveredInverter(id));
-
-    const idToKeys = buildIdToDeviceKeysMap(this.trackedDevices());
-
-    this.invertersByKey.update(current => {
-      let nextState = current;
-      let changed = false;
-
-      for (const update of updates) {
-        // Resolve target device keys: tracked keys for this id, or id itself as fallback
-        const keysForId = idToKeys.get(update.id);
-        const targetKeys: string[] = keysForId?.length ? keysForId : [update.id];
-
-        for (const deviceKey of targetKeys) {
-          const isTracked = !!(keysForId?.length);
-          const trackedDevice = isTracked ? this.trackedDevices().find(d => d.key === deviceKey) : null;
-          const existing = nextState[deviceKey] ?? {
-            id: update.id,
-            source: trackedDevice?.source ?? null,
-            deviceKey: isTracked ? deviceKey : undefined
-          };
-          const next = { ...existing } as InverterSnapshot;
-          const fieldChanged = this.applyValue(next, update.key, update.value, update.state);
-
-          if (!fieldChanged) continue;
-
-          // Derive DC power when not explicit
-          if (next.dcVoltage != null && next.dcCurrent != null) {
-            const derived = next.dcVoltage * next.dcCurrent;
-            next.dcPower = Number.isFinite(derived) ? derived : null;
-            next.dcPowerState = resolveMostSevereState(next.dcVoltageState ?? null, next.dcCurrentState ?? null);
-          } else {
-            next.dcPower = null;
-            next.dcPowerState = null;
-          }
-
-          if (!changed) { nextState = { ...nextState }; changed = true; }
-          nextState[deviceKey] = next;
-        }
-      }
-
-      return changed ? nextState : current;
-    });
-  }
-
-  private trackDiscoveredInverter(id: string): void {
-    const ids = this.discoveredInverterIds();
-    if (ids.includes(id)) return;
-    this.discoveredInverterIds.set([...ids, id].sort((a, b) => a.localeCompare(b)));
   }
 
   private applyValue(snapshot: InverterSnapshot, key: string, value: unknown, state: TState | null): boolean {
@@ -451,24 +307,15 @@ export class WidgetInverterComponent implements AfterViewInit, OnDestroy {
     }
   }
 
-  private requestRender(snapshot?: InverterRenderSnapshot): void {
-    const widgetColors = this.widgetColors();
-    if (!this.svg || !widgetColors) return;
-
-    this.pendingRenderSnapshot = snapshot ?? {
-      inverters: this.visibleInverters(),
-      displayModels: this.displayModels(),
-      widgetColors
-    };
-    if (this.renderFrameId !== null) return;
-
-    this.renderFrameId = requestAnimationFrame(() => {
-      this.renderFrameId = null;
-      const nextSnapshot = this.pendingRenderSnapshot;
-      this.pendingRenderSnapshot = null;
-      if (!nextSnapshot) return;
-      this.render(nextSnapshot);
-    });
+  private deriveDcPower(snapshot: InverterSnapshot): void {
+    if (snapshot.dcVoltage != null && snapshot.dcCurrent != null) {
+      const derived = snapshot.dcVoltage * snapshot.dcCurrent;
+      snapshot.dcPower = Number.isFinite(derived) ? derived : null;
+      snapshot.dcPowerState = resolveMostSevereState(snapshot.dcVoltageState ?? null, snapshot.dcCurrentState ?? null);
+    } else {
+      snapshot.dcPower = null;
+      snapshot.dcPowerState = null;
+    }
   }
 
   private render(snapshot: InverterRenderSnapshot): void {


### PR DESCRIPTION
## Why

Stage 2a of the #4 electrical extraction — the stateful core. The six electrical widgets each carried a verbatim copy of the same data pipeline (buffer + coalescing timer + reproject + rAF + subscription, ~130 lines each). This extracts the genuinely-shared machinery into two composable layers and adopts them in the source-blind trio. **Follows the layered plan (v2)** posted on #4 after document-review corrected the v1 design.

## What

Two new per-widget-owned collaborators under `widgets/shared/` (composition, not a base class — matches the host-directive idiom, no spec-provider churn):

- **`ElectricalIngestScheduler`** (Layer 0) — the universal *timing* machinery: de-duping pending buffer, 500 ms coalescing timer with the initial-paint synchronous drain + first-live-immediate-flush fast path, single-flight rAF scheduler, and the path-tree subscription lifecycle + teardown. Parse / store-mutation / snapshot-resolution / draw are injected seams, so it's behavior-neutral.
- **`ElectricalTopologyStore`** (Layer 1) — the source-blind keyed-snapshot store + discovered-id/tracked-device signals, the batch-apply flush body, reproject, and the tracked-else-discovered visible selection. `applyValue` and the per-changed-key `derive` are injected seams.

`alternator`, `inverter`, `ac` adopt both layers, keeping thin **delegating aliases** (`visibleX = store.visibleSnapshots`, etc.) so their templates and specs read unchanged. `solar-charger` and `bms` are untouched here — they compose their own paths in 2c/2d.

## Strictly behavior-preserving

Zero intentional behavior changes. The derive hook fires **per-changed-key** (matching the old inline flush cadence, not once-per-batch). The trio's reproject guard is carried over exactly. (The separate solar-leak investigation confirmed there is no solar-specific leak; it did surface a pre-existing family-wide untrack-duplicate bug, filed as **#354**, which this PR faithfully preserves.)

## Verification

- New layer specs pin the timing invariants with fake timers + rAF stub (coalescing, initial-drain, first-live-immediate, rAF single-flight, teardown) and the store invariants (reproject-on-late-config, tracked-else-discovered, derive-sees-full-batch).
- `npm run snc` + `npm run lint` clean; **the three migrated widgets' full existing specs stay green unchanged** (the behavior-preservation net) — 98 tests total across the six widget specs + two layer specs.
- Net ~480 lines of duplicated pipeline removed from the trio.

Stage 2a of #4. Next: 2b bms (primitive only), 2c solar (layer via hooks), 2d charger (source-aware, highest-risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
