### PR TITLE
docs: reflect the current design; fix SK/embed accuracy across help + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,26 +63,25 @@ The goal is to replicate and enhance the functionality of modern marine instrume
 ## User Experience
 
 ### Interactions
-- Swipe up and down to navigate through your dashboards effortlessly.
-- Swipe left and right to access notifications and other system features quickly.
-- Use keyboard shortcuts for essential features, ensuring fast and efficient navigation across devices types.
+- **Touch:** swipe left/right to move between pages, swipe down from the top to reveal the auto-hiding toolbar, and tap a page's icon to jump straight to it.
+- **Mouse:** scroll to change pages, click the top peek strip (or scroll up) to reveal the toolbar, and click any control.
+- **Keyboard:** single-key shortcuts for the essentials — <kbd>←</kbd>/<kbd>→</kbd> change pages, <kbd>E</kbd> edit, <kbd>F</kbd> fullscreen, <kbd>N</kbd> night mode, <kbd>Esc</kbd> cancel an edit.
 
 ### Customize
 - Effortlessly create and customize dashboards using an intuitive grid layout system.
 - Add, resize, and align widgets to design tailored displays for your specific needs.
 - Duplicate widgets or entire dashboards, including their configurations, with a single click.
-- Simply drag dashboards to reorganize them. Double-click any dashboard to open the icon gallery and give each page a unique visual identity.
+- Reorder pages by dragging, and give each a unique icon and name — open the toolbar's **Manage pages** panel, tap a page, and choose Edit.
 - Easily switch between multiple user and device configurations profiles for different roles, formfactors or use cases.
 
-Sidenav for quick access to all important features.
-![Sidenav Dashboard Access](./images/ActionSidenav.png)
+An auto-hiding toolbar keeps the screen clutter-free and puts navigation one tap away: page icons to jump between pages, a **Manage pages** button, and a menu for Settings, Connection, Remote Control, and Help.
 
 ## Dashboards and Configuration
 
 ### Customizable and Easy
 Meant to build purposeful dashboards with however many widgets you want, wherever you want them.
 
-Add, resize, and position the widgets of your choosing. Need more? Add as many additional dashboards as you wish to keep your display purposeful. Simply swipe up and down to quickly cycle through dashboards or effortlessly jump between dashboards with a single tap in the action sidenav, always knowing exactly where you are thanks to clear highlighting of your current dashboard.
+Add, resize, and position the widgets of your choosing. Need more? Add as many pages as you wish to keep your display purposeful. Swipe left and right to cycle through pages, or tap a page's icon in the toolbar to jump straight to it — the current page is always clearly highlighted.
 
 Widget lists are sorted by category.
 ![Layouts Configuration Image](./images/SkipWidgetConfig-layout-1024.png)
@@ -96,8 +95,7 @@ See what Signal K has to offer that you can leverage with widgets. Select it and
 Many units are supported. Choose your preferred app defaults, then tweak them widget-by-widget as necessary. Skip will automatically convert the units for you.
 ![Units Configuration Image](./images/SkipConfig-Units-1024.png)
 
-Organize your dashboards and access tools.
-![Options and Dashboards](./images/Options.png)
+Organize your pages from the toolbar's **Manage pages** panel — add, reorder, rename, duplicate, and delete.
 
 ## Widget Library
 All Skip widgets are visual presentation controls that are very versatile, with multiple advanced configuration options available to suit your needs:
@@ -262,13 +260,13 @@ Once done with your work, from your fork's working branch, make a GitHub pull re
 For comprehensive development guidance, please refer to these instruction files:
 
 ### Primary Instructions
-- **[Project Instructions](./.github/instructions/project.instructions.md)**: Skip policy owner for architecture/domain rules, including widget creation and Host2 contracts.
-- **[COPILOT.md](./COPILOT.md)**: Architecture context, rationale, and evolution notes (non-policy).
+- **[CLAUDE.md](./CLAUDE.md)**: The authoritative repo guide — architecture, commands, the testing model, and fork-specific gotchas. **Start here.**
+- **[Project Instructions](./.github/instructions/project.instructions.md)**: Skip policy for architecture/domain rules, including widget creation and Host2 contracts.
 - **[Angular Instructions](./.github/instructions/angular.instructions.md)**: Modern Angular v21+ coding standards, component patterns, and framework best practices.
-- **[Copilot Agent Instructions](./.github/copilot-instructions.md)**: Architecture details and coding-agent guardrails for this repository.
+- `COPILOT.md` and `.github/copilot-instructions.md` are inherited from upstream Kip — useful as loose architecture context, but partly stale; verify any command or claim against CLAUDE.md and the code.
 
 ### Development Workflow
