### PR TITLE
fix(dashboard): keep the mobile add-widget drawer open on touch

### DIFF
--- a/src/app/core/components/action-menu/action-menu.component.ts
+++ b/src/app/core/components/action-menu/action-menu.component.ts
@@ -33,14 +33,13 @@ export class ActionMenuComponent {
 
   public open(x: number, y: number): void {
     if (this._breakpoint.isMatched(PHONE_QUERY)) {
-      // Linux Firefox ghost-clicks the backdrop right after the opening tap and
-      // would auto-dismiss the drawer; disable backdrop-close there (the always
-      // present Cancel row is the exit).
-      const isLinuxFirefox = typeof navigator !== 'undefined' &&
-        /Linux/.test(navigator.platform) && /Firefox/.test(navigator.userAgent);
+      // A long-press opens this sheet; the same gesture's trailing tap/click ghost-hits the backdrop
+      // and immediately dismisses it on touch devices (first seen on Linux Firefox, but real mobile
+      // browsers do it too — the drawer vanishes the instant it opens). Disable backdrop-close on the
+      // phone path; the always-present Cancel row is the exit.
       this._bottomSheet.open(WidgetHostBottomSheetComponent, {
         data: { items: this.items() },
-        ...(isLinuxFirefox ? { disableClose: true } : {}),
+        disableClose: true,
       })
         .afterDismissed()
         .subscribe((id?: string) => {


### PR DESCRIPTION
## Problem

On a phone, long-pressing an empty dashboard area to add a widget opens the action bottom sheet — which then **disappears immediately**. You can't add a widget on mobile at all.

## Root cause

The opening long-press's trailing tap/click ghost-hits the bottom-sheet backdrop and auto-dismisses it. `action-menu.component.ts` already guarded against this, but scoped the guard to **Linux Firefox only** (`isLinuxFirefox`) — the same ghost-tap happens on real mobile browsers (iOS Safari, Android Chrome), which weren't covered.

## Fix

Apply `disableClose: true` on the whole phone path, not just Linux Firefox. The bottom sheet's **always-present Cancel row** stays the exit (`clickAction('cancel')`), so nothing is trapped — verified the Cancel row exists before removing backdrop-close.

Pre-existing bug, unrelated to the units work; surfaced during on-device testing. Separate PR to keep it a single logical change.

## Verification

`npm run snc` · `npm run lint` · action-menu + bottom-sheet specs green. Real proof is on-device: long-press an empty area on a phone → the drawer stays open, Cancel dismisses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5ipa885FVk3kTiL5b523F