### PR TITLE
Fix electrical severity ordering: alarm must outrank alert (#351 D1)

### DIFF
--- a/src/app/widgets/shared/electrical-apply.util.spec.ts
+++ b/src/app/widgets/shared/electrical-apply.util.spec.ts
@@ -101,10 +101,14 @@ describe('electrical-apply.util', () => {
   });
 
   describe('resolveMostSevereState', () => {
-    it('applies Alert > Alarm > Warn > Normal priority', () => {
-      expect(resolveMostSevereState(States.Normal, States.Alarm, States.Alert)).toBe(States.Alert);
+    it('returns the highest-ranked state by Signal K severity order', () => {
+      // normal < nominal < alert < warn < alarm < emergency
+      expect(resolveMostSevereState(States.Normal, States.Alarm, States.Alert)).toBe(States.Alarm);
+      expect(resolveMostSevereState(States.Alert, States.Warn)).toBe(States.Warn);
       expect(resolveMostSevereState(States.Normal, States.Alarm)).toBe(States.Alarm);
       expect(resolveMostSevereState(States.Warn, States.Normal)).toBe(States.Warn);
+      expect(resolveMostSevereState(States.Nominal, States.Normal)).toBe(States.Nominal);
+      expect(resolveMostSevereState(States.Alarm, States.Emergency)).toBe(States.Emergency);
       expect(resolveMostSevereState(States.Normal, null)).toBe(States.Normal);
     });
 

--- a/src/app/widgets/shared/electrical-apply.util.ts
+++ b/src/app/widgets/shared/electrical-apply.util.ts
@@ -6,9 +6,11 @@ import { States, type TState } from '../../core/interfaces/signalk-interfaces';
  * parsed Signal K value is written onto a widget's snapshot. Extracted from the
  * verbatim copies the charger/alternator/inverter/ac widgets carried.
  *
- * solar-charger keeps its own `toStringValue` (which stringifies non-strings)
- * and `resolveMostSevereState` (rank-based ordering); bms uses a different
- * write path entirely. Those variants are behaviorally distinct — see #351.
+ * `resolveMostSevereState` is the family's canonical severity fold: it ranks
+ * TState by the Signal K severity order (normal < nominal < alert < warn <
+ * alarm < emergency) and returns the highest present. solar-charger keeps its
+ * own `toStringValue` (which stringifies non-strings); bms uses a different
+ * write path entirely.
  */
 
 export function setValue<T, K extends keyof T>(target: T, key: K, nextValue: T[K]): boolean {
@@ -62,9 +64,22 @@ export function toBoolean(value: unknown): boolean | null {
 }
 
 export function resolveMostSevereState(...states: (TState | null | undefined)[]): TState | null {
-  if (states.some(state => state === States.Alert)) return States.Alert;
-  if (states.some(state => state === States.Alarm)) return States.Alarm;
-  if (states.some(state => state === States.Warn)) return States.Warn;
-  if (states.some(state => state === States.Normal)) return States.Normal;
-  return null;
+  const rank: Record<TState, number> = {
+    [States.Normal]: 0,
+    [States.Nominal]: 1,
+    [States.Alert]: 2,
+    [States.Warn]: 3,
+    [States.Alarm]: 4,
+    [States.Emergency]: 5
+  };
+
+  let current: TState | null = null;
+  for (const state of states) {
+    if (!state) continue;
+    if (!current || rank[state] > rank[current]) {
+      current = state;
+    }
+  }
+
+  return current;
 }

--- a/src/app/widgets/widget-solar-charger/widget-solar-charger.component.ts
+++ b/src/app/widgets/widget-solar-charger/widget-solar-charger.component.ts
@@ -12,7 +12,7 @@ import { getElectricalWidgetFamilyDescriptor } from '../../core/contracts/electr
 import type { ElectricalCardDisplayMode } from '../../core/contracts/electrical-topology-card.contract';
 import { ELECTRICAL_DIRECT_CARD_GAP, ELECTRICAL_DIRECT_CARD_HEIGHT, ELECTRICAL_DIRECT_CARD_VIEWBOX_WIDTH, ELECTRICAL_DIRECT_CARD_FULL_LAYOUT } from '../shared/electrical-card-layout.constants';
 import { normalizeOptionalString, normalizeStringList } from '../shared/electrical-config.util';
-import { setValue } from '../shared/electrical-apply.util';
+import { setValue, resolveMostSevereState } from '../shared/electrical-apply.util';
 import { ElectricalIngestScheduler } from '../shared/electrical-ingest-scheduler';
 import type { ElectricalTopologyEntry } from '../shared/electrical-topology-store';
 import { WidgetTitleComponent } from '../../core/components/widget-title/widget-title.component';
@@ -202,7 +202,7 @@ export class WidgetSolarChargerComponent implements AfterViewInit {
         theme,
         ignoreZones
       );
-      const chargerMetaState = this.resolveMostSevereState(
+      const chargerMetaState = resolveMostSevereState(
         solar.voltageState ?? null,
         solar.temperatureState ?? null
       );
@@ -212,7 +212,7 @@ export class WidgetSolarChargerComponent implements AfterViewInit {
         theme,
         ignoreZones
       );
-      const panelValuesState = this.resolveMostSevereState(
+      const panelValuesState = resolveMostSevereState(
         solar.panelCurrentState ?? null,
         solar.panelVoltageState ?? null,
         solar.panelTemperatureState ?? null
@@ -977,27 +977,6 @@ export class WidgetSolarChargerComponent implements AfterViewInit {
     if (value === null) return '--';
     if (value === undefined) return '';
     return `${value.toFixed(2)}`;
-  }
-
-  private resolveMostSevereState(...states: (TState | null | undefined)[]): TState | null {
-    let current: TState | null = null;
-    const rank: Record<TState, number> = {
-      [States.Normal]: 0,
-      [States.Nominal]: 1,
-      [States.Alert]: 2,
-      [States.Warn]: 3,
-      [States.Alarm]: 4,
-      [States.Emergency]: 5
-    };
-
-    for (const state of states) {
-      if (!state) continue;
-      if (!current || rank[state] > rank[current]) {
-        current = state;
-      }
-    }
-
-    return current;
   }
 
   private debugSolarLayout(id: string, gaugeProgress: number): void {


### PR DESCRIPTION
## What & why

Fixes divergence **D1** of #351: the shared electrical `resolveMostSevereState` short-circuited `Alert > Alarm > Warn > Normal`, which **inverts** the Signal K severity order (`normal < nominal < alert < warn < alarm < emergency`, per the codebase's own canonical `states` array).

**Impact:** an electrical device with a co-occurring `alert` on one metric and `alarm` on another rendered the *alert* zone colour — visually downgrading a more-severe alarm on a safety display. The old body also dropped `nominal`/`emergency` entirely (→ null).

## Approach

- Replace the short-circuit with the canonical rank fold (returns the highest-ranked present state; handles all six states).
- `widget-solar-charger` carried a byte-identical correct rank fold privately — fold it onto the now-correct shared helper and delete the copy.
- Flip the `electrical-apply.util.spec.ts` assertion that had *codified* the inversion (`resolveMostSevereState(Normal, Alarm, Alert)` now correctly returns `Alarm`), and add coverage for the full ordering incl. `nominal`/`emergency`.

The other four consumers (charger/alternator/inverter/ac) import the shared helper and inherit the fix; all electrical widget specs stay green.

## Scope

D1 only. The other two #351 divergences (D2 `toNumber` fallback, D3 device parsing) are inert today and left for a separate "unify the electrical helpers" cleanup — triage recorded in the issue.

## Verification

`npm run snc` + `npm run lint` green; the 7 electrical specs (`electrical-apply.util` + all 6 widgets) pass (108 tests).

Refs #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)
