### PR TITLE
Unify electrical toNumber + normalizeTrackedDevices helpers (#351 D2+D3)

### DIFF
--- a/src/app/widgets/shared/electrical-apply.util.spec.ts
+++ b/src/app/widgets/shared/electrical-apply.util.spec.ts
@@ -1,11 +1,18 @@
 import { States } from '../../core/interfaces/signalk-interfaces';
+import type { UnitsService } from '../../core/services/units.service';
 import {
   resolveMostSevereState,
   setMetricValue,
   setValue,
   toBoolean,
+  toFiniteNumber,
+  toNumber,
   toStringValue
 } from './electrical-apply.util';
+
+function unitsWith(convert: (unit: string, value: number) => number | null): UnitsService {
+  return { convertToUnit: convert } as unknown as UnitsService;
+}
 
 interface TestSnapshot {
   voltage: number | null;
@@ -61,6 +68,54 @@ describe('electrical-apply.util', () => {
       s.voltage = 12.4;
       s.voltageState = States.Normal;
       expect(setMetricValue(s, 'voltage', 'voltageState', 12.4, States.Normal)).toBe(false);
+    });
+  });
+
+  describe('toFiniteNumber', () => {
+    it('passes finite numbers through', () => {
+      expect(toFiniteNumber(12.4)).toBe(12.4);
+      expect(toFiniteNumber(0)).toBe(0);
+    });
+
+    it('returns null for non-numbers, NaN and infinities (no string coercion)', () => {
+      expect(toFiniteNumber('12')).toBeNull();
+      expect(toFiniteNumber(NaN)).toBeNull();
+      expect(toFiniteNumber(Infinity)).toBeNull();
+      expect(toFiniteNumber(true)).toBeNull();
+      expect(toFiniteNumber(null)).toBeNull();
+      expect(toFiniteNumber(undefined)).toBeNull();
+    });
+  });
+
+  describe('toNumber', () => {
+    it('applies the unit conversion to a finite number', () => {
+      const units = unitsWith((unit, value) => (unit === 'K' ? value + 273.15 : value));
+      expect(toNumber(units, 300, 'K')).toBe(573.15);
+    });
+
+    it('coerces genuine numeric strings before converting', () => {
+      const units = unitsWith((unit, value) => (unit === 'K' ? value + 273.15 : value));
+      expect(toNumber(units, '300', 'K')).toBe(573.15);
+    });
+
+    it('rejects blank/non-numeric strings, booleans, null and NaN without converting', () => {
+      let called = false;
+      const units = unitsWith(() => {
+        called = true;
+        return 0;
+      });
+      expect(toNumber(units, '', 'K')).toBeNull();
+      expect(toNumber(units, '   ', 'K')).toBeNull();
+      expect(toNumber(units, 'abc', 'K')).toBeNull();
+      expect(toNumber(units, true, 'K')).toBeNull();
+      expect(toNumber(units, null, 'K')).toBeNull();
+      expect(toNumber(units, NaN, 'K')).toBeNull();
+      expect(called).toBe(false);
+    });
+
+    it('falls back to the raw number when the conversion is non-finite', () => {
+      expect(toNumber(unitsWith(() => NaN), 42, 'V')).toBe(42);
+      expect(toNumber(unitsWith(() => null), 42, 'V')).toBe(42);
     });
   });
 

--- a/src/app/widgets/shared/electrical-apply.util.ts
+++ b/src/app/widgets/shared/electrical-apply.util.ts
@@ -1,10 +1,16 @@
 import { States, type TState } from '../../core/interfaces/signalk-interfaces';
+import type { UnitsService } from '../../core/services/units.service';
 
 /**
  * Shared value-apply helpers for the electrical widget family: the dirty-check
  * snapshot writers, the raw-value coercers, and the severity fold used when a
- * parsed Signal K value is written onto a widget's snapshot. Extracted from the
- * verbatim copies the charger/alternator/inverter/ac widgets carried.
+ * parsed Signal K value is written onto a widget's snapshot.
+ *
+ * `toNumber` is the family's canonical numeric coercer: a strict number guard
+ * (no `Number()` string coercion), a unit conversion via `UnitsService`, and a
+ * raw-value fallback when the conversion is non-finite. charger, alternator,
+ * inverter, ac and solar-charger apply it at delta time. bms uses `toFiniteNumber`
+ * (the same strict guard with no conversion) because it converts at format time.
  *
  * `resolveMostSevereState` is the family's canonical severity fold: it ranks
  * TState by the Signal K severity order (normal < nominal < alert < warn <
@@ -42,6 +48,27 @@ export function setMetricValue<T, K extends keyof T, S extends keyof T>(
 
 export function toStringValue(value: unknown): string | null {
   return typeof value === 'string' ? value : null;
+}
+
+export function toFiniteNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+export function toNumber(units: UnitsService, value: unknown, unitHint: string): number | null {
+  if (value == null || typeof value === 'boolean') {
+    return null;
+  }
+  // Coerce genuine numeric strings — some Signal K sources deliver stringified numbers
+  // (convertToUnit carries the same defense) — but reject empty/whitespace so a blank
+  // never silently becomes 0 (Number('') === 0).
+  const raw = typeof value === 'number'
+    ? value
+    : (typeof value === 'string' && value.trim() !== '' ? Number(value) : NaN);
+  if (!Number.isFinite(raw)) {
+    return null;
+  }
+  const converted = units.convertToUnit(unitHint, raw);
+  return typeof converted === 'number' && Number.isFinite(converted) ? converted : raw;
 }
 
 export function toBoolean(value: unknown): boolean | null {

--- a/src/app/widgets/shared/electrical-config.util.spec.ts
+++ b/src/app/widgets/shared/electrical-config.util.spec.ts
@@ -40,14 +40,25 @@ describe('electrical-config.util', () => {
       expect(normalizeTrackedDevices(undefined)).toEqual([]);
     });
 
-    it('drops items missing id or source and skips non-objects', () => {
+    it('drops only items without a usable id and skips non-objects', () => {
       const result = normalizeTrackedDevices([
         'plain-string',
-        { id: 'a' },
         { source: 'x' },
+        { id: '   ' },
         { id: 'a', source: 'x' }
       ]);
       expect(result).toEqual([{ id: 'a', source: 'x', key: 'a||x' }]);
+    });
+
+    it('defaults a missing or blank source to "default" and keeps the item', () => {
+      const result = normalizeTrackedDevices([
+        { id: 'a' },
+        { id: 'b', source: '   ' }
+      ]);
+      expect(result).toEqual([
+        { id: 'a', source: 'default', key: 'a||default' },
+        { id: 'b', source: 'default', key: 'b||default' }
+      ]);
     });
 
     it('synthesizes a key from id and source when key is absent', () => {

--- a/src/app/widgets/shared/electrical-config.util.ts
+++ b/src/app/widgets/shared/electrical-config.util.ts
@@ -2,11 +2,12 @@ import type { ElectricalTrackedDevice } from '../../core/interfaces/widgets-inte
 
 /**
  * Shared configuration/device normalizers for the electrical widget family
- * (charger, alternator, inverter, ac, and the parts of solar-charger/bms that
- * share the object-based device model). Each widget previously carried its own
- * verbatim copy of these; solar-charger and bms keep their own divergent
- * `normalizeTrackedDevices`, and ac keeps `normalizeAcTrackedDevices` (a
- * reserved-aggregate-id guard) — all behaviorally distinct, see #351.
+ * (charger, alternator, inverter, ac, solar-charger, bms). `normalizeTrackedDevices`
+ * is the family's canonical device normalizer: it accepts object items only,
+ * defaults a missing or blank `source` to `'default'` (matching what the widget
+ * config modal writes at save time), drops only items without a usable `id`, and
+ * dedupes by `key`. ac keeps `normalizeAcTrackedDevices` (a reserved-aggregate-id
+ * guard) — a distinct AC-phase variant, see #351.
  */
 
 export function normalizeOptionalString(value: unknown): string | null {
@@ -51,11 +52,11 @@ export function normalizeTrackedDevices(value: unknown): ElectricalTrackedDevice
 
     const candidate = item as { id?: unknown; source?: unknown; key?: unknown };
     const id = normalizeOptionalString(candidate.id);
-    const source = normalizeOptionalString(candidate.source);
-    if (!id || !source) {
+    if (!id) {
       return;
     }
 
+    const source = normalizeOptionalString(candidate.source) ?? 'default';
     const key = normalizeOptionalString(candidate.key) ?? `${id}||${source}`;
     devices.set(key, { id, source, key });
   });

