### PR TITLE
fix(electrical): drop stale device-key cards when untracking a device (#354)

### DIFF
--- a/src/app/widgets/shared/electrical-topology-store.spec.ts
+++ b/src/app/widgets/shared/electrical-topology-store.spec.ts
@@ -91,4 +91,102 @@ describe('ElectricalTopologyStore', () => {
     expect(map['a1||victron']?.source).toBe('victron');
     expect(store.visibleKeys()).toEqual(['a1||n2k', 'a1||victron']);
   });
+
+  it('re-keys an untracked device back to a discovered plain-id, keeping the card (#354)', () => {
+    const store = new ElectricalTopologyStore(config);
+    store.applyConfig([device('278', 'victron.0')]);
+    store.processBatch([entry('278', 'voltage', 12)]);
+    expect(store.store()['278||victron.0']?.voltage).toBe(12);
+
+    store.applyConfig([]); // untrack the device
+
+    const map = store.store();
+    expect(map['278||victron.0']).toBeUndefined(); // stale device-key does not survive
+    expect(map['278']?.voltage).toBe(12); // preserved as a discovered plain-id
+    expect(map['278']?.deviceKey).toBeUndefined();
+    expect(store.visibleKeys()).toEqual(['278']);
+  });
+
+  it('never renders a duplicate card for a device tracked then untracked then re-seen (#354)', () => {
+    const store = new ElectricalTopologyStore(config);
+    store.applyConfig([device('278', 'victron.0')]);
+    store.processBatch([entry('278', 'voltage', 12)]);
+
+    store.applyConfig([]); // untrack
+    store.processBatch([entry('278', 'voltage', 13)]); // a later live delta for the same id
+
+    const map = store.store();
+    const keysForId278 = Object.keys(map).filter(key => map[key]?.id === '278');
+    expect(keysForId278).toEqual(['278']); // exactly one entry for the id
+    expect(map['278']?.voltage).toBe(13);
+    expect(store.visibleKeys()).toEqual(['278']);
+  });
+
+  it('holds no deviceKey-bearing snapshot once every device is untracked (#354 invariant)', () => {
+    const store = new ElectricalTopologyStore(config);
+    store.applyConfig([device('a1', 'n2k'), device('b2', 'victron')]);
+    store.processBatch([entry('a1', 'voltage', 1), entry('b2', 'voltage', 2)]);
+    expect(Object.keys(store.store()).sort()).toEqual(['a1||n2k', 'b2||victron']);
+
+    store.applyConfig([]); // untrack all
+
+    const snapshots = Object.values(store.store());
+    expect(snapshots.every(snapshot => snapshot.deviceKey === undefined)).toBe(true);
+    expect(store.visibleKeys()).toEqual(['a1', 'b2']);
+  });
+
+  it('keeps the still-tracked key and re-keys the untracked one on a partial untrack (#354)', () => {
+    const store = new ElectricalTopologyStore(config);
+    store.applyConfig([device('a1', 'n2k'), device('b2', 'victron')]);
+    store.processBatch([entry('a1', 'voltage', 1), entry('b2', 'voltage', 2)]);
+
+    store.applyConfig([device('a1', 'n2k')]); // untrack b2 only
+
+    const map = store.store();
+    expect(map['a1||n2k']?.voltage).toBe(1);
+    expect(map['b2||victron']).toBeUndefined();
+    expect(map['b2']?.voltage).toBe(2);
+    expect(map['b2']?.deviceKey).toBeUndefined();
+    expect(store.visibleKeys()).toEqual(['a1||n2k']); // discovered b2 hidden while a1 tracked
+  });
+
+  it('drops one source of a still-tracked id without leaving a phantom discovered card (#354)', () => {
+    const store = new ElectricalTopologyStore(config);
+    store.applyConfig([device('a1', 'n2k'), device('a1', 'victron')]);
+    store.processBatch([entry('a1', 'voltage', 12)]);
+
+    store.applyConfig([device('a1', 'n2k')]); // drop the victron source; id a1 still tracked via n2k
+
+    const map = store.store();
+    expect(map['a1||n2k']?.voltage).toBe(12);
+    expect(map['a1||victron']).toBeUndefined();
+    expect(map['a1']).toBeUndefined(); // no phantom plain-id — id still tracked
+    expect(Object.keys(map).filter(key => map[key]?.id === 'a1')).toEqual(['a1||n2k']);
+    expect(store.visibleKeys()).toEqual(['a1||n2k']);
+  });
+
+  it('collapses multiple sources of one id to a single discovered card on full untrack (#354)', () => {
+    const store = new ElectricalTopologyStore(config);
+    store.applyConfig([device('a1', 'n2k'), device('a1', 'victron')]);
+    store.processBatch([entry('a1', 'voltage', 12)]);
+    expect(Object.keys(store.store()).sort()).toEqual(['a1||n2k', 'a1||victron']);
+
+    store.applyConfig([]); // untrack all
+
+    const map = store.store();
+    expect(Object.keys(map).filter(key => map[key]?.id === 'a1')).toEqual(['a1']);
+    expect(map['a1']?.deviceKey).toBeUndefined();
+    expect(map['a1']?.voltage).toBe(12);
+    expect(store.visibleKeys()).toEqual(['a1']);
+  });
+
+  it('does not commit the store when re-applying an identical device set', () => {
+    const store = new ElectricalTopologyStore(config);
+    store.applyConfig([device('a1', 'n2k')]);
+    store.processBatch([entry('a1', 'voltage', 12)]);
+    const before = store.store();
+
+    store.applyConfig([device('a1', 'n2k')]); // identical config, no intervening data change
+    expect(store.store()).toBe(before);
+  });
 });

