### PR TITLE
fix(windtrends): follow server display units for wind speed

### DIFF
--- a/src/app/widgets/widget-windtrends-chart/widget-windtrends-chart.component.spec.ts
+++ b/src/app/widgets/widget-windtrends-chart/widget-windtrends-chart.component.spec.ts
@@ -33,6 +33,7 @@ import { WidgetWindTrendsChartComponent } from './widget-windtrends-chart.compon
 import { HistoryChartStreamService, HISTORY_UNAVAILABLE } from '../../core/services/history-chart-stream.service';
 import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
 import { UnitsService } from '../../core/services/units.service';
+import { DataService } from '../../core/services/data.service';
 import { CanvasService } from '../../core/services/canvas.service';
 import type { ITheme } from '../../core/services/app-service';
 import type { IDatasetServiceDatapoint } from '../../core/interfaces/dataset.interfaces';
@@ -51,7 +52,13 @@ describe('WidgetWindTrendsChartComponent', () => {
 
   const runtimeMock = { options: vi.fn() };
   const historyMock = { getBackfillThenLive: vi.fn() };
-  const unitsMock = { convertToUnit: (_unit: string, value: number) => value };
+  const unitsMock = {
+    convertToUnit: (_unit: string, value: number) => value,
+    resolvePathMeasure: () => 'knots',
+    getUnitDisplaySymbol: (measure: string) => measure
+  };
+  // Speed measure resolution folds the path's meta subject; a single emission is enough to resolve it.
+  const dataMock = { getPathMetaObservable: () => of(null) };
   const canvasMock = { registerCanvas: vi.fn(), releaseCanvas: vi.fn(), unregisterCanvas: vi.fn() };
   const breakpointMock = { observe: vi.fn().mockReturnValue(of({ matches: false, breakpoints: {} })) };
 
@@ -64,6 +71,7 @@ describe('WidgetWindTrendsChartComponent', () => {
         { provide: WidgetRuntimeDirective, useValue: runtimeMock },
         { provide: HistoryChartStreamService, useValue: historyMock },
         { provide: UnitsService, useValue: unitsMock },
+        { provide: DataService, useValue: dataMock },
         { provide: CanvasService, useValue: canvasMock },
         { provide: BreakpointObserver, useValue: breakpointMock }
       ]
@@ -84,6 +92,11 @@ describe('WidgetWindTrendsChartComponent', () => {
     const probe = fixture.componentInstance as unknown as { chart: unknown; isChartReady(chart: unknown): boolean };
     return probe.isChartReady(probe.chart);
   };
+
+  // The big-number unit label is drawn inside the chart plugin (which the MockChart never invokes), so
+  // its source — speedUnitSymbol() — is probed directly, the same private-seam pattern as readiness().
+  const speedLabel = (): string =>
+    (fixture.componentInstance as unknown as { speedUnitSymbol(): string }).speedUnitSymbol();
 
   beforeEach(() => {
     vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({} as unknown as CanvasRenderingContext2D);
@@ -138,6 +151,96 @@ describe('WidgetWindTrendsChartComponent', () => {
       { timestamp: 2000, data: { value: 350, sma: 340, lastAverage: 345, lastMinimum: 10, lastMaximum: 350 } }
     ];
     expect(() => { dir.next(batch); spd.next(batch); }).not.toThrow();
+  });
+
+  it('converts the speed series with the server-resolved measure, not hardcoded knots', async () => {
+    const dir = new Subject();
+    const spd = new Subject();
+    historyMock.getBackfillThenLive
+      .mockReturnValueOnce(dir)
+      .mockReturnValueOnce(spd);
+    // Server prefers m/s for this speed path (as on the live boat); the widget must follow it.
+    const resolveSpy = vi.spyOn(unitsMock, 'resolvePathMeasure').mockReturnValue('m/s');
+    const convertSpy = vi.spyOn(unitsMock, 'convertToUnit');
+    await setup('Last 30 Minutes');
+
+    spd.next([
+      { timestamp: 1000, data: { value: 5, sma: 5, lastAverage: 5, lastMinimum: 5, lastMaximum: 5 } }
+    ]);
+
+    expect(resolveSpy).toHaveBeenCalledWith('self.environment.wind.speedTrue');
+    // Speed datasets are converted to the server-resolved measure ('m/s'), never the old hardcoded 'knots'.
+    const speedConversionUnits = convertSpy.mock.calls.map(c => c[0]).filter(u => u !== 'deg');
+    expect(speedConversionUnits).toContain('m/s');
+    expect(speedConversionUnits).not.toContain('knots');
+  });
+
+  it('labels the speed readout with the server-resolved symbol, not a hardcoded kts', async () => {
+    vi.spyOn(unitsMock, 'resolvePathMeasure').mockReturnValue('m/s');
+    const symbolSpy = vi.spyOn(unitsMock, 'getUnitDisplaySymbol');
+    await setup('Last 30 Minutes');
+
+    expect(speedLabel()).toBe('m/s');
+    expect(symbolSpy).toHaveBeenCalledWith('m/s');
+  });
+
+  it('shows base-SI values with no unit label when the server has no speed preference', async () => {
+    const spd = new Subject();
+    historyMock.getBackfillThenLive.mockReturnValueOnce(new Subject()).mockReturnValueOnce(spd);
+    vi.spyOn(unitsMock, 'resolvePathMeasure').mockReturnValue('unitless');
+    const convertSpy = vi.spyOn(unitsMock, 'convertToUnit');
+    await setup('Last 30 Minutes');
+
+    spd.next([{ timestamp: 1000, data: { value: 5, sma: 5, lastAverage: 5, lastMinimum: 5, lastMaximum: 5 } }]);
+
+    // No client-side fallback: values pass through in base SI (convertToUnit('unitless') is identity),
+    // never re-substituted to knots.
+    const speedUnits = convertSpy.mock.calls.map(c => c[0]).filter(u => u !== 'deg');
+    expect(speedUnits).toContain('unitless');
+    expect(speedUnits).not.toContain('knots');
+    // The readout is unlabeled rather than showing the raw 'unitless' key.
+    expect(speedLabel()).toBe('');
+  });
+
+  it('re-resolves and rebuilds the speed series when the server displayUnits change', async () => {
+    const metaSubject = new Subject<null>();
+    vi.spyOn(dataMock, 'getPathMetaObservable').mockReturnValue(metaSubject);
+    const resolveSpy = vi.spyOn(unitsMock, 'resolvePathMeasure').mockReturnValue('knots');
+    const convertSpy = vi.spyOn(unitsMock, 'convertToUnit');
+    const spd2 = new Subject();
+    historyMock.getBackfillThenLive
+      .mockReturnValueOnce(new Subject())   // initial direction stream
+      .mockReturnValueOnce(new Subject())   // initial speed stream
+      .mockReturnValueOnce(new Subject())   // rebuilt direction stream
+      .mockReturnValueOnce(spd2);           // rebuilt speed stream
+
+    await setup('Last 30 Minutes');
+    const callsBefore = historyMock.getBackfillThenLive.mock.calls.length;
+
+    // A late/changed displayUnits fires the path's meta subject; the resolved measure flips to m/s.
+    resolveSpy.mockReturnValue('m/s');
+    metaSubject.next(null);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    // The measure change fed the rebuild signature and re-opened the streams…
+    expect(historyMock.getBackfillThenLive.mock.calls.length).toBeGreaterThan(callsBefore);
+    // …so new data now converts in the new unit rather than the stale knots.
+    convertSpy.mockClear();
+    spd2.next([{ timestamp: 3000, data: { value: 5, sma: 5, lastAverage: 5, lastMinimum: 5, lastMaximum: 5 } }]);
+    const speedUnits = convertSpy.mock.calls.map(c => c[0]).filter(u => u !== 'deg');
+    expect(speedUnits).toContain('m/s');
+    expect(speedUnits).not.toContain('knots');
+  });
+
+  it('keeps TWD structural but TWS a display path, so the history dialog follows the server unit', () => {
+    // The history dialog classifies a slot as structural (stored unit) vs display (server measure) by
+    // showConvertUnitTo===false. TWS must stay a display path or the dialog pins to knots while the tile
+    // shows the server unit — the lock-step break this fix closes.
+    const paths = WidgetWindTrendsChartComponent.DEFAULT_CONFIG.paths as IPathArray;
+    expect(paths.trueWindDirection.showConvertUnitTo).toBe(false);
+    expect(paths.trueWindSpeed.showConvertUnitTo).toBeUndefined();
   });
 
   it('opens the History streams on the user-configured direction and speed paths', async () => {

--- a/src/app/widgets/widget-windtrends-chart/widget-windtrends-chart.component.ts
+++ b/src/app/widgets/widget-windtrends-chart/widget-windtrends-chart.component.ts
@@ -1,12 +1,13 @@
-import { Component, OnDestroy, ElementRef, viewChild, inject, effect, NgZone, input, untracked, Signal, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnDestroy, ElementRef, viewChild, inject, effect, NgZone, input, untracked, computed, Signal, ChangeDetectionStrategy } from '@angular/core';
 import { BreakpointObserver, Breakpoints, BreakpointState } from '@angular/cdk/layout';
-import { toSignal } from '@angular/core/rxjs-interop';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { IWidgetSvcConfig, IWidgetPath } from '../../core/interfaces/widgets-interface';
 import { HistoryChartStreamService, IHistoryChartStreamParams, isHistoryUnavailable } from '../../core/services/history-chart-stream.service';
 import { IDatasetServiceDatapoint } from '../../core/interfaces/dataset.interfaces';
 import { resolveWindowMs, deriveDataSourceInfo, IChartDataSourceInfo } from '../../core/utils/chart-window.util';
-import { Subscription } from 'rxjs';
+import { Subscription, distinctUntilChanged, map, of, switchMap } from 'rxjs';
 import { CanvasService } from '../../core/services/canvas.service';
+import { DataService } from '../../core/services/data.service';
 import { UnitsService } from '../../core/services/units.service';
 import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
 import { ITheme } from '../../core/services/app-service';
@@ -54,9 +55,13 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
     filterSelfPaths: true,
     color: 'contrast',
     timeScale: 'Last 30 Minutes',
-    // The axes are fixed to degrees (TWD) / knots (TWS) and the widget hardcodes those conversions,
-    // so the slots hide the unit-filter and Format dropdowns (showPathSkUnitsFilter/showConvertUnitTo
-    // false) — a picker there would be inert and misleading; only path and source are configurable.
+    // TWD is STRUCTURAL: fixed to degrees (showConvertUnitTo:false) because the widget's angle-wrap and
+    // tick math are degree-native — the history dialog keeps it in degrees too. TWS is a DISPLAY path:
+    // it follows the server's displayUnits preference, resolved at render like widget-data-chart (and by
+    // the history dialog via resolvePathMeasure), so it must NOT carry showConvertUnitTo:false — that
+    // flag would pin the dialog to the stored knots while the tile shows the server unit. Skip owns no
+    // per-widget speed unit; convertUnitTo:'knots' is an inert stored default kept to match the other
+    // wind widgets. showPathSkUnitsFilter:false hides the unit-filter on both slots.
     paths: {
       trueWindDirection: {
         description: 'True Wind Direction',
@@ -81,7 +86,6 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
         showPathSkUnitsFilter: false,
         pathSkUnitsFilter: 'm/s',
         convertUnitTo: 'knots',
-        showConvertUnitTo: false,
         sampleTime: 1000
       }
     }
@@ -90,8 +94,27 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
   private readonly historyStream = inject(HistoryChartStreamService);
   private readonly canvasService = inject(CanvasService);
   private readonly unitsService = inject(UnitsService);
+  private readonly dataService = inject(DataService);
   private readonly responsive = inject(BreakpointObserver);
   protected isPhonePortrait: Signal<BreakpointState>;
+  /** Configured wind-speed path (record-form slot), or null when the slot is cleared. */
+  private readonly speedPath = computed<string | null>(() =>
+    this.windPathSlot(this.runtime?.options(), 'trueWindSpeed')?.path ?? null);
+  /**
+   * Server-resolved display measure for the wind-speed series. resolvePathMeasure() reads a non-signal
+   * meta cache, so it is folded through the path's meta subject to re-emit when the server's
+   * displayUnits land late or change; that change flows into computeRebuildSignature and rebuilds the
+   * chart in the new unit. Mirrors widget-data-chart's reactive pathMeasure. The actual conversion and
+   * label read the resolved measure directly at build time (see speedMeasureKey).
+   */
+  private readonly speedMeasure = toSignal(
+    toObservable(this.speedPath).pipe(
+      switchMap(path => path
+        ? this.dataService.getPathMetaObservable(path).pipe(map(() => this.unitsService.resolvePathMeasure(path)))
+        : of<string | undefined>(undefined)),
+      distinctUntilChanged()
+    )
+  );
   readonly widgetDataChart = viewChild('widgetDataChart', { read: ElementRef });
   public lineChartData: ChartData<'line', { x: number, y: number }[]> = {
     datasets: []
@@ -124,6 +147,9 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
    * startStreaming and read by the overlay-readiness gate so a cleared slot is not awaited forever. */
   private dirSeriesActive = false;
   private spdSeriesActive = false;
+  /** Server-resolved display measure applied to the speed datasets + big-number label; null when no
+   *  speed path. Re-resolved on each (re)build, so a late/changed displayUnits reconverts the series. */
+  private speedMeasureKey: string | null = null;
   private dataSourceInfo: IChartDataSourceInfo | null = null;
   private xCenter: number | null = null;
   private xStep: number | null = null;
@@ -292,7 +318,7 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
         const unitY = area.top - (this.isPhonePortrait().matches ? this.TOP_UNIT_PHONE_PORTRAIT_Y_OFFSET : this.TOP_UNIT_Y_OFFSET);
         ctx.font = this.isPhonePortrait().matches ? `bold ${this.UNIT_PHONE_PORTRAIT_FONT_SIZE}px ${def.family}` : `bold ${this.UNIT_FONT_SIZE}px ${def.family}`;
         ctx.textAlign = 'left';
-        ctx.fillText('kts', unitX, unitY);
+        ctx.fillText(this.speedUnitSymbol(), unitX, unitY);
         ctx.restore();
       }
 
@@ -413,7 +439,7 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
     const xDefaultMin = 0;
     const xDefaultMax = 360;
     const xDefaultStep = (xDefaultMax - xDefaultMin) / 4; // 5 ticks
-    // Provide initial xSpeed (knots) range as well
+    // Provide an initial xSpeed range (display-unit agnostic; the dynamic scaler resizes from data)
     const xsDefaultMin = 0;
     const xsDefaultMax = 20;
     const xsDefaultStep = (xsDefaultMax - xsDefaultMin) / 4; // 5 ticks
@@ -763,7 +789,7 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
   private computeRebuildSignature(cfg: IWidgetSvcConfig): string {
     const dir = this.windPathSlot(cfg, 'trueWindDirection');
     const spd = this.windPathSlot(cfg, 'trueWindSpeed');
-    return [cfg.timeScale, dir?.path, dir?.source, spd?.path, spd?.source].join('|');
+    return [cfg.timeScale, dir?.path, dir?.source, spd?.path, spd?.source, this.speedMeasure()].join('|');
   }
 
   /**
@@ -805,6 +831,9 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
     const spdPath = spd?.path;
     this.dirSeriesActive = !!dirPath;
     this.spdSeriesActive = !!spdPath;
+    // Resolve the server's display measure for the speed path once per build; a late/changed
+    // displayUnits re-emits through speedMeasure and triggers another build (see computeRebuildSignature).
+    this.speedMeasureKey = spdPath ? this.unitsService.resolvePathMeasure(spdPath) : null;
 
     if (dirPath) {
       // TWD is a direction path; the History engine auto-resolves its circular domain from the unit.
@@ -872,7 +901,14 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
   }
 
   private pushRowsToSpeedDatasets(rows: IDatasetServiceDatapoint[]): void {
-    this.pushRowsGeneric(rows, 5, 'knots', false);
+    this.pushRowsGeneric(rows, 5, this.speedMeasureKey ?? 'unitless', false);
+  }
+
+  /** Display symbol for the resolved wind-speed measure; empty (no label) before the server's
+   *  displayUnits resolve or when the path carries no unit preference — never a wrong or raw-key label. */
+  private speedUnitSymbol(): string {
+    const measure = this.speedMeasureKey;
+    return measure && measure !== 'unitless' ? this.unitsService.getUnitDisplaySymbol(measure) : '';
   }
 
   private getRowValue(row: IDatasetServiceDatapoint, datasetType: 'value' | 'sma' | 'ema' | 'dema' | 'avg' | 'min' | 'max'): number | null {
@@ -888,8 +924,8 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
     }
   }
 
-  // Generic transform for degree/knots series
-  private transformRows(rows: IDatasetServiceDatapoint[], datasetType: 'value' | 'sma' | 'ema' | 'dema' | 'avg' | 'min' | 'max', toUnit: 'deg' | 'knots', unwrap: boolean): IDataSetRow[] {
+  // Generic transform for the degree (structural) and speed (server-resolved measure) series
+  private transformRows(rows: IDatasetServiceDatapoint[], datasetType: 'value' | 'sma' | 'ema' | 'dema' | 'avg' | 'min' | 'max', toUnit: string, unwrap: boolean): IDataSetRow[] {
     const vals = rows.map(row => {
       const raw = this.getRowValue(row, datasetType);
       return raw == null ? null : this.unitsService.convertToUnit(toUnit, raw);
@@ -905,7 +941,7 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
   }
 
   // Push a batch of rows into 5 consecutive datasets starting at baseIndex
-  private pushRowsGeneric(rows: IDatasetServiceDatapoint[], baseIndex: 0 | 5, toUnit: 'deg' | 'knots', unwrap: boolean): void {
+  private pushRowsGeneric(rows: IDatasetServiceDatapoint[], baseIndex: 0 | 5, toUnit: string, unwrap: boolean): void {
     const types: ('value' | 'sma' | 'avg' | 'min' | 'max')[] = ['value', 'sma', 'avg', 'min', 'max'];
     types.forEach((type, i) => {
       (this.chart.data.datasets[baseIndex + i].data as IDataSetRow[])
@@ -1012,8 +1048,8 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
       const sDiffMin = Math.abs(sAvg - sMin);
       const sDiffMax = Math.abs(sMax - sAvg);
       let halfRangeS = Math.max(sDiffMin, sDiffMax);
-      // Guard minimum half-range to avoid collapse
-      const minHalfRangeS = 0.5; // knots
+      // Guard minimum half-range to avoid collapse (in the resolved display unit)
+      const minHalfRangeS = 0.5;
       halfRangeS = Math.max(halfRangeS, minHalfRangeS);
       // Target 5 ticks (4 intervals) with a nice step (ceiling)
       const requestedStep = (2 * halfRangeS) / 4; // = halfRangeS / 2

--- a/src/assets/skip-dashboard-schema.json
+++ b/src/assets/skip-dashboard-schema.json
@@ -3056,7 +3056,6 @@
             "pathSkUnitsFilter": "m/s",
             "pathType": "number",
             "sampleTime": 1000,
-            "showConvertUnitTo": false,
             "showPathSkUnitsFilter": false,
             "source": "default"
           }


### PR DESCRIPTION
## Why

The wind-trends chart hardcoded **knots** for the True Wind Speed series — the conversion, the axis, and the `kts` label — ignoring the Signal K server's `displayUnits` preference. It was the one self-converting chart surface the #347 units flip missed. On a server that prefers m/s (the live boat overrides `environment.wind.speed*` → m/s), the wind-trends tile showed knots while every other speed readout (windsteer, data-chart) showed m/s.

## How

Make TWS a proper **display path**, mirroring `widget-data-chart`:

- A meta-folded `speedMeasure` signal (`getPathMetaObservable(path)` → `resolvePathMeasure(path)`) feeds the rebuild signature, so a late or changed `displayUnits` re-backfills the series in the new unit.
- The conversion and the big-number label both derive from the server-resolved measure (`convertToUnit` / `getUnitDisplaySymbol`), never a literal.
- **Stop marking the TWS slot `showConvertUnitTo:false`.** The history-chart dialog reads that flag as "structural → use stored `convertUnitTo`" and would otherwise pin the dialog to knots while the tile shows the server unit, breaking the dialog↔tile lock-step. This matches the windsteer model: speed is a display path; direction stays structural degrees (the widget's angle-wrap/tick math is degree-native, and TWD is kept in degrees on both tile and dialog).

`convertUnitTo:'knots'` is retained as an inert stored default (matches the other wind widgets). No config-version bump / migration: the flag isn't persisted in saved dashboards, so the deep-merge default applies (verified against the live boat's stored config).

## Scope

Speed only. Direction (TWD) intentionally stays structural degrees.

## Verification

- `npm run snc` + `npm run lint` clean.
- Full suite: **1531 pass** (+4 new tests: conversion, rendered label, unitless/no-preference base-SI, and reactive rebuild-on-measure-change). The rebuild-reactivity test was **mutation-tested** — dropping `speedMeasure()` from the rebuild signature fails exactly that test.
- Live boat: server resolves `environment.wind.speedTrue`/`speedOverGround` → `displayUnits { targetUnit: m/s }`; the widget now follows it.

## Review

Ran a multi-persona adversarial review (correctness / units-contract / testing) before this PR. It found the dialog lock-step break (now fixed) and three coverage gaps (now closed); the correctness pass found no init-order or reactivity defects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)