--- a/src/app/widgets/widget-ac/widget-ac.component.ts
+++ b/src/app/widgets/widget-ac/widget-ac.component.ts
@@ -10,7 +10,7 @@ import { getColors, resolveZoneAwareColor } from '../../core/utils/themeColors.u
 import { getElectricalWidgetFamilyDescriptor } from '../../core/contracts/electrical-widget-family.contract';
 import type { ElectricalCardDisplayMode } from '../../core/contracts/electrical-topology-card.contract';
 import { normalizeOptionalString, normalizeStringList } from '../shared/electrical-config.util';
-import { setValue, setMetricValue, toStringValue, resolveMostSevereState } from '../shared/electrical-apply.util';
+import { setValue, setMetricValue, toStringValue, toNumber, resolveMostSevereState } from '../shared/electrical-apply.util';
 import { ElectricalIngestScheduler } from '../shared/electrical-ingest-scheduler';
 import { ElectricalTopologyStore, type ElectricalTopologyEntry } from '../shared/electrical-topology-store';
 import { drawDirectCards, initDirectCardSvg } from '../shared/electrical-direct-card-draw';
@@ -345,22 +345,22 @@ export class WidgetAcComponent implements AfterViewInit {
       case 'associatedBus': return setValue(snapshot, 'associatedBus', toStringValue(value));
       case 'mode': return setMetricValue(snapshot, 'mode', 'modeState', toStringValue(value), state);
       // Backward-compatible flat AC keys map to line 1 when source data is single-phase per id.
-      case 'voltage': return setMetricValue(snapshot, 'line1Voltage', 'line1VoltageState', this.toNumber(value, 'V'), state);
-      case 'current': return setMetricValue(snapshot, 'line1Current', 'line1CurrentState', this.toNumber(value, 'A'), state);
-      case 'frequency': return setMetricValue(snapshot, 'line1Frequency', 'line1FrequencyState', this.toNumber(value, 'Hz'), state);
-      case 'line1.voltage': return setMetricValue(snapshot, 'line1Voltage', 'line1VoltageState', this.toNumber(value, 'V'), state);
-      case 'line1.current': return setMetricValue(snapshot, 'line1Current', 'line1CurrentState', this.toNumber(value, 'A'), state);
-      case 'line1.frequency': return setMetricValue(snapshot, 'line1Frequency', 'line1FrequencyState', this.toNumber(value, 'Hz'), state);
-      case 'line1.realPower': return setMetricValue(snapshot, 'power', 'line1CurrentState', this.toNumber(value, 'W'), state);
-      case 'line2.voltage': return setMetricValue(snapshot, 'line2Voltage', 'line2VoltageState', this.toNumber(value, 'V'), state);
-      case 'line2.current': return setMetricValue(snapshot, 'line2Current', 'line2CurrentState', this.toNumber(value, 'A'), state);
-      case 'line2.frequency': return setMetricValue(snapshot, 'line2Frequency', 'line2FrequencyState', this.toNumber(value, 'Hz'), state);
-      case 'line2.realPower': return setMetricValue(snapshot, 'power', 'line2CurrentState', this.toNumber(value, 'W'), state);
-      case 'line3.voltage': return setMetricValue(snapshot, 'line3Voltage', 'line3VoltageState', this.toNumber(value, 'V'), state);
-      case 'line3.current': return setMetricValue(snapshot, 'line3Current', 'line3CurrentState', this.toNumber(value, 'A'), state);
-      case 'line3.frequency': return setMetricValue(snapshot, 'line3Frequency', 'line3FrequencyState', this.toNumber(value, 'Hz'), state);
-      case 'line3.realPower': return setMetricValue(snapshot, 'power', 'line3CurrentState', this.toNumber(value, 'W'), state);
-      case 'power': return setMetricValue(snapshot, 'power', 'line1CurrentState', this.toNumber(value, 'W'), state);
+      case 'voltage': return setMetricValue(snapshot, 'line1Voltage', 'line1VoltageState', toNumber(this.units, value, 'V'), state);
+      case 'current': return setMetricValue(snapshot, 'line1Current', 'line1CurrentState', toNumber(this.units, value, 'A'), state);
+      case 'frequency': return setMetricValue(snapshot, 'line1Frequency', 'line1FrequencyState', toNumber(this.units, value, 'Hz'), state);
+      case 'line1.voltage': return setMetricValue(snapshot, 'line1Voltage', 'line1VoltageState', toNumber(this.units, value, 'V'), state);
+      case 'line1.current': return setMetricValue(snapshot, 'line1Current', 'line1CurrentState', toNumber(this.units, value, 'A'), state);
+      case 'line1.frequency': return setMetricValue(snapshot, 'line1Frequency', 'line1FrequencyState', toNumber(this.units, value, 'Hz'), state);
+      case 'line1.realPower': return setMetricValue(snapshot, 'power', 'line1CurrentState', toNumber(this.units, value, 'W'), state);
+      case 'line2.voltage': return setMetricValue(snapshot, 'line2Voltage', 'line2VoltageState', toNumber(this.units, value, 'V'), state);
+      case 'line2.current': return setMetricValue(snapshot, 'line2Current', 'line2CurrentState', toNumber(this.units, value, 'A'), state);
+      case 'line2.frequency': return setMetricValue(snapshot, 'line2Frequency', 'line2FrequencyState', toNumber(this.units, value, 'Hz'), state);
+      case 'line2.realPower': return setMetricValue(snapshot, 'power', 'line2CurrentState', toNumber(this.units, value, 'W'), state);
+      case 'line3.voltage': return setMetricValue(snapshot, 'line3Voltage', 'line3VoltageState', toNumber(this.units, value, 'V'), state);
+      case 'line3.current': return setMetricValue(snapshot, 'line3Current', 'line3CurrentState', toNumber(this.units, value, 'A'), state);
+      case 'line3.frequency': return setMetricValue(snapshot, 'line3Frequency', 'line3FrequencyState', toNumber(this.units, value, 'Hz'), state);
+      case 'line3.realPower': return setMetricValue(snapshot, 'power', 'line3CurrentState', toNumber(this.units, value, 'W'), state);
+      case 'power': return setMetricValue(snapshot, 'power', 'line1CurrentState', toNumber(this.units, value, 'W'), state);
       default:
         return false;
     }
