### PR TITLE
Hotkeys: bare keys with focus guards, and Esc to cancel edit

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -19,10 +19,20 @@ import { ToolbarComponent } from './core/components/toolbar/toolbar.component';
 import { IConfig } from './core/interfaces/app-settings.interfaces';
 import { LATEST_APP_CONFIG_VERSION } from './core/constants/config-versions.const';
 
+// A minimal stand-in for the KeyboardEvent fields the handler reads.
+interface HotkeyTestEvent {
+  ctrlKey?: boolean;
+  altKey?: boolean;
+  metaKey?: boolean;
+  shiftKey?: boolean;
+  target?: EventTarget | null;
+  preventDefault?: ReturnType<typeof vi.fn>;
+}
+
 // Access the component's private surface without widening the class API.
 interface AppComponentHotkeyApi {
   dashboardVisible: { set: (v: boolean) => void };
-  handleKeyDown: (key: string, event: { shiftKey: boolean }) => void;
+  handleKeyDown: (key: string, event: HotkeyTestEvent) => void;
   onShellPointerDown: (event: { target: { closest: (sel: string) => unknown } }) => void;
 }
 
@@ -202,53 +212,123 @@ describe('AppComponent', () => {
     });
   });
 
-  describe('consolidated hotkeys', () => {
-    it('Ctrl+Arrow navigates pages when static, visible and not dragging', () => {
+  describe('bare-key hotkeys', () => {
+    function keyEvent(overrides: Partial<HotkeyTestEvent> = {}): HotkeyTestEvent {
+      return {
+        ctrlKey: false, altKey: false, metaKey: false, shiftKey: false,
+        target: document.body, preventDefault: vi.fn(),
+        ...overrides,
+      };
+    }
+
+    it('bare arrows navigate pages when static, visible and not dragging, and preventDefault', () => {
       const app = create();
       app.dashboardVisible.set(true);
-      app.handleKeyDown('arrowright', { shiftKey: false });
-      app.handleKeyDown('arrowleft', { shiftKey: false });
+      const right = keyEvent();
+      const left = keyEvent();
+      app.handleKeyDown('arrowright', right);
+      app.handleKeyDown('arrowleft', left);
       expect(dashboard.navigateToNextDashboard).toHaveBeenCalledTimes(1);
       expect(dashboard.navigateToPreviousDashboard).toHaveBeenCalledTimes(1);
+      expect(right.preventDefault).toHaveBeenCalledTimes(1);
+      expect(left.preventDefault).toHaveBeenCalledTimes(1);
     });
 
-    it('Ctrl+Shift+Arrow does not navigate (Shift is reserved for actions)', () => {
+    it('any modifier suppresses the hotkey (bare keys only)', () => {
       const app = create();
       app.dashboardVisible.set(true);
-      app.handleKeyDown('arrowright', { shiftKey: true });
+      app.handleKeyDown('arrowright', keyEvent({ ctrlKey: true }));
+      app.handleKeyDown('arrowright', keyEvent({ shiftKey: true }));
+      app.handleKeyDown('n', keyEvent({ metaKey: true }));
+      app.handleKeyDown('f', keyEvent({ altKey: true }));
       expect(dashboard.navigateToNextDashboard).not.toHaveBeenCalled();
+      expect(appService.toggleNightMode).not.toHaveBeenCalled();
+      expect(uiEvent.toggleFullScreen).not.toHaveBeenCalled();
     });
 
-    it('page nav is a no-op while the dashboard is unlocked (edit mode)', () => {
+    it('an editable / interactive focus target suppresses the hotkey and does not preventDefault', () => {
+      const app = create();
+      app.dashboardVisible.set(true);
+      const input = document.createElement('input');
+      const nightEv = keyEvent({ target: input });
+      const arrowEv = keyEvent({ target: input });
+      app.handleKeyDown('n', nightEv);
+      app.handleKeyDown('arrowright', arrowEv);
+      expect(appService.toggleNightMode).not.toHaveBeenCalled();
+      expect(dashboard.navigateToNextDashboard).not.toHaveBeenCalled();
+      expect(nightEv.preventDefault).not.toHaveBeenCalled();
+      expect(arrowEv.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('page nav is a no-op — and does not preventDefault — while the dashboard is unlocked', () => {
       const app = create();
       app.dashboardVisible.set(true);
       dashboard.isDashboardStatic.set(false);
-      app.handleKeyDown('arrowright', { shiftKey: false });
+      const ev = keyEvent();
+      app.handleKeyDown('arrowright', ev);
       expect(dashboard.navigateToNextDashboard).not.toHaveBeenCalled();
+      expect(ev.preventDefault).not.toHaveBeenCalled();
     });
 
     it('page nav is a no-op off a dashboard route', () => {
       const app = create();
       app.dashboardVisible.set(false);
-      app.handleKeyDown('arrowright', { shiftKey: false });
+      app.handleKeyDown('arrowright', keyEvent());
       expect(dashboard.navigateToNextDashboard).not.toHaveBeenCalled();
     });
 
-    it('Ctrl+Shift+E/F/N trigger edit / fullscreen / night; the unshifted keys do not', () => {
+    it('bare e/f/n enter edit / toggle fullscreen / toggle night, and preventDefault', () => {
       const app = create();
-      app.handleKeyDown('e', { shiftKey: true });
-      app.handleKeyDown('f', { shiftKey: true });
-      app.handleKeyDown('n', { shiftKey: true });
+      app.dashboardVisible.set(true);
+      const e = keyEvent();
+      const f = keyEvent();
+      const n = keyEvent();
+      app.handleKeyDown('e', e);
+      app.handleKeyDown('f', f);
+      app.handleKeyDown('n', n);
       expect(dashboard.setStaticDashboard).toHaveBeenCalledWith(false);
       expect(uiEvent.toggleFullScreen).toHaveBeenCalledTimes(1);
       expect(appService.toggleNightMode).toHaveBeenCalledTimes(1);
+      expect(e.preventDefault).toHaveBeenCalledTimes(1);
+      expect(f.preventDefault).toHaveBeenCalledTimes(1);
+      expect(n.preventDefault).toHaveBeenCalledTimes(1);
+    });
 
-      app.handleKeyDown('e', { shiftKey: false });
-      app.handleKeyDown('f', { shiftKey: false });
-      app.handleKeyDown('n', { shiftKey: false });
-      expect(dashboard.setStaticDashboard).toHaveBeenCalledTimes(1);
-      expect(uiEvent.toggleFullScreen).toHaveBeenCalledTimes(1);
-      expect(appService.toggleNightMode).toHaveBeenCalledTimes(1);
+    it('bare e does not enter edit off a dashboard route', () => {
+      const app = create();
+      app.dashboardVisible.set(false);
+      const e = keyEvent();
+      app.handleKeyDown('e', e);
+      expect(dashboard.setStaticDashboard).not.toHaveBeenCalled();
+      expect(e.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('suppresses hotkeys while a modal overlay (dialog/menu/select) is open', () => {
+      const app = create();
+      app.dashboardVisible.set(true);
+      const backdrop = document.createElement('div');
+      backdrop.className = 'cdk-overlay-backdrop';
+      document.body.appendChild(backdrop);
+      try {
+        const n = keyEvent();
+        const right = keyEvent();
+        app.handleKeyDown('n', n);
+        app.handleKeyDown('arrowright', right);
+        expect(appService.toggleNightMode).not.toHaveBeenCalled();
+        expect(dashboard.navigateToNextDashboard).not.toHaveBeenCalled();
+        expect(n.preventDefault).not.toHaveBeenCalled();
+      } finally {
+        backdrop.remove();
+      }
+    });
+
+    it('registers the bare hotkey set with no modifier filter', () => {
+      const app = create() as unknown as { ngAfterViewInit: () => void };
+      app.ngAfterViewInit();
+      expect(uiEvent.addHotkeyListener).toHaveBeenCalledWith(
+        expect.any(Function),
+        { keys: ['arrowleft', 'arrowright', 'e', 'f', 'n'] }
+      );
     });
   });
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -28,6 +28,7 @@ import { SsoRedirectService } from './core/services/sso-redirect.service';
 import { NotificationOverlayService } from './core/services/notification-overlay.service';
 import { DialogService } from './core/services/dialog.service';
 import { resolveBrowserTabTitle } from './core/utils/browser-tab-title.util';
+import { HOTKEY_KEYS, isInteractiveKeyTarget, isBlockingOverlayOpen } from './core/utils/hotkey-target.util';
 
 const MOUSE_PEEK_THROTTLE_MS = 250;
 
@@ -235,40 +236,58 @@ export class AppComponent implements AfterViewInit, OnDestroy {
   }
 
   ngAfterViewInit(): void {
-    // Single hotkey registration for the whole shell (always mounted):
-    // Ctrl+←/→ page nav, Ctrl+Shift+E/F/N edit/fullscreen/night. Shift
-    // disambiguates the two groups within the one keydown listener.
+    // Single hotkey registration for the whole shell (always mounted).
+    // Bare keys guarded by focus (see handleKeyDown): ←/→ page nav,
+    // e/f/n edit/fullscreen/night. No modifiers, so nothing clashes with a
+    // browser shortcut.
     this._uiEvent.addHotkeyListener(
       this._hotkeyHandler,
-      { ctrlKey: true, keys: ['arrowright', 'arrowleft', 'e', 'f', 'n'] }
+      { keys: HOTKEY_KEYS.map((key) => key.toLowerCase()) }
     );
   }
 
   private handleKeyDown(key: string, event: KeyboardEvent): void {
+    // Bare keys only: a modifier means the user is invoking a browser/OS
+    // shortcut, not a Skip hotkey.
+    if (event.ctrlKey || event.altKey || event.metaKey || event.shiftKey) return;
+    // Yield to a focused control that consumes the keystroke, or to an open
+    // modal (dialog/menu/select) that owns the keyboard.
+    if (isInteractiveKeyTarget(event.target) || isBlockingOverlayOpen()) return;
     switch (key) {
       case 'arrowright':
-        if (!event.shiftKey) this.pageNav('next');
+        if (this.pageNav('next')) event.preventDefault();
         break;
       case 'arrowleft':
-        if (!event.shiftKey) this.pageNav('prev');
+        if (this.pageNav('prev')) event.preventDefault();
         break;
       case 'e':
-        if (event.shiftKey) this._dashboard.setStaticDashboard(false);
+        // Edit is dashboard-scoped: don't unlock a dashboard that isn't showing.
+        if (this.dashboardVisible()) {
+          this._dashboard.setStaticDashboard(false);
+          event.preventDefault();
+        }
         break;
       case 'f':
-        if (event.shiftKey) this._uiEvent.toggleFullScreen();
+        this._uiEvent.toggleFullScreen();
+        event.preventDefault();
         break;
       case 'n':
-        if (event.shiftKey) this._app.toggleNightMode();
+        this._app.toggleNightMode();
+        event.preventDefault();
         break;
     }
   }
 
-  /** Navigate pages, honoring locked mode and suppressing during a drag. */
-  protected pageNav(direction: PageNavDirection): void {
-    if (!this.dashboardVisible() || !this._dashboard.isDashboardStatic() || this._uiEvent.isDragging()) return;
+  /**
+   * Navigate pages, honoring locked mode and suppressing during a drag.
+   * Returns whether the key was consumed, so the caller can preventDefault
+   * only when a page actually changed (bare arrows otherwise scroll).
+   */
+  protected pageNav(direction: PageNavDirection): boolean {
+    if (!this.dashboardVisible() || !this._dashboard.isDashboardStatic() || this._uiEvent.isDragging()) return false;
     if (direction === 'next') this._dashboard.navigateToNextDashboard();
     else this._dashboard.navigateToPreviousDashboard();
+    return true;
   }
 
   protected onChromeIntent(intent: ChromeIntent): void {

--- a/src/app/core/components/dashboard/dashboard.component.spec.ts
+++ b/src/app/core/components/dashboard/dashboard.component.spec.ts
@@ -24,6 +24,11 @@ interface DashboardComponentPrivateApi {
     };
 }
 
+interface DashboardEscApi {
+    onEscapeKey: () => void;
+    loadDashboard: (id: number | null) => void;
+}
+
 describe('DashboardComponent', () => {
     let fixture: ComponentFixture<DashboardComponent>;
     let component: DashboardComponent;
@@ -129,6 +134,55 @@ describe('DashboardComponent', () => {
 
     it('should create', () => {
         expect(component).toBeTruthy();
+    });
+
+    describe('Esc cancels layout edit', () => {
+        function escApi(): DashboardEscApi {
+            const api = component as unknown as DashboardEscApi;
+            vi.spyOn(api, 'loadDashboard').mockImplementation(() => undefined);
+            return api;
+        }
+
+        it('cancels the edit (reloads + re-locks) when editing and no overlay is open', () => {
+            mockDashboardService.isDashboardStatic.set(false);
+            escApi().onEscapeKey();
+            expect(mockDashboardService.setStaticDashboard).toHaveBeenCalledWith(true);
+            expect(mockDashboardService.notifyLayoutEditCanceled).toHaveBeenCalledTimes(1);
+        });
+
+        it('does nothing when the dashboard is not in edit mode', () => {
+            mockDashboardService.isDashboardStatic.set(true);
+            escApi().onEscapeKey();
+            expect(mockDashboardService.setStaticDashboard).not.toHaveBeenCalled();
+            expect(mockDashboardService.notifyLayoutEditCanceled).not.toHaveBeenCalled();
+        });
+
+        it('yields to an open modal overlay (dialog / menu / select) so its own Esc wins', () => {
+            mockDashboardService.isDashboardStatic.set(false);
+            const backdrop = document.createElement('div');
+            backdrop.className = 'cdk-overlay-backdrop';
+            document.body.appendChild(backdrop);
+            try {
+                escApi().onEscapeKey();
+                expect(mockDashboardService.notifyLayoutEditCanceled).not.toHaveBeenCalled();
+            } finally {
+                backdrop.remove();
+            }
+        });
+
+        it('does not cancel while a widget drag is in progress', () => {
+            mockDashboardService.isDashboardStatic.set(false);
+            (TestBed.inject(uiEventService) as unknown as { isDragging: { set: (v: boolean) => void } }).isDragging.set(true);
+            escApi().onEscapeKey();
+            expect(mockDashboardService.notifyLayoutEditCanceled).not.toHaveBeenCalled();
+        });
+
+        it('cancels via a real Escape keydown (HostListener wiring)', () => {
+            mockDashboardService.isDashboardStatic.set(false);
+            vi.spyOn(component as unknown as DashboardEscApi, 'loadDashboard').mockImplementation(() => undefined);
+            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+            expect(mockDashboardService.notifyLayoutEditCanceled).toHaveBeenCalledTimes(1);
+        });
     });
 
     it('should save dashboard configuration', () => {

--- a/src/app/core/components/dashboard/dashboard.component.ts
+++ b/src/app/core/components/dashboard/dashboard.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, ChangeDetectionStrategy, Component, DestroyRef, inject, OnDestroy, viewChild, ElementRef, computed, effect, untracked, signal } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, DestroyRef, HostListener, inject, OnDestroy, viewChild, ElementRef, computed, effect, untracked, signal } from '@angular/core';
 import { GestureDirective } from '../../directives/gesture.directive';
 import { GridstackComponent, NgGridStackWidget, NgGridStackOptions, } from 'gridstack/dist/angular';
 import { GridItemHTMLElement, GridStackOptions } from 'gridstack';
@@ -11,6 +11,7 @@ import { DialogService } from '../../services/dialog.service';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { finalize } from 'rxjs/operators';
 import { uiEventService } from '../../services/uiEvent.service';
+import { isBlockingOverlayOpen } from '../../utils/hotkey-target.util';
 import { WidgetDescription } from '../../services/widget.service';
 import cloneDeep from 'lodash-es/cloneDeep';
 import { Router } from '@angular/router';
@@ -370,6 +371,19 @@ export class DashboardComponent implements AfterViewInit, OnDestroy {
     this.loadDashboard(this.dashboard.activeDashboard());
     this.dashboard.setStaticDashboard(true);
     this.dashboard.notifyLayoutEditCanceled();
+  }
+
+  /**
+   * Esc cancels an in-progress layout edit. If an overlay (dialog / menu /
+   * select) is open, its own Esc handling wins — a later bare Esc, with
+   * nothing open, then cancels the edit.
+   */
+  @HostListener('document:keydown.escape')
+  protected onEscapeKey(): void {
+    if (this.dashboard.isDashboardStatic()) return;
+    if (this._uiEvent.isDragging()) return;
+    if (isBlockingOverlayOpen()) return;
+    this.cancelLayoutChanges();
   }
 
   protected onEmptyAreaTap(e: Event | CustomEvent): void {

--- a/src/app/core/components/upgrade-config/upgrade-config.component.html
+++ b/src/app/core/components/upgrade-config/upgrade-config.component.html
@@ -23,22 +23,27 @@
       <td>Move between pages</td>
       <td>Swipe left or right</td>
       <td>Scroll horizontally</td>
-      <td><kbd>Ctrl</kbd> + <kbd style="font-size: x-large;">&#8592;</kbd>/<kbd style="font-size: x-large;">&#8594;</kbd> (Left/Right Arrow)</td>
+      <td><kbd style="font-size: x-large;">&#8592;</kbd>/<kbd style="font-size: x-large;">&#8594;</kbd> (Left/Right Arrow)</td>
     </tr>
     <tr>
       <td>Enter page edit mode</td>
       <td colspan="2">Tap the edit button on the toolbar</td>
-      <td><kbd>Shift</kbd> + <kbd>Ctrl</kbd> + <kbd>E</kbd></td>
+      <td><kbd>E</kbd></td>
+    </tr>
+    <tr>
+      <td>Cancel page edit</td>
+      <td colspan="2">Tap the Cancel button</td>
+      <td><kbd>Esc</kbd></td>
     </tr>
     <tr>
       <td>Toggle Fullscreen</td>
       <td colspan="2">Tap the fullscreen button on the toolbar</td>
-      <td><kbd>Shift</kbd> + <kbd>Ctrl</kbd> + <kbd>F</kbd></td>
+      <td><kbd>F</kbd></td>
     </tr>
     <tr>
       <td>Toggle Night mode</td>
       <td colspan="2">Tap the night-mode button on the toolbar</td>
-      <td><kbd>Shift</kbd> + <kbd>Ctrl</kbd> + <kbd>N</kbd></td>
+      <td><kbd>N</kbd></td>
     </tr>
   </tbody>
 </table>

--- a/src/app/core/utils/hotkey-target.util.spec.ts
+++ b/src/app/core/utils/hotkey-target.util.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { HOTKEY_KEYS, isInteractiveKeyTarget, isBlockingOverlayOpen } from './hotkey-target.util';
+
+function el(html: string): HTMLElement {
+  const host = document.createElement('div');
+  host.innerHTML = html;
+  return host.firstElementChild as HTMLElement;
+}
+
+describe('HOTKEY_KEYS', () => {
+  it('is the bare key set the app and the injector both key off', () => {
+    expect([...HOTKEY_KEYS]).toEqual(['ArrowLeft', 'ArrowRight', 'e', 'f', 'n']);
+  });
+});
+
+describe('isInteractiveKeyTarget', () => {
+  it('suppresses on text-entry controls', () => {
+    expect(isInteractiveKeyTarget(el('<input>'))).toBe(true);
+    expect(isInteractiveKeyTarget(el('<textarea></textarea>'))).toBe(true);
+    expect(isInteractiveKeyTarget(el('<select></select>'))).toBe(true);
+    expect(isInteractiveKeyTarget(el('<div contenteditable="true">x</div>'))).toBe(true);
+  });
+
+  it('suppresses on arrow-consuming ARIA / Material widgets', () => {
+    expect(isInteractiveKeyTarget(el('<div role="listbox"></div>'))).toBe(true);
+    expect(isInteractiveKeyTarget(el('<div role="slider"></div>'))).toBe(true);
+    expect(isInteractiveKeyTarget(el('<div role="combobox"></div>'))).toBe(true);
+    expect(isInteractiveKeyTarget(el('<div role="radiogroup"></div>'))).toBe(true);
+    expect(isInteractiveKeyTarget(el('<mat-select></mat-select>'))).toBe(true);
+  });
+
+  it('suppresses when focus is nested inside an interactive control', () => {
+    const host = document.createElement('div');
+    host.innerHTML = '<div role="listbox"><span id="opt">a</span></div>';
+    expect(isInteractiveKeyTarget(host.querySelector('#opt'))).toBe(true);
+  });
+
+  it('does not suppress on targets that do not consume the hotkeys', () => {
+    expect(isInteractiveKeyTarget(el('<div>x</div>'))).toBe(false);
+    expect(isInteractiveKeyTarget(el('<button>go</button>'))).toBe(false);
+    expect(isInteractiveKeyTarget(document)).toBe(false);
+    expect(isInteractiveKeyTarget(null)).toBe(false);
+  });
+});
+
+describe('isBlockingOverlayOpen', () => {
+  it('is true only while a CDK backdrop (dialog / menu / select) is present', () => {
+    expect(isBlockingOverlayOpen()).toBe(false);
+    const backdrop = document.createElement('div');
+    backdrop.className = 'cdk-overlay-backdrop';
+    document.body.appendChild(backdrop);
+    try {
+      expect(isBlockingOverlayOpen()).toBe(true);
+    } finally {
+      backdrop.remove();
+    }
+    expect(isBlockingOverlayOpen()).toBe(false);
+  });
+
+  it('ignores an overlay pane with no backdrop (snackbar / tooltip)', () => {
+    const pane = document.createElement('div');
+    pane.className = 'cdk-overlay-pane';
+    document.body.appendChild(pane);
+    try {
+      expect(isBlockingOverlayOpen()).toBe(false);
+    } finally {
+      pane.remove();
+    }
+  });
+});

--- a/src/app/core/utils/hotkey-target.util.ts
+++ b/src/app/core/utils/hotkey-target.util.ts
@@ -1,0 +1,42 @@
+/**
+ * The bare keys the app's global hotkey listener acts on, in `KeyboardEvent.key`
+ * form: page nav (←/→) and e/f/n (edit/fullscreen/night). Single source for the
+ * global shell hotkeys — the listener lowercases these to match its normalized
+ * filter. Esc-cancels-edit is deliberately NOT here: it is component-local and
+ * registered separately in dashboard.component.ts.
+ */
+export const HOTKEY_KEYS = ['ArrowLeft', 'ArrowRight', 'e', 'f', 'n'] as const;
+
+/**
+ * Controls that legitimately consume the hotkeys' keystrokes: text entry and the
+ * arrow-navigating ARIA / Material widgets. A focused one means a bare hotkey
+ * must yield rather than fire.
+ */
+const INTERACTIVE_TARGET_SELECTOR =
+  'input, textarea, select, [contenteditable=""], [contenteditable="true"],' +
+  ' [role="textbox"], [role="searchbox"], [role="combobox"], [role="listbox"],' +
+  ' [role="option"], [role="menu"], [role="menuitem"], [role="slider"],' +
+  ' [role="spinbutton"], [role="radiogroup"], [role="radio"], [role="tab"],' +
+  ' [role="tablist"], mat-select, mat-slider';
+
+/**
+ * True when a key event targets a control that legitimately consumes the
+ * keystroke, so a bare-key hotkey must yield rather than fire. Covers text entry
+ * (so typing "n" never toggles night mode) and arrow-navigating widgets (so
+ * arrows adjust a focused slider / select instead of paging the dashboard).
+ */
+export function isInteractiveKeyTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  if ((target as HTMLElement).isContentEditable) return true;
+  return target.closest(INTERACTIVE_TARGET_SELECTOR) !== null;
+}
+
+/**
+ * True while a modal overlay that owns the keyboard is open — a dialog, menu, or
+ * select, all of which render a CDK backdrop. Snackbars/toasts and tooltips have
+ * no backdrop and are excluded. Bare hotkeys must not drive the app behind such
+ * an overlay, and Esc must yield to it (its own Escape closes it first).
+ */
+export function isBlockingOverlayOpen(): boolean {
+  return document.querySelector('.cdk-overlay-backdrop') !== null;
+}

--- a/src/app/core/utils/iframe-inputs-inject.utils.spec.ts
+++ b/src/app/core/utils/iframe-inputs-inject.utils.spec.ts
@@ -8,20 +8,14 @@ describe('generateSwipeScript', () => {
     expect(script).toContain("instanceId='abc-123'");
   });
 
-  it('forwards Ctrl+Arrow (no Shift) as page navigation', () => {
-    expect(script).toContain("['ArrowLeft','ArrowRight'].includes(event.key)");
-    // page-nav arrows must be gated to NOT-shift so they stay distinct from the
-    // Ctrl+Shift+E/F/N actions the parent handler disambiguates on Shift.
-    expect(script).toContain('!event.shiftKey');
+  it('detects swipes and forwards them to the parent', () => {
+    expect(script).toContain('window.parent.postMessage');
+    expect(script).toContain('swipeleft');
+    expect(script).toContain('swiperight');
   });
 
-  it('forwards Ctrl+Shift+E/F/N as actions', () => {
-    expect(script).toContain("['E','F','N'].includes(event.key)");
-    expect(script).toContain('event.ctrlKey && event.shiftKey');
-  });
-
-  it('no longer forwards the retired vertical arrow hotkeys', () => {
-    expect(script).not.toContain('ArrowUp');
-    expect(script).not.toContain('ArrowDown');
+  it('does not forward keyboard events — embeds own their keyboard', () => {
+    expect(script).not.toContain('keydown');
+    expect(script).not.toContain('keyEventData');
   });
 });

--- a/src/app/core/utils/iframe-inputs-inject.utils.ts
+++ b/src/app/core/utils/iframe-inputs-inject.utils.ts
@@ -61,12 +61,5 @@ export function generateSwipeScript(config: SwipeScriptConfig): string {
     document.addEventListener('pointermove', track, {passive:true});
     document.addEventListener('pointerup', onUp, {passive:true});
     document.addEventListener('pointercancel', onCancel, {passive:true});
-    document.addEventListener('keydown', (event) => {
-      const pageNav = event.ctrlKey && !event.shiftKey && ['ArrowLeft','ArrowRight'].includes(event.key);
-      const action = event.ctrlKey && event.shiftKey && ['E','F','N'].includes(event.key);
-      if (pageNav || action) {
-        window.parent.postMessage({ type:'keydown', keyEventData:{ key:event.key, ctrlKey:event.ctrlKey, shiftKey:event.shiftKey, instanceId }}, '*');
-      }
-    });
   })();`;
 }

--- a/src/app/widgets/widget-anchor-alarm/widget-anchor-alarm.component.ts
+++ b/src/app/widgets/widget-anchor-alarm/widget-anchor-alarm.component.ts
@@ -85,7 +85,7 @@ export class WidgetAnchorAlarmComponent implements AfterViewInit, OnDestroy {
     if (!iframeWindow || event.source !== iframeWindow) return;
     if (event.origin !== window.location.origin) return;
 
-    const instanceId = event.data?.eventData?.instanceId || event.data?.keyEventData?.instanceId;
+    const instanceId = event.data?.eventData?.instanceId;
     if (!instanceId || instanceId !== this.id()) return;
 
     // Handle gestures
@@ -106,12 +106,6 @@ export class WidgetAnchorAlarmComponent implements AfterViewInit, OnDestroy {
         default:
           break;
       }
-    }
-    // Handle keydown events
-    if (event.data.type === 'keydown' && event.data.keyEventData) {
-      const { key, ctrlKey, shiftKey } = event.data.keyEventData;
-      const keyboardEvent = new KeyboardEvent('keydown', { key, ctrlKey, shiftKey, bubbles: true, cancelable: true });
-      document.dispatchEvent(keyboardEvent);
     }
   };
 

--- a/src/app/widgets/widget-freeboardsk/widget-freeboardsk.component.ts
+++ b/src/app/widgets/widget-freeboardsk/widget-freeboardsk.component.ts
@@ -138,11 +138,6 @@ export class WidgetFreeboardskComponent implements AfterViewInit, OnDestroy {
           break;
       }
     }
-    if (event.data.type === 'keydown' && event.data.keyEventData?.instanceId === instanceId) {
-      const { key, ctrlKey, shiftKey } = event.data.keyEventData;
-      const keyboardEvent = new KeyboardEvent('keydown', { key, ctrlKey, shiftKey, bubbles: true, cancelable: true });
-      document.dispatchEvent(keyboardEvent);
-    }
   };
 
   private getExpectedIframeOrigin(): string | null {

--- a/src/app/widgets/widget-hoekens-anchor-alarm/widget-hoekens-anchor-alarm.component.ts
+++ b/src/app/widgets/widget-hoekens-anchor-alarm/widget-hoekens-anchor-alarm.component.ts
@@ -84,7 +84,7 @@ export class WidgetHoekensAnchorAlarmComponent implements AfterViewInit, OnDestr
     if (!iframeWindow || event.source !== iframeWindow) return;
     if (event.origin !== window.location.origin) return;
 
-    const instanceId = event.data?.eventData?.instanceId || event.data?.keyEventData?.instanceId;
+    const instanceId = event.data?.eventData?.instanceId;
     if (!instanceId || instanceId !== this.id()) return;
 
     // Handle gestures
@@ -105,12 +105,6 @@ export class WidgetHoekensAnchorAlarmComponent implements AfterViewInit, OnDestr
         default:
           break;
       }
-    }
-    // Handle keydown events
-    if (event.data.type === 'keydown' && event.data.keyEventData) {
-      const { key, ctrlKey, shiftKey } = event.data.keyEventData;
-      const keyboardEvent = new KeyboardEvent('keydown', { key, ctrlKey, shiftKey, bubbles: true, cancelable: true });
-      document.dispatchEvent(keyboardEvent);
     }
   };
 

--- a/src/app/widgets/widget-iframe/widget-iframe.component.ts
+++ b/src/app/widgets/widget-iframe/widget-iframe.component.ts
@@ -99,7 +99,7 @@ export class WidgetIframeComponent implements AfterViewInit, OnDestroy {
     const expectedOrigin = this.getExpectedIframeOrigin();
     if (expectedOrigin && event.origin !== expectedOrigin) return;
 
-    const instanceId = event.data?.eventData?.instanceId || event.data?.keyEventData?.instanceId;
+    const instanceId = event.data?.eventData?.instanceId;
     if (!instanceId || instanceId !== this.id()) return;
 
     // Handle gestures
@@ -120,12 +120,6 @@ export class WidgetIframeComponent implements AfterViewInit, OnDestroy {
         default:
           break;
       }
-    }
-    // Handle keydown events
-    if (event.data.type === 'keydown' && event.data.keyEventData) {
-      const { key, ctrlKey, shiftKey } = event.data.keyEventData;
-      const keyboardEvent = new KeyboardEvent('keydown', { key, ctrlKey, shiftKey, bubbles: true, cancelable: true });
-      document.dispatchEvent(keyboardEvent);
     }
   };
 

--- a/src/assets/help-docs/embedwidget.md
+++ b/src/assets/help-docs/embedwidget.md
@@ -60,7 +60,7 @@ CORS restrictions only apply when the protocol, hostname, or port of the embedde
    - Some websites may allow embedding only for specific trusted domains, which most probably, do not include your Signal K installation.
 
 3. **Consequences of Blocked Content in Skip**:
-   - When you enable the "Allow Input" Embed widget option, Skip needs to inject gestures within the embedded application to trigger page navigation, reveal the auto-hiding toolbar, or use Skip's keyboard hotkeys while the focus is inside the iframe. To achieve this, Skip dynamically injects scripts into the iframe application. If CORS restrictions apply, this will be prohibited by the browser. This means that gestures and hotkeys will not work over the Embed widget. If you have a full-screen Embed widget, you could get stuck with no way to change pages or reveal the toolbar.
+   - When you enable the "Allow Input" Embed widget option, Skip needs to inject gestures within the embedded application to trigger page navigation or reveal the auto-hiding toolbar. To achieve this, Skip dynamically injects scripts into the iframe application. If CORS restrictions apply, this will be prohibited by the browser. This means that gestures will not work over the Embed widget. If you have a full-screen Embed widget, you could get stuck with no way to change pages or reveal the toolbar.
 
 4. **No Workaround for Restricted Websites**:
    - If the application does not allow iframe embedding, there is no way to bypass this restriction without the application owner's adding some kind of authorization for you. This is a browser-enforced security feature.

--- a/src/assets/help-docs/welcome.md
+++ b/src/assets/help-docs/welcome.md
@@ -4,14 +4,17 @@ Skip supports touch, mouse, and keyboard input across devices.
 | Action               | Touch                        | Mouse / wheel                         | Keyboard                                          |
 |----------------------|------------------------------|---------------------------------------|---------------------------------------------------|
 | Show the toolbar     | Swipe down from the top      | Scroll up, or tap the top peek strip  | —                                                 |
-| Move between pages   | Swipe left or right          | Scroll horizontally                   | <kbd>Ctrl</kbd> + <kbd>←</kbd>/<kbd>→</kbd> (Left/Right Arrow) |
+| Move between pages   | Swipe left or right          | Scroll horizontally                   | <kbd>←</kbd>/<kbd>→</kbd> (Left/Right Arrow)       |
 | Jump to a page       | Tap its icon in the toolbar  | Click its icon in the toolbar         | —                                                 |
-| Enter page edit mode | Tap the edit button          | Click the edit button                 | <kbd>Shift</kbd> + <kbd>Ctrl</kbd> + <kbd>E</kbd>  |
-| Toggle Fullscreen    | —                            | Click the fullscreen button           | <kbd>Shift</kbd> + <kbd>Ctrl</kbd> + <kbd>F</kbd>  |
-| Toggle Night mode    | Tap the night-mode button    | Click the night-mode button           | <kbd>Shift</kbd> + <kbd>Ctrl</kbd> + <kbd>N</kbd>  |
+| Enter page edit mode | Tap the edit button          | Click the edit button                 | <kbd>E</kbd>                                       |
+| Cancel page edit     | Tap the Cancel button        | Click the Cancel button               | <kbd>Esc</kbd>                                     |
+| Toggle Fullscreen    | —                            | Click the fullscreen button           | <kbd>F</kbd>                                       |
+| Toggle Night mode    | Tap the night-mode button    | Click the night-mode button           | <kbd>N</kbd>                                       |
 | Open notifications   | Tap the notifications button (or alarm badge) | Click the notifications button (or alarm badge) | —                                |
 
 > Note that the words Touch and Tap are synonymous with mouse click.
+
+> Keyboard shortcuts are single keys with no modifier, and are ignored while you are typing in a text field or adjusting a control.
 
 ## The Toolbar
 Skip has no permanent navigation bar. A toolbar sits hidden at the top of the page and slides down when you need it — swipe down from the top, scroll up, or tap the thin strip that peeks at the top edge. It hides again when you scroll back, tap elsewhere, or leave it idle.


### PR DESCRIPTION
## Why

The hotkeys inherited from upstream Kip were built around swipe-in sidenavs that the `navigation-chrome` redesign (#183) removed. #183 already reconciled the code, iframe injector, and docs (the original #191 findings were stale) — but it left the `Ctrl` / `Ctrl+Shift` scheme, whose one *unfixable* defect is browser-chrome collision: `Ctrl+Shift+N` is consumed by the browser as **New Incognito Window** before the page sees it and cannot be reclaimed with `preventDefault`; `Ctrl+Shift+E` opens Firefox's Network panel.

## What

Switch the keymap to **bare keys guarded by focus**, which collide with no browser shortcut. Per-action semantics are preserved; only the key scheme changes and focus guards are added.

| Key | Action |
|---|---|
| `←` / `→` | Prev / next dashboard page (unchanged gating: visible + locked + not dragging) |
| `e` | Enter edit mode (enter-only) |
| `f` | Toggle fullscreen |
| `n` | Toggle night mode |
| `Esc` | Cancel an in-progress layout edit (discard + re-lock) — the keyboard exit for enter-only `e` |

Highlights:

- **Single source for the keymap** — `HOTKEY_KEYS` + a shared `INTERACTIVE_TARGET_SELECTOR` in a new `hotkey-target.util.ts`; the app listener lowercases the set and the iframe injector JSON-interpolates both, so handler / injector / guard can't drift.
- **Focus guard** (`isInteractiveKeyTarget`) suppresses on text entry and arrow-navigating ARIA/Material widgets, so typing "n" never toggles night mode and arrows adjust a focused slider instead of paging. Mirrored inside the iframe injector — the *only* protection for the embed path, since a re-dispatched key reaches the parent with a safe (`document`) target.
- **Bare-only + preventDefault on consume** — any modifier bails (so `Ctrl+E` etc. still reach the browser); arrows only `preventDefault` when a page actually changes, so they still scroll off-dashboard.
- **`Esc` cancels an edit** via `@HostListener` in `DashboardComponent` (cancel is component-local — it reloads the gridstack instance). Guarded so an open dialog/menu (`.cdk-overlay-pane`) keeps its own `Esc`; kept out of the shared/injector key set so an embedded app's `Esc` never cancels Skip's edit.
- Docs (`welcome.md`, `upgrade-config.component.html`) reconciled to the bare keymap.

## Verification

`npm test` (1466 tests / 160 files), `npm run snc`, `npm run lint` all green. TDD throughout. **Not yet driven end-to-end in a real browser** — the live keypress behavior (and overlay-Esc precedence) is best confirmed on the boat MFD; happy to add a headless-browser check if wanted.

Closes #191.
