### PR TITLE
Regression test for dataset-chart null-path init (#329, already fixed)

### DIFF
--- a/src/app/widget-config/dataset-chart-options/dataset-chart-options.component.spec.ts
+++ b/src/app/widget-config/dataset-chart-options/dataset-chart-options.component.spec.ts
@@ -51,6 +51,21 @@ describe('DatasetChartOptionsComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  it('does not crash on init when a configured path has no resolvable data (#329)', () => {
+    // A saved config references a path whose data has not (yet) arrived in _skData,
+    // so getPathObject returns null. ngOnInit must skip setPathSources, not deref null.
+    pathObject = null;
+    const fx = TestBed.createComponent(DatasetChartOptionsComponent);
+    const set = fx.componentRef.setInput.bind(fx.componentRef) as (k: string, v: unknown) => void;
+    set('filterSelfPaths', new UntypedFormControl(false));
+    set('datachartPath', new UntypedFormControl('self.navigation.speedOverGround'));
+    set('datachartSource', new UntypedFormControl({ value: '', disabled: true }));
+    set('timeScale', new UntypedFormControl(''));
+    set('period', new UntypedFormControl(''));
+    expect(() => fx.detectChanges()).not.toThrow();
+    expect(fx.componentInstance).toBeTruthy();
+  });
+
   const setPathSources = (obj: Pick<ISkPathData, 'sources'>) =>
     (component as unknown as { setPathSources: (p: unknown) => void }).setPathSources(obj);
   const changePath = (path: string) =>


### PR DESCRIPTION
## What & why

#329 reported that `DatasetChartOptionsComponent.ngOnInit` crashes on a configured path whose data hasn't arrived in `_skData` (unguarded null from `getPathObject`). **That bug is already fixed** — and, better, type-enforced:

- The `if (pathObject) { setPathSources(pathObject) }` guard landed in the strictNullChecks pass (`28aa36b0`). Removing it now doesn't just risk a runtime crash — it **fails to compile** (`setPathSources(ISkPathData)` can't take a nullable), so the regression can't silently recur.
- The issue's second unguarded call — `unitList.set(getConversionsForPath(...))` — was removed entirely with the units retirement (`5832791f`).

What was missing was **coverage**: the spec booted an empty `datachartPath`, so `if (currentPath)` was false and the guard branch never ran in any test.

## Change

Adds the one missing regression test: boot the component with a configured `datachartPath` while `getPathObject` returns null, and assert `ngOnInit` (via `detectChanges`) does not throw. Locks the graceful-skip behaviour for the exact #329 scenario. No production code change.

## Verification

`npm run snc` + `npm run lint` green; the dataset-chart-options spec passes (6 tests). Verified the test is meaningful: it passes with the guard, and removing the guard breaks the build (confirming the fix is type-enforced).

Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)
