### PR TITLE
refactor(dashboard): remove unused isDashboardStatic computed

### DIFF
--- a/src/app/core/components/dashboard/dashboard.component.ts
+++ b/src/app/core/components/dashboard/dashboard.component.ts
@@ -70,7 +70,6 @@ export class DashboardComponent implements AfterViewInit, OnDestroy {
   private readonly _pluginConfig = inject(PluginConfigClientService);
   protected readonly _router = inject(Router);
   private readonly _hostEl = inject(ElementRef<HTMLElement>);
-  protected isDashboardStatic = computed(() => this.dashboard.isDashboardStatic());
   protected readonly dashboardStaticView = computed(() => this.dashboard.isDashboardStatic());
   protected readonly gridIsEmpty = signal<boolean>(true);
   private readonly _gridstack = viewChild.required<GridstackComponent>('grid');


### PR DESCRIPTION
## Why

Follow-up to #402 review (finding #5). `DashboardComponent` declared two computeds with identical bodies:

```
protected isDashboardStatic = computed(() => this.dashboard.isDashboardStatic());
protected readonly dashboardStaticView = computed(() => this.dashboard.isDashboardStatic());
```

Only `dashboardStaticView` is bound (the template's `@let dashboardStatic = dashboardStaticView() ?? true`). Every other `isDashboardStatic` reference in the component is the **service** method `this.dashboard.isDashboardStatic()`. The component-level `isDashboardStatic` computed had zero readers — a duplicate that invites editing the wrong one.

## What

Delete the unused `isDashboardStatic` computed. No behavior change; pure dead-code removal.

## Tests

Verified locally: `npm run lint` OK, `npm run snc` OK, `dashboard.component.spec` OK (38 passing). CI on Node 24 is the authoritative gate.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — dead-code removal with no runtime effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)