-1. **Start Here**: Read `.github/instructions/project.instructions.md` for Skip policy contracts.
+1. **Start Here**: Read `CLAUDE.md` for architecture, commands, and the testing model; then `.github/instructions/project.instructions.md` for Skip policy contracts.
 2. **Angular Standards**: Follow `.github/instructions/angular.instructions.md` for modern Angular development.
 3. **Architecture Context**: Use `COPILOT.md` for rationale and dated architecture notes.
 4. **Setup & Build**: Use this README for project setup and build commands.

--- a/src/assets/help-docs/ais-radar.md
+++ b/src/assets/help-docs/ais-radar.md
@@ -15,7 +15,7 @@ This page explains:
 
 ## Data Requirements
 
-> AIS data must be available in the Signal K server for the widget to function correctly. This usually means using compatible AIS hardware receiver or connecting to a Virtual AIS service over the internet with a Server Connection of type WebSocket.
+> AIS data must be available in the Signal K server for the widget to function correctly. This usually means a compatible AIS hardware receiver, or a Virtual AIS service configured **on the Signal K server** (for example a WebSocket data connection in the server's settings). Skip subscribes to whatever AIS data the server provides — it has no connection settings of its own.
 
 Skip subscribes to remote AIS and DSC targets automatically, so no connection setting is required to receive them.
 
@@ -119,7 +119,7 @@ Own ship shows an orange dashed vector when own COG and SOG are available and ow
 
 After you understand the visual cues above, use these options to tune what you see.
 
-The widget is configured in the Options dialog under the Display and Filter tabs.
+To configure the widget, enter edit mode (tap the pen), tap the widget to open its action menu, and choose **Configure** — the options dialog has **Display** and **Filter** tabs.
 
 ### Display and range options
 

--- a/src/assets/help-docs/community.md
+++ b/src/assets/help-docs/community.md
@@ -19,7 +19,7 @@ Improve or add entries: PR or Discord #showcase.
 
 
 ## Authors & Channels
-Creator channels producing helpful Kip or Signal K related content.
+Creator channels producing helpful Skip, Kip, or Signal K related content.
 
 ### Boating with the Baileys
 - Channel: https://www.youtube.com/@BoatingwiththeBaileys

--- a/src/assets/help-docs/configuration.md
+++ b/src/assets/help-docs/configuration.md
@@ -34,7 +34,7 @@ Then sign in to that account from Skip via **Menu > Connection > Sign in**.
 
 A **profile** is a named set of pages, layouts, and theme, stored under your Signal K user account. Profiles let a single account keep several independent setups — for example one per station, role, or device form factor. Each device remembers which profile it is showing, so different displays signed in as the same user can each show a different profile.
 
-Manage profiles in **Settings > Configurations**:
+Manage profiles in **Menu > Settings > Configurations**:
 
 - **New** — create a new profile.
 - **Switch** — show a different profile on this device.
@@ -51,7 +51,7 @@ To keep devices independent, either sign in with **different** Signal K users, o
 
 ## Backup, Import, and Reset
 
-The **Advanced** section of **Settings > Configurations** provides:
+The **Advanced** section of **Menu > Settings > Configurations** provides:
 
 - **Download** — save the active profile's configuration to a file, for backup or to move it to another Signal K server.
 - **Import** — load a configuration file as a **new profile**. This never overwrites an existing profile.

--- a/src/assets/help-docs/contact-us.md
+++ b/src/assets/help-docs/contact-us.md
@@ -25,7 +25,7 @@ Before creating a new issue:
 Provide clear, specific details so we can reproduce and fix the problem faster:
 - What you expected vs. what happened
 - Steps to reproduce (numbered list if possible)
-- Skip version (see About / build info) and deployment method (e.g. Signal K app store, manual build)
+- Skip version (shown in the toolbar menu footer, or on the **Connection** status page alongside your browser and OS) and deployment method (e.g. Signal K app store, manual build)
 - Signal K server version
 - Browser + version (e.g. Firefox 128, Chrome 129, Safari 18)
 - Relevant widget(s) or data paths (e.g. `navigation.speedOverGround`)
@@ -51,7 +51,7 @@ If something critical slips through, feel free to politely bump the issue after 
 
 
 ## Contributing Beyond Issues
-- Share dashboards, layouts, or usage patterns. Use the Discord #showcase chanel with a few pictures (great inspiration for others!).
+- Share dashboards, layouts, or usage patterns. Use the Discord #showcase channel with a few pictures (great inspiration for others!).
 - Help answer other users’ questions on Discord.
 - Test new widgets or configuration flows and give feedback.
 

--- a/src/assets/help-docs/contributing-widgets.md
+++ b/src/assets/help-docs/contributing-widgets.md
@@ -29,8 +29,8 @@ Developer references:
 2. Generate and implement the widget.
 3. Generate and implement the widget test when necessary.
 4. Add an svg icon
-5. Update README.md and Skip documentation with your plugin information.
-6. Validate with lint/tests (ng lint/ng test).
+5. Update README.md and Skip documentation with your widget information.
+6. Validate with lint/tests (`npm run lint` / `npm test`, or `npm run ci` for the full gate).
 7. Submit a pull request with screenshots and a short behavior summary.
 
 ## Notes

--- a/src/assets/help-docs/dashboards.md
+++ b/src/assets/help-docs/dashboards.md
@@ -7,36 +7,34 @@ Reveal the toolbar and tap the **Manage pages** button (the wrench next to the p
 
 Here you can:
 - Add a new page (+ button)
-- Reorder pages (drag with touch or mouse)
-- Rename and pick an icon (double tap or double click)
-- Duplicate a page (long press or long click → Duplicate)
-- Delete a page (long press or long click → Delete)
+- Reorder pages (drag a page card, with touch or mouse)
+- Rename, change the icon, duplicate, or delete a page — **tap or click the page card** to open its menu, then choose **Edit** (rename + icon), **Duplicate**, or **Delete**
 
 Choose icons that reflect each page’s purpose (e.g. compass for navigation, droplet for tanks, bolt for power). Icons appear wherever pages are listed.
 
 ### Gesture / Action Summary
-| Action        | Touch / Mobile         | Mouse / Desktop         |
-|---------------|------------------------|-------------------------|
-| Add page      | Tap (+)                | Click (+)               |
-| Reorder       | Drag tile              | Drag tile               |
-| Rename/Icon   | Double tap             | Double click            |
-| Duplicate     | Long press → Duplicate | Long click → Duplicate  |
-| Delete        | Long press → Delete    | Long click → Delete     |
+| Action                        | Touch / Mobile        | Mouse / Desktop        | Keyboard                          |
+|-------------------------------|-----------------------|------------------------|-----------------------------------|
+| Add a page                    | Tap (+)               | Click (+)              | Focus (+), press Enter/Space      |
+| Reorder pages                 | Drag a page card      | Drag a page card       | —                                 |
+| Rename / duplicate / delete   | Tap a page → menu     | Click a page → menu    | Focus a page, Enter/Space → menu  |
+
+The page's menu offers **Edit** (rename + change icon), **Duplicate**, and **Delete** (Delete asks you to confirm).
 
 
 ## Editing Page Layouts
 1. Go to the page you want to change (swipe sideways, scroll horizontally, or tap its icon in the toolbar’s page navigator).
 2. Reveal the toolbar (swipe down from the top, scroll up, or tap the top peek strip).
-3. Tap the edit button to unlock the page.
+3. Tap the edit button (the pen) to unlock the page — or press **E** on a keyboard.
 
-In edit mode, widgets show dashed outlines.
+In edit mode, widgets show dashed outlines, and the toolbar swaps to an "Editing layout" label with **Cancel** and **Done** buttons (Done sits in the pen's former slot). The page navigator is hidden while editing, so finish (Done/Cancel) before switching pages.
 
 ### What You Can Do in Edit Mode
 - Add a widget (tap empty space → Add Widget)
 - Move a widget (drag)
 - Resize a widget (drag edges/corners)
 - Configure, duplicate, or delete a widget (tap it → action menu; Delete asks to confirm)
-- Save changes (Check button) or discard (X button) in the lower right
+- **Save** changes (Done) or **discard** them (Cancel, or press **Esc**) — both are in the toolbar while editing
 
 >**Tip:** If you can’t add a widget, free up space by resizing or moving existing ones first.
 
@@ -110,7 +108,7 @@ Skip widgets turn Signal K data into readable visuals and controls. Available wi
 | Issue                  | Possible Cause                        | Fix                                                                 |
 |------------------------|---------------------------------------|---------------------------------------------------------------------|
 | Data shows “—” or blank| Path missing/not configured/null value | Open widget config, verify Signal K path exists and updates. Use the Signal K Data Browser to view raw data from the server. |
-| Wrong units            | Default convert unit used              | Edit widget config paths and set the desired target unit.            |
+| Wrong units            | Server display-unit preference, or a per-widget override | Skip shows units from the Signal K server's unit preferences by default; to override for one widget, edit its config paths and set the desired target unit. |
 | Slow page switching    | Excessive data sampling/too many widgets| Increase sample times; remove unused widgets. Split widgets into separate pages. Optimize system resource usage. |
 | Embedded page blank    | Cross‑origin blocked                   | See "Embed Page Viewer" help section.                               |
 | History dialog not opening on a locked page | The page is still in edit mode, or the widget has no numeric data | Lock the page first, then press and hold the widget. Only numeric‑data widgets have a history. |

--- a/src/assets/help-docs/embedwidget.md
+++ b/src/assets/help-docs/embedwidget.md
@@ -1,66 +1,66 @@
 ## Using the Embed Page Viewer Widget
 
-The Embed Page Viewer widget allows you to display external web pages or web applications directly within your dashboard. By default, the Embed Page Viewer widget does not allow input (touch, mouse and keyboard interactions) with the content in the Embed. To enable interactions, check the setting the widget's options. 
+The Embed Page Viewer widget allows you to display external web pages or web applications directly within your dashboard. By default, the Embed Page Viewer widget does not allow input (touch, mouse and keyboard interactions) with the content in the Embed. To enable interactions, check the setting in the widget's options.
 
-While this embedding feature is powerful, it comes with certain limitations due to browser security policies, specifically related to Cross-Origin Resource Sharing (CORS). This guide explains these limitations in simple terms and how they might affect your use of the widget.
+While this embedding feature is powerful, it comes with certain limitations due to browser security policies — specifically, whether the embedded site permits being shown in an iframe, and whether it shares the same origin as Skip. This guide explains these limitations in simple terms and how they might affect your use of the widget.
 
-## What Are CORS Limitations?
+## Why Some Pages Won't Embed
 
-CORS (Cross-Origin Resource Sharing) is a security feature built into web browsers. It prevents one website from accessing resources (like web pages or data) from another website unless the other website explicitly allows it. This is done to protect users from malicious websites trying to steal data or perform unauthorized actions.
+Whether a page can be shown inside an iframe is decided by **the page you are embedding**, not by Skip or Signal K. A site controls this with the `X-Frame-Options` HTTP header or a `Content-Security-Policy: frame-ancestors` directive. If the site forbids framing (many banking, social-media, and login sites do), the browser blocks it and you see a blank area or an error. Nothing the widget does can bypass it — the site owner has to allow it (see "Authorizing Skip to Load Embedded Content" below).
 
-When you use the Embed Page Viewer widget, it tries to load the content of the URL you provide into an iframe. However, if the website you are trying to embed does not allow its content to be displayed in an iframe on another website (like embeding their app in your Skip dashboard), the browser will block it. This is not something the widget or Signal K can control—it is a restriction set by the website you are trying to embed.
+> This is a different mechanism from CORS. CORS governs cross-origin *data* requests (fetch/XHR); it does not decide whether a page can be framed.
 
-## Understanding CORS and Hostname/Port Behavior
+## Same-Origin Content and Gestures
 
-It is important to clarify that CORS (Cross-Origin Resource Sharing) restrictions are not enforced when the hostname and port of the embedded content match the hostname and port of the Skip dashboard. This is because CORS only applies to requests made across different origins. An origin is defined as a combination of the protocol (e.g., `http` or `https`), hostname (e.g., `localhost` or `example.com`), and optional port (e.g., `80`, `443`, or a custom port). If all those are the same as the ones used by Skip, irrespective of the paths that can be present after the port, it is a same-origin path and CORS restrictions do not apply.
+A second browser rule matters here: the **same-origin policy**. When you turn on **Enable Input**, Skip injects small gestures into the embedded page so you can still swipe to change pages or reveal the auto-hiding toolbar over a full-screen embed. The browser only lets Skip script the iframe when the embedded content is **same-origin** — the same protocol, hostname, and port as the Skip dashboard. An origin is that combination of protocol (e.g. `http` or `https`), hostname (e.g. `localhost` or `example.com`), and optional port (e.g. `80`, `443`, or a custom port); the path after the port doesn't matter.
 
-### When CORS Does Not Apply
+### When Content Is Same-Origin
 
-If the URL you are embedding in the Embed Page Viewer widget uses the same hostname and port as your Skip dashboard (e.g., all Signal K app store applications), the browser considers it to be the same origin. In this case, CORS restrictions do not apply, and the content can be embedded without issues.
+If the URL you embed uses the same protocol, hostname, and port as your Skip dashboard (e.g. any Signal K app-store application served by your own server), the browser treats it as same-origin: Skip's gestures work over it, and framing is not an issue.
 
 #### Examples:
 
-1. **Same Origin (No CORS Restrictions)**:
+1. **Same Origin**:
    - Skip Dashboard URL: `http://localhost:3000/@halos-org/skip/`
    - Embedded Content URL: `http://localhost:3000/some-page/`
-   - Since both Skip and the embedded URL share the same protocol (`http`), hostname (`localhost`), and port (`3000`), CORS does not apply.
+   - Both share the same protocol (`http`), hostname (`localhost`), and port (`3000`), so this is same-origin — Skip's gestures work over it.
 
-2. **Different Origin (CORS Restrictions Apply)**:
+2. **Different Origin (cross-origin)**:
    - Skip Dashboard URL: `http://localhost:3000/@halos-org/skip/`
    - Embedded Content URL: `http://localhost:4000/some-page/`
-   - In this case, the ports are different (`3000` vs. `4000`), so the browser considers them to be different origins, and CORS restrictions will apply.
+   - The ports differ (`3000` vs. `4000`), so the browser treats them as different origins: Skip can't inject gestures, and whether the page frames at all is up to its own policy.
 
-3. **Different Hostname (CORS Restrictions Apply)**:
+3. **Different Hostname (cross-origin)**:
    - Skip Dashboard URL: `http://dashboard.local/@halos-org/skip/`
    - Embedded Content URL: `http://example.com/some-page`
-   - Even if the ports are the same, the hostnames are different (`dashboard.local` vs. `example.com`), so CORS restrictions will apply.
+   - Even with the same port, the hostnames differ (`dashboard.local` vs. `example.com`), so this is cross-origin.
 
-4. **Different Protocol (CORS Restrictions Apply)**:
+4. **Different Protocol (cross-origin)**:
    - Skip Dashboard URL: `http://localhost:3000/@halos-org/skip/`
    - Embedded Content URL: `https://localhost:3000/some-page/`
-   - Even though the hostname and port are the same, the protocols are different (`http` vs. `https`), so CORS restrictions will apply.
+   - Even with the same hostname and port, the protocols differ (`http` vs. `https`), so this is cross-origin.
 
 ### IMPORTANT:  Practical Implications for Skip Users
 
-- Embedding webapp and websites is far from perfect. Their are tradeoffs and limitations. If you find yourself unhappy with the result, keep your smile and give back to the community by build a dedicated Skip widget. We will help and many have done so.
+- Embedding webapps and websites is far from perfect. There are tradeoffs and limitations. If you find yourself unhappy with the result, keep your smile and give back to the community by building a dedicated Skip widget. We will help and many have done so.
 - By default you cannot interact with the Embed content. Activate the **Enable Input** widget option if you need to interact with the content.
 - If you are hosting custom web pages or applications on the same server as your Skip dashboard, ideally you've created a Signal K webapp and shared it with the community, ensure they use the same hostname and port. Use a relative URL path in the Embed configuration. For example, if your Skip dashboard is running on `http://localhost:3000/@halos-org/skip/` and your custom content is under the same origin, such as `http://localhost:3000/signalk-anchoralarm-plugin/` simply enter a relative URL in the widget options, like `/signalk-anchoralarm-plugin/`. Skip will automatically add the proper protocol, hostname, port and load the content. This will prevent issues loading the embedded content when launching Skip from different devices such as: the server, on your phone, tablet, laptop, etc.
 
 ### Summary
 
-CORS restrictions only apply when the protocol, hostname, or port of the embedded content differs from the Skip dashboard. By ensuring that your embedded content shares the same origin as the dashboard, you can avoid CORS-related issues and seamlessly use the Embed Page Viewer widget.
+Two independent rules apply: the embedded site's framing policy (`X-Frame-Options` / `frame-ancestors`) decides whether it can be shown at all, and the same-origin policy decides whether Skip can inject gestures over it. Hosting your embedded content at the same origin as the dashboard avoids the second problem entirely and lets you use the Embed Page Viewer widget seamlessly.
 
 ## How Does This Affect the Embed Widget?
 
 1. **Blocked Content**:
-   - If the website you are trying to embed has CORS restrictions or does not allow embedding via iframes, the widget will not display the content. Instead, you might see a blank area or an error message.
+   - If the website you are trying to embed forbids framing (via `X-Frame-Options` or a `frame-ancestors` policy), the widget will not display the content. Instead, you might see a blank area or an error message.
 
 2. **Common Examples of Blocked Content**:
    - Many popular websites (e.g., banking sites, social media platforms, or secure portals) block iframe embedding for security reasons.
    - Some websites may allow embedding only for specific trusted domains, which most probably, do not include your Signal K installation.
 
-3. **Consequences of Blocked Content in Skip**:
-   - When you enable the "Allow Input" Embed widget option, Skip needs to inject gestures within the embedded application to trigger page navigation or reveal the auto-hiding toolbar. To achieve this, Skip dynamically injects scripts into the iframe application. If CORS restrictions apply, this will be prohibited by the browser. This means that gestures will not work over the Embed widget. If you have a full-screen Embed widget, you could get stuck with no way to change pages or reveal the toolbar.
+3. **Consequences of Cross-Origin Content in Skip**:
+   - When you enable the "Enable Input" Embed widget option, Skip needs to inject gestures within the embedded application to trigger page navigation or reveal the auto-hiding toolbar. To do this, Skip scripts the iframe. The same-origin policy only permits this for same-origin content, so over a **cross-origin** embed the gestures will not work. If you have a full-screen cross-origin Embed widget, you could get stuck with no way to change pages or reveal the toolbar.
 
 4. **No Workaround for Restricted Websites**:
    - If the application does not allow iframe embedding, there is no way to bypass this restriction without the application owner's adding some kind of authorization for you. This is a browser-enforced security feature.
@@ -92,4 +92,4 @@ When using the Embed Page Viewer widget, it is important to understand that the 
        ```
 
 2. **Test the Configuration**:
-   - After updating the HTTP headers, test the website in the Embed Page Viewer widget. To ensure it loads correctly, look in the Browser's consol log for error messages.
+   - After updating the HTTP headers, test the website in the Embed Page Viewer widget. To ensure it loads correctly, look in the browser's console log for error messages.

--- a/src/assets/help-docs/grafana.md
+++ b/src/assets/help-docs/grafana.md
@@ -1,4 +1,4 @@
-## 5 Minutes with Graphana
-Introduction to using Graphana (by Boating with the Baileys)
+## 5 Minutes with Grafana
+Introduction to using Grafana (by Boating with the Baileys)
 
 [![Watch the video](https://img.youtube.com/vi/b3lHwLnYgx0/0.jpg)](https://www.youtube.com/watch?v=b3lHwLnYgx0)

--- a/src/assets/help-docs/history-api.md
+++ b/src/assets/help-docs/history-api.md
@@ -1,7 +1,7 @@
 ## Using a History API Provider
 
 Skip reads historical data from an external Signal K History API provider plugin. With a compatible provider installed, Skip can:
-1. Pre-seed Data Plot and Wind Trends so they show recent trends immediately.
+1. Pre-seed Realtime Data Plot and Wind Trends so they show recent trends immediately.
 2. Populate historical views for widgets on your pages that use numeric value paths.
 
 You must configure the provider plugin to capture the paths you want to plot, and it must have enough recorded data to cover your plot time span. This is not automatic.
@@ -116,7 +116,7 @@ To seed plots with historical data, you must configure your provider to collect 
 1. Verify that a History API plugin is installed on your Signal K server.
 2. Configure the plugin to capture the paths you want to plot.
 3. Wait for the plugin to collect enough data to fill your plot time span.
-4. Open a Data Plot or Wind Trends widget with a time scale of minutes or longer.
+4. Open a Realtime Data Plot or Wind Trends widget with a time scale of minutes or longer.
 5. Let the plot load; history appears when available.
 6. For more details, consult plugin documentation and Signal K community resources.
 

--- a/src/assets/help-docs/kiosk.md
+++ b/src/assets/help-docs/kiosk.md
@@ -3,6 +3,8 @@
 This guide launches Chromium in kiosk mode to display Skip at:
 http://<sk_server_IP>:3000/@halos-org/skip/#/page/0
 
+Use your server's real address and port. `:3000` is the default for a bare Signal K server; on a secured/proxied setup use the **HTTPS** address served through the reverse proxy instead (also required if you want Skip's own *Keep screen awake* Display setting to work — see Screen Blanking below). Substitute your URL in every command that follows.
+
 It supports Raspberry Pi OS Bullseye (X11/LXDE) and Bookworm (Wayland).
 
 ## What is “kiosk mode”?

--- a/src/assets/help-docs/time-series.md
+++ b/src/assets/help-docs/time-series.md
@@ -7,7 +7,7 @@ History is served by an external **Signal K History API provider** — a server 
 See [History-API Provider](#/help/history-api.md) in the Integrations help menu for how to install and configure a provider.
 
 ## What Skip Does With History
-- Pre-seeds Data Plot and Wind Trends so they show recent trends immediately on open.
+- Pre-seeds Realtime Data Plot and Wind Trends so they show recent trends immediately on open.
 - Provides a pop-up historical view for numeric-value widgets on your pages.
 
 The detail and time span available depend entirely on what your provider has recorded and how it is configured.
@@ -20,7 +20,7 @@ The pop-up plot displays recorded data only (no live-stream overlay), across a f
 ## Supported Widgets
 Most widgets that use numeric paths support history, including Horizon, Battery Monitor, Solar, and similar numeric-based widgets. Plot widgets seed from history according to their configuration:
 
-#### Data Plot Widget
+#### Realtime Data Plot Widget
 - **Supported:** Yes, seeded with history data.
 - **Requirements:** Time scale must be minutes or longer.
 

--- a/src/assets/help-docs/video-recipes.md
+++ b/src/assets/help-docs/video-recipes.md
@@ -1,8 +1,9 @@
 ## Video Recipes
 
 Short, step-by-step guides for the most common things people do with the Video widget. Each one
-starts from a page in **edit mode** (tap the pencil/unlock to add or change widgets). For the
-full reference, see **The Video Widget** help page.
+starts from a page in **edit mode**: tap the edit button (pen) to unlock the page, then tap an
+empty grid space and choose **Add Widget** → **Video**. For the full reference, see **The Video
+Widget** help page.
 
 > Recipes that use a **camera** or **uploaded video** need the free **SK Video** add-on installed on
 > your boat's Signal K server. Recipes that use a **web address (URL)** work with no add-on.

--- a/src/assets/help-docs/welcome.md
+++ b/src/assets/help-docs/welcome.md
@@ -7,6 +7,7 @@ Skip supports touch, mouse, and keyboard input across devices.
 | Move between pages   | Swipe left or right          | Scroll horizontally                   | <kbd>←</kbd>/<kbd>→</kbd> (Left/Right Arrow)       |
 | Jump to a page       | Tap its icon in the toolbar  | Click its icon in the toolbar         | —                                                 |
 | Enter page edit mode | Tap the edit button          | Click the edit button                 | <kbd>E</kbd>                                       |
+| Save page edit       | Tap the Done button          | Click the Done button                 | —                                                 |
 | Cancel page edit     | Tap the Cancel button        | Click the Cancel button               | <kbd>Esc</kbd>                                     |
 | Toggle Fullscreen    | —                            | Click the fullscreen button           | <kbd>F</kbd>                                       |
 | Toggle Night mode    | Tap the night-mode button    | Click the night-mode button           | <kbd>N</kbd>                                       |
@@ -22,7 +23,7 @@ Skip has no permanent navigation bar. A toolbar sits hidden at the top of the pa
 <img src="assets/help-docs/img/toolbar.png" alt="The Skip toolbar with numbered callouts, left to right" title="The Skip toolbar" width="100%">
 
 The toolbar holds, from left to right:
-1. Menu — opens Settings, Connection, Remote Control, and Help
+1. Menu — opens Settings, Connection, Remote Control, and Help (with a footer showing the Skip version and host)
 2. *Fullscreen toggle
 3. **Night-mode toggle
 4. Page navigator — one icon per page; tap a page’s icon to jump to it
@@ -37,25 +38,28 @@ When an alarm is active, a notification badge also appears in the lower-left cor
 **Only visible if automatic day and night is not enabled. See <Menu / Settings / Display>.
 
 ## Loading Skip on Phones, Tablets, Raspberry Pi, and Computers
-Simply navigate to `http://<Signal K Server URL>:<port>/@halos-org/skip/` to load Skip and enjoy its features remotely on any device.
+Navigate to `<Signal K Server URL>:<port>/@halos-org/skip/` to load Skip on any device. On a secured server Skip is reached over **HTTPS** through the Signal K reverse proxy; use that HTTPS address, since a secure connection is required for features like keeping the screen awake.
 
 ## Mobile App
-Run Skip in full screen, without browser controls, just like a regular mobile app. This feature is supported on most mobile operating systems. Each browser has its own way of handling Progressive Web App (PWA) installations.
+Add Skip to your home screen to launch it full-screen, without browser controls, like a native app — a single-tap icon on most mobile and desktop browsers. This uses your browser's standard "Add to Home Screen" and creates a shortcut (Skip has no offline/service-worker install).
 
 **iOS**
 1. Press the "Share" button.
 2. Select "Add to Home Screen" from the action popup list.
 3. Tap "Add" in the top right corner to finish installation.
-Skip is now installed and available on your home screen.
+Skip now launches full-screen from your home screen.
 
 **Android**
 1. Press the "three dot" icon in the upper right to open the menu.
 2. Select "Add to Home screen."
 3. Press the "Add" button in the popup.
-Skip is now installed and available on your home screen.
+Skip now launches full-screen from your home screen.
 
 ## Fullscreen
-You can toggle fullscreen mode on and off, and disable the screen saver and computer sleep mode (if supported by the device/browser), by tapping the Expand/Reduce button on the toolbar or using the keyboard hotkey. This button is not available on mobile devices.
+Toggle fullscreen mode with the Expand/Reduce button on the toolbar or the <kbd>F</kbd> hotkey (not available on mobile devices).
+
+## Keeping the Screen Awake
+Suppressing the screen saver and device sleep is a separate setting: **Settings > Display > Keep screen awake** (on by default). It needs a secure connection (HTTPS), so use your server's HTTPS address.
 
 ## Night Mode
 Save your night vision by automatically switching Skip to day or night mode based on sunrise and sunset hours (the Signal K Derived Data plugin is required for automatic switching). This feature can be enabled in the **Settings > Display** page. You can also manually set the mode by tapping the Moon/Sun button on the toolbar. Note that if automatic switching is enabled, brightness will reset to the Signal K mode value.
@@ -104,7 +108,7 @@ If multiple devices log in with the same Signal K user to share configuration, t
 
 > **Tips**
 >- Keep Instance Names short but meaningful (e.g. Mast, Helm, NavTV).
->- For unattended displays, enable the browser’s keep‑awake / no‑sleep features if supported.
+>- For unattended displays, keep the screen awake via **Settings > Display > Keep screen awake** (needs an HTTPS connection).
 >- Combine with Night Mode + per‑profile layouts for role‑specific remote switching.
 >- Use different Signal K users if you want fully isolated configurations.
 

--- a/src/assets/help-docs/zones.md
+++ b/src/assets/help-docs/zones.md
@@ -49,7 +49,7 @@ You can **Silence** or **Resolve** notifications.
 - **Notifications Menu:**  
   The Notifications Menu lists all active notifications, including details such as path, severity, and message. You can silence or resolve notifications directly from this menu. At the bottom of the Notifications menu, you will find a Mute button. This button mutes the notification volume. It does not Silence the notifications. It is meant as a quick noise cancelling button to spare your ears until you resolve the issue(s) but has no effect on the notifications.
   
-  By default, the Notifications menu is hidden; when an alarm is active, a notification badge appears in the lower-left corner and stays there until the alarm clears. Tap or click it to open the menu.
+  Open the Notifications menu from the bell button in the toolbar. When an alarm is active, a notification badge also appears in the lower-left corner and stays there until the alarm clears; tap or click either to open the menu.
 
 - **Zones State Panel:**
 


### PR DESCRIPTION
A documentation sweep of the README + all help docs, checking them against the current (post-#388) design and the project goals (Signal-K-integrated MFD, usable on both touch and pointer devices). Driven by a multi-reviewer pass; text-only, no code.

## What was wrong

**Retired UI still documented (high):**
- **dashboards.md** — described a lower-right **Save/Discard FAB** (removed; edit exit is toolbar **Cancel · Done** + Esc) and a **wrong Pages-Panel gesture map** (double-tap-rename / long-press-delete; actually a single **tap → action menu**). Both fixed.
- **README** — swipe directions were **inverted** ("swipe up/down to navigate"; actually left/right change pages, down reveals the toolbar) and it still sold the retired **sidenav / "Options" page**. Rewritten to the auto-hiding toolbar + Manage-pages panel + menu, with a proper touch/mouse/keyboard interactions block.

**Signal K / technical accuracy (medium):**
- **embedwidget.md** — blamed **CORS** for iframe blocking (actually the target site's `X-Frame-Options`/`frame-ancestors`) and for gesture injection (actually the **same-origin policy**). Reframed correctly; CORS now appears only where it belongs.
- **units** (dashboards.md) — noted display units are **server-driven** (SK unit preferences) with per-widget override.
- **ais-radar.md** — "Server Connection" clarified as a **Signal K server-side** setting (Skip has no connection settings since #385/#388).

**PWA / keep-awake drift (medium):** Skip ships **no service worker**, so "Add to Home Screen" is a shortcut (not a PWA install), and screen-keep-awake is now **Settings › Display › keepScreenAwake** (secure-context) — reconciled in welcome.md + kiosk.md, with HTTPS/reverse-proxy notes.

**Polish (low):** keyboard rows/paths (Enter/Space, E/Esc, Done); "Realtime Data Plot" (was "Data Plot"); contact-us version pointer → the Connection page (no "About" screen exists); **"Grafana"** (was "Graphana"); README dev section now points at **CLAUDE.md**; npm scripts in contributing-widgets; assorted typos.

## What was already good

SK grounding is strong and accurate across the board — the external-provider History API (Skip stores nothing), the PUT→handler→PUT-Support chain, zones-as-metadata, session-SSO auth + profiles, and the "plays nicely alongside Grafana/InfluxDB/Node-RED" scope. `welcome.md` and `configuration.md` had already absorbed the #388 nav change. Touch+mouse coverage is genuinely dual; keyboard was the under-documented modality (now filled in the core docs).

## Follow-up (not in this PR)
The README **screenshots** predate the toolbar/menu redesign — the two whose captions described retired features (sidenav, Options page) were removed; the rest (`SkipDemo`, `formfactor`, config shots) need a **manual reshoot** against the current UI, which can't be captured from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)