@@ -430,15 +430,5 @@ export class WidgetAcComponent implements AfterViewInit {
   private formatValue(value: number | null | undefined, unit: string): string {
     if (value == null || Number.isNaN(value)) return '-';
     return `${value.toFixed(1)} ${unit}`;
-  }
-
-  private toNumber(value: unknown, unitHint: string): number | null {
-    if (value == null || typeof value === 'boolean') return null;
-
-    const rawNumber = typeof value === 'number' ? value : Number(value);
-    if (!Number.isFinite(rawNumber)) return null;
-
-    const converted = this.units.convertToUnit(unitHint, rawNumber);
-    return typeof converted === 'number' && Number.isFinite(converted) ? converted : null;
   }
 }

--- a/src/app/widgets/widget-alternator/widget-alternator.component.ts
+++ b/src/app/widgets/widget-alternator/widget-alternator.component.ts
@@ -12,7 +12,7 @@ import type { ElectricalCardDisplayMode } from '../../core/contracts/electrical-
 import type { AlternatorDisplayModel, AlternatorSnapshot, AlternatorWidgetConfig, ElectricalCardModeConfig } from './widget-alternator.types';
 import { WidgetTitleComponent } from '../../core/components/widget-title/widget-title.component';
 import { normalizeOptionalString, normalizeStringList, normalizeTrackedDevices } from '../shared/electrical-config.util';
-import { setValue, setMetricValue, toStringValue, resolveMostSevereState } from '../shared/electrical-apply.util';
+import { setValue, setMetricValue, toStringValue, toNumber, resolveMostSevereState } from '../shared/electrical-apply.util';
 import { ElectricalIngestScheduler } from '../shared/electrical-ingest-scheduler';
 import { ElectricalTopologyStore, type ElectricalTopologyEntry } from '../shared/electrical-topology-store';
 import { drawDirectCards, initDirectCardSvg } from '../shared/electrical-direct-card-draw';
@@ -311,24 +311,24 @@ export class WidgetAlternatorComponent implements AfterViewInit {
       case 'chargingMode':
         return setMetricValue(snapshot, 'chargingMode', 'chargingModeState', toStringValue(value), state);
       case 'voltage':
-        return setMetricValue(snapshot, 'voltage', 'voltageState', this.toNumber(value, 'V'), state);
+        return setMetricValue(snapshot, 'voltage', 'voltageState', toNumber(this.units, value, 'V'), state);
       case 'current':
-        return setMetricValue(snapshot, 'current', 'currentState', this.toNumber(value, 'A'), state);
+        return setMetricValue(snapshot, 'current', 'currentState', toNumber(this.units, value, 'A'), state);
       case 'power':
       case 'realPower':
-        return setMetricValue(snapshot, 'rawPower', 'powerState', this.toNumber(value, 'W'), state);
+        return setMetricValue(snapshot, 'rawPower', 'powerState', toNumber(this.units, value, 'W'), state);
       case 'temperature':
-        return setMetricValue(snapshot, 'temperature', 'temperatureState', this.toNumber(value, 'K'), state);
+        return setMetricValue(snapshot, 'temperature', 'temperatureState', toNumber(this.units, value, 'K'), state);
       case 'revolutions':
-        return setMetricValue(snapshot, 'revolutions', 'revolutionsState', this.toNumber(value, 'Hz'), state);
+        return setMetricValue(snapshot, 'revolutions', 'revolutionsState', toNumber(this.units, value, 'Hz'), state);
       case 'fieldDrive':
-        return setMetricValue(snapshot, 'fieldDrive', 'fieldDriveState', this.toNumber(value, '%'), state);
+        return setMetricValue(snapshot, 'fieldDrive', 'fieldDriveState', toNumber(this.units, value, '%'), state);
       case 'regulatorTemperature':
-        return setMetricValue(snapshot, 'regulatorTemperature', 'regulatorTemperatureState', this.toNumber(value, 'K'), state);
+        return setMetricValue(snapshot, 'regulatorTemperature', 'regulatorTemperatureState', toNumber(this.units, value, 'K'), state);
       case 'setpointVoltage':
-        return setMetricValue(snapshot, 'setpointVoltage', 'setpointVoltageState', this.toNumber(value, 'V'), state);
+        return setMetricValue(snapshot, 'setpointVoltage', 'setpointVoltageState', toNumber(this.units, value, 'V'), state);
       case 'setpointCurrent':
-        return setMetricValue(snapshot, 'setpointCurrent', 'setpointCurrentState', this.toNumber(value, 'A'), state);
+        return setMetricValue(snapshot, 'setpointCurrent', 'setpointCurrentState', toNumber(this.units, value, 'A'), state);
       default:
         return false;
     }
@@ -468,19 +468,5 @@ export class WidgetAlternatorComponent implements AfterViewInit {
     }
 
     return `${value.toFixed(0)} %`;
