### PR TITLE
feat(units): add convertBetweenMeasures affine primitive (#347 Phase 2 Step 2b-1)

### DIFF
--- a/src/app/core/services/units.service.spec.ts
+++ b/src/app/core/services/units.service.spec.ts
@@ -60,6 +60,56 @@ describe('UnitsService', () => {
     });
   });
 
+  describe('convertBetweenMeasures (affine round-trip)', () => {
+    it('returns the value unchanged when from === to', () => {
+      const s = setup({});
+      expect(s.convertBetweenMeasures('m', 'm', 42)).toBe(42);
+    });
+
+    it('converts within the Length group (m -> feet) and back exactly', () => {
+      const s = setup({});
+      const feet = s.convertBetweenMeasures('m', 'feet', 10);
+      expect(feet).toBeCloseTo(32.8084, 3);
+      expect(s.convertBetweenMeasures('feet', 'm', feet)).toBeCloseTo(10, 9);
+    });
+
+    it('converts an offset (Temperature) measure: 293.15 K <-> 20 C', () => {
+      const s = setup({});
+      expect(s.convertBetweenMeasures('K', 'celsius', 293.15)).toBeCloseTo(20, 9);
+      expect(s.convertBetweenMeasures('celsius', 'K', 20)).toBeCloseTo(293.15, 9);
+    });
+
+    it('converts a scaled Ratio measure: ratio 0.5 -> 50 percent', () => {
+      const s = setup({});
+      expect(s.convertBetweenMeasures('ratio', 'percent', 0.5)).toBeCloseTo(50, 9);
+    });
+
+    it('is identity across different groups (never fabricates a cross-dimension value)', () => {
+      const s = setup({});
+      expect(s.convertBetweenMeasures('knots', 'celsius', 7)).toBe(7);
+      expect(s.convertBetweenMeasures('m', 'V', 3)).toBe(3);
+    });
+
+    it('is identity when either same-group endpoint is a string-format measure', () => {
+      const s = setup({});
+      // Time group mixes numeric ('s') with a string-format measure ('D HH:MM:SS').
+      expect(s.convertBetweenMeasures('D HH:MM:SS', 's', 5)).toBe(5);
+      expect(s.convertBetweenMeasures('s', 'D HH:MM:SS', 5)).toBe(5);
+    });
+
+    it('is identity for an unknown measure or a unitless endpoint', () => {
+      const s = setup({});
+      expect(s.convertBetweenMeasures('not-a-unit', 'm', 5)).toBe(5);
+      expect(s.convertBetweenMeasures('unitless', 'knots', 5)).toBe(5);
+    });
+
+    it('passes a non-finite value through unchanged', () => {
+      const s = setup({});
+      expect(s.convertBetweenMeasures('m', 'feet', NaN)).toBeNaN();
+      expect(s.convertBetweenMeasures('m', 'feet', Infinity)).toBe(Infinity);
+    });
+  });
+
   describe('getConversionsForPath server displayUnits (#246 Phase 1)', () => {
     // Build a UnitsService whose DataService reports a path's SI unit + optional server displayUnits.
     function setupWithData(

--- a/src/app/core/services/units.service.ts
+++ b/src/app/core/services/units.service.ts
@@ -655,6 +655,41 @@ export class UnitsService {
   }
 
   /**
+   * Re-express a value already in `fromMeasure` as `toMeasure` within the same conversion group,
+   * for the case where a stored number is in one display unit while the value it must line up with
+   * is now converted to another (e.g. a gauge's user-set displayScale bounds after the server unit
+   * preference flip). Recovers the SI base from two forward evaluations of the affine
+   * `convertToUnit(fromMeasure, ·)` and forward-converts to the target, so no inverse table is needed.
+   *
+   * Returns the value unchanged (a safe no-op) whenever the round-trip is not a valid affine numeric
+   * conversion: identical measures, an unknown or cross-group pair (same-group is asserted, never
+   * assumed), a string-format measure (position/duration produce non-numeric output), a degenerate
+   * span, or a non-finite input.
+   */
+  public convertBetweenMeasures(fromMeasure: string, toMeasure: string, value: number): number {
+    if (!Number.isFinite(value)) { return value; }
+    if (fromMeasure === toMeasure) { return value; }
+    const group = this.measureGroup(fromMeasure);
+    if (!group || group !== this.measureGroup(toMeasure)) { return value; }
+    const f0 = this.convertToUnit(fromMeasure, 0);
+    const f1 = this.convertToUnit(fromMeasure, 1);
+    if (typeof f0 !== 'number' || typeof f1 !== 'number' || !Number.isFinite(f0) || !Number.isFinite(f1)) { return value; }
+    const span = f1 - f0;
+    if (span === 0 || !Number.isFinite(span)) { return value; }
+    const base = (value - f0) / span;
+    const out = this.convertToUnit(toMeasure, base);
+    return (typeof out === 'number' && Number.isFinite(out)) ? out : value;
+  }
+
+  /** The conversion group a measure belongs to, or undefined when it is not a known measure. */
+  private measureGroup(measure: string): string | undefined {
+    for (const group of this._conversionList) {
+      if (group.units.some(unit => unit.measure === measure)) { return group.group; }
+    }
+    return undefined;
+  }
+
+  /**
    * Returns the list Skip configured preferred unit conversion settings.
    * as configured by user in Skip's Units configuration.
    *


### PR DESCRIPTION
## What & why

**Step 2b-1 of #347** (units Phase 2 — the server-driven unit flip). Lands the one new primitive the flip needs, in isolation and fully tested, ahead of the large flip PR.

`UnitsService` only converts SI→measure; nothing re-expresses a value already in measure A as measure B. The flip makes a gauge's **value** follow the server's resolved unit while the user's stored **displayScale bounds** remain in the widget's prior unit — so those bounds must be re-expressed to line up, or the needle renders against a scale in the wrong unit.

## How

`convertBetweenMeasures(from, to, value)` recovers the SI base from two forward evaluations of the affine `convertToUnit(from, ·)` (`base = (v − f(0))/(f(1) − f(0))`) and forward-converts to the target — no inverse table to maintain. Exact for every affine conversion Skip uses (linear scale, temperature offset, ratio↔percent).

It returns the value **unchanged** (safe no-op) whenever the round-trip isn't a valid affine numeric conversion — hardened per the design review:
- identical measures / unitless endpoint
- **cross-group** pair (same-group is *asserted*, never assumed — no fabricating a temperature from a speed)
- **string-format** measure (position `latitude*`, duration `D HH:MM:SS`) where a forward eval is non-numeric
- degenerate span or non-finite input

## Verification

`npm run snc` ✓ · `npm run lint` ✓ · `units.service.spec` 26/26 ✓ (8 new: round-trip exactness for Length/Temperature/Ratio, cross-group identity, format-measure identity, unknown/unitless/non-finite guards) · `test:mcp-schema` ✓ (no widget-schema impact).

Unused until Step 2b-2 (the flip) consumes it — deliberately landed separately so the flip PR stays focused. Refs #347.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5ipa885FVk3kTiL5b523F