### PR TITLE
fix(display): keep screen awake regardless of PWA/install context (#359)

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -60,6 +60,7 @@ describe('AppComponent', () => {
     addHotkeyListener: ReturnType<typeof vi.fn>;
     removeHotkeyListener: ReturnType<typeof vi.fn>;
     toggleFullScreen: ReturnType<typeof vi.fn>;
+    setKeepAwake: ReturnType<typeof vi.fn>;
   };
   let appService: { toggleNightMode: ReturnType<typeof vi.fn> };
   let chrome: {
@@ -86,6 +87,7 @@ describe('AppComponent', () => {
       addHotkeyListener: vi.fn(),
       removeHotkeyListener: vi.fn(),
       toggleFullScreen: vi.fn(),
+      setKeepAwake: vi.fn(),
     };
     appService = { toggleNightMode: vi.fn() };
     chrome = { revealed: signal(false), reveal: vi.fn(), hide: vi.fn(), pulsePeek: vi.fn() };
@@ -424,6 +426,7 @@ describe('AppComponent — embed mode chrome', () => {
       addHotkeyListener: vi.fn(),
       removeHotkeyListener: vi.fn(),
       toggleFullScreen: vi.fn(),
+      setKeepAwake: vi.fn(),
     };
 
     TestBed.configureTestingModule({
@@ -487,6 +490,7 @@ describe('AppComponent — embed read-only invariants (#216 E6)', () => {
       addHotkeyListener: vi.fn(),
       removeHotkeyListener: vi.fn(),
       toggleFullScreen: vi.fn(),
+      setKeepAwake: vi.fn(),
     };
     const toast = { show: vi.fn().mockReturnValue({ onAction: () => new Subject() }) };
 
@@ -571,6 +575,7 @@ describe('AppComponent — embed boot performs zero server-config writes (#216 E
       addHotkeyListener: vi.fn(),
       removeHotkeyListener: vi.fn(),
       toggleFullScreen: vi.fn(),
+      setKeepAwake: vi.fn(),
     };
 
     TestBed.configureTestingModule({

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -91,6 +91,11 @@ export class AppComponent implements AfterViewInit, OnDestroy {
       this._titleService.setTitle(resolveBrowserTabTitle(this._browserTabTitle()));
     });
 
+    // Hold the screen wake lock per the keepScreenAwake setting, regardless of install/PWA context (#359).
+    effect(() => {
+      this._uiEvent.setKeepAwake(this.settings.keepScreenAwake());
+    });
+
     effect(() => {
       // Embed is strictly read-only: never run the config migration (it writes every user slot and
       // reloads the app), nor surface the manual upgrade-instructions dialog. Defer both to a

--- a/src/app/core/components/settings/display/display.component.html
+++ b/src/app/core/components/settings/display/display.component.html
@@ -106,6 +106,32 @@
           }
         </mat-form-field>
       </mat-expansion-panel>
+      <mat-expansion-panel>
+        <mat-expansion-panel-header>
+          <mat-panel-title>
+            Screen
+          </mat-panel-title>
+          @if (!isPhonePortrait().matches) {
+            <mat-panel-description [hidden]="isPhonePortrait().matches">
+              Keep the display on while Skip is in the foreground.
+            </mat-panel-description>
+          }
+        </mat-expansion-panel-header>
+        <mat-slide-toggle class="full-width sliders"
+          [(ngModel)]="keepScreenAwake"
+          name="keepScreenAwake"
+          [disabled]="!uiEvent.noSleepSupported()"
+          aria-describedby="keep-awake-helper">
+          Keep screen awake
+        </mat-slide-toggle>
+        <p id="keep-awake-helper" class="mat-body-small" role="note">
+          @if (uiEvent.noSleepSupported()) {
+            Prevents the device screen from blanking on its inactivity timer while Skip is the foreground app.
+          } @else {
+            This device or browser does not support the screen wake lock (a secure HTTPS connection is required).
+          }
+        </p>
+      </mat-expansion-panel>
     </mat-accordion>
     <br />
     <mat-accordion>

--- a/src/app/core/components/settings/display/display.component.spec.ts
+++ b/src/app/core/components/settings/display/display.component.spec.ts
@@ -39,6 +39,7 @@ class SettingsServiceMock {
     public getInstanceName() { return ''; }
     public getBrowserTabTitle() { return 'Skip'; }
     public getDisablePathValidation() { return false; }
+    public getKeepScreenAwake() { return true; }
     public setAutoNightMode(): void { }
     public setRedNightMode(): void { }
     public setNightModeBrightness(): void { }
@@ -47,6 +48,7 @@ class SettingsServiceMock {
     public setThemeName(): void { }
     public setBrowserTabTitle(): void { }
     public setDisablePathValidation(): void { }
+    public setKeepScreenAwake(): void { }
 }
 
 class PluginConfigClientServiceMock {

--- a/src/app/core/components/settings/display/display.component.ts
+++ b/src/app/core/components/settings/display/display.component.ts
@@ -4,6 +4,7 @@ import { BreakpointObserver, Breakpoints, BreakpointState } from '@angular/cdk/l
 import { AppService } from '../../../services/app-service';
 import { ToastService } from '../../../services/toast.service';
 import { SettingsService } from '../../../services/settings.service';
+import { uiEventService } from '../../../services/uiEvent.service';
 import { PluginConfigClientService } from '../../../services/plugin-config-client.service';
 import { IPluginApiFailure, ISignalkPlugin } from '../../../interfaces/signalk-plugin-config.interfaces';
 import { FormsModule, NgForm } from '@angular/forms';
@@ -36,6 +37,7 @@ export class SettingsDisplayComponent implements OnInit {
   private readonly app = inject(AppService);
   private readonly toast = inject(ToastService);
   private readonly settings = inject(SettingsService);
+  protected readonly uiEvent = inject(uiEventService);
   private readonly responsive = inject(BreakpointObserver);
   private readonly pluginConfig = inject(PluginConfigClientService);
   protected isPhonePortrait: Signal<BreakpointState>;
@@ -47,6 +49,7 @@ export class SettingsDisplayComponent implements OnInit {
   protected instanceName = model<string>('');
   protected browserTabTitle = model<string>('Skip');
   protected isPathValidationDisabled = model<boolean>(this.settings.getDisablePathValidation());
+  protected keepScreenAwake = model<boolean>(true);
   // Guards concurrent plugin enable checks to avoid stale promise handlers mutating state
   private _pluginCheckSeq = 0;
 
@@ -62,6 +65,7 @@ export class SettingsDisplayComponent implements OnInit {
     this.isRemoteControl.set(this.settings.getIsRemoteControl());
     this.instanceName.set(this.settings.getInstanceName());
     this.browserTabTitle.set(this.settings.getBrowserTabTitle());
+    this.keepScreenAwake.set(this.settings.getKeepScreenAwake());
   }
 
   protected saveAllSettings():void {
@@ -104,6 +108,7 @@ export class SettingsDisplayComponent implements OnInit {
     }
     this.settings.setBrowserTabTitle(this.browserTabTitle());
     this.settings.setDisablePathValidation(this.isPathValidationDisabled());
+    this.settings.setKeepScreenAwake(this.keepScreenAwake());
     this.displayForm()?.form.markAsPristine();
     this.toast.show("Configuration saved", 1000, true, 'message');
   }

--- a/src/app/core/interfaces/app-settings.interfaces.ts
+++ b/src/app/core/interfaces/app-settings.interfaces.ts
@@ -26,6 +26,7 @@ export interface IAppConfig {
   nightModeBrightness: number;
   notificationConfig: INotificationConfig;
   browserTabTitle?: string;
+  keepScreenAwake?: boolean;
 }
 
 export interface IThemeConfig {

--- a/src/app/core/services/settings.service.spec.ts
+++ b/src/app/core/services/settings.service.spec.ts
@@ -370,7 +370,7 @@ describe('SettingsService — default config isolation', () => {
 
 describe('SettingsService — hydration (pushSettings) characterization', () => {
   const APP_CONFIG_KEYS = [
-    'autoNightMode', 'browserTabTitle', 'configVersion',
+    'autoNightMode', 'browserTabTitle', 'configVersion', 'keepScreenAwake',
     'nightModeBrightness', 'notificationConfig', 'redNightMode'
   ];
 
@@ -390,6 +390,16 @@ describe('SettingsService — hydration (pushSettings) characterization', () => 
     expect(service.getNotificationConfig()).toEqual(fullNotificationConfig());
     expect(service.getDashboardConfig()).toEqual([{ id: 'd1' }]);
     expect(service.getConfigVersion()).toBe(LOADED_CONFIG_VERSION);
+  });
+
+  it('hydrates keepScreenAwake to true when the stored config omits it (#359)', () => {
+    const { service } = setupHydrated({ app: loadedAppConfig(), theme: null, dashboards: [] });
+    expect(service.getKeepScreenAwake()).toBe(true);
+  });
+
+  it('honors a stored keepScreenAwake=false (#359)', () => {
+    const { service } = setupHydrated({ app: { ...loadedAppConfig(), keepScreenAwake: false }, theme: null, dashboards: [] });
+    expect(service.getKeepScreenAwake()).toBe(false);
   });
 
   // The persist-on-missing bootstrap fields: exactly these three (widgetHistoryDisabled was

--- a/src/app/core/services/settings.service.ts
+++ b/src/app/core/services/settings.service.ts
@@ -38,8 +38,10 @@ export class SettingsService {
   private readonly _isRemoteControl = signal<boolean>(false);
   private readonly _instanceName = signal<string>('');
   private readonly _browserTabTitle = signal<string>('Skip');
+  private readonly _keepScreenAwake = signal<boolean>(true);
 
   public readonly themeName = this._themeName.asReadonly();
+  public readonly keepScreenAwake = this._keepScreenAwake.asReadonly();
   public readonly notificationConfig = this._notificationConfig.asReadonly();
   public readonly autoNightMode = this._autoNightMode.asReadonly();
   public readonly redNightMode = this._redNightMode.asReadonly();
@@ -238,6 +240,7 @@ export class SettingsService {
     this._autoNightMode.set(app.autoNightMode === undefined ? false : app.autoNightMode);
     this._redNightMode.set(app.redNightMode === undefined ? false : app.redNightMode);
     this._nightModeBrightness.set(app.nightModeBrightness === undefined ? 0.2 : app.nightModeBrightness);
+    this._keepScreenAwake.set(app.keepScreenAwake === undefined ? true : app.keepScreenAwake);
 
     // Embed is strictly read-only: the in-memory defaults above are applied, but the persist-on-missing
     // self-heal write is suppressed so a framed read-only boot never PATCHes the profile's app config.
@@ -348,6 +351,15 @@ export class SettingsService {
 
   public getAutoNightMode(): boolean {
     return this.autoNightMode();
+  }
+
+  public setKeepScreenAwake(enabled: boolean) {
+    this._keepScreenAwake.set(enabled);
+    this.saveAppConfig();
+  }
+
+  public getKeepScreenAwake(): boolean {
+    return this.keepScreenAwake();
   }
 
   // Red night mode
@@ -498,7 +510,8 @@ export class SettingsService {
       redNightMode: this.redNightMode(),
       nightModeBrightness: this.nightModeBrightness(),
       notificationConfig: this.notificationConfig(),
-      browserTabTitle: this.browserTabTitle()
+      browserTabTitle: this.browserTabTitle(),
+      keepScreenAwake: this.keepScreenAwake()
     }
     return storageObject;
   }

--- a/src/app/core/services/uiEvent.service.spec.ts
+++ b/src/app/core/services/uiEvent.service.spec.ts
@@ -1,9 +1,16 @@
 import { TestBed } from '@angular/core/testing';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { uiEventService } from './uiEvent.service';
 
-describe('GestureService', () => {
+describe('uiEventService', () => {
   let service: uiEventService;
+
+  const injectFakeNoSleep = () => {
+    const noSleep = { enable: vi.fn(), disable: vi.fn() };
+    (service as unknown as { noSleep: typeof noSleep }).noSleep = noSleep;
+    service.noSleepSupported.set(true);
+    return noSleep;
+  };
 
   beforeEach(() => {
     TestBed.configureTestingModule({});
@@ -12,5 +19,34 @@ describe('GestureService', () => {
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('setKeepAwake no-ops when the wake lock is unsupported (#359)', () => {
+    service.noSleepSupported.set(false);
+    service.setKeepAwake(true);
+    expect(service.noSleepStatus()).toBe(false);
+  });
+
+  it('setKeepAwake enables, is idempotent, then disables the wake lock (#359)', () => {
+    const noSleep = injectFakeNoSleep();
+
+    service.setKeepAwake(true);
+    expect(noSleep.enable).toHaveBeenCalledTimes(1);
+    expect(service.noSleepStatus()).toBe(true);
+
+    service.setKeepAwake(true); // already on — no redundant enable
+    expect(noSleep.enable).toHaveBeenCalledTimes(1);
+
+    service.setKeepAwake(false);
+    expect(noSleep.disable).toHaveBeenCalledTimes(1);
+    expect(service.noSleepStatus()).toBe(false);
+  });
+
+  it('toggleFullScreen never touches the wake lock (decoupled, #359)', () => {
+    const noSleep = injectFakeNoSleep();
+    service.toggleFullScreen();
+    expect(noSleep.enable).not.toHaveBeenCalled();
+    expect(noSleep.disable).not.toHaveBeenCalled();
+    expect(service.noSleepStatus()).toBe(false);
   });
 });

--- a/src/app/core/services/uiEvent.service.ts
+++ b/src/app/core/services/uiEvent.service.ts
@@ -16,13 +16,6 @@ export class uiEventService implements OnDestroy {
   private hotkeyListeners = new Map<(key: string, event: KeyboardEvent) => void, EventListener>();
   private readonly fullscreenChangeHandler = () => {
     this.fullscreenStatus.set(screenfull.isFullscreen);
-    if (!screenfull.isFullscreen) {
-      // On exit, disable NoSleep if we enabled it purely for fullscreen
-      if (this.noSleep && this.noSleepStatus()) {
-        try { this.noSleep.disable(); } catch { /* ignore disable errors */ }
-        this.noSleepStatus.set(false);
-      }
-    }
   };
 
   constructor() {
@@ -43,9 +36,8 @@ export class uiEventService implements OnDestroy {
       }
 
       this.checkNoSleepSupport();
-      if (this.checkPwaMode() && this.noSleepSupported() && !this.noSleepStatus()) {
-        this.toggleNoSleep();
-      }
+      // The screen wake lock is driven by the keepScreenAwake setting (applied from app.component),
+      // never by install/PWA/standalone detection — so it holds in a plain browser tab too (#359).
     } else {
       // In tests mark features unsupported to short-circuit code paths gracefully
       this.fullscreenSupported.set(false);
@@ -68,23 +60,22 @@ export class uiEventService implements OnDestroy {
     }
   }
 
-  private checkPwaMode(): boolean {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const isStandalone = window.matchMedia('(display-mode: standalone)').matches || (window.navigator as any).standalone !== undefined;
-    console.log('[UI Event Service] PWA mode:', isStandalone);
-    return isStandalone;
-  }
-
-  private toggleNoSleep(): void {
-    if (this.noSleepSupported()) {
-      if (!this.noSleepStatus()) {
+  /** Enable or disable the screen wake lock. Driven by the keepScreenAwake setting; no-ops when unsupported. */
+  public setKeepAwake(enabled: boolean): void {
+    if (!this.noSleepSupported() || enabled === this.noSleepStatus()) {
+      return;
+    }
+    try {
+      if (enabled) {
         if (!this.noSleep) this.checkNoSleepSupport();
-        try { this.noSleep?.enable(); } catch (e) { console.warn('[UI Event Service] Failed to enable NoSleep:', e); }
+        this.noSleep?.enable();
       } else {
-        try { this.noSleep?.disable(); } catch { /* ignore */ }
+        this.noSleep?.disable();
       }
-      this.noSleepStatus.set(!this.noSleepStatus());
-      console.log('[UI Event Service] NoSleep active:', this.noSleepStatus());
+      this.noSleepStatus.set(enabled);
+      console.log('[UI Event Service] Screen wake lock active:', enabled);
+    } catch (e) {
+      console.warn('[UI Event Service] Failed to toggle screen wake lock:', e);
     }
   }
 
@@ -96,15 +87,8 @@ export class uiEventService implements OnDestroy {
     if (screenfull.isEnabled) {
       if (!this.fullscreenStatus()) {
         screenfull.request();
-        if (!this.noSleepStatus()) {
-          if (!this.noSleep) this.checkNoSleepSupport();
-          try { this.noSleep?.enable(); this.noSleepStatus.set(true); } catch { /* enable failed */ }
-        }
-      } else {
-        if (screenfull.isFullscreen) {
-          screenfull.exit();
-        }
-        if (this.noSleepStatus()) { try { this.noSleep?.disable(); } catch { /* ignore */ } this.noSleepStatus.set(false); }
+      } else if (screenfull.isFullscreen) {
+        screenfull.exit();
       }
       this.fullscreenStatus.set(!this.fullscreenStatus());
     } else {


### PR DESCRIPTION
## Why

Skip's display blanked on the boat's Android screen after inactivity, while Freeboard-SK on the same device kept it on (#359).

**Root cause:** Skip *has* a keep-awake mechanism (`@zakj/no-sleep`, wrapping the Screen Wake Lock API), but `uiEvent.service` only engaged it when `checkPwaMode()` detected an **installed standalone PWA** — or on manual fullscreen. The boat display runs Skip as a normal browser/WebView tab (`display-mode: browser`, `navigator.standalone` undefined), so `checkPwaMode()` was false and the lock was never requested.

Researched Freeboard-SK for parity: it requests the wake lock **unconditionally** on load (no PWA/standalone gate), default-on with an opt-out setting, re-acquiring on `visibilitychange`.

## What changed

Adopt Freeboard's **policy**, keeping Skip's existing `@zakj/no-sleep` **mechanism**:

- **New persisted setting** `keepScreenAwake` (default **true**, opt-out) in `IAppConfig`, surfaced as a **"Keep screen awake"** toggle in Settings → Display → Screen.
- **Driven by an `app.component` effect** — `setKeepAwake(settings.keepScreenAwake())` — so it applies on load and live on change, regardless of install/PWA/standalone context.
- **Removed the PWA gate:** `checkPwaMode()` deleted (its only caller is gone; also removes its latent iOS over-trigger bug — `navigator.standalone !== undefined` was true for *any* iOS Safari tab).
- **Decoupled from fullscreen:** fullscreen no longer enables/disables the wake lock.
- **Graceful degradation:** `setKeepAwake` no-ops when the wake lock is unsupported (the API is secure-context-only); the Display toggle is `[disabled]` and the helper text explains it then.

## Tests

- `uiEvent.service.spec`: `setKeepAwake` enables/idempotent/disables with a fake NoSleep; no-ops when unsupported; `toggleFullScreen` never touches the lock.
- `settings.service.spec`: `keepScreenAwake` hydrates to `true` when omitted, honors a stored `false`, and is carried in the persisted `IAppConfig` blob (`APP_CONFIG_KEYS`).
- Updated the display/app.component spec mocks for the new method + effect.

`npm run snc` + `npm run lint` clean; full unit suite green (1500); production build succeeds.

## Verification note

Wake-lock behavior can't be meaningfully unit-tested — the unit tests lock the wiring. The user-visible effect needs an **on-device check on the boat display**: confirm the screen stays on across a real idle period **and survives a lock/unwake cycle** (the one residual risk — whether `@zakj/no-sleep`'s re-acquisition holds after the OS releases the sentinel; if not, fall back to an explicit re-request). It requires HTTPS (`:4430`), since the API is secure-context only.

## Scope

Retiring the remaining **inert PWA metadata** (manifest install fields, `apple-*` splash links, ~2.5 MB assets, `pwa-asset-generator`) is tracked separately in #382 — this PR removes only the one piece of *live* PWA code (`checkPwaMode`).

Closes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)