-  }
-
-  private toNumber(value: unknown, unitHint: string): number | null {
-    if (value == null || typeof value === 'boolean') {
-      return null;
-    }
-
-    const rawNumber = typeof value === 'number' ? value : Number(value);
-    if (!Number.isFinite(rawNumber)) {
-      return null;
-    }
-
-    const converted = this.units.convertToUnit(unitHint, rawNumber);
-    return Number.isFinite(converted) ? converted : rawNumber;
   }
 }

--- a/src/app/widgets/widget-bms/widget-bms.component.ts
+++ b/src/app/widgets/widget-bms/widget-bms.component.ts
@@ -3,7 +3,7 @@ import { select, type Selection } from 'd3-selection';
 import { arc } from 'd3-shape';
 import { take } from 'rxjs/operators';
 import { getColors, resolveZoneAwareColor } from '../../core/utils/themeColors.utils';
-import { BmsBankConfig, BmsBankConnectionMode, BmsWidgetConfig, ElectricalCardModeConfig, ElectricalTrackedDevice, IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
+import { BmsBankConfig, BmsBankConnectionMode, BmsWidgetConfig, ElectricalCardModeConfig, IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
 import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
 import { DataService } from '../../core/services/data.service';
 import { UnitsService } from '../../core/services/units.service';
@@ -14,7 +14,8 @@ import type { BmsBankDisplayModel, BmsBankSummary, BmsBatteryDisplayModel, BmsBa
 import type { ElectricalCardDisplayMode } from '../../core/contracts/electrical-topology-card.contract';
 import type { ITheme } from '../../core/services/app-service';
 import { ELECTRICAL_DIRECT_CARD_HEIGHT, ELECTRICAL_DIRECT_CARD_FULL_LAYOUT, ELECTRICAL_DIRECT_CARD_VIEWBOX_WIDTH } from '../shared/electrical-card-layout.constants';
-import { normalizeOptionalString, normalizeStringList } from '../shared/electrical-config.util';
+import { normalizeOptionalString, normalizeStringList, normalizeTrackedDevices } from '../shared/electrical-config.util';
+import { toFiniteNumber } from '../shared/electrical-apply.util';
 import { ElectricalIngestScheduler } from '../shared/electrical-ingest-scheduler';
 import type { ElectricalTopologyEntry } from '../shared/electrical-topology-store';
 import { WidgetTitleComponent } from '../../core/components/widget-title/widget-title.component';
@@ -392,7 +393,7 @@ export class WidgetBmsComponent implements AfterViewInit {
 
   private resolveBmsConfig(cfg: IWidgetSvcConfig): BmsWidgetConfig {
     const bms = cfg.bms;
-    const trackedDevices = this.normalizeTrackedDevices(bms?.trackedDevices);
+    const trackedDevices = normalizeTrackedDevices(bms?.trackedDevices);
     const groupBanks = this.normalizeBanksFromGroups(bms?.groups);
     const legacyBanks = this.normalizeBanksFromLegacy(bms?.banks);
 
@@ -402,33 +403,6 @@ export class WidgetBmsComponent implements AfterViewInit {
       banks: groupBanks.length > 0 ? groupBanks : legacyBanks,
       cardMode: this.normalizeCardMode(bms?.cardMode)
     };
-  }
-
-  private normalizeTrackedDevices(value: unknown): ElectricalTrackedDevice[] {
-    if (!Array.isArray(value)) {
-      return [];
-    }
-
-    const devices = new Map<string, ElectricalTrackedDevice>();
-    value.forEach(item => {
-      if (!item || typeof item !== 'object') {
-        return;
-      }
-
-      const candidate = item as Partial<ElectricalTrackedDevice>;
-      const id = typeof candidate.id === 'string' ? candidate.id.trim() : '';
-      const source = typeof candidate.source === 'string' ? candidate.source.trim() : 'default';
-      if (!id || !source) {
-        return;
-      }
-
-      const key = typeof candidate.key === 'string' && candidate.key.trim().length > 0
-        ? candidate.key.trim()
-        : `${id}||${source}`;
-      devices.set(key, { id, source, key });
-    });
-
-    return [...devices.values()].sort((left, right) => left.key.localeCompare(right.key));
   }
 
   private normalizeCardMode(value: unknown): ElectricalCardModeConfig {
@@ -565,13 +539,13 @@ export class WidgetBmsComponent implements AfterViewInit {
         return true;
       }
       case 'voltage': {
-        const nextValue = this.toNumber(value);
+        const nextValue = toFiniteNumber(value);
         if (Object.is(battery.voltage, nextValue)) return false;
         battery.voltage = nextValue;
         return true;
       }
       case 'current': {
-        const nextValue = this.toNumber(value);
+        const nextValue = toFiniteNumber(value);
         const stateChanged = !Object.is(battery.currentState ?? null, state ?? null);
         if (Object.is(battery.current, nextValue) && !stateChanged) return false;
         battery.current = nextValue;
@@ -579,31 +553,31 @@ export class WidgetBmsComponent implements AfterViewInit {
         return true;
       }
       case 'temperature': {
-        const nextValue = this.toNumber(value);
+        const nextValue = toFiniteNumber(value);
         if (Object.is(battery.temperature, nextValue)) return false;
         battery.temperature = nextValue;
         return true;
       }
       case 'capacity.nominal': {
-        const nextValue = this.toNumber(value);
+        const nextValue = toFiniteNumber(value);
         if (Object.is(battery.capacityNominal, nextValue)) return false;
         battery.capacityNominal = nextValue;
         return true;
       }
       case 'capacity.actual': {
-        const nextValue = this.toNumber(value);
+        const nextValue = toFiniteNumber(value);
         if (Object.is(battery.capacityActual, nextValue)) return false;
         battery.capacityActual = nextValue;
         return true;
       }
       case 'capacity.remaining': {
-        const nextValue = this.toNumber(value);
+        const nextValue = toFiniteNumber(value);
         if (Object.is(battery.capacityRemaining, nextValue)) return false;
         battery.capacityRemaining = nextValue;
         return true;
       }
       case 'capacity.stateOfCharge': {
-        const nextValue = this.toNumber(value);
+        const nextValue = toFiniteNumber(value);
         const stateChanged = !Object.is(battery.stateOfChargeState ?? null, state ?? null);
         if (Object.is(battery.stateOfCharge, nextValue) && !stateChanged) return false;
         battery.stateOfCharge = nextValue;
@@ -611,7 +585,7 @@ export class WidgetBmsComponent implements AfterViewInit {
         return true;
       }
       case 'capacity.timeRemaining': {
-        const nextValue = this.toNumber(value);
+        const nextValue = toFiniteNumber(value);
         if (Object.is(battery.timeRemaining, nextValue)) return false;
         battery.timeRemaining = nextValue;
         return true;
@@ -1192,12 +1166,6 @@ export class WidgetBmsComponent implements AfterViewInit {
     const filtered = values.filter((value): value is number => typeof value === 'number');
     if (!filtered.length) return null;
     return Math.min(...filtered);
-  }
-
-  private toNumber(value: unknown): number | null {
-    if (value == null) return null;
-    if (typeof value !== 'number') return null;
-    return value;
   }
 
   private buildSemiGaugeArcPath(radius: number, ratio: number | null | undefined): string {

--- a/src/app/widgets/widget-charger/widget-charger.component.ts
+++ b/src/app/widgets/widget-charger/widget-charger.component.ts
@@ -12,7 +12,7 @@ import type { ITheme } from '../../core/services/app-service';
 import type { ChargerDisplayModel, ChargerSnapshot } from './widget-charger.types';
 import { ELECTRICAL_DIRECT_CARD_COMPACT_LAYOUT, ELECTRICAL_DIRECT_CARD_FULL_LAYOUT, ELECTRICAL_DIRECT_CARD_GAP, ELECTRICAL_DIRECT_CARD_HEIGHT, ELECTRICAL_DIRECT_CARD_VIEWBOX_WIDTH, ELECTRICAL_DIRECT_COMPACT_CARD_HEIGHT } from '../shared/electrical-card-layout.constants';
 import { normalizeOptionalString, normalizeTrackedDevices, buildIdToDeviceKeysMap } from '../shared/electrical-config.util';
-import { setValue, setMetricValue, toStringValue, toBoolean, resolveMostSevereState } from '../shared/electrical-apply.util';
+import { setValue, setMetricValue, toStringValue, toBoolean, toNumber, resolveMostSevereState } from '../shared/electrical-apply.util';
 import { ElectricalIngestScheduler } from '../shared/electrical-ingest-scheduler';
 import { WidgetTitleComponent } from '../../core/components/widget-title/widget-title.component';
 
@@ -405,27 +405,27 @@ export class WidgetChargerComponent implements AfterViewInit {
       case 'modeState':
         return setMetricValue(snapshot, 'mode', 'modeState', toStringValue(value), state);
       case 'modeNumber':
-        return setMetricValue(snapshot, 'modeNumber', 'modeNumberState', this.toNumber(value, ''), state);
+        return setMetricValue(snapshot, 'modeNumber', 'modeNumberState', toNumber(this.units, value, ''), state);
       case 'chargingMode':
         return setMetricValue(snapshot, 'chargingMode', 'chargingModeState', toStringValue(value), state);
       case 'chargingModeNumber':
-        return setMetricValue(snapshot, 'chargingModeNumber', 'chargingModeNumberState', this.toNumber(value, ''), state);
+        return setMetricValue(snapshot, 'chargingModeNumber', 'chargingModeNumberState', toNumber(this.units, value, ''), state);
       case 'output.voltage': {
-        const nextVoltage = this.toNumber(value, 'V');
+        const nextVoltage = toNumber(this.units, value, 'V');
         const outputChanged = setMetricValue(snapshot, 'outputVoltage', 'outputVoltageState', nextVoltage, state);
         const voltageChanged = setMetricValue(snapshot, 'voltage', 'voltageState', nextVoltage, state);
         return outputChanged || voltageChanged;
       }
       case 'input.voltage':
-        return setMetricValue(snapshot, 'inputVoltage', 'inputVoltageState', this.toNumber(value, 'V'), state);
+        return setMetricValue(snapshot, 'inputVoltage', 'inputVoltageState', toNumber(this.units, value, 'V'), state);
       case 'voltage':
-        return setMetricValue(snapshot, 'voltage', 'voltageState', this.toNumber(value, 'V'), state);
+        return setMetricValue(snapshot, 'voltage', 'voltageState', toNumber(this.units, value, 'V'), state);
       case 'current':
-        return setMetricValue(snapshot, 'current', 'currentState', this.toNumber(value, 'A'), state);
+        return setMetricValue(snapshot, 'current', 'currentState', toNumber(this.units, value, 'A'), state);
       case 'power':
-        return setMetricValue(snapshot, 'rawPower', 'powerState', this.toNumber(value, 'W'), state);
+        return setMetricValue(snapshot, 'rawPower', 'powerState', toNumber(this.units, value, 'W'), state);
       case 'temperature':
-        return setMetricValue(snapshot, 'temperature', 'temperatureState', this.toNumber(value, 'K'), state);
+        return setMetricValue(snapshot, 'temperature', 'temperatureState', toNumber(this.units, value, 'K'), state);
       case 'leds.absorption':
         return setMetricValue(snapshot, 'ledsAbsorption', 'ledsAbsorptionState', toBoolean(value), state);
       case 'leds.bulk':
@@ -765,19 +765,5 @@ export class WidgetChargerComponent implements AfterViewInit {
     }
 
     return `${converted.toFixed(0)}`;
-  }
-
-  private toNumber(value: unknown, unitHint: string): number | null {
-    if (value == null || typeof value === 'boolean') {
-      return null;
-    }
-
-    const rawNumber = typeof value === 'number' ? value : Number(value);
-    if (!Number.isFinite(rawNumber)) {
-      return null;
-    }
-
-    const converted = this.units.convertToUnit(unitHint, rawNumber);
-    return Number.isFinite(converted) ? converted : rawNumber;
   }
 }

--- a/src/app/widgets/widget-inverter/widget-inverter.component.ts
+++ b/src/app/widgets/widget-inverter/widget-inverter.component.ts
@@ -12,7 +12,7 @@ import type { ElectricalCardDisplayMode } from '../../core/contracts/electrical-
 import type { InverterDisplayModel, InverterSnapshot, InverterWidgetConfig, ElectricalCardModeConfig } from './widget-inverter.types';
 import { WidgetTitleComponent } from '../../core/components/widget-title/widget-title.component';
 import { normalizeOptionalString, normalizeStringList, normalizeTrackedDevices } from '../shared/electrical-config.util';
-import { setValue, setMetricValue, toStringValue, toBoolean, resolveMostSevereState } from '../shared/electrical-apply.util';
+import { setValue, setMetricValue, toStringValue, toBoolean, toNumber, resolveMostSevereState } from '../shared/electrical-apply.util';
 import { ElectricalIngestScheduler } from '../shared/electrical-ingest-scheduler';
 import { ElectricalTopologyStore, type ElectricalTopologyEntry } from '../shared/electrical-topology-store';
 import { drawDirectCards, initDirectCardSvg } from '../shared/electrical-direct-card-draw';
@@ -274,28 +274,28 @@ export class WidgetInverterComponent implements AfterViewInit {
       case 'name': return setValue(snapshot, 'name', toStringValue(value));
       case 'location': return setValue(snapshot, 'location', toStringValue(value));
       case 'associatedBus': return setValue(snapshot, 'associatedBus', toStringValue(value));
-      case 'dc.voltage': return setMetricValue(snapshot, 'dcVoltage', 'dcVoltageState', this.toNumber(value, 'V'), state);
-      case 'dc.current': return setMetricValue(snapshot, 'dcCurrent', 'dcCurrentState', this.toNumber(value, 'A'), state);
-      case 'acin.voltage': return setMetricValue(snapshot, 'acInVoltage', 'acInVoltageState', this.toNumber(value, 'V'), state);
-      case 'acin.current': return setMetricValue(snapshot, 'acInCurrent', 'acInCurrentState', this.toNumber(value, 'A'), state);
-      case 'acin.frequency': return setMetricValue(snapshot, 'acInFrequency', 'acInFrequencyState', this.toNumber(value, 'Hz'), state);
-      case 'acin.power': return setMetricValue(snapshot, 'acInPower', 'acInPowerState', this.toNumber(value, 'W'), state);
-      case 'acin.1.currentLimit': return setMetricValue(snapshot, 'acIn1CurrentLimit', 'acIn1CurrentLimitState', this.toNumber(value, 'A'), state);
-      case 'acin.currentLimit': return setMetricValue(snapshot, 'acInCurrentLimit', 'acInCurrentLimitState', this.toNumber(value, 'A'), state);
+      case 'dc.voltage': return setMetricValue(snapshot, 'dcVoltage', 'dcVoltageState', toNumber(this.units, value, 'V'), state);
+      case 'dc.current': return setMetricValue(snapshot, 'dcCurrent', 'dcCurrentState', toNumber(this.units, value, 'A'), state);
+      case 'acin.voltage': return setMetricValue(snapshot, 'acInVoltage', 'acInVoltageState', toNumber(this.units, value, 'V'), state);
+      case 'acin.current': return setMetricValue(snapshot, 'acInCurrent', 'acInCurrentState', toNumber(this.units, value, 'A'), state);
+      case 'acin.frequency': return setMetricValue(snapshot, 'acInFrequency', 'acInFrequencyState', toNumber(this.units, value, 'Hz'), state);
+      case 'acin.power': return setMetricValue(snapshot, 'acInPower', 'acInPowerState', toNumber(this.units, value, 'W'), state);
+      case 'acin.1.currentLimit': return setMetricValue(snapshot, 'acIn1CurrentLimit', 'acIn1CurrentLimitState', toNumber(this.units, value, 'A'), state);
+      case 'acin.currentLimit': return setMetricValue(snapshot, 'acInCurrentLimit', 'acInCurrentLimitState', toNumber(this.units, value, 'A'), state);
       case 'acState.acIn1Available': return setMetricValue(snapshot, 'acIn1Available', 'acIn1AvailableState', toBoolean(value), state);
       case 'acState.ignoreAcIn1.state': return setMetricValue(snapshot, 'ignoreAcIn1', 'ignoreAcIn1State', toBoolean(value), state);
-      case 'ac.voltage': return setMetricValue(snapshot, 'acVoltage', 'acVoltageState', this.toNumber(value, 'V'), state);
-      case 'ac.current': return setMetricValue(snapshot, 'acCurrent', 'acCurrentState', this.toNumber(value, 'A'), state);
-      case 'ac.frequency': return setMetricValue(snapshot, 'acFrequency', 'acFrequencyState', this.toNumber(value, 'Hz'), state);
-      case 'acout.voltage': return setMetricValue(snapshot, 'acOutVoltage', 'acOutVoltageState', this.toNumber(value, 'V'), state);
-      case 'acout.current': return setMetricValue(snapshot, 'acOutCurrent', 'acOutCurrentState', this.toNumber(value, 'A'), state);
-      case 'acout.frequency': return setMetricValue(snapshot, 'acOutFrequency', 'acOutFrequencyState', this.toNumber(value, 'Hz'), state);
-      case 'acout.power': return setMetricValue(snapshot, 'acOutPower', 'acOutPowerState', this.toNumber(value, 'W'), state);
+      case 'ac.voltage': return setMetricValue(snapshot, 'acVoltage', 'acVoltageState', toNumber(this.units, value, 'V'), state);
+      case 'ac.current': return setMetricValue(snapshot, 'acCurrent', 'acCurrentState', toNumber(this.units, value, 'A'), state);
+      case 'ac.frequency': return setMetricValue(snapshot, 'acFrequency', 'acFrequencyState', toNumber(this.units, value, 'Hz'), state);
+      case 'acout.voltage': return setMetricValue(snapshot, 'acOutVoltage', 'acOutVoltageState', toNumber(this.units, value, 'V'), state);
+      case 'acout.current': return setMetricValue(snapshot, 'acOutCurrent', 'acOutCurrentState', toNumber(this.units, value, 'A'), state);
+      case 'acout.frequency': return setMetricValue(snapshot, 'acOutFrequency', 'acOutFrequencyState', toNumber(this.units, value, 'Hz'), state);
+      case 'acout.power': return setMetricValue(snapshot, 'acOutPower', 'acOutPowerState', toNumber(this.units, value, 'W'), state);
       case 'inverterMode': return setMetricValue(snapshot, 'inverterMode', 'inverterModeState', toStringValue(value), state);
-      case 'inverterModeNumber': return setMetricValue(snapshot, 'inverterModeNumber', 'inverterModeNumberState', this.toNumber(value, ''), state);
+      case 'inverterModeNumber': return setMetricValue(snapshot, 'inverterModeNumber', 'inverterModeNumberState', toNumber(this.units, value, ''), state);
       case 'preferRenewableEnergy': return setMetricValue(snapshot, 'preferRenewableEnergy', 'preferRenewableEnergyState', toBoolean(value), state);
       case 'preferRenewableEnergyActive': return setMetricValue(snapshot, 'preferRenewableEnergyActive', 'preferRenewableEnergyActiveState', toBoolean(value), state);
-      case 'temperature': return setMetricValue(snapshot, 'temperature', 'temperatureState', this.toNumber(value, 'K'), state);
+      case 'temperature': return setMetricValue(snapshot, 'temperature', 'temperatureState', toNumber(this.units, value, 'K'), state);
       default: return false;
     }
   }
@@ -398,14 +398,6 @@ export class WidgetInverterComponent implements AfterViewInit {
     const converted = this.units.convertToUnit(measure, value);
     if (converted == null || !Number.isFinite(converted)) return '-';
     return `${converted.toFixed(1)} ${this.units.getUnitDisplaySymbol(measure)}`;
-  }
-
-  private toNumber(value: unknown, unitHint: string): number | null {
-    if (value == null || typeof value === 'boolean') return null;
-    const rawNumber = typeof value === 'number' ? value : Number(value);
-    if (!Number.isFinite(rawNumber)) return null;
-    const converted = this.units.convertToUnit(unitHint, rawNumber);
-    return typeof converted === 'number' && Number.isFinite(converted) ? converted : null;
   }
 
 }

--- a/src/app/widgets/widget-solar-charger/widget-solar-charger.component.ts
+++ b/src/app/widgets/widget-solar-charger/widget-solar-charger.component.ts
@@ -11,8 +11,8 @@ import type { ElectricalCardModeConfig, ElectricalTrackedDevice, SolarChargerDis
 import { getElectricalWidgetFamilyDescriptor } from '../../core/contracts/electrical-widget-family.contract';
 import type { ElectricalCardDisplayMode } from '../../core/contracts/electrical-topology-card.contract';
 import { ELECTRICAL_DIRECT_CARD_GAP, ELECTRICAL_DIRECT_CARD_HEIGHT, ELECTRICAL_DIRECT_CARD_VIEWBOX_WIDTH, ELECTRICAL_DIRECT_CARD_FULL_LAYOUT } from '../shared/electrical-card-layout.constants';
-import { normalizeOptionalString, normalizeStringList } from '../shared/electrical-config.util';
-import { setValue, resolveMostSevereState } from '../shared/electrical-apply.util';
+import { normalizeOptionalString, normalizeStringList, normalizeTrackedDevices } from '../shared/electrical-config.util';
+import { setValue, toNumber, resolveMostSevereState } from '../shared/electrical-apply.util';
 import { ElectricalIngestScheduler } from '../shared/electrical-ingest-scheduler';
 import type { ElectricalTopologyEntry } from '../shared/electrical-topology-store';
 import { WidgetTitleComponent } from '../../core/components/widget-title/widget-title.component';
@@ -344,7 +344,7 @@ export class WidgetSolarChargerComponent implements AfterViewInit {
 
   private resolveSolarConfig(cfg: IWidgetSvcConfig): SolarWidgetConfig {
     const solar = cfg.solarCharger;
-    const trackedDevices = this.normalizeTrackedDevices(solar?.trackedDevices);
+    const trackedDevices = normalizeTrackedDevices(solar?.trackedDevices);
     const optionsById = this.normalizeOptionsById(solar?.optionsById);
 
     return {
@@ -352,42 +352,6 @@ export class WidgetSolarChargerComponent implements AfterViewInit {
       optionsById,
       cardMode: this.normalizeCardMode(solar?.cardMode)
     };
-  }
-
-  private normalizeTrackedDevices(value: unknown): ElectricalTrackedDevice[] {
-    if (!Array.isArray(value)) {
-      return [];
-    }
-
-    const devices = new Map<string, ElectricalTrackedDevice>();
-    value.forEach(item => {
-      if (typeof item === 'string') {
-        const id = item.trim();
-        if (!id) return;
-        const key = `${id}||default`;
-        devices.set(key, { id, source: 'default', key });
-        return;
-      }
-
-      if (!item || typeof item !== 'object') {
-        return;
-      }
-
-      const candidate = item as { id?: unknown; source?: unknown; key?: unknown };
-      const id = typeof candidate.id === 'string' ? candidate.id.trim() : '';
-      const source = typeof candidate.source === 'string' ? candidate.source.trim() : 'default';
-      if (!id || !source) {
-        return;
-      }
-
-      const key = typeof candidate.key === 'string' && candidate.key.trim().length > 0
-        ? candidate.key.trim()
-        : `${id}||${source}`;
-
-      devices.set(key, { id, source, key });
-    });
-
-    return [...devices.values()].sort((left, right) => left.key.localeCompare(right.key));
   }
 
   private reprojectSnapshotsToDeviceKeys(devices: ElectricalTrackedDevice[]): void {
@@ -568,7 +532,7 @@ export class WidgetSolarChargerComponent implements AfterViewInit {
       case 'location': return setValue(charger, 'location', this.toStringValue(value));
       case 'associatedBus': return setValue(charger, 'associatedBus', this.toStringValue(value));
       case 'voltage': {
-        const nextValue = this.toNumber(value, 'V');
+        const nextValue = toNumber(this.units, value, 'V');
         const stateChanged = !Object.is(charger.voltageState ?? null, state ?? null);
         if (Object.is(charger.voltage, nextValue) && !stateChanged) return false;
         charger.voltage = nextValue;
@@ -576,7 +540,7 @@ export class WidgetSolarChargerComponent implements AfterViewInit {
         return true;
       }
       case 'current': {
-        const nextValue = this.toNumber(value, 'A');
+        const nextValue = toNumber(this.units, value, 'A');
         const stateChanged = !Object.is(charger.currentState ?? null, state ?? null);
         if (Object.is(charger.current, nextValue) && !stateChanged) return false;
         charger.current = nextValue;
@@ -585,7 +549,7 @@ export class WidgetSolarChargerComponent implements AfterViewInit {
       }
       case 'power': return this.setPowerPathValue(charger, 'rawBatteryPower', value);
       case 'temperature': {
-        const nextValue = this.toNumber(value, 'K');
+        const nextValue = toNumber(this.units, value, 'K');
         const stateChanged = !Object.is(charger.temperatureState ?? null, state ?? null);
         charger.temperaturePath = path;
         if (Object.is(charger.temperature, nextValue) && !stateChanged) return false;
@@ -596,11 +560,11 @@ export class WidgetSolarChargerComponent implements AfterViewInit {
       case 'chargingAlgorithm': return setValue(charger, 'chargingAlgorithm', this.toStringValue(value));
       case 'chargerRole': return setValue(charger, 'chargerRole', this.toStringValue(value));
       case 'chargingMode': return setValue(charger, 'chargingMode', this.toStringValue(value));
-      case 'setpointVoltage': return setValue(charger, 'setpointVoltage', this.toNumber(value, 'V'));
-      case 'setpointCurrent': return setValue(charger, 'setpointCurrent', this.toNumber(value, 'A'));
+      case 'setpointVoltage': return setValue(charger, 'setpointVoltage', toNumber(this.units, value, 'V'));
+      case 'setpointCurrent': return setValue(charger, 'setpointCurrent', toNumber(this.units, value, 'A'));
       case 'controllerMode': return setValue(charger, 'controllerMode', this.toStringValue(value));
       case 'panelVoltage': {
-        const nextValue = this.toNumber(value, 'V');
+        const nextValue = toNumber(this.units, value, 'V');
         const stateChanged = !Object.is(charger.panelVoltageState ?? null, state ?? null);
         if (Object.is(charger.panelVoltage, nextValue) && !stateChanged) return false;
         charger.panelVoltage = nextValue;
@@ -608,7 +572,7 @@ export class WidgetSolarChargerComponent implements AfterViewInit {
         return true;
       }
       case 'panelCurrent': {
-        const nextValue = this.toNumber(value, 'A');
+        const nextValue = toNumber(this.units, value, 'A');
         const stateChanged = !Object.is(charger.panelCurrentState ?? null, state ?? null);
         if (Object.is(charger.panelCurrent, nextValue) && !stateChanged) return false;
         charger.panelCurrent = nextValue;
@@ -616,17 +580,17 @@ export class WidgetSolarChargerComponent implements AfterViewInit {
         return true;
       }
       case 'panelPower': {
-        const nextValue = this.toNumber(value, 'W');
+        const nextValue = toNumber(this.units, value, 'W');
         const stateChanged = !Object.is(charger.panelPowerState ?? null, state ?? null);
         if (Object.is(charger.rawPanelPower, nextValue) && !stateChanged) return false;
         charger.rawPanelPower = nextValue;
         charger.panelPowerState = state;
         return true;
       }
-      case 'yieldToday': return setValue(charger, 'yieldToday', this.toNumber(value, 'kWh'));
-      case 'yieldYesterday': return setValue(charger, 'yieldYesterday', this.toNumber(value, 'kWh'));
+      case 'yieldToday': return setValue(charger, 'yieldToday', toNumber(this.units, value, 'kWh'));
+      case 'yieldYesterday': return setValue(charger, 'yieldYesterday', toNumber(this.units, value, 'kWh'));
       case 'panelTemperature': {
-        const nextValue = this.toNumber(value, 'K');
+        const nextValue = toNumber(this.units, value, 'K');
         const stateChanged = !Object.is(charger.panelTemperatureState ?? null, state ?? null);
         charger.panelTemperaturePath = path;
         if (Object.is(charger.panelTemperature, nextValue) && !stateChanged) return false;
@@ -639,7 +603,7 @@ export class WidgetSolarChargerComponent implements AfterViewInit {
       case 'load.state':
         return setValue(charger, 'load', value as string | number | boolean | null);
       case 'loadCurrent': {
-        const nextValue = this.toNumber(value, 'A');
+        const nextValue = toNumber(this.units, value, 'A');
         const stateChanged = !Object.is(charger.loadCurrentState ?? null, state ?? null);
         if (Object.is(charger.loadCurrent, nextValue) && !stateChanged) return false;
         charger.loadCurrent = nextValue;
@@ -652,7 +616,7 @@ export class WidgetSolarChargerComponent implements AfterViewInit {
   }
 
   private setPowerPathValue(charger: SolarChargerSnapshot, key: 'rawBatteryPower' | 'rawPanelPower', value: unknown): boolean {
-    const parsedValue = this.toNumber(value, 'W');
+    const parsedValue = toNumber(this.units, value, 'W');
     return setValue(charger, key, parsedValue);
   }
 
@@ -904,11 +868,6 @@ export class WidgetSolarChargerComponent implements AfterViewInit {
 
   private resolveTitleText(solar: SolarChargerSnapshot): string {
     return solar.name || `Solar ${solar.id}`;
-  }
-
-  private toNumber(value: unknown, unit: string): number | null {
-    if (value == null || typeof value !== 'number') return null;
-    return this.units.convertToUnit(unit, value) ?? value;
   }
 
   private isRelayActive(value: string | number | boolean | null | undefined): boolean {


### PR DESCRIPTION
## What & why

Closes out #351 (D2 + D3): folds the electrical widget family's divergent private helpers onto shared implementations, eliminating the copy-paste drift the issue triaged (D1, the severity bug, already shipped in #371). Behaviour-preserving on real Signal K data — the divergent branches were inert or unrendered — with two honestly-acknowledged edge changes (below).

## Approach

**D2 — `toNumber` / `toFiniteNumber`** (extracted to `electrical-apply.util`):
- `toNumber(units, value, hint)` — coerces genuine numeric strings **(footgun-guarded: blank/whitespace → null, never silently `Number('')===0`)**, applies the unit conversion, then falls back to the raw value when the conversion is non-finite. Replaces the six private copies.
- Aligns **inverter/ac** (which used a null-fallback) onto the raw-fallback the rest of the family already used.
- **bms** keeps its no-conversion model via the strict `toFiniteNumber` (it converts at format time via `resolvePathMeasure`).

**D3 — `normalizeTrackedDevices`** (shared `electrical-config.util`):
- solar-charger and bms drop their private copies; solar's vestigial bare-string branch (dead since the `trackedSolarIds` key was renamed, no producer/migration) is removed.
- The shared helper now **defaults a missing source to `'default'` (kept)** to match `root-modal` save, instead of dropping source-less items — reconciling the parse-vs-save inconsistency the triage flagged.

## Review — adversarial pass findings (all addressed)

A dedicated adversarial reviewer attacked the "behaviour-preserving" claim. Three of four claims held; two things surfaced and are handled:

1. **Dropped string coercion was a *deliberate* defense** (the quad's old `Number(value)`; `convertToUnit` still carries `+value; // sometime we get strings here`). The initial extraction had switched to a strict guard, which would regress default-rendered voltage/current to blank if any source ever stringifies. **Resolved** by the footgun-guarded coercion above — preserves the defense *and* fixes the `Number('')===0` footgun the triage worried about.
2. **inverter `inverterModeNumber`**: the old null-fallback + `''` hint made this field *permanently* null (always "Mode# -" — a latent bug). Raw-fallback now shows the actual mode number. Reachable only via a hand-authored `cardMode.metrics` (the default excludes it, no config UI writes it); the displayed value is correct. **Acknowledged** as a benign latent-bug fix, not claimed as inert.

Inert-verified (no change on real data): AC uses only valid conversion hints; tracked-device configs Skip produces always carry a source; bms's `Set<id>` and solar's `reprojectSnapshotsToDeviceKeys` both operate unchanged on the shared `{id,source,key}` output; bms NaN/Infinity nulling can't arrive over JSON deltas.

## Verification

`npm run snc` + `npm run lint` green; full suite passes; the two shared-util specs + all six electrical widget specs green (126 tests in the focused run). Net −44 lines.

ac's `normalizeAcTrackedDevices` (separate AC-phase variant) intentionally untouched.

Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)
