### PR TITLE
fix(electrical): read layout constants at access time in charger/bms/solar (#360)

### DIFF
--- a/src/app/widgets/widget-bms/widget-bms.component.spec.ts
+++ b/src/app/widgets/widget-bms/widget-bms.component.spec.ts
@@ -281,4 +281,24 @@ describe('WidgetBmsComponent', () => {
         expect(host.querySelector('tspan.bms-soc-value')?.textContent).toBe('55');
         expect(host.querySelector('tspan.bms-soc-unit')?.textContent).toBe('%');
     });
+
+    // Guards #360: the layout-constant getters must yield well-formed geometry. The
+    // NaN only appears when >=2 electrical specs share a test bundle, so this bites
+    // in the full suite, not when this spec runs alone.
+    it('renders well-formed geometry (no NaN/undefined viewBox)', async () => {
+        vi.useFakeTimers();
+        try {
+            fixture.detectChanges();
+            await vi.runAllTimersAsync();
+            fixture.detectChanges();
+            await vi.runAllTimersAsync();
+            const svg = fixture.nativeElement.querySelector('svg') as SVGSVGElement | null;
+            const viewBox = svg?.getAttribute('viewBox') ?? '';
+            expect(viewBox).not.toBe('');
+            expect(viewBox).not.toContain('NaN');
+            expect(viewBox).not.toContain('undefined');
+        } finally {
+            vi.useRealTimers();
+        }
+    });
 });

--- a/src/app/widgets/widget-bms/widget-bms.component.ts
+++ b/src/app/widgets/widget-bms/widget-bms.component.ts
@@ -78,15 +78,17 @@ export class WidgetBmsComponent implements AfterViewInit {
     }
   };
 
-  private static readonly VIEWBOX_WIDTH = ELECTRICAL_DIRECT_CARD_VIEWBOX_WIDTH;
+  // Getters, not fields: read the shared layout constants at access time. A
+  // class-def-time capture reads undefined in combined test bundles (#360).
+  private static get VIEWBOX_WIDTH(): number { return ELECTRICAL_DIRECT_CARD_VIEWBOX_WIDTH; }
   private static readonly MIN_VIEWBOX_HEIGHT = 1;
-  private static readonly BANK_CARD_WIDTH = ELECTRICAL_DIRECT_CARD_VIEWBOX_WIDTH;
+  private static get BANK_CARD_WIDTH(): number { return ELECTRICAL_DIRECT_CARD_VIEWBOX_WIDTH; }
   private static readonly BATTERY_CARD_HEIGHT = 50;
   private static readonly BATTERY_CARD_WIDTH = 200;
   private static readonly CARD_GAP = 8;
   private static readonly BANK_HEADER_HEIGHT = 80;
   private static readonly BANK_MIN_HEIGHT = 75;
-  private static readonly SINGLE_ROW_BANK_HEIGHT = ELECTRICAL_DIRECT_CARD_HEIGHT;
+  private static get SINGLE_ROW_BANK_HEIGHT(): number { return ELECTRICAL_DIRECT_CARD_HEIGHT; }
   private static readonly IN_BANK_COLUMNS = 2;
   private static readonly IN_BANK_COLUMN_GAP = 5;
   private static readonly IN_BANK_PADDING_X = 0;

--- a/src/app/widgets/widget-charger/widget-charger.component.spec.ts
+++ b/src/app/widgets/widget-charger/widget-charger.component.spec.ts
@@ -430,4 +430,27 @@ describe('WidgetChargerComponent', () => {
     const map = (component as unknown as { chargersByKey: () => Record<string, unknown> }).chargersByKey();
     expect(map['c9']).toBeUndefined();
   });
+
+  // Guards #360: the layout-constant getters must yield well-formed geometry. The
+  // NaN only appears when >=2 electrical specs share a test bundle, so this bites
+  // in the full suite, not when this spec runs alone.
+  it('renders well-formed geometry (no NaN/undefined viewBox)', async () => {
+    vi.useFakeTimers();
+    try {
+      await setup([
+        makeUpdate('self.electrical.chargers.c1.voltage', 27.5),
+        makeUpdate('self.electrical.chargers.c2.voltage', 28.1)
+      ]);
+      await vi.runAllTimersAsync();
+      fixture.detectChanges();
+      await vi.runAllTimersAsync();
+      const svg = fixture.nativeElement.querySelector('svg') as SVGSVGElement | null;
+      const viewBox = svg?.getAttribute('viewBox') ?? '';
+      expect(viewBox).not.toBe('');
+      expect(viewBox).not.toContain('NaN');
+      expect(viewBox).not.toContain('undefined');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/app/widgets/widget-charger/widget-charger.component.ts
+++ b/src/app/widgets/widget-charger/widget-charger.component.ts
@@ -42,10 +42,12 @@ export class WidgetChargerComponent implements AfterViewInit {
   })();
   private static readonly ROOT_PATTERN = `${WidgetChargerComponent.SELF_ROOT_PATH}.*`;
   private static readonly PATH_REGEX = new RegExp(`^${escapeRegex(WidgetChargerComponent.SELF_ROOT_PATH)}\\.([^.]+)\\.(.+)$`);
-  private static readonly VIEWBOX_WIDTH = ELECTRICAL_DIRECT_CARD_VIEWBOX_WIDTH;
-  private static readonly CARD_HEIGHT = ELECTRICAL_DIRECT_CARD_HEIGHT;
-  private static readonly COMPACT_CARD_HEIGHT = ELECTRICAL_DIRECT_COMPACT_CARD_HEIGHT;
-  private static readonly CARD_GAP = ELECTRICAL_DIRECT_CARD_GAP;
+  // Getters, not fields: read the shared layout constants at access time. A
+  // class-def-time capture reads undefined in combined test bundles (#360).
+  private static get VIEWBOX_WIDTH(): number { return ELECTRICAL_DIRECT_CARD_VIEWBOX_WIDTH; }
+  private static get CARD_HEIGHT(): number { return ELECTRICAL_DIRECT_CARD_HEIGHT; }
+  private static get COMPACT_CARD_HEIGHT(): number { return ELECTRICAL_DIRECT_COMPACT_CARD_HEIGHT; }
+  private static get CARD_GAP(): number { return ELECTRICAL_DIRECT_CARD_GAP; }
   private static readonly PATH_BATCH_WINDOW_MS = 500;
   private static readonly CHARGER_DISPLAY_BASE_WIDTH = 145;
   private static readonly CHARGER_DISPLAY_BASE_HEIGHT = 37;

--- a/src/app/widgets/widget-solar-charger/widget-solar-charger.component.spec.ts
+++ b/src/app/widgets/widget-solar-charger/widget-solar-charger.component.spec.ts
@@ -575,4 +575,24 @@ describe('WidgetSolarChargerComponent', () => {
       expect(merged.color).toBe('green');
     });
   });
