### PR TITLE
fix(charger): drop stale device-key cards when untracking (#376)

### DIFF
--- a/src/app/widgets/widget-charger/widget-charger.component.spec.ts
+++ b/src/app/widgets/widget-charger/widget-charger.component.spec.ts
@@ -193,6 +193,145 @@ describe('WidgetChargerComponent', () => {
     expect(visible.map(v => v.id).sort()).toEqual(['c1', 'c2']);
   });
 
+  it('does not freeze a card behind a stale tracked device-key after untracking (#376)', async () => {
+    await setup(
+      [makeUpdate('self.electrical.chargers.c1.voltage', 12, States.Normal, 'sourceA')],
+      { charger: { trackedDevices: [{ id: 'c1', source: 'sourceA', key: 'c1||sourceA' }] } }
+    );
+    const probe = component as unknown as {
+      applyConfig: (cfg: unknown) => void;
+      processBatch: (entries: { id: string; key: string; source: string | null; value: unknown; state: States }[]) => void;
+      visibleChargers: () => { id: string; voltage?: number | null; deviceKey?: string }[];
+    };
+    expect(probe.visibleChargers().filter(c => c.id === 'c1')).toHaveLength(1);
+
+    runtimeMock.options.mockReturnValue({ charger: { trackedDevices: [] } });
+    probe.applyConfig({ charger: { trackedDevices: [] } });
+
+    // the same device re-reports without a source after being untracked
+    probe.processBatch([{ id: 'c1', key: 'voltage', source: null, value: 13, state: States.Normal }]);
+
+    const c1 = probe.visibleChargers().filter(c => c.id === 'c1');
+    expect(c1).toHaveLength(1);
+    expect(c1[0]?.voltage).toBe(13); // live, not frozen at the stale tracked value
+    expect(c1[0]?.deviceKey).toBeUndefined();
+  });
+
+  it('does not leave a ghost duplicate after untracking then re-seeing under a new source (#376)', async () => {
+    await setup(
+      [makeUpdate('self.electrical.chargers.c1.voltage', 12, States.Normal, 'sourceA')],
+      { charger: { trackedDevices: [{ id: 'c1', source: 'sourceA', key: 'c1||sourceA' }] } }
+    );
+    const probe = component as unknown as {
+      applyConfig: (cfg: unknown) => void;
+      processBatch: (entries: { id: string; key: string; source: string | null; value: unknown; state: States }[]) => void;
+      visibleChargers: () => { id: string; voltage?: number | null; deviceKey?: string }[];
+    };
+
+    runtimeMock.options.mockReturnValue({ charger: { trackedDevices: [] } });
+    probe.applyConfig({ charger: { trackedDevices: [] } });
+
+    probe.processBatch([{ id: 'c1', key: 'voltage', source: 'sourceB', value: 13, state: States.Normal }]);
+
+    const c1 = probe.visibleChargers().filter(c => c.id === 'c1');
+    expect(c1).toHaveLength(1);
+    expect(c1[0]?.voltage).toBe(13);
+    expect(c1[0]?.deviceKey).toBe('c1||sourceB');
+  });
+
+  it('keeps a never-tracked source-qualified discovered card across a config re-apply (#376)', async () => {
+    await setup(
+      [makeUpdate('self.electrical.chargers.c1.voltage', 12, States.Normal, 'sourceA')],
+      { charger: { trackedDevices: [] } }
+    );
+    const probe = component as unknown as {
+      applyConfig: (cfg: unknown) => void;
+      visibleChargers: () => { id: string; deviceKey?: string }[];
+    };
+    let c1 = probe.visibleChargers().filter(c => c.id === 'c1');
+    expect(c1).toHaveLength(1);
+    expect(c1[0]?.deviceKey).toBe('c1||sourceA'); // discovered as source-qualified
+
+    // a benign config re-emit with still-no tracked devices must not collapse the discovered card
+    probe.applyConfig({ charger: { trackedDevices: [] } });
+
+    c1 = probe.visibleChargers().filter(c => c.id === 'c1');
+    expect(c1).toHaveLength(1);
+    expect(c1[0]?.deviceKey).toBe('c1||sourceA');
+  });
+
+  it('drops one source of a still-tracked charger without leaving a phantom plain-id (#376)', async () => {
+    await setup(
+      [
+        makeUpdate('self.electrical.chargers.c1.voltage', 28, States.Normal, 'sourceA'),
+        makeUpdate('self.electrical.chargers.c1.voltage', 31, States.Normal, 'sourceB')
+      ],
+      {
+        charger: {
+          trackedDevices: [
+            { id: 'c1', source: 'sourceA', key: 'c1||sourceA' },
+            { id: 'c1', source: 'sourceB', key: 'c1||sourceB' }
+          ]
+        }
+      }
+    );
+    const probe = component as unknown as {
+      applyConfig: (cfg: unknown) => void;
+      chargersByKey: () => Record<string, { voltage?: number | null; deviceKey?: string }>;
+      visibleChargers: () => { id: string; deviceKey?: string }[];
+    };
+    const cfg = { charger: { trackedDevices: [{ id: 'c1', source: 'sourceB', key: 'c1||sourceB' }] } };
+    runtimeMock.options.mockReturnValue(cfg);
+    probe.applyConfig(cfg);
+
+    const map = probe.chargersByKey();
+    expect(map['c1||sourceA']).toBeUndefined();
+    expect(map['c1']).toBeUndefined(); // id still tracked via sourceB → no phantom plain-id
+    expect(map['c1||sourceB']?.voltage).toBe(31);
+
+    const visible = probe.visibleChargers();
+    expect(visible).toHaveLength(1);
+    expect(visible[0]?.deviceKey).toBe('c1||sourceB');
+  });
+
+  it('does not commit the store when re-applying an identical charger config (#376)', async () => {
+    await setup(
+      [makeUpdate('self.electrical.chargers.c1.voltage', 12, States.Normal, 'sourceA')],
+      { charger: { trackedDevices: [{ id: 'c1', source: 'sourceA', key: 'c1||sourceA' }] } }
+    );
+    const probe = component as unknown as {
+      applyConfig: (cfg: unknown) => void;
+      chargersByKey: () => Record<string, unknown>;
+    };
+    const before = probe.chargersByKey();
+    const cfg = { charger: { trackedDevices: [{ id: 'c1', source: 'sourceA', key: 'c1||sourceA' }] } };
+    runtimeMock.options.mockReturnValue(cfg);
+    probe.applyConfig(cfg);
+
+    expect(probe.chargersByKey()).toBe(before);
+  });
+
+  it('self-heals in place when the same source re-reports after untracking (#376)', async () => {
+    await setup(
+      [makeUpdate('self.electrical.chargers.c1.voltage', 12, States.Normal, 'sourceA')],
+      { charger: { trackedDevices: [{ id: 'c1', source: 'sourceA', key: 'c1||sourceA' }] } }
+    );
+    const probe = component as unknown as {
+      applyConfig: (cfg: unknown) => void;
+      processBatch: (entries: { id: string; key: string; source: string | null; value: unknown; state: States }[]) => void;
+      visibleChargers: () => { id: string; voltage?: number | null; deviceKey?: string }[];
+    };
+    runtimeMock.options.mockReturnValue({ charger: { trackedDevices: [] } });
+    probe.applyConfig({ charger: { trackedDevices: [] } });
+
+    probe.processBatch([{ id: 'c1', key: 'voltage', source: 'sourceA', value: 13, state: States.Normal }]);
+
+    const c1 = probe.visibleChargers().filter(c => c.id === 'c1');
+    expect(c1).toHaveLength(1);
+    expect(c1[0]?.voltage).toBe(13);
+    expect(c1[0]?.deviceKey).toBe('c1||sourceA');
+  });
+
   it('materializes separate cards for same id across different sources', async () => {
     await setup(
       [

--- a/src/app/widgets/widget-charger/widget-charger.component.ts
+++ b/src/app/widgets/widget-charger/widget-charger.component.ts
@@ -246,13 +246,12 @@ export class WidgetChargerComponent implements AfterViewInit {
 
   private applyConfig(cfg: IWidgetSvcConfig): void {
     const trackedDevices = normalizeTrackedDevices(cfg.charger?.trackedDevices);
+    const previousTrackedKeys = new Set(this.trackedDevices().map(device => device.key));
     this.trackedDevices.set(trackedDevices);
-    this.reprojectSnapshotsToDeviceKeys(trackedDevices);
+    this.reprojectSnapshotsToDeviceKeys(trackedDevices, previousTrackedKeys);
   }
 
-  private reprojectSnapshotsToDeviceKeys(devices: ElectricalTrackedDevice[]): void {
-    if (!devices.length) return;
-
+  private reprojectSnapshotsToDeviceKeys(devices: ElectricalTrackedDevice[], previousTrackedKeys: Set<string>): void {
     const idToKeys = new Map<string, string[]>();
     const devicesByKey = new Map<string, ElectricalTrackedDevice>();
     devices.forEach(d => {
@@ -261,10 +260,15 @@ export class WidgetChargerComponent implements AfterViewInit {
       idToKeys.set(d.id, existing);
       devicesByKey.set(d.key, d);
     });
+    const trackedKeys = new Set(devices.map(d => d.key));
+    const untrackedKeys = [...previousTrackedKeys].filter(key => !trackedKeys.has(key));
 
     this.chargersByKey.update(current => {
       let next = current;
       let changed = false;
+      const forkStore = (): void => {
+        if (!changed) { next = { ...current }; changed = true; }
+      };
 
       idToKeys.forEach((keys, id) => {
         const sourceSnapshot = current[id];
@@ -273,18 +277,30 @@ export class WidgetChargerComponent implements AfterViewInit {
         for (const deviceKey of keys) {
           if (current[deviceKey]) continue;
           const trackedDevice = devicesByKey.get(deviceKey);
-          if (!changed) { next = { ...current }; changed = true; }
+          forkStore();
           next[deviceKey] = { ...sourceSnapshot, source: trackedDevice?.source ?? null, deviceKey };
         }
 
         if (next[id] && (next[id].deviceKey === undefined || next[id].deviceKey === id)) {
-          if (!changed) {
-            next = { ...current };
-            changed = true;
-          }
+          forkStore();
           delete next[id];
         }
       });
+
+      // Reconcile removals. A device that was just untracked leaves a source-qualified snapshot
+      // that visibleChargerKeys would keep suppressing a fresh plain-id delta (frozen card) or
+      // rendering alongside a new-source delta (ghost duplicate). Re-key only those just-untracked
+      // keys back to a discovered plain-id so the card persists and any later source-qualified
+      // delta supersedes it. Never-tracked discovered source-qualified snapshots are untouched.
+      for (const key of untrackedKeys) {
+        const snapshot = next[key];
+        if (!snapshot) continue;
+        forkStore();
+        delete next[key];
+        if (!idToKeys.has(snapshot.id) && !next[snapshot.id]) {
+          next[snapshot.id] = { ...snapshot, source: null, deviceKey: undefined };
+        }
+      }
 
       return changed ? next : current;
     });


### PR DESCRIPTION
## Why

Follow-up to #354. `widget-charger` shared the same root gap but in its **own source-qualified** `reprojectSnapshotsToDeviceKeys` (it was never migrated to the shared `ElectricalTopologyStore`), so the #354 fix didn't reach it. Its early-return on empty devices left a tracked device's `id||source` snapshot frozen in the store after untracking. Because `visibleChargerKeys` **suppresses** a plain-id key when a source-qualified key exists for the same id, the stale snapshot then either:
- **froze the card** — a later source-less delta for the id was suppressed, so the card showed the stale value while live updates were dropped; or
- **ghost-duplicated** — a later delta under a *different* source rendered alongside the stale one.

(A *same*-source re-see updated the stale key in place and self-healed, which is why the trigger was narrow.)

## How

Charger is **source-aware**: in the untracked state it legitimately keys *discovered* devices by `id||source` too. So the #354 "re-key every non-tracked device-key back to a plain-id" reconciliation would wrongly **collapse never-tracked discovered source-qualified cards** on any config re-emit. The fix is therefore **diff-based**:

- `applyConfig` captures `previousTrackedKeys` **before** setting the new tracked devices.
- `reproject` drops the empty-devices early-return and, after the forward re-key loop, re-keys back to a discovered plain-id **only the keys that were just untracked** (`previousTrackedKeys \ newTrackedKeys`) — unless the id is still tracked under another source (no phantom plain-id) or a plain-id already exists.

The card persists as a discovered plain-id; any later source-qualified delta supersedes it via the existing suppression. Never-tracked discovered source-qualified snapshots are untouched. Copy-on-write is preserved (identical re-apply returns the store by reference).

## Tests

Six new specs assert the **rendered card set** (`visibleChargers`), not a proxy:
- untrack → source-less re-see shows **live** data, not the frozen value (the frozen bug);
- untrack → different-source re-see yields a **single** card, no ghost (the duplicate bug);
- a **never-tracked** source-qualified discovered card survives a config re-emit (guards the diff-based scope);
- partial multi-source untrack drops only the removed source, leaves **no phantom** plain-id;
- idempotent re-apply returns the store **by reference**;
- untrack → same-source re-see self-heals in place.

An adversarial correctness review of the diff found **zero defects**. `npm run snc` + `npm run lint` clean; full unit suite green.

Closes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)