--- a/src/app/widgets/shared/electrical-topology-store.ts
+++ b/src/app/widgets/shared/electrical-topology-store.ts
@@ -25,8 +25,10 @@ export interface ElectricalTopologyConfig<TSnapshot extends IElectricalTopologyS
  * Source-blind keyed-snapshot store shared by the electrical widget family
  * (alternator, inverter, ac, solar). Owns the by-key snapshot store, the
  * discovered-id and tracked-device signals, the batch-apply flush body,
- * reproject (re-key id-arrived-before-config snapshots onto configured device
- * keys), and the tracked-else-discovered visible selection. Per-widget metric
+ * reproject (reconcile snapshots to the tracked set: re-key id-arrived-before-config
+ * snapshots onto configured device keys, and re-key an untracked device's snapshot
+ * back to a discovered plain-id so no stale device-key card lingers), and the
+ * tracked-else-discovered visible selection. Per-widget metric
  * mapping and derivation are injected seams. Charger's source-qualified variant
  * and bms's id-only store compose their own paths (Stage 2b/2d).
  */
@@ -111,43 +113,59 @@ export class ElectricalTopologyStore<TSnapshot extends IElectricalTopologySnapsh
   }
 
   private reproject(devices: ElectricalTrackedDevice[]): void {
-    if (!devices.length) {
-      return;
-    }
-
     const idToKeys = new Map<string, string[]>();
     devices.forEach(device => {
       const existing = idToKeys.get(device.id) ?? [];
       existing.push(device.key);
       idToKeys.set(device.id, existing);
     });
+    const trackedKeys = new Set(devices.map(device => device.key));
 
     this._store.update(current => {
       let next = current;
       let changed = false;
+      const forkStore = (): void => {
+        if (!changed) {
+          next = { ...current };
+          changed = true;
+        }
+      };
 
       idToKeys.forEach((keys, id) => {
         const sourceSnapshot = current[id];
         if (!sourceSnapshot) {
           return;
         }
-
         for (const deviceKey of keys) {
           if (current[deviceKey]) {
             continue;
           }
           const trackedDevice = devices.find(device => device.key === deviceKey);
-          if (!changed) {
-            next = { ...current };
-            changed = true;
-          }
+          forkStore();
           next[deviceKey] = { ...sourceSnapshot, source: trackedDevice?.source ?? null, deviceKey };
         }
-
-        if (changed && next[id]?.deviceKey === undefined) {
-          delete next[id];
-        }
       });
+
+      for (const key of Object.keys(current)) {
+        const snapshot = current[key];
+        if (!snapshot) {
+          continue;
+        }
+        if (snapshot.deviceKey === undefined) {
+          if (idToKeys.has(snapshot.id)) {
+            forkStore();
+            delete next[key];
+          }
+          continue;
+        }
+        if (!trackedKeys.has(key)) {
+          forkStore();
+          delete next[key];
+          if (!idToKeys.has(snapshot.id) && !next[snapshot.id]) {
+            next[snapshot.id] = { ...snapshot, source: null, deviceKey: undefined };
+          }
+        }
+      }
 
       return changed ? next : current;
     });

--- a/src/app/widgets/widget-solar-charger/widget-solar-charger.component.spec.ts
+++ b/src/app/widgets/widget-solar-charger/widget-solar-charger.component.spec.ts
@@ -201,6 +201,64 @@ describe('WidgetSolarChargerComponent', () => {
     expect(visible.map(item => item.id).sort()).toEqual(['sc1', 'sc2']);
   });
 
+  it('renders no duplicate card for a charger tracked, untracked, then seen again (#354)', () => {
+    runtimeOptions.solarCharger = {
+      trackedDevices: [{ id: 'sc1', source: 'victron.0', key: 'sc1||victron.0' }],
+      optionsById: {}
+    };
+    fixture.detectChanges();
+
+    const probe = component as unknown as {
+      applyConfig: (cfg: unknown) => void;
+      processBatch: (entries: { id: string; key: string; value: unknown; state: States; path: string }[]) => void;
+      visibleSolarUnits: () => { id: string; deviceKey?: string }[];
+    };
+    const readSc1 = () => probe.visibleSolarUnits().filter(unit => unit.id === 'sc1');
+
+    expect(readSc1()).toHaveLength(1);
+    expect(readSc1()[0]?.deviceKey).toBe('sc1||victron.0');
+
+    runtimeOptions.solarCharger = { trackedDevices: [], optionsById: {} };
+    probe.applyConfig({ solarCharger: runtimeOptions.solarCharger });
+
+    // the untracked charger is preserved as a discovered plain-id card
+    expect(readSc1()).toHaveLength(1);
+    expect(readSc1()[0]?.deviceKey).toBeUndefined();
+
+    // a fresh live delta arrives for the previously-tracked id: still one card
+    probe.processBatch([
+      { id: 'sc1', key: 'voltage', value: 14.9, state: States.Normal, path: 'self.electrical.solar.sc1.voltage' }
+    ]);
+
+    const sc1Cards = readSc1();
+    expect(sc1Cards).toHaveLength(1);
+    expect(sc1Cards[0]?.deviceKey).toBeUndefined();
+  });
+
+  it('collapses multiple sources of one charger to a single discovered card on full untrack (#354)', () => {
+    runtimeOptions.solarCharger = {
+      trackedDevices: [
+        { id: 'sc1', source: 'sourceA', key: 'sc1||sourceA' },
+        { id: 'sc1', source: 'sourceB', key: 'sc1||sourceB' }
+      ],
+      optionsById: {}
+    };
+    fixture.detectChanges();
+
+    const probe = component as unknown as {
+      applyConfig: (cfg: unknown) => void;
+      visibleSolarUnits: () => { id: string; deviceKey?: string }[];
+    };
+    expect(probe.visibleSolarUnits().filter(unit => unit.id === 'sc1')).toHaveLength(2);
+
+    runtimeOptions.solarCharger = { trackedDevices: [], optionsById: {} };
+    probe.applyConfig({ solarCharger: runtimeOptions.solarCharger });
+
+    const sc1Cards = probe.visibleSolarUnits().filter(unit => unit.id === 'sc1');
+    expect(sc1Cards).toHaveLength(1);
+    expect(sc1Cards[0]?.deviceKey).toBeUndefined();
+  });
+
   it('uses runtime-provided colorRole and ignoreZones values', () => {
     runtimeOptions.color = 'contrast';
     runtimeOptions.ignoreZones = false;

--- a/src/app/widgets/widget-solar-charger/widget-solar-charger.component.ts
+++ b/src/app/widgets/widget-solar-charger/widget-solar-charger.component.ts
@@ -355,18 +355,20 @@ export class WidgetSolarChargerComponent implements AfterViewInit {
   }
 
   private reprojectSnapshotsToDeviceKeys(devices: ElectricalTrackedDevice[]): void {
-    if (!devices.length) return;
-
     const idToKeys = new Map<string, string[]>();
     devices.forEach(device => {
       const existing = idToKeys.get(device.id) ?? [];
       existing.push(device.key);
       idToKeys.set(device.id, existing);
     });
+    const trackedKeys = new Set(devices.map(device => device.key));
 
     this.chargersByKey.update(current => {
       let next = current;
       let changed = false;
+      const forkStore = (): void => {
+        if (!changed) { next = { ...current }; changed = true; }
+      };
 
       idToKeys.forEach((keys, id) => {
         const sourceSnapshot = current[id];
@@ -375,14 +377,30 @@ export class WidgetSolarChargerComponent implements AfterViewInit {
         for (const deviceKey of keys) {
           if (current[deviceKey]) continue;
           const trackedDevice = devices.find(device => device.key === deviceKey);
-          if (!changed) { next = { ...current }; changed = true; }
+          forkStore();
           next[deviceKey] = { ...sourceSnapshot, source: trackedDevice?.source ?? null, deviceKey };
         }
-
-        if (changed && next[id]?.deviceKey === undefined) {
-          delete next[id];
-        }
       });
+
+      for (const key of Object.keys(current)) {
+        const snapshot = current[key];
+        if (!snapshot) continue;
+
+        if (snapshot.deviceKey === undefined) {
+          if (idToKeys.has(snapshot.id)) {
+            forkStore();
+            delete next[key];
+          }
+          continue;
+        }
+        if (!trackedKeys.has(key)) {
+          forkStore();
+          delete next[key];
+          if (!idToKeys.has(snapshot.id) && !next[snapshot.id]) {
+            next[snapshot.id] = { ...snapshot, source: null, deviceKey: undefined };
+          }
+        }
+      }
 
       return changed ? next : current;
     });


### PR DESCRIPTION
## Why

The source-blind electrical widgets (`widget-alternator`, `widget-inverter`, `widget-ac` via the shared `ElectricalTopologyStore`; `widget-solar-charger` via its own inline copy) left a **stale device-key snapshot** in their by-key store when a previously-tracked device was **untracked**, then rendered a **duplicate card** once a fresh delta arrived for the same id (#354).

Two root gaps:
- `reproject` early-returned on empty devices (`if (!devices.length) return;`), so untracking never pruned the removed device's snapshot.
- A shared `changed`-flag delete-guard made the plain-id cleanup order-dependent (a stale plain-id could survive alongside its device-key entry).

## How

`reproject` now **reconciles the store to the tracked set** instead of only forward-projecting:
1. Re-key plain-id snapshots onto their configured device keys (unchanged).
2. Walk every current key and: drop a plain-id already covered by a device key; for a device-key entry **no longer tracked**, delete it and **re-key it back to a discovered plain-id** (`{ ...snapshot, source: null, deviceKey: undefined }`) unless the id is still tracked or a plain-id already exists.

Re-keying (rather than pruning) is deliberate: an untracked device's card stays visible as a discovered card, and a later delta updates that **same** entry — so no duplicate. The cleanup walk runs regardless of the copy-on-write flag, making the plain-id drop order-independent. Copy-on-write is preserved, so an identical re-apply still returns the store by reference (no spurious signal commit).

Applied identically to the shared store and solar-charger's inline copy.

## Tests

New behavior specs drive the exact track → untrack → re-see sequence and assert the **rendered card set** (`visibleKeys` / `visibleSolarUnits`), not a proxy:
- re-key-back keeps the card; no duplicate on a later delta; the "no deviceKey survives full untrack" invariant.
- partial untrack (one of two ids); untracking one source of a still-tracked multi-source id (no phantom card); multi-source collapse to a single discovered card on full untrack; idempotent re-apply returns the store by reference.
- solar-charger's independent copy gets its own #354 + multi-source-collapse specs.

Full suite green (`npm run snc`, `npm run lint`, unit tests).

## Scope

`widget-charger` carries the **same gap** in its own **source-qualified** reproject, but its visible-key suppression differs (frozen card, not a plain duplicate), so the shared fix is not a drop-in — split out as #376. `widget-bms` is structurally immune (id-only store, no device keys).

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)
