### PR TITLE
fix(toolbar): use apps icon for the actions-hub button (#350)

### DIFF
--- a/src/app/core/components/toolbar/toolbar.component.html
+++ b/src/app/core/components/toolbar/toolbar.component.html
@@ -16,8 +16,8 @@
     (mouseleave)="onPointerLeave()"
   >
     <div class="toolbar-group toolbar-start">
-      <button mat-icon-button aria-label="Settings" (click)="openSettings()">
-        <mat-icon svgIcon="skip" />
+      <button mat-icon-button aria-label="Actions" (click)="openActions()">
+        <mat-icon>apps</mat-icon>
       </button>
       @if (fullscreenSupported()) {
         <button

--- a/src/app/core/components/toolbar/toolbar.component.spec.ts
+++ b/src/app/core/components/toolbar/toolbar.component.spec.ts
@@ -83,7 +83,7 @@ describe('ToolbarComponent', () => {
 
   it('opens the actions view via the router', () => {
     init();
-    byLabel('Settings')!.click();
+    byLabel('Actions')!.click();
     expect(router.navigate).toHaveBeenCalledWith(['/actions']);
   });
 

--- a/src/app/core/components/toolbar/toolbar.component.ts
+++ b/src/app/core/components/toolbar/toolbar.component.ts
@@ -96,7 +96,7 @@ export class ToolbarComponent implements OnDestroy {
     this.app.toggleNightMode();
   }
 
-  protected openSettings(): void {
+  protected openActions(): void {
     this.router.navigate(['/actions']);
   }
 


### PR DESCRIPTION
## Why

#350 proposed swapping the toolbar's leftmost button from the app's three-slider brand glyph (`svgIcon="skip"`) to a **cogwheel**. Reconsidered: that button opens the **actions hub** (`/actions`) — a full-screen view with Settings / Remote Control / Help tiles plus the dashboards editor — **not** the settings page. A cogwheel would misdirect users into expecting to land on settings (settings is just one tile inside the hub).

## What changed

- Icon → Material `apps` (`<mat-icon>apps</mat-icon>`): reads as "open a hub of options / grid of tiles", matches the hub's tiled layout, and is a Material Symbols **font** icon like the rest of the toolbar (`fullscreen`, `mode_night`, `notifications`, `lock_open`) — retiring the last custom sprite on this bar.
- `aria-label` "Settings" → **"Actions"** (the old label named one tile, not the destination; mirrors the `/actions` route and the on-screen "action tiles").
- Method `openSettings()` → `openActions()` to match.

Chosen from a design panel (three independent perspectives + an adversarial judge); `apps` selected over `menu`/`more_vert`, and over the rejected cogwheel/`tune` (misdirect toward settings) and `dashboard`/`widgets` (collide with the app's dashboard/widget concepts).

## Not changed

The `skip` brand glyph (three sliders) is now unreferenced but **kept** in `src/assets/svg/icons.svg` as the app's brand mark — dropping it is a separate branding decision (per #350's own note). Confirmed via grep that no other code references the `skip` sprite id.

## Verification

`npm run snc` + `npm run lint` clean; the toolbar spec (updated to select the "Actions"-labelled button and assert it navigates to `/actions`) passes. Visual confirmation of the `apps` glyph is best seen on a deployed device; `apps` is a core Material Symbol already provided by the app's icon font (same mechanism as the other toolbar font icons).

Closes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)