+
+  // Guards #360: the layout-constant getters must yield well-formed geometry. The
+  // NaN only appears when >=2 electrical specs share a test bundle, so this bites
+  // in the full suite, not when this spec runs alone.
+  it('renders well-formed geometry (no NaN/undefined viewBox)', async () => {
+    vi.useFakeTimers();
+    try {
+      fixture.detectChanges();
+      await vi.runAllTimersAsync();
+      fixture.detectChanges();
+      await vi.runAllTimersAsync();
+      const svg = fixture.nativeElement.querySelector('svg') as SVGSVGElement | null;
+      const viewBox = svg?.getAttribute('viewBox') ?? '';
+      expect(viewBox).not.toBe('');
+      expect(viewBox).not.toContain('NaN');
+      expect(viewBox).not.toContain('undefined');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/app/widgets/widget-solar-charger/widget-solar-charger.component.ts
+++ b/src/app/widgets/widget-solar-charger/widget-solar-charger.component.ts
@@ -53,9 +53,11 @@ export class WidgetSolarChargerComponent implements AfterViewInit {
     }
   };
 
-  private static readonly VIEWBOX_WIDTH = ELECTRICAL_DIRECT_CARD_VIEWBOX_WIDTH;
-  private static readonly CARD_HEIGHT = ELECTRICAL_DIRECT_CARD_HEIGHT;
-  private static readonly CARD_GAP = ELECTRICAL_DIRECT_CARD_GAP;
+  // Getters, not fields: read the shared layout constants at access time. A
+  // class-def-time capture reads undefined in combined test bundles (#360).
+  private static get VIEWBOX_WIDTH(): number { return ELECTRICAL_DIRECT_CARD_VIEWBOX_WIDTH; }
+  private static get CARD_HEIGHT(): number { return ELECTRICAL_DIRECT_CARD_HEIGHT; }
+  private static get CARD_GAP(): number { return ELECTRICAL_DIRECT_CARD_GAP; }
   private static readonly SOLAR_PANEL_SYMBOL_WIDTH = 158.90796;
   private static readonly SOLAR_PANEL_SYMBOL_HEIGHT = 94.949027;
   private static readonly SOLAR_PANEL_SCALE = 0.77;


### PR DESCRIPTION
## What & why

Fixes the **misfit half of #360**. `charger`, `bms` and `solar-charger` captured the shared layout scalars (`VIEWBOX_WIDTH`, `CARD_HEIGHT`, `CARD_GAP`, `COMPACT_CARD_HEIGHT`, `BANK_CARD_WIDTH`, `SINGLE_ROW_BANK_HEIGHT`) into class-static fields. In a combined vitest/esbuild test bundle those captures read `undefined` (bundle-linearization order over the dependency-free leaf constants module), so the widgets rendered `viewBox="0 0 undefined NaN"`. Each spec **alone** was fine; **production** (a single deterministic bundle) is unaffected — verified on-device in Stage 2.

The trio half (alternator/inverter/ac) is fixed in **#361** via the shared-draw extraction. #360 fully resolves once both land.

## Approach

- Convert the affected **import-alias statics** to `static get` accessors that read the constants **at access time**. Minimal, decl-only diff that preserves every read site and the semantic names (e.g. bms `BANK_CARD_WIDTH`). No computed static depends on these (checked), so deferring the read is a complete fix.
- Untouched: bms's bare-literal `CARD_GAP = 8`, `BATTERY_*`, and solar's computed panel geometry — they're literals / literal-derived, not import aliases, so not subject to the bug.
- Each widget gains a guard asserting a **well-formed viewBox**. It bites in the full suite (the combined bundle) — where the bug actually manifests — not when a spec runs alone.

## Verification

- **Red → green**, all three widgets, 3-spec combined bundle: with the fix reverted the guards fail (`0 0 undefined NaN`); with the fix they pass.
- `npm run snc` ✓ · `npm run lint` ✓ · full suite **1415/1415** ✓ (guards pass in the exact combined condition that manifested the bug).
- No production/visual change: the getters return the same values the statics captured; byte-identical on-device.

## Landing

Refs #360. Independent of #361 (touches only the misfits). Close #360 once both this and #361 land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5ipa885FVk3kTiL5b523F
