### PR TITLE
Actions redesign · Phase 1 — page management in Edit mode

### DIFF
--- a/src/app/core/components/dashboard/dashboard.component.html
+++ b/src/app/core/components/dashboard/dashboard.component.html
@@ -45,22 +45,3 @@
 }
 </div>
 <action-menu #actionMenu [items]="emptyAreaActions()" (selected)="onEmptyAreaAction($event)" />
-@if (!dashboardStatic) {
-  <div class="edit-layout-close-icon">
-    <button
-      mat-fab
-      class="cancel"
-      style="margin-right: 10px"
-      (click)="cancelLayoutChanges()"
-    >
-      <mat-icon>close</mat-icon>
-    </button>
-    <button
-      mat-fab
-      class="save"
-      (click)="saveLayoutChanges()"
-    >
-      <mat-icon>done</mat-icon>
-    </button>
-  </div>
-}

--- a/src/app/core/components/dashboard/dashboard.component.scss
+++ b/src/app/core/components/dashboard/dashboard.component.scss
@@ -35,28 +35,6 @@
   }
 }
 
-.edit-layout-close-icon {
-  position: absolute;
-  bottom: 20px;
-  right: 20px;
-  cursor: pointer;
-  z-index: 100;
-}
-.cancel {
-  @include mat.fab-overrides((
-    container-color: var(--mat-sys-primary),
-    foreground-color: var(--mat-sys-background),
-  ));
-}
-
-.save {
-  @include mat.fab-overrides((
-    container-color: var(--mat-sys-primary-fixed),
-    foreground-color: var(--mat-sys-background),
-
-  ));
-}
-
 /* Empty Dashboard State Styles */
 .dashboard-empty-state-container {
   position: absolute; /* detach from normal flow so it cannot change grid height */

--- a/src/app/core/components/dashboard/dashboard.component.spec.ts
+++ b/src/app/core/components/dashboard/dashboard.component.spec.ts
@@ -6,7 +6,7 @@ import { signal } from '@angular/core';
 import { provideRouter } from '@angular/router';
 
 import { DashboardComponent } from './dashboard.component';
-import { DashboardService } from '../../services/dashboard.service';
+import { Dashboard, DashboardService } from '../../services/dashboard.service';
 import { ToastService } from '../../services/toast.service';
 import { PluginConfigClientService } from '../../services/plugin-config-client.service';
 import { DialogService } from '../../services/dialog.service';
@@ -243,6 +243,39 @@ describe('DashboardComponent', () => {
             fresh.detectChanges();
             expect(mockDashboardService.notifyLayoutEditSaved).not.toHaveBeenCalled();
             expect(mockDashboardService.notifyLayoutEditCanceled).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('active-page identity reload', () => {
+        function stubLoad(): ReturnType<typeof vi.spyOn> {
+            return vi.spyOn(component as unknown as DashboardEscApi, 'loadDashboard').mockImplementation(() => undefined);
+        }
+
+        it('reloads the grid when a page op swaps the page at the active index', () => {
+            const loadSpy = stubLoad();
+            const pages: Dashboard[] = [
+                { id: 'a', configuration: [] }, { id: 'b', configuration: [] }, { id: 'c', configuration: [] }
+            ];
+            mockDashboardService.dashboards.set(pages);
+            mockDashboardService.activeDashboard.set(1);
+            fixture.detectChanges();
+            loadSpy.mockClear();
+            // Delete the active page (index 1): the index stays 1 but now points at a different page.
+            mockDashboardService.dashboards.set([{ id: 'a', configuration: [] }, { id: 'c', configuration: [] }]);
+            fixture.detectChanges();
+            expect(loadSpy).toHaveBeenCalledWith(1);
+        });
+
+        it('does not reload on a config-only change to the active page (widget save)', () => {
+            const loadSpy = stubLoad();
+            mockDashboardService.dashboards.set([{ id: 'a', configuration: [] }, { id: 'b', configuration: [] }]);
+            mockDashboardService.activeDashboard.set(1);
+            fixture.detectChanges();
+            loadSpy.mockClear();
+            // Same id at the active index, different configuration → grid is the source of truth, no reload.
+            mockDashboardService.dashboards.set([{ id: 'a', configuration: [] }, { id: 'b', name: 'edited', configuration: [] }]);
+            fixture.detectChanges();
+            expect(loadSpy).not.toHaveBeenCalled();
         });
     });
 

--- a/src/app/core/components/dashboard/dashboard.component.spec.ts
+++ b/src/app/core/components/dashboard/dashboard.component.spec.ts
@@ -277,6 +277,19 @@ describe('DashboardComponent', () => {
             fixture.detectChanges();
             expect(loadSpy).not.toHaveBeenCalled();
         });
+
+        it('does not reload over an unsaved edit: a config change while editing (same id) never reloads', () => {
+            const loadSpy = stubLoad();
+            mockDashboardService.dashboards.set([{ id: 'a', configuration: [] }, { id: 'b', configuration: [] }]);
+            mockDashboardService.activeDashboard.set(1);
+            mockDashboardService.isDashboardStatic.set(false); // active widget edit in progress
+            fixture.detectChanges();
+            loadSpy.mockClear();
+            // A Done commit writes the active page's configuration back (same id) — must not reload the live grid.
+            mockDashboardService.dashboards.set([{ id: 'a', configuration: [] }, { id: 'b', name: 'edited', configuration: [] }]);
+            fixture.detectChanges();
+            expect(loadSpy).not.toHaveBeenCalled();
+        });
     });
 
     it('should save dashboard configuration', () => {

--- a/src/app/core/components/dashboard/dashboard.component.spec.ts
+++ b/src/app/core/components/dashboard/dashboard.component.spec.ts
@@ -188,8 +188,8 @@ describe('DashboardComponent', () => {
     });
 
     describe('toolbar-driven layout edit requests', () => {
-        function stubLoad(): void {
-            vi.spyOn(component as unknown as DashboardEscApi, 'loadDashboard').mockImplementation(() => undefined);
+        function stubLoad(): ReturnType<typeof vi.spyOn> {
+            return vi.spyOn(component as unknown as DashboardEscApi, 'loadDashboard').mockImplementation(() => undefined);
         }
 
         it('ignores the initial (zero) request tick', () => {
@@ -208,14 +208,41 @@ describe('DashboardComponent', () => {
             expect(mockDashboardService.notifyLayoutEditSaved).toHaveBeenCalledTimes(1);
         });
 
-        it('discards the edit when the toolbar requests a cancel', () => {
-            stubLoad();
+        it('re-commits on a second save request in the same session (counter 1 -> 2)', () => {
             mockDashboardService.isDashboardStatic.set(false);
             fixture.detectChanges();
+            mockDashboardService.layoutEditSaveRequested.set(1);
+            fixture.detectChanges();
+            mockDashboardService.layoutEditSaveRequested.set(2);
+            fixture.detectChanges();
+            expect(mockDashboardService.notifyLayoutEditSaved).toHaveBeenCalledTimes(2);
+        });
+
+        it('discards the edit when the toolbar requests a cancel (reloads the persisted page)', () => {
+            const loadSpy = stubLoad();
+            mockDashboardService.isDashboardStatic.set(false);
+            fixture.detectChanges();
+            loadSpy.mockClear();
             mockDashboardService.layoutEditCancelRequested.set(1);
             fixture.detectChanges();
+            expect(loadSpy).toHaveBeenCalledWith(0);
             expect(mockDashboardService.setStaticDashboard).toHaveBeenCalledWith(true);
             expect(mockDashboardService.notifyLayoutEditCanceled).toHaveBeenCalledTimes(1);
+        });
+
+        it('does not replay a stale request counter on a fresh mount (navigation remount)', () => {
+            // A prior Done/Cancel this session left the root-scoped counters non-zero; the
+            // component is recreated on navigation and must not auto-fire on construction.
+            fixture.destroy();
+            mockDashboardService.layoutEditSaveRequested.set(2);
+            mockDashboardService.layoutEditCancelRequested.set(2);
+            const fresh = TestBed.createComponent(DashboardComponent);
+            vi.spyOn(fresh.componentInstance, 'ngOnDestroy').mockImplementation(() => undefined);
+            vi.spyOn(fresh.componentInstance as unknown as DashboardComponentPrivateApi, '_gridstack').mockReturnValue(gridMock);
+            vi.spyOn(fresh.componentInstance as unknown as DashboardEscApi, 'loadDashboard').mockImplementation(() => undefined);
+            fresh.detectChanges();
+            expect(mockDashboardService.notifyLayoutEditSaved).not.toHaveBeenCalled();
+            expect(mockDashboardService.notifyLayoutEditCanceled).not.toHaveBeenCalled();
         });
     });
 

--- a/src/app/core/components/dashboard/dashboard.component.spec.ts
+++ b/src/app/core/components/dashboard/dashboard.component.spec.ts
@@ -60,6 +60,8 @@ describe('DashboardComponent', () => {
             setStaticDashboard: vi.fn().mockName("DashboardService.setStaticDashboard"),
             notifyLayoutEditSaved: vi.fn().mockName("DashboardService.notifyLayoutEditSaved"),
             notifyLayoutEditCanceled: vi.fn().mockName("DashboardService.notifyLayoutEditCanceled"),
+            layoutEditSaveRequested: signal(0),
+            layoutEditCancelRequested: signal(0),
             navigateToNextDashboard: vi.fn().mockName("DashboardService.navigateToNextDashboard"),
             navigateToPreviousDashboard: vi.fn().mockName("DashboardService.navigateToPreviousDashboard"),
             consumePendingPageDirection: vi.fn().mockName("DashboardService.consumePendingPageDirection").mockReturnValue(null),
@@ -181,6 +183,38 @@ describe('DashboardComponent', () => {
             mockDashboardService.isDashboardStatic.set(false);
             vi.spyOn(component as unknown as DashboardEscApi, 'loadDashboard').mockImplementation(() => undefined);
             document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+            expect(mockDashboardService.notifyLayoutEditCanceled).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('toolbar-driven layout edit requests', () => {
+        function stubLoad(): void {
+            vi.spyOn(component as unknown as DashboardEscApi, 'loadDashboard').mockImplementation(() => undefined);
+        }
+
+        it('ignores the initial (zero) request tick', () => {
+            fixture.detectChanges();
+            expect(mockDashboardService.notifyLayoutEditSaved).not.toHaveBeenCalled();
+            expect(mockDashboardService.notifyLayoutEditCanceled).not.toHaveBeenCalled();
+        });
+
+        it('commits the edit when the toolbar requests a save', () => {
+            mockDashboardService.isDashboardStatic.set(false);
+            fixture.detectChanges();
+            mockDashboardService.layoutEditSaveRequested.set(1);
+            fixture.detectChanges();
+            expect(privateApi._gridstack().grid.save).toHaveBeenCalledWith(false, false);
+            expect(mockDashboardService.setStaticDashboard).toHaveBeenCalledWith(true);
+            expect(mockDashboardService.notifyLayoutEditSaved).toHaveBeenCalledTimes(1);
+        });
+
+        it('discards the edit when the toolbar requests a cancel', () => {
+            stubLoad();
+            mockDashboardService.isDashboardStatic.set(false);
+            fixture.detectChanges();
+            mockDashboardService.layoutEditCancelRequested.set(1);
+            fixture.detectChanges();
+            expect(mockDashboardService.setStaticDashboard).toHaveBeenCalledWith(true);
             expect(mockDashboardService.notifyLayoutEditCanceled).toHaveBeenCalledTimes(1);
         });
     });
@@ -542,6 +576,8 @@ describe('DashboardComponent — embed mode empty state', () => {
             setStaticDashboard: vi.fn(),
             notifyLayoutEditSaved: vi.fn(),
             notifyLayoutEditCanceled: vi.fn(),
+            layoutEditSaveRequested: signal(0),
+            layoutEditCancelRequested: signal(0),
             navigateToNextDashboard: vi.fn(),
             navigateToPreviousDashboard: vi.fn(),
             consumePendingPageDirection: vi.fn().mockReturnValue(null),

--- a/src/app/core/components/dashboard/dashboard.component.ts
+++ b/src/app/core/components/dashboard/dashboard.component.ts
@@ -84,6 +84,10 @@ export class DashboardComponent implements AfterViewInit, OnDestroy {
   private _previousIsStaticState = true;
   /** Suppress starting a drag sequence right after a long-press add (until pointer released) */
   private _suppressDrag = false;
+  /** Index/identity of the page last loaded into the grid, so a page op that swaps the page
+   *  at the active index (e.g. deleting the active page) triggers a reload, config saves don't. */
+  private _loadedActiveIndex: number | null = null;
+  private _loadedActiveId: string | null = null;
 
 
   private subGridOptions: GridStackOptions = {
@@ -130,10 +134,19 @@ export class DashboardComponent implements AfterViewInit, OnDestroy {
       });
     });
 
+    // Reload the grid when the active page's index OR identity changes. Tracking identity —
+    // not just the index — catches a structural page op that swaps the page occupying the
+    // current index (deleting the active page leaves the index unchanged but pointing at a
+    // different page). A config-only change (a widget save) keeps the same id, so it never
+    // reloads over the live grid.
     effect(() => {
-      this.dashboard.activeDashboard();
+      const active = this.dashboard.activeDashboard();
+      const activeId = active === null ? null : this.dashboard.dashboards()[active]?.id ?? null;
 
       untracked(() => {
+        if (active === this._loadedActiveIndex && activeId === this._loadedActiveId) return;
+        this._loadedActiveIndex = active;
+        this._loadedActiveId = activeId;
         void this.runPageChange();
       });
     });

--- a/src/app/core/components/dashboard/dashboard.component.ts
+++ b/src/app/core/components/dashboard/dashboard.component.ts
@@ -138,18 +138,24 @@ export class DashboardComponent implements AfterViewInit, OnDestroy {
       });
     });
 
-    // Done/Cancel now live on the toolbar (outside this component). They reach the grid
-    // through these request counters; the transactional save/cancel logic stays here,
-    // the only holder of the gridstack instance.
+    // Done/Cancel live on the toolbar, outside this component; they reach the grid through
+    // these request counters. The commit/discard logic stays here, the only holder of the
+    // gridstack instance. The counters are root-scoped and monotonic, so a stale value from
+    // an earlier edit would otherwise auto-fire when this component is re-created on
+    // navigation — snapshot the value seen at construction and act only on a later increment.
+    let lastSaveRequest = this.dashboard.layoutEditSaveRequested();
     effect(() => {
       const tick = this.dashboard.layoutEditSaveRequested();
-      if (!tick) return;
+      if (tick === lastSaveRequest) return;
+      lastSaveRequest = tick;
       untracked(() => this.saveLayoutChanges());
     });
 
+    let lastCancelRequest = this.dashboard.layoutEditCancelRequested();
     effect(() => {
       const tick = this.dashboard.layoutEditCancelRequested();
-      if (!tick) return;
+      if (tick === lastCancelRequest) return;
+      lastCancelRequest = tick;
       untracked(() => this.cancelLayoutChanges());
     });
   }
@@ -376,13 +382,13 @@ export class DashboardComponent implements AfterViewInit, OnDestroy {
     this.dashboard.updateConfiguration(activeDashboard, immutableConfiguration);
   }
 
-  protected saveLayoutChanges(): void {
+  private saveLayoutChanges(): void {
     this.dashboard.setStaticDashboard(true);
     this.saveDashboard();
     this.dashboard.notifyLayoutEditSaved();
   }
 
-  protected cancelLayoutChanges(): void {
+  private cancelLayoutChanges(): void {
     this.loadDashboard(this.dashboard.activeDashboard());
     this.dashboard.setStaticDashboard(true);
     this.dashboard.notifyLayoutEditCanceled();

--- a/src/app/core/components/dashboard/dashboard.component.ts
+++ b/src/app/core/components/dashboard/dashboard.component.ts
@@ -137,6 +137,21 @@ export class DashboardComponent implements AfterViewInit, OnDestroy {
         void this.runPageChange();
       });
     });
+
+    // Done/Cancel now live on the toolbar (outside this component). They reach the grid
+    // through these request counters; the transactional save/cancel logic stays here,
+    // the only holder of the gridstack instance.
+    effect(() => {
+      const tick = this.dashboard.layoutEditSaveRequested();
+      if (!tick) return;
+      untracked(() => this.saveLayoutChanges());
+    });
+
+    effect(() => {
+      const tick = this.dashboard.layoutEditCancelRequested();
+      if (!tick) return;
+      untracked(() => this.cancelLayoutChanges());
+    });
   }
 
   ngAfterViewInit(): void {

--- a/src/app/core/components/dashboards-editor/dashboards-editor.component.html
+++ b/src/app/core/components/dashboards-editor/dashboards-editor.component.html
@@ -1,4 +1,4 @@
-<div class="dashboard-manage" cdkDropList cdkDropListOrientation="mixed" (cdkDropListDropped)="drop($event)">
+<div class="dashboard-manage" [class.compact]="compact()" cdkDropList cdkDropListOrientation="mixed" (cdkDropListDropped)="drop($event)">
   @for (dashboard of _dashboard.dashboards(); track dashboard.id; let index = $index) {
     <div class="dashboard-card dashboard-item"
       skipGestures
@@ -19,8 +19,8 @@
       <div >
         <mat-icon class="dashboard-icon"
           [svgIcon]="dashboard.icon || 'dashboard'"
-          [style.width.px]="72"
-          [style.height.px]="72"
+          [style.width.px]="iconSizePx()"
+          [style.height.px]="iconSizePx()"
           aria-hidden="false"
         ></mat-icon>
       </div>

--- a/src/app/core/components/dashboards-editor/dashboards-editor.component.scss
+++ b/src/app/core/components/dashboards-editor/dashboards-editor.component.scss
@@ -94,6 +94,60 @@
   font-size: 1.1em;
 }
 
+/* Compact single-row strip for the page-manager bottom sheet. */
+:host.compact {
+  height: auto;
+  overflow-y: hidden;
+}
+
+.dashboard-manage.compact {
+  height: auto;
+  padding: 4px 12px 12px;
+  flex-wrap: nowrap;
+  justify-content: flex-start;
+  overflow-x: auto;
+  overflow-y: hidden;
+
+  .dashboard-card {
+    flex: 0 0 auto;
+    height: 112px;
+    width: 128px;
+    margin: 6px;
+    border-radius: 10px;
+    padding: 6px;
+  }
+
+  .item-index {
+    top: 8px;
+    left: 8px;
+    height: 26px;
+    width: 26px;
+    font-size: 0.9em;
+  }
+
+  .dashboard-name {
+    margin-top: 4px;
+    font-size: 0.85em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .dashboard-add-btn button {
+    transform: scale(0.75);
+  }
+}
+
+@media (max-width: 600px) and (orientation: portrait) {
+  .dashboard-manage.compact {
+    padding: 4px 12px 12px;
+
+    .dashboard-card {
+      height: 112px;
+    }
+  }
+}
+
 .cdk-drag-preview {
   box-sizing: border-box;
   border-radius: 4px;

--- a/src/app/core/components/dashboards-editor/dashboards-editor.component.spec.ts
+++ b/src/app/core/components/dashboards-editor/dashboards-editor.component.spec.ts
@@ -145,4 +145,18 @@ describe('DashboardsEditorComponent', () => {
     expect(dialog.openConfirmationDialog).not.toHaveBeenCalled();
     expect(dashboard.delete).not.toHaveBeenCalled();
   });
+
+  it('renders the full tiled layout by default', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('.dashboard-manage.compact')).toBeNull();
+    expect((component as unknown as { iconSizePx: () => number }).iconSizePx()).toBe(72);
+  });
+
+  it('renders the compact single-row strip when compact is set', () => {
+    fixture.componentRef.setInput('compact', true);
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('.dashboard-manage.compact')).not.toBeNull();
+    expect((component as unknown as { iconSizePx: () => number }).iconSizePx()).toBe(40);
+  });
 });

--- a/src/app/core/components/dashboards-editor/dashboards-editor.component.ts
+++ b/src/app/core/components/dashboards-editor/dashboards-editor.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, viewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, viewChild } from '@angular/core';
 import { GestureDirective } from '../../directives/gesture.directive';
 import { Dashboard, DashboardService } from '../../services/dashboard.service';
 import { MatButtonModule } from '@angular/material/button';
@@ -16,12 +16,17 @@ import { ActionMenuItem } from '../action-menu/action-menu-item';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [MatButtonModule, MatIconModule, CdkDropList, CdkDrag, MatRippleModule, GestureDirective, ActionMenuComponent],
   templateUrl: './dashboards-editor.component.html',
-  styleUrl: './dashboards-editor.component.scss'
+  styleUrl: './dashboards-editor.component.scss',
+  host: { '[class.compact]': 'compact()' }
 })
 export class DashboardsEditorComponent {
   protected _dashboard = inject(DashboardService);
   private _uiEvent = inject(uiEventService);
   private _dialog = inject(DialogService);
+
+  /** Compact single-row layout for the page-manager bottom sheet; full tiled grid otherwise. */
+  public readonly compact = input<boolean>(false);
+  protected readonly iconSizePx = computed(() => this.compact() ? 40 : 72);
 
   private readonly _actionMenu = viewChild.required(ActionMenuComponent);
   /** The tile whose action menu is currently open. */

--- a/src/app/core/components/page-manager-bottom-sheet/page-manager-bottom-sheet.component.html
+++ b/src/app/core/components/page-manager-bottom-sheet/page-manager-bottom-sheet.component.html
@@ -1,0 +1,9 @@
+<div class="page-manager-header">
+  <span class="page-manager-title">Pages</span>
+  <span class="page-manager-hint">drag to reorder · tap for options</span>
+  <button mat-icon-button aria-label="Close page manager" (click)="close()">
+    <mat-icon>close</mat-icon>
+  </button>
+</div>
+
+<dashboards-editor [compact]="true" />

--- a/src/app/core/components/page-manager-bottom-sheet/page-manager-bottom-sheet.component.scss
+++ b/src/app/core/components/page-manager-bottom-sheet/page-manager-bottom-sheet.component.scss
@@ -1,0 +1,25 @@
+:host {
+  display: block;
+}
+
+.page-manager-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 4px 4px 4px 16px;
+}
+
+.page-manager-title {
+  font-weight: 600;
+  font-size: 1.1em;
+}
+
+.page-manager-hint {
+  flex: 1 1 auto;
+  min-width: 0;
+  color: var(--mat-sys-on-surface-variant);
+  font-size: 0.85em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/src/app/core/components/page-manager-bottom-sheet/page-manager-bottom-sheet.component.spec.ts
+++ b/src/app/core/components/page-manager-bottom-sheet/page-manager-bottom-sheet.component.spec.ts
@@ -1,0 +1,52 @@
+import { signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatBottomSheetRef } from '@angular/material/bottom-sheet';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PageManagerBottomSheetComponent } from './page-manager-bottom-sheet.component';
+import { Dashboard, DashboardService } from '../../services/dashboard.service';
+import { DialogService } from '../../services/dialog.service';
+import { uiEventService } from '../../services/uiEvent.service';
+import { ensureTestIconsReady } from '../../../../test-helpers/icon-test-utils';
+
+describe('PageManagerBottomSheetComponent', () => {
+  let component: PageManagerBottomSheetComponent;
+  let fixture: ComponentFixture<PageManagerBottomSheetComponent>;
+  const bottomSheetRef = { dismiss: vi.fn() };
+  const dashboard = {
+    dashboards: signal<Dashboard[]>([{ id: 'a', name: 'Nav', icon: 'ic', configuration: [] }]),
+    activeDashboard: signal(0)
+  };
+
+  beforeEach(async () => {
+    bottomSheetRef.dismiss.mockClear();
+    await TestBed.configureTestingModule({
+      imports: [PageManagerBottomSheetComponent],
+      providers: [
+        { provide: MatBottomSheetRef, useValue: bottomSheetRef },
+        { provide: DashboardService, useValue: dashboard },
+        { provide: DialogService, useValue: { openDashboardPageEditorDialog: vi.fn(), openConfirmationDialog: vi.fn() } },
+        { provide: uiEventService, useValue: { isDragging: signal(false) } }
+      ]
+    }).compileComponents();
+
+    ensureTestIconsReady();
+    fixture = TestBed.createComponent(PageManagerBottomSheetComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('embeds the page editor in its compact layout', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('dashboards-editor')).not.toBeNull();
+    expect(el.querySelector('.dashboard-manage.compact')).not.toBeNull();
+  });
+
+  it('dismisses the sheet when closed', () => {
+    (component as unknown as { close: () => void }).close();
+    expect(bottomSheetRef.dismiss).toHaveBeenCalled();
+  });
+});

--- a/src/app/core/components/page-manager-bottom-sheet/page-manager-bottom-sheet.component.ts
+++ b/src/app/core/components/page-manager-bottom-sheet/page-manager-bottom-sheet.component.ts
@@ -1,0 +1,28 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { MatBottomSheetRef } from '@angular/material/bottom-sheet';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { DashboardsEditorComponent } from '../dashboards-editor/dashboards-editor.component';
+
+/**
+ * Bottom-sheet host for page management in edit mode. Presents the same page ops
+ * as the (retiring) full-page actions editor — add / drag-reorder / rename /
+ * duplicate / delete — as a compact horizontal card strip suited to a Pi-class
+ * touch display. The management logic itself lives in {@link DashboardsEditorComponent},
+ * rendered here in its compact layout.
+ */
+@Component({
+  selector: 'page-manager-bottom-sheet',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [MatButtonModule, MatIconModule, DashboardsEditorComponent],
+  templateUrl: './page-manager-bottom-sheet.component.html',
+  styleUrl: './page-manager-bottom-sheet.component.scss',
+})
+export class PageManagerBottomSheetComponent {
+  private readonly _bottomSheetRef =
+    inject<MatBottomSheetRef<PageManagerBottomSheetComponent>>(MatBottomSheetRef);
+
+  protected close(): void {
+    this._bottomSheetRef.dismiss();
+  }
+}

--- a/src/app/core/components/toolbar/toolbar.component.html
+++ b/src/app/core/components/toolbar/toolbar.component.html
@@ -1,4 +1,9 @@
-<div class="toolbar-host" [class.revealed]="chrome.revealed()" [class.peeking]="chrome.peeking()">
+<div
+  class="toolbar-host"
+  [class.revealed]="chrome.revealed()"
+  [class.peeking]="chrome.peeking()"
+  [class.editing]="isEditing()"
+>
   <button
     type="button"
     class="peek-strip"
@@ -16,26 +21,30 @@
     (mouseleave)="onPointerLeave()"
   >
     <div class="toolbar-group toolbar-start">
-      <button mat-icon-button aria-label="Actions" (click)="openActions()">
-        <mat-icon>apps</mat-icon>
-      </button>
-      @if (fullscreenSupported()) {
-        <button
-          mat-icon-button
-          [attr.aria-label]="fullscreenStatus() ? 'Exit fullscreen' : 'Enter fullscreen'"
-          (click)="toggleFullScreen()"
-        >
-          <mat-icon>{{ fullscreenStatus() ? 'close_fullscreen' : 'fullscreen' }}</mat-icon>
+      @if (isEditing()) {
+        <span class="editing-label"><mat-icon>edit</mat-icon>Editing layout</span>
+      } @else {
+        <button mat-icon-button aria-label="Actions" (click)="openActions()">
+          <mat-icon>apps</mat-icon>
         </button>
-      }
-      @if (!autoNightMode()) {
-        <button
-          mat-icon-button
-          [attr.aria-label]="isNightMode() ? 'Day mode' : 'Night mode'"
-          (click)="toggleNightMode()"
-        >
-          <mat-icon>{{ isNightMode() ? 'light_mode' : 'mode_night' }}</mat-icon>
-        </button>
+        @if (fullscreenSupported()) {
+          <button
+            mat-icon-button
+            [attr.aria-label]="fullscreenStatus() ? 'Exit fullscreen' : 'Enter fullscreen'"
+            (click)="toggleFullScreen()"
+          >
+            <mat-icon>{{ fullscreenStatus() ? 'close_fullscreen' : 'fullscreen' }}</mat-icon>
+          </button>
+        }
+        @if (!autoNightMode()) {
+          <button
+            mat-icon-button
+            [attr.aria-label]="isNightMode() ? 'Day mode' : 'Night mode'"
+            (click)="toggleNightMode()"
+          >
+            <mat-icon>{{ isNightMode() ? 'light_mode' : 'mode_night' }}</mat-icon>
+          </button>
+        }
       }
     </div>
 
@@ -44,17 +53,29 @@
     </div>
 
     <div class="toolbar-group toolbar-end">
-      <button mat-icon-button aria-label="Notifications" (click)="openNotifications()">
-        <mat-icon
-          [matBadge]="alarmCount()"
-          [matBadgeHidden]="!alarmCount()"
-          matBadgeSize="small"
-          matBadgeColor="warn"
-        >notifications</mat-icon>
-      </button>
-      <button mat-icon-button aria-label="Edit page" (click)="enterEdit()">
-        <mat-icon>lock_open</mat-icon>
-      </button>
+      @if (isEditing()) {
+        <button mat-icon-button aria-label="Manage pages" (click)="openPageManager()">
+          <mat-icon>dashboard_customize</mat-icon>
+        </button>
+        <button mat-icon-button aria-label="Cancel editing" (click)="cancelEdit()">
+          <mat-icon>close</mat-icon>
+        </button>
+        <button mat-icon-button aria-label="Done editing" (click)="doneEdit()">
+          <mat-icon>done</mat-icon>
+        </button>
+      } @else {
+        <button mat-icon-button aria-label="Notifications" (click)="openNotifications()">
+          <mat-icon
+            [matBadge]="alarmCount()"
+            [matBadgeHidden]="!alarmCount()"
+            matBadgeSize="small"
+            matBadgeColor="warn"
+          >notifications</mat-icon>
+        </button>
+        <button mat-icon-button aria-label="Edit page" (click)="enterEdit()">
+          <mat-icon>lock_open</mat-icon>
+        </button>
+      }
     </div>
   </div>
 </div>

--- a/src/app/core/components/toolbar/toolbar.component.html
+++ b/src/app/core/components/toolbar/toolbar.component.html
@@ -49,8 +49,8 @@
     </div>
 
     <div class="toolbar-group toolbar-center">
-      <page-nav-control />
       @if (!isEditing()) {
+        <page-nav-control />
         <button mat-icon-button class="manage-pages" aria-label="Manage pages" (click)="openPageManager()">
           <mat-icon>build</mat-icon>
         </button>

--- a/src/app/core/components/toolbar/toolbar.component.html
+++ b/src/app/core/components/toolbar/toolbar.component.html
@@ -50,13 +50,15 @@
 
     <div class="toolbar-group toolbar-center">
       <page-nav-control />
+      @if (!isEditing()) {
+        <button mat-icon-button class="manage-pages" aria-label="Manage pages" (click)="openPageManager()">
+          <mat-icon>build</mat-icon>
+        </button>
+      }
     </div>
 
     <div class="toolbar-group toolbar-end">
       @if (isEditing()) {
-        <button mat-icon-button aria-label="Manage pages" (click)="openPageManager()">
-          <mat-icon>dashboard_customize</mat-icon>
-        </button>
         <button mat-icon-button aria-label="Cancel editing" (click)="cancelEdit()">
           <mat-icon>close</mat-icon>
         </button>

--- a/src/app/core/components/toolbar/toolbar.component.scss
+++ b/src/app/core/components/toolbar/toolbar.component.scss
@@ -59,7 +59,8 @@
 
 // While a layout edit is active the peek strip is persistently visible and accent-coloured,
 // so the "reveal for Done/Cancel" affordance never fully disappears behind the auto-hide.
-// Only when the full toolbar is hidden — revealed, its own edit contents are the affordance.
+// The accent applies only while the toolbar is hidden (:not(.revealed)); once revealed, its
+// own Done/Cancel contents are the affordance.
 .toolbar-host.editing:not(.revealed) .peek-strip {
   background: var(--mat-sys-primary, #6ea8fe);
   box-shadow: 0 1px 8px 0 var(--mat-sys-primary, #6ea8fe);

--- a/src/app/core/components/toolbar/toolbar.component.scss
+++ b/src/app/core/components/toolbar/toolbar.component.scss
@@ -104,3 +104,10 @@
   min-width: 0;
   overflow: hidden;
 }
+
+// Manage-pages sits next to the page navigator; a small spacer sets it apart from the
+// page icons so it doesn't read as another page.
+.manage-pages {
+  margin-left: 8px;
+  flex: 0 0 auto;
+}

--- a/src/app/core/components/toolbar/toolbar.component.scss
+++ b/src/app/core/components/toolbar/toolbar.component.scss
@@ -41,9 +41,9 @@
   margin: 0;
   padding: 0;
   border: 0;
-  // A bright accent so the cue is easy to notice against dashboard content.
-  background: var(--mat-sys-primary, #6ea8fe);
-  box-shadow: 0 1px 8px 0 var(--mat-sys-primary, #6ea8fe);
+  // A neutral cue by default; it turns accent while editing (see .editing below) as a
+  // persistent "you're editing → reveal for Done/Cancel" reminder.
+  background: var(--mat-sys-outline-variant, #4a4d52);
   opacity: 0;
   transform: translateY(-100%);
   transition: transform 300ms ease, opacity 300ms ease;
@@ -55,6 +55,33 @@
   opacity: 1;
   transform: translateY(0);
   pointer-events: auto;
+}
+
+// While a layout edit is active the peek strip is persistently visible and accent-coloured,
+// so the "reveal for Done/Cancel" affordance never fully disappears behind the auto-hide.
+// Only when the full toolbar is hidden — revealed, its own edit contents are the affordance.
+.toolbar-host.editing:not(.revealed) .peek-strip {
+  background: var(--mat-sys-primary, #6ea8fe);
+  box-shadow: 0 1px 8px 0 var(--mat-sys-primary, #6ea8fe);
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.editing-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 8px;
+  font-weight: 500;
+  white-space: nowrap;
+  color: var(--mat-sys-primary, #6ea8fe);
+
+  mat-icon {
+    font-size: 20px;
+    width: 20px;
+    height: 20px;
+  }
 }
 
 .peek-strip:focus-visible {

--- a/src/app/core/components/toolbar/toolbar.component.spec.ts
+++ b/src/app/core/components/toolbar/toolbar.component.spec.ts
@@ -122,9 +122,10 @@ describe('ToolbarComponent', () => {
       expect(byLabel('Edit page')).toBeNull();
       // …replaced by the edit contents.
       expect(el.querySelector('.editing-label')).not.toBeNull();
-      expect(byLabel('Manage pages')).not.toBeNull();
       expect(byLabel('Cancel editing')).not.toBeNull();
       expect(byLabel('Done editing')).not.toBeNull();
+      // Page management is a normal-mode action, not part of the widget-layout edit.
+      expect(byLabel('Manage pages')).toBeNull();
       // The page dots stay put for switching pages mid-edit.
       expect(el.querySelector('page-nav-control')).not.toBeNull();
     });
@@ -144,11 +145,28 @@ describe('ToolbarComponent', () => {
       expect(dashboard.requestLayoutEditCancel).toHaveBeenCalledTimes(1);
     });
 
-    it('Manage pages opens the page-manager bottom sheet', () => {
-      dashboard.isDashboardStatic.set(false);
+  });
+
+  describe('manage-pages (normal-mode)', () => {
+    it('shows the Manage pages control next to the page dots in normal mode', () => {
+      dashboard.isDashboardStatic.set(true);
+      init();
+      const control = byLabel('Manage pages');
+      expect(control).not.toBeNull();
+      expect(control!.classList.contains('manage-pages')).toBe(true);
+    });
+
+    it('opens the page-manager bottom sheet from normal mode', () => {
+      dashboard.isDashboardStatic.set(true);
       init();
       byLabel('Manage pages')!.click();
       expect(bottomSheet.open).toHaveBeenCalledWith(PageManagerBottomSheetComponent);
+    });
+
+    it('hides Manage pages while editing (kept out of the widget-layout transaction)', () => {
+      dashboard.isDashboardStatic.set(false);
+      init();
+      expect(byLabel('Manage pages')).toBeNull();
     });
   });
 

--- a/src/app/core/components/toolbar/toolbar.component.spec.ts
+++ b/src/app/core/components/toolbar/toolbar.component.spec.ts
@@ -1,6 +1,7 @@
 import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
+import { MatBottomSheet } from '@angular/material/bottom-sheet';
 import { of } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppService } from '../../services/app-service';
@@ -10,6 +11,7 @@ import { DialogService } from '../../services/dialog.service';
 import { NotificationsService } from '../../services/notifications.service';
 import { SettingsService } from '../../services/settings.service';
 import { uiEventService } from '../../services/uiEvent.service';
+import { PageManagerBottomSheetComponent } from '../page-manager-bottom-sheet/page-manager-bottom-sheet.component';
 import { ToolbarComponent } from './toolbar.component';
 
 const chrome = {
@@ -22,9 +24,13 @@ const chrome = {
 const dashboard = {
   dashboards: signal([{ id: 'a', name: 'Nav', icon: 'ic' }]),
   activeDashboard: signal(0),
+  isDashboardStatic: signal(true),
   navigateTo: vi.fn(),
   setStaticDashboard: vi.fn(),
+  requestLayoutEditSave: vi.fn(),
+  requestLayoutEditCancel: vi.fn(),
 };
+const bottomSheet = { open: vi.fn() };
 const uiEvent = {
   toggleFullScreen: vi.fn(),
   fullscreenSupported: signal(true),
@@ -48,10 +54,12 @@ describe('ToolbarComponent', () => {
     for (const spy of [
       chrome.reveal, chrome.suppressHide, chrome.allowHide,
       dashboard.navigateTo, dashboard.setStaticDashboard,
+      dashboard.requestLayoutEditSave, dashboard.requestLayoutEditCancel, bottomSheet.open,
       uiEvent.toggleFullScreen, app.toggleDayNightMode, app.toggleNightMode, dialog.openNotifications, router.navigate,
     ]) spy.mockClear();
     chrome.revealed.set(false);
     chrome.peeking.set(false);
+    dashboard.isDashboardStatic.set(true);
     uiEvent.fullscreenSupported.set(true);
     uiEvent.fullscreenStatus.set(false);
     app.isNightMode.set(false);
@@ -69,6 +77,7 @@ describe('ToolbarComponent', () => {
         { provide: DialogService, useValue: dialog },
         { provide: NotificationsService, useValue: notifications },
         { provide: Router, useValue: router },
+        { provide: MatBottomSheet, useValue: bottomSheet },
       ],
     });
   });
@@ -101,6 +110,46 @@ describe('ToolbarComponent', () => {
     expect(dashboard.setStaticDashboard).toHaveBeenCalledWith(false);
     byLabel('Notifications')!.click();
     expect(dialog.openNotifications).toHaveBeenCalled();
+  });
+
+  describe('edit-mode toolbar swap', () => {
+    it('swaps normal nav controls for edit contents while the dashboard is non-static', () => {
+      dashboard.isDashboardStatic.set(false);
+      init();
+      // Normal controls are gone…
+      expect(byLabel('Actions')).toBeNull();
+      expect(byLabel('Notifications')).toBeNull();
+      expect(byLabel('Edit page')).toBeNull();
+      // …replaced by the edit contents.
+      expect(el.querySelector('.editing-label')).not.toBeNull();
+      expect(byLabel('Manage pages')).not.toBeNull();
+      expect(byLabel('Cancel editing')).not.toBeNull();
+      expect(byLabel('Done editing')).not.toBeNull();
+      // The page dots stay put for switching pages mid-edit.
+      expect(el.querySelector('page-nav-control')).not.toBeNull();
+    });
+
+    it('marks the host as editing so the peek strip renders accent', () => {
+      dashboard.isDashboardStatic.set(false);
+      init();
+      expect(el.querySelector('.toolbar-host')!.classList.contains('editing')).toBe(true);
+    });
+
+    it('Done requests a save and Cancel requests a cancel', () => {
+      dashboard.isDashboardStatic.set(false);
+      init();
+      byLabel('Done editing')!.click();
+      expect(dashboard.requestLayoutEditSave).toHaveBeenCalledTimes(1);
+      byLabel('Cancel editing')!.click();
+      expect(dashboard.requestLayoutEditCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('Manage pages opens the page-manager bottom sheet', () => {
+      dashboard.isDashboardStatic.set(false);
+      init();
+      byLabel('Manage pages')!.click();
+      expect(bottomSheet.open).toHaveBeenCalledWith(PageManagerBottomSheetComponent);
+    });
   });
 
   it('reveals on peek-strip click and suppresses/resumes hide on hover', () => {

--- a/src/app/core/components/toolbar/toolbar.component.spec.ts
+++ b/src/app/core/components/toolbar/toolbar.component.spec.ts
@@ -26,11 +26,12 @@ const dashboard = {
   activeDashboard: signal(0),
   isDashboardStatic: signal(true),
   navigateTo: vi.fn(),
+  navigateToActive: vi.fn(),
   setStaticDashboard: vi.fn(),
   requestLayoutEditSave: vi.fn(),
   requestLayoutEditCancel: vi.fn(),
 };
-const bottomSheet = { open: vi.fn() };
+const bottomSheet = { open: vi.fn(() => ({ afterDismissed: () => of(undefined) })) };
 const uiEvent = {
   toggleFullScreen: vi.fn(),
   fullscreenSupported: signal(true),
@@ -53,7 +54,7 @@ describe('ToolbarComponent', () => {
   beforeEach(() => {
     for (const spy of [
       chrome.reveal, chrome.suppressHide, chrome.allowHide,
-      dashboard.navigateTo, dashboard.setStaticDashboard,
+      dashboard.navigateTo, dashboard.navigateToActive, dashboard.setStaticDashboard,
       dashboard.requestLayoutEditSave, dashboard.requestLayoutEditCancel, bottomSheet.open,
       uiEvent.toggleFullScreen, app.toggleDayNightMode, app.toggleNightMode, dialog.openNotifications, router.navigate,
     ]) spy.mockClear();
@@ -161,6 +162,15 @@ describe('ToolbarComponent', () => {
       init();
       byLabel('Manage pages')!.click();
       expect(bottomSheet.open).toHaveBeenCalledWith(PageManagerBottomSheetComponent);
+    });
+
+    it('re-syncs the route to the active page when the sheet is dismissed', () => {
+      // A sheet delete can shift the active index without navigating; the URL must be re-synced
+      // on dismiss or a page dot at the stale index becomes a dead tap.
+      dashboard.isDashboardStatic.set(true);
+      init();
+      byLabel('Manage pages')!.click();
+      expect(dashboard.navigateToActive).toHaveBeenCalledTimes(1);
     });
 
     it('hides Manage pages while editing (kept out of the widget-layout transaction)', () => {

--- a/src/app/core/components/toolbar/toolbar.component.spec.ts
+++ b/src/app/core/components/toolbar/toolbar.component.spec.ts
@@ -125,10 +125,10 @@ describe('ToolbarComponent', () => {
       expect(el.querySelector('.editing-label')).not.toBeNull();
       expect(byLabel('Cancel editing')).not.toBeNull();
       expect(byLabel('Done editing')).not.toBeNull();
-      // Page management is a normal-mode action, not part of the widget-layout edit.
+      // Page navigation and management are normal-mode only: no page dots and no Manage pages
+      // while editing, so a mid-edit page switch can't discard the unsaved layout.
       expect(byLabel('Manage pages')).toBeNull();
-      // The page dots stay put for switching pages mid-edit.
-      expect(el.querySelector('page-nav-control')).not.toBeNull();
+      expect(el.querySelector('page-nav-control')).toBeNull();
     });
 
     it('marks the host as editing so the peek strip renders accent', () => {
@@ -149,9 +149,10 @@ describe('ToolbarComponent', () => {
   });
 
   describe('manage-pages (normal-mode)', () => {
-    it('shows the Manage pages control next to the page dots in normal mode', () => {
+    it('shows the page dots and the Manage pages control in normal mode', () => {
       dashboard.isDashboardStatic.set(true);
       init();
+      expect(el.querySelector('page-nav-control')).not.toBeNull();
       const control = byLabel('Manage pages');
       expect(control).not.toBeNull();
       expect(control!.classList.contains('manage-pages')).toBe(true);

--- a/src/app/core/components/toolbar/toolbar.component.ts
+++ b/src/app/core/components/toolbar/toolbar.component.ts
@@ -122,7 +122,13 @@ export class ToolbarComponent implements OnDestroy {
 
   /** Open the page-manager sheet (add / reorder / rename / duplicate / delete pages). */
   protected openPageManager(): void {
-    this.bottomSheet.open(PageManagerBottomSheetComponent);
+    // A sheet page op (e.g. deleting a lower page) can reassign the active page without
+    // navigating, leaving the URL on a now-stale index; re-sync the route on dismiss so the
+    // page dots stay tappable.
+    this.bottomSheet
+      .open(PageManagerBottomSheetComponent)
+      .afterDismissed()
+      .subscribe(() => this.dashboard.navigateToActive());
   }
 
   protected openNotifications(): void {

--- a/src/app/core/components/toolbar/toolbar.component.ts
+++ b/src/app/core/components/toolbar/toolbar.component.ts
@@ -3,6 +3,7 @@ import { Router } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatBadgeModule } from '@angular/material/badge';
+import { MatBottomSheet } from '@angular/material/bottom-sheet';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ChromeVisibilityService, CHROME_HOVER_DWELL_MS } from '../../services/chrome-visibility.service';
 import { DashboardService } from '../../services/dashboard.service';
@@ -12,6 +13,7 @@ import { SettingsService } from '../../services/settings.service';
 import { DialogService } from '../../services/dialog.service';
 import { NotificationsService } from '../../services/notifications.service';
 import { PageNavControlComponent } from '../page-nav-control/page-nav-control.component';
+import { PageManagerBottomSheetComponent } from '../page-manager-bottom-sheet/page-manager-bottom-sheet.component';
 
 /** Top-edge band (px) whose cursor dwell exposes the toolbar; matches `--peek-height` in the SCSS. */
 const PEEK_HOTZONE_PX = 8;
@@ -42,11 +44,15 @@ export class ToolbarComponent implements OnDestroy {
   private readonly dialog = inject(DialogService);
   private readonly router = inject(Router);
   private readonly notifications = inject(NotificationsService);
+  private readonly bottomSheet = inject(MatBottomSheet);
 
   protected readonly isNightMode = this.app.isNightMode;
   protected readonly autoNightMode = this.settings.autoNightMode;
   protected readonly fullscreenSupported = this.uiEvent.fullscreenSupported;
   protected readonly fullscreenStatus = this.uiEvent.fullscreenStatus;
+
+  /** While a layout edit is active the toolbar swaps its normal nav controls for edit contents. */
+  protected readonly isEditing = computed(() => !this.dashboard.isDashboardStatic());
 
   private readonly notificationsInfo = toSignal(this.notifications.observerNotificationsInfo());
   protected readonly alarmCount = computed(() => this.notificationsInfo()?.alarmCount ?? 0);
@@ -102,6 +108,21 @@ export class ToolbarComponent implements OnDestroy {
 
   protected enterEdit(): void {
     this.dashboard.setStaticDashboard(false);
+  }
+
+  /** Commit the current page's layout edit; the mounted dashboard serialises and saves the grid. */
+  protected doneEdit(): void {
+    this.dashboard.requestLayoutEditSave();
+  }
+
+  /** Discard the current page's layout edit; the mounted dashboard reloads the persisted config. */
+  protected cancelEdit(): void {
+    this.dashboard.requestLayoutEditCancel();
+  }
+
+  /** Open the page-manager sheet (add / reorder / rename / duplicate / delete pages). */
+  protected openPageManager(): void {
+    this.bottomSheet.open(PageManagerBottomSheetComponent);
   }
 
   protected openNotifications(): void {

--- a/src/app/core/services/dashboard.service.spec.ts
+++ b/src/app/core/services/dashboard.service.spec.ts
@@ -571,6 +571,16 @@ describe('DashboardService', () => {
       expect(service.layoutEditSaved()).toBe(2);
       expect(service.layoutEditCanceled()).toBe(1);
     });
+
+    it('counts inbound save and cancel edit requests', () => {
+      expect(service.layoutEditSaveRequested()).toBe(0);
+      expect(service.layoutEditCancelRequested()).toBe(0);
+      service.requestLayoutEditSave();
+      service.requestLayoutEditCancel();
+      service.requestLayoutEditCancel();
+      expect(service.layoutEditSaveRequested()).toBe(1);
+      expect(service.layoutEditCancelRequested()).toBe(2);
+    });
   });
 
   // Embed mode pins isDashboardStatic true at this single read-only choke point (#216 E6).

--- a/src/app/core/services/dashboard.service.ts
+++ b/src/app/core/services/dashboard.service.ts
@@ -47,6 +47,12 @@ export class DashboardService {
   public readonly layoutEditSaved = signal<number>(0);
   public readonly layoutEditCanceled = signal<number>(0);
 
+  // Inbound request channel: chrome outside the dashboard (the toolbar's edit-mode
+  // Done/Cancel) asks the mounted DashboardComponent — the only holder of the grid —
+  // to commit or discard. Counters, mirroring the layoutEdit{Saved,Canceled} notifications.
+  public readonly layoutEditSaveRequested = signal<number>(0);
+  public readonly layoutEditCancelRequested = signal<number>(0);
+
   /** True while a page-transition animation is in flight; blocks re-entrant navigation (#194). */
   public readonly isPageTransitioning = signal<boolean>(false);
   /** Travel direction of the pending navigation, set (wrap-aware) by the navigate* methods
@@ -507,5 +513,15 @@ export class DashboardService {
 
   public notifyLayoutEditCanceled(): void {
     this.layoutEditCanceled.update(v => v + 1);
+  }
+
+  /** Ask the mounted DashboardComponent to commit the current page's layout edit (toolbar Done). */
+  public requestLayoutEditSave(): void {
+    this.layoutEditSaveRequested.update(v => v + 1);
+  }
+
+  /** Ask the mounted DashboardComponent to discard the current page's layout edit (toolbar Cancel). */
+  public requestLayoutEditCancel(): void {
+    this.layoutEditCancelRequested.update(v => v + 1);
   }
 }

--- a/src/app/core/services/remote-dashboards.service.spec.ts
+++ b/src/app/core/services/remote-dashboards.service.spec.ts
@@ -32,6 +32,7 @@ class SettingsServiceStub {
 class DashboardServiceStub {
   public dashboards = signal<Dashboard[]>(DASHBOARDS);
   public activeDashboard = signal<number | null>(null);
+  public isDashboardStatic = signal<boolean>(true);
   public navigateTo: Mock = vi.fn();
 }
 
@@ -335,6 +336,17 @@ describe('RemoteDashboardsService', () => {
       enableRemoteControl();
 
       data.push(OWN_ACTIVE_SCREEN_PATH, 1);
+      TestBed.tick();
+
+      expect(dashboard.navigateTo).not.toHaveBeenCalled();
+    });
+
+    it('ignores a remote change while a local layout edit is in progress (local pre-empts)', () => {
+      dashboard.isDashboardStatic.set(false); // editing locally
+      createService();
+      enableRemoteControl();
+
+      data.push(OWN_ACTIVE_SCREEN_PATH, 2);
       TestBed.tick();
 
       expect(dashboard.navigateTo).not.toHaveBeenCalled();

--- a/src/app/core/services/remote-dashboards.service.ts
+++ b/src/app/core/services/remote-dashboards.service.ts
@@ -138,6 +138,9 @@ export class RemoteDashboardsService {
 
       untracked(() => {
         if (!this.isRemoteControl()) return;
+        // Local edits pre-empt remote nav: a controller changing the page while someone edits
+        // here must not navigate and reload the grid, which would discard the unsaved layout.
+        if (!this.dashboard.isDashboardStatic()) return;
         if (changeTo === undefined || changeTo.data.value == null) return;
         const idx = Number(changeTo.data.value);
         if (!isNaN(idx) && idx >= 0 && idx < this.dashboard.dashboards().length) {


### PR DESCRIPTION
Phase 1 of the Actions-surface redesign (#388). **Additive** — `/actions` and its full-page `dashboards-editor` stay in place this phase; Phase 2 (#390/#392) removes them.

## What changed

**Page management is a normal-mode "Manage pages" wrench** next to the page dots (small spacer sets it apart) → opens a new `page-manager-bottom-sheet` hosting `dashboards-editor` in a new **compact** single-row layout (add / drag-reorder / rename / duplicate / delete). Page ops persist immediately and self-confirm — a separate, non-transactional surface.

**Edit mode is widget-layout only, on the auto-hiding toolbar.** While non-static the toolbar swaps to an accent **"Editing layout"** label + **Cancel · Done** (Done in the former pen slot). Page navigation (dots) and management (wrench) are **hidden while editing** — normal-mode only. With `pageNav()`'s existing keyboard/swipe guard and the new remote-nav guard (a local edit pre-empts a remote page change), this closes the mid-edit page-switch data loss for every **in-app** path. Browser Back still navigates: page-level Back intentionally abandons the edit; Back-should-close-the-widget-settings-dialog is tracked in #393. The pinned in-dashboard Done/Cancel FABs are gone; the peek strip is neutral normally and **accent while editing**.

> **Design note:** an earlier iteration put "Manage pages" *inside* edit mode. Review showed that gave edit mode a Cancel that couldn't undo the immediate page ops, and let a page op corrupt an in-flight widget edit. Splitting them (wrench in normal mode; edit mode widget-only) fixes both — see #388.

**How Done/Cancel reach the grid:** the toolbar doesn't hold the gridstack, so `DashboardService` gains `requestLayoutEditSave/Cancel` counters; the mounted `DashboardComponent` runs its existing transactional `saveLayoutChanges()`/`cancelLayoutChanges()`. Counters are snapshotted at construction so a stale value can't auto-fire on a navigation remount.

**Active-page identity reload:** the grid reloads when the active page's *id* changes (not just its index), so deleting the active page doesn't leave the deleted page's widgets on screen.

## Verification

- `npm run ci` green; `build:prod` succeeds.
- Specs: manage-pages wrench (present/opens in normal mode, absent in edit); edit-mode swap + Done/Cancel wiring; request-counter remount guard; active-page identity reload (reloads on delete-active, not on config saves); compact editor; page-manager sheet.
- On-boat smoke pending.

Part of #388.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

