### PR TITLE
test(widgets): cover svg-zone-states null-theme init path; close #332 as already-fixed

### DIFF
--- a/src/app/widgets/svg-zone-states/svg-zone-states.component.spec.ts
+++ b/src/app/widgets/svg-zone-states/svg-zone-states.component.spec.ts
@@ -1,0 +1,72 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { SvgZoneStatesComponent } from './svg-zone-states.component';
+import type { IDynamicControl } from '../../core/interfaces/widgets-interface';
+import type { ITheme } from '../../core/services/app-service';
+import { States } from '../../core/interfaces/signalk-interfaces';
+
+const control = (overrides: Partial<IDynamicControl> = {}): IDynamicControl => ({
+  ctrlLabel: 'Zone',
+  type: '4',
+  pathID: 'p1',
+  color: 'contrast',
+  isNumeric: false,
+  ...overrides
+});
+
+const theme = {
+  contrast: '#fff',
+  contrastDim: '#ccc',
+  contrastDimmer: '#999',
+  zoneEmergency: '#f0f',
+  zoneAlarm: '#f00',
+  zoneWarn: '#fa0',
+  zoneAlert: '#ff0',
+  background: '#000'
+} as unknown as ITheme;
+
+describe('SvgZoneStatesComponent', () => {
+  let fixture: ComponentFixture<SvgZoneStatesComponent>;
+  let component: SvgZoneStatesComponent;
+
+  const build = (themeValue: ITheme | null, ctrl: IDynamicControl) => {
+    fixture = TestBed.createComponent(SvgZoneStatesComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('controlData', ctrl);
+    fixture.componentRef.setInput('theme', themeValue);
+    fixture.componentRef.setInput('dimensions', { width: 180, height: 75 });
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({ imports: [SvgZoneStatesComponent] }).compileComponents();
+  });
+
+  it('does not throw and sets no colors while the theme is still null during init (#332)', () => {
+    build(null, control({ notificationState: States.Emergency }));
+
+    expect(() => fixture.detectChanges()).not.toThrow();
+    expect(component.ctrlStateColor()).toBeNull();
+    expect(component.messageTxtColor()).toBeNull();
+    expect(component.ctrlLabelColor()).toBeNull();
+  });
+
+  it('resolves zone colors from the theme once it is provided', () => {
+    build(theme, control({ notificationState: States.Emergency }));
+    fixture.detectChanges();
+
+    expect(component.ctrlStateColor()).toBe(theme.zoneEmergency);
+    expect(component.messageTxtColor()).toBe(theme.background);
+  });
+
+  it('paints late once the theme resolves after an initial null binding (#332)', () => {
+    build(null, control({ notificationState: States.Alarm }));
+    fixture.detectChanges();
+    expect(component.ctrlStateColor()).toBeNull();
+
+    fixture.componentRef.setInput('theme', theme);
+    fixture.detectChanges();
+
+    expect(component.ctrlStateColor()).toBe(theme.zoneAlarm);
+    expect(component.messageTxtColor()).toBe(theme.background);
+  });
+});


### PR DESCRIPTION
## Why

#332 reported a crash: `SvgZoneStatesComponent`'s constructor `effect()` dereferenced a nullable `theme`/`data` with no guard, throwing during init before the theme resolved.

**That crash is already fixed** — the strictNullChecks migration (`3075df92`) resolved it, via a different route than the issue proposed:

- **`theme` null is prevented at compile time.** `theme` is `input.required<ITheme | null>()` guarded by `if (!theme) return;`. The guard is load-bearing: remove it and the app fails to build (under strictNullChecks `theme.zoneEmergency` is a "possibly null" type error).
- **`data` null is unreachable.** `controlData` is a non-null `input.required<IDynamicControl>`, and the sole consumer (`widget-zones-state-panel`) binds it from `zonesControls()` — built as `(cfg.multiChildCtrls || []).map(...)`, always non-null objects.

So the issue's suggested `if (!data || !theme) return;` + typing `data` as `| null` would now be dead code. This PR does **not** add it.

## What this adds

The component had **zero** test coverage. This adds a regression spec locking the runtime contract the type system doesn't express:

- a null `theme` during init sets no colors and does not throw;
- zone colors resolve from the theme once it's provided;
- a **late** theme resolution (after an initial null binding) repaints correctly.

`npm run snc` + `npm run lint` clean; the spec passes.

## Note

If the boat is running a build older than `3075df92`, it could still crash there — a redeploy carries the fix. The code on `main` is sound.

Closes #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)
