### PR TITLE
units Phase 2 Step 1: per-path measure resolver seam (#347)

### DIFF
--- a/src/app/core/services/units.service.spec.ts
+++ b/src/app/core/services/units.service.spec.ts
@@ -144,16 +144,40 @@ describe('UnitsService', () => {
       }
     });
 
-    it('every conversion-list measure has a working conversion (a group-valid server base is never value-less)', () => {
-      // Underpins the group-membership guard: because every measure converts, resolving a server
-      // target to any group-valid measure guarantees a real value + matching symbol. Fails loudly if
-      // a future measure is added to the table without a conversion function.
+    it('every conversion-list measure drives BOTH a working conversion and a non-empty symbol (label-matches-conversion, comprehensively)', () => {
+      // Underpins the whole Phase-2 resolver: because every group-valid measure both converts and
+      // labels, resolving a server target (or the client default) to any group-valid measure yields a
+      // real value AND a matching symbol from one source. Fails loudly if a future measure is added to
+      // the table without a conversion function or a resolvable symbol.
       const service = setup({});
       for (const group of service.getConversions()) {
         for (const unit of group.units) {
-          expect(service.convertToUnit(unit.measure, 1), `measure ${unit.measure}`).not.toBeNull();
+          expect(service.convertToUnit(unit.measure, 1), `conversion ${unit.measure}`).not.toBeNull();
+          expect(service.getUnitDisplaySymbol(unit.measure), `symbol ${unit.measure}`).not.toBe('');
         }
       }
+    });
+
+    // --- Phase 2 (#347): the public per-path measure resolver ---
+    it('resolvePathMeasure returns the honourable server preference over the group default', () => {
+      const service = setupWithData({ Speed: 'mph' }, 'm/s', { targetUnit: 'kn' });
+      expect(service.resolvePathMeasure('self.navigation.speedOverGround')).toBe('knots');
+    });
+
+    it('resolvePathMeasure falls back to the group default when there is no server preference', () => {
+      const service = setupWithData({ Speed: 'mph' }, 'm/s', undefined);
+      expect(service.resolvePathMeasure('self.navigation.speedOverGround')).toBe('mph');
+    });
+
+    it('resolvePathMeasure returns unitless for a path with no SI unit', () => {
+      const service = setupWithData({}, null, undefined);
+      expect(service.resolvePathMeasure('self.some.stringPath')).toBe('unitless');
+    });
+
+    it('resolvePathMeasure never drifts from getConversionsForPath().base', () => {
+      const service = setupWithData({ Temperature: 'K' }, 'K', { targetUnit: 'C' });
+      const path = 'self.environment.water.temperature';
+      expect(service.resolvePathMeasure(path)).toBe(service.getConversionsForPath(path).base);
     });
   });
 });

--- a/src/app/core/services/units.service.ts
+++ b/src/app/core/services/units.service.ts
@@ -741,6 +741,18 @@ export class UnitsService {
     }
   }
 
+  /**
+   * The measure Skip applies to a path's value — the single source of BOTH the conversion
+   * (convertToUnit) and its display symbol (getUnitDisplaySymbol), so the rendered label always
+   * matches the applied conversion. Resolves to the server's honourable displayUnits preference when
+   * present, else Skip's per-group default, else 'unitless'. This is the Phase-2 seam (#347) that
+   * display widgets and the streams directive read in place of a stored per-widget convertUnitTo;
+   * structural (fixed-unit) paths bypass it and keep their widget-owned unit.
+   */
+  public resolvePathMeasure(path: string): string {
+    return this.getConversionsForPath(path).base;
+  }
+
   /** Map a server displayUnits.targetUnit onto a Skip conversion measure key (identity when no alias). */
   private mapServerTargetToMeasure(targetUnit: string): string {
     return SERVER_TARGET_UNIT_ALIASES[targetUnit] ?? targetUnit;


### PR DESCRIPTION
## What & why

**Step 1 of #347** (units Phase 2 — retire client-side unit ownership). Adds the single public seam later steps consume: **`resolvePathMeasure(path)`** — the measure Skip applies to a path's value (the server `displayUnits` preference when honourable, else the per-group default, else `unitless`).

## Additive — no behaviour change

It delegates to the existing `getConversionsForPath(path).base` (the exact value `path-control-config` already seeds from), so nothing changes at runtime yet. This lands the seam and its guard *before* the risky Step 2 flip (streams directive + label sites → the resolver), which waits on the Step 0 display/structural path classification.

## Also lands the invariant guard early

Extends the conversion-table test to assert **every** measure drives BOTH a working `convertToUnit` AND a non-empty `getUnitDisplaySymbol` — the "label matches the applied conversion" invariant, asserted comprehensively (not per-widget). Plus resolver coverage: server-preference wins, group-default fallback, unitless path, and a no-drift check against `getConversionsForPath().base`.

## Verification

`npm run snc` ✓ · `npm run lint` ✓ · `units.service.spec` 18/18 ✓.

Refs #347 (Step 1 of 5). The refined Phase-2 plan — including the `convertUnitTo` dual-role scope correction and the deferred-formula-eval / delete-Units-screen decisions — is on #347.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5ipa885FVk3kTiL5b523F
