### PR TITLE
feat: legibility floor + background-color halo for widget labels & units

### DIFF
--- a/src/app/core/services/canvas.service.spec.ts
+++ b/src/app/core/services/canvas.service.spec.ts
@@ -122,3 +122,55 @@ describe('CanvasService text measurement (#321 font-race)', () => {
     await expect(service.whenFontsReady()).resolves.toBeUndefined();
   });
 });
+
+/**
+ * Auxiliary text (widget labels and unit symbols) is sized as a fraction of the
+ * tile height and shrinks below legibility on small tiles. A pixel floor keeps it
+ * readable; the fit is capped only from below, and the floor is applied on read so
+ * floored and unfloored callers share one memo entry.
+ */
+describe('CanvasService font-size floor (label/unit legibility)', () => {
+  let service: CanvasService;
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(CanvasService);
+  });
+
+  // measured width scales with font px and text length, so the binary search is deterministic.
+  function fakeCtx(onMeasure?: () => void) {
+    return {
+      font: '',
+      measureText(text: string): TextMetrics {
+        onMeasure?.();
+        const px = parseInt(this.font, 10) || 10;
+        return { width: text.length * px * 0.5 } as TextMetrics;
+      }
+    } as unknown as CanvasRenderingContext2D;
+  }
+
+  it('floors the result at floorPx when the box would force a smaller size', () => {
+    const ctx = fakeCtx();
+    const unfloored = service.calculateOptimalFontSize(ctx, 'Label', 200, 6, 'normal');
+    expect(unfloored).toBeLessThanOrEqual(6);            // height-bound to the tiny box
+    const floored = service.calculateOptimalFontSize(ctx, 'Label', 200, 6, 'normal', 12);
+    expect(floored).toBe(12);                            // never below the floor
+  });
+
+  it('leaves the size unchanged when the fitted size already clears the floor', () => {
+    const ctx = fakeCtx();
+    const fitted = service.calculateOptimalFontSize(ctx, 'X', 200, 40, 'normal');
+    expect(fitted).toBeGreaterThan(12);
+    expect(service.calculateOptimalFontSize(ctx, 'X', 200, 40, 'normal', 12)).toBe(fitted);
+  });
+
+  it('applies the floor on read without re-running the search (shared memo entry)', () => {
+    let measureCalls = 0;
+    const ctx = fakeCtx(() => { measureCalls++; });
+    const unfloored = service.calculateOptimalFontSize(ctx, 'Label', 200, 6, 'normal');
+    const afterSearch = measureCalls;
+    const floored = service.calculateOptimalFontSize(ctx, 'Label', 200, 6, 'normal', 12);
+    expect(measureCalls).toBe(afterSearch);              // cache hit: no new search
+    expect(unfloored).toBeLessThan(12);
+    expect(floored).toBe(12);                            // floor applied on the cached value
+  });
+});

--- a/src/app/core/services/canvas.service.spec.ts
+++ b/src/app/core/services/canvas.service.spec.ts
@@ -136,13 +136,16 @@ describe('CanvasService font-size floor (label/unit legibility)', () => {
     service = TestBed.inject(CanvasService);
   });
 
-  // measured width scales with font px and text length, so the binary search is deterministic.
+  // measured width scales with the font's px size (parsed from the `<weight> <n>px <family>`
+  // shorthand) and text length, so the binary search — including its width-bound branch — is
+  // deterministic. A naive parseInt(font) reads the leading weight word as NaN and collapses width
+  // to a constant, hiding the width path; extract the px number explicitly instead.
   function fakeCtx(onMeasure?: () => void) {
     return {
       font: '',
       measureText(text: string): TextMetrics {
         onMeasure?.();
-        const px = parseInt(this.font, 10) || 10;
+        const px = Number(/(\d+(?:\.\d+)?)px/.exec(this.font)?.[1]) || 10;
         return { width: text.length * px * 0.5 } as TextMetrics;
       }
     } as unknown as CanvasRenderingContext2D;
@@ -172,5 +175,95 @@ describe('CanvasService font-size floor (label/unit legibility)', () => {
     expect(measureCalls).toBe(afterSearch);              // cache hit: no new search
     expect(unfloored).toBeLessThan(12);
     expect(floored).toBe(12);                            // floor applied on the cached value
+  });
+
+  it('floors a width-bound fit (long text in a narrow box) at floorPx', () => {
+    const ctx = fakeCtx();
+    // Tall box so height never binds; narrow box so the WIDTH branch limits the fit small.
+    const unfloored = service.calculateOptimalFontSize(ctx, 'LongLabel', 30, 100, 'normal');
+    expect(unfloored).toBeLessThan(12);                  // width-bound below the floor
+    expect(service.calculateOptimalFontSize(ctx, 'LongLabel', 30, 100, 'normal', 12)).toBe(12);
+  });
+});
+
+/**
+ * The background-color halo is the feature's other half: a strokeText pass under the fill, gated on a
+ * haloColor, that knocks the value out where overlapping text sits over it. drawText runs synchronously
+ * under the fonts shim, but awaiting whenFontsReady() also covers the deferred cold-boot path.
+ */
+describe('CanvasService background-color halo (knockout stroke)', () => {
+  let service: CanvasService;
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(CanvasService);
+  });
+
+  interface Recorded { op: 'strokeText' | 'fillText'; args: unknown[]; strokeStyle?: unknown; lineWidth?: number; font?: string; }
+  function spyCtx() {
+    const calls: Recorded[] = [];
+    const ctx = {
+      font: '', fillStyle: '', strokeStyle: '', lineWidth: 0, lineJoin: '', miterLimit: 0,
+      textAlign: '', textBaseline: '',
+      save() { /* no-op */ }, restore() { /* no-op */ }, setTransform() { /* no-op */ },
+      measureText(text: string): TextMetrics {
+        const px = Number(/(\d+(?:\.\d+)?)px/.exec(this.font)?.[1]) || 10;
+        return { width: text.length * px * 0.5 } as TextMetrics;
+      },
+      strokeText(...args: unknown[]) { calls.push({ op: 'strokeText', args, strokeStyle: ctx.strokeStyle, lineWidth: ctx.lineWidth, font: ctx.font }); },
+      fillText(...args: unknown[]) { calls.push({ op: 'fillText', args }); },
+    };
+    return { ctx: ctx as unknown as CanvasRenderingContext2D, calls };
+  }
+
+  it('strokes a halo in the given color, sized to the font, before the fill', async () => {
+    const { ctx, calls } = spyCtx();
+    service.drawText(ctx, 'X', 10, 10, 100, 40, 'normal', '#ffffff', 'left', 'top', '#123456', 0);
+    await service.whenFontsReady();
+    const stroke = calls.find(c => c.op === 'strokeText');
+    const fill = calls.find(c => c.op === 'fillText');
+    expect(stroke).toBeDefined();
+    expect(fill).toBeDefined();
+    expect(stroke!.strokeStyle).toBe('#123456');                       // halo uses the passed color
+    const fontPx = Number(/(\d+)px/.exec(stroke!.font ?? '')?.[1]);
+    expect(stroke!.lineWidth).toBe(Math.max(2, fontPx / 5));           // width scales with the font
+    expect(calls.indexOf(stroke!)).toBeLessThan(calls.indexOf(fill!)); // stroke UNDER the fill
+  });
+
+  it('skips the halo stroke entirely when no haloColor is passed', async () => {
+    const { ctx, calls } = spyCtx();
+    service.drawText(ctx, 'X', 10, 10, 100, 40, 'normal', '#ffffff', 'left', 'top');
+    await service.whenFontsReady();
+    expect(calls.some(c => c.op === 'strokeText')).toBe(false);
+    expect(calls.some(c => c.op === 'fillText')).toBe(true);
+  });
+
+  it('drops the fillText width cap when floored (overflow, not squish) and keeps it otherwise', async () => {
+    const floored = spyCtx();
+    service.drawText(floored.ctx, 'X', 10, 10, 100, 40, 'normal', '#fff', 'left', 'top', undefined, 12);
+    await service.whenFontsReady();
+    expect(floored.calls.find(c => c.op === 'fillText')!.args[3]).toBeUndefined();
+
+    const unfloored = spyCtx();
+    service.drawText(unfloored.ctx, 'X', 10, 10, 100, 40, 'normal', '#fff', 'left', 'top');
+    await service.whenFontsReady();
+    expect(unfloored.calls.find(c => c.op === 'fillText')!.args[3]).toBe(100);
+  });
+});
+
+describe('CanvasService drawTextBitmap (label-layer composite)', () => {
+  let service: CanvasService;
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(CanvasService);
+  });
+
+  it('blits a valid bitmap once and no-ops on null or zero-size', async () => {
+    let drawn = 0;
+    const ctx = { drawImage() { drawn++; } } as unknown as CanvasRenderingContext2D;
+    service.drawTextBitmap(ctx, { width: 20, height: 10 } as HTMLCanvasElement, 100, 50);
+    service.drawTextBitmap(ctx, null, 100, 50);
+    service.drawTextBitmap(ctx, { width: 0, height: 0 } as HTMLCanvasElement, 100, 50);
+    await service.whenFontsReady();                        // covers the deferred cold-boot blit path
+    expect(drawn).toBe(1);                                 // only the valid bitmap; null / zero-size skipped
   });
 });

--- a/src/app/core/services/canvas.service.ts
+++ b/src/app/core/services/canvas.service.ts
@@ -428,6 +428,23 @@ export class CanvasService {
     ctx.clearRect(0, 0, width, height);
   }
 
+  /**
+   * Composites a cached text-layer bitmap (a widget's label/unit) over the canvas. Defers through the
+   * same font-readiness gate as {@link drawText}: on a cold boot the value paint is deferred until
+   * fonts settle, so blitting synchronously would land the label *under* the late value. Deferring
+   * here registers the blit after the value's paint (same draw call), preserving the label-over-value
+   * order the background-color halo knockout depends on. No-op for a null or zero-size bitmap.
+   */
+  public drawTextBitmap(ctx: CanvasRenderingContext2D, bitmap: HTMLCanvasElement | null, width: number, height: number): void {
+    if (!ctx || !bitmap || bitmap.width <= 0 || bitmap.height <= 0) return;
+    const blit = () => ctx.drawImage(bitmap, 0, 0, width, height);
+    if (this.areFontsLoaded()) {
+      blit();
+    } else {
+      this.fontsReadyPromise.then(blit).catch(() => blit());
+    }
+  }
+
 
   /**
    * Draws text on the canvas as large as possible with optimal font size.

--- a/src/app/core/services/canvas.service.ts
+++ b/src/app/core/services/canvas.service.ts
@@ -6,6 +6,14 @@ import { Injectable } from '@angular/core';
 export class CanvasService {
   public readonly DEFAULT_FONT = 'Roboto';
   public readonly EDGE_BUFFER = 10;
+  /**
+   * Minimum on-screen size (CSS px) for auxiliary text — widget labels and unit symbols — so it
+   * stays legible on small tiles and in daylight. Below this the text overflows its box instead of
+   * shrinking; callers pair the floor with a background-color halo so the overflow reads over the
+   * value (see {@link drawText}/{@link drawTitle} `haloColor`). Tunable.
+   */
+  public readonly MIN_LABEL_PX = 16;
+  public readonly MIN_UNIT_PX = 12;
   /** Enable verbose canvas diagnostics (dev only) */
   public debug = false;
   public scaleFactor = window.devicePixelRatio || 1;
@@ -333,7 +341,9 @@ export class CanvasService {
     fontWeight = 'normal',
     canvasWidth: number,
     canvasHeight: number,
-    titleFraction = 0.1 // default for widgets
+    titleFraction = 0.1, // default for widgets
+    haloColor?: string,
+    floorPx = 0
   ): void {
     if (!ctx) return;
     const runDraw = () => {
@@ -355,12 +365,12 @@ export class CanvasService {
           try { ctx.save(); ctx.setTransform(this.scaleFactor, 0, 0, this.scaleFactor, 0, 0); restored = true; } catch { /* ignore */ }
         }
 
-        this.drawTitleInternal(ctx, text, color, fontWeight, canvasWidth, canvasHeight, titleFraction);
+        this.drawTitleInternal(ctx, text, color, fontWeight, canvasWidth, canvasHeight, titleFraction, haloColor, floorPx);
 
         if (restored) ctx.restore();
       } catch (err) {
         console.warn('[CanvasService] drawTitle failed', err);
-        try { this.drawTitleInternal(ctx, text, color, fontWeight, canvasWidth, canvasHeight, titleFraction); } catch { /* ignore */ }
+        try { this.drawTitleInternal(ctx, text, color, fontWeight, canvasWidth, canvasHeight, titleFraction, haloColor, floorPx); } catch { /* ignore */ }
       }
     };
 
@@ -384,20 +394,27 @@ export class CanvasService {
     fontWeight = 'normal',
     canvasWidth: number,
     canvasHeight: number,
-    titleFraction: number
+    titleFraction: number,
+    haloColor?: string,
+    floorPx = 0
   ): void {
     if (!ctx) return;
 
     const maxWidth = canvasWidth - 2 * this.EDGE_BUFFER;
     const maxHeight = Math.round(canvasHeight * titleFraction);
-    const fontSize = this.calculateOptimalFontSize(ctx, text, maxWidth, maxHeight, fontWeight);
+    const fontSize = this.calculateOptimalFontSize(ctx, text, maxWidth, maxHeight, fontWeight, floorPx);
+    // Floored text may exceed its width box: let it overflow rather than squish (drop the maxWidth cap).
+    const widthArg = floorPx > 0 ? undefined : maxWidth;
 
     ctx.clearRect(0, 0, canvasWidth, canvasHeight);
     ctx.font = `${fontWeight} ${fontSize}px ${this.DEFAULT_FONT}`;
-    ctx.fillStyle = color;
     ctx.textAlign = 'left';
     ctx.textBaseline = 'top';
-    ctx.fillText(text, this.EDGE_BUFFER, this.EDGE_BUFFER, maxWidth);
+    if (haloColor) {
+      this.strokeTextHalo(ctx, text, this.EDGE_BUFFER, this.EDGE_BUFFER, fontSize, haloColor, widthArg);
+    }
+    ctx.fillStyle = color;
+    ctx.fillText(text, this.EDGE_BUFFER, this.EDGE_BUFFER, widthArg);
   }
 
   /**
@@ -436,7 +453,9 @@ export class CanvasService {
     fontWeight = 'normal',
     color = '#000',
     textAlign: CanvasTextAlign = 'center',
-    textBaseline: CanvasTextBaseline = 'middle'
+    textBaseline: CanvasTextBaseline = 'middle',
+    haloColor?: string,
+    floorPx = 0
   ): void {
     if (!ctx) return;
     const runDraw = () => {
@@ -444,7 +463,7 @@ export class CanvasService {
       try {
         ctx.save();
         ctx.setTransform(this.scaleFactor, 0, 0, this.scaleFactor, 0, 0);
-        this.drawTextInternal(ctx, text, x, y, maxWidth, maxHeight, fontWeight, color, textAlign, textBaseline);
+        this.drawTextInternal(ctx, text, x, y, maxWidth, maxHeight, fontWeight, color, textAlign, textBaseline, haloColor, floorPx);
       } finally {
         try { ctx.restore(); } catch { /* ignore */ }
       }
@@ -465,13 +484,18 @@ export class CanvasService {
   /**
    * Draws text on the canvas with optimal font size.
    */
-  private drawTextInternal(ctx: CanvasRenderingContext2D, text: string, x: number = this.EDGE_BUFFER, y: number = this.EDGE_BUFFER, maxWidth: number, maxHeight: number, fontWeight = 'normal', color = '#000', textAlign: CanvasTextAlign = 'center', textBaseline: CanvasTextBaseline = 'middle'): void {
-    const fontSize = this.calculateOptimalFontSize(ctx, text, maxWidth, maxHeight, fontWeight);
+  private drawTextInternal(ctx: CanvasRenderingContext2D, text: string, x: number = this.EDGE_BUFFER, y: number = this.EDGE_BUFFER, maxWidth: number, maxHeight: number, fontWeight = 'normal', color = '#000', textAlign: CanvasTextAlign = 'center', textBaseline: CanvasTextBaseline = 'middle', haloColor?: string, floorPx = 0): void {
+    const fontSize = this.calculateOptimalFontSize(ctx, text, maxWidth, maxHeight, fontWeight, floorPx);
+    // Floored text may exceed its width box: let it overflow rather than squish (drop the maxWidth cap).
+    const widthArg = floorPx > 0 ? undefined : maxWidth;
     ctx.font = `${fontWeight} ${fontSize}px ${this.DEFAULT_FONT}`;
-    ctx.fillStyle = color;
     ctx.textAlign = textAlign;
     ctx.textBaseline = textBaseline;
-    ctx.fillText(text, x, y, maxWidth);
+    if (haloColor) {
+      this.strokeTextHalo(ctx, text, x, y, fontSize, haloColor, widthArg);
+    }
+    ctx.fillStyle = color;
+    ctx.fillText(text, x, y, widthArg);
   }
 
   /**
@@ -489,11 +513,11 @@ export class CanvasService {
   * context has been transformed to device pixels (service methods generally
   * ensure the context transform so callers may pass CSS units).
    */
-  public calculateOptimalFontSize(ctx: CanvasRenderingContext2D, text: string, maxWidth: number, maxHeight: number, fontWeight = 'normal'): number {
+  public calculateOptimalFontSize(ctx: CanvasRenderingContext2D, text: string, maxWidth: number, maxHeight: number, fontWeight = 'normal', floorPx = 0): number {
     const cacheKey = `${fontWeight}|${Math.round(maxWidth)}|${Math.round(maxHeight)}|${text}`;
     const cached = this._fontSizeCache.get(cacheKey);
     if (cached !== undefined) {
-      return cached;
+      return floorPx > 0 ? Math.max(cached, Math.round(floorPx)) : cached;
     }
 
     let minFontSize = 1;
@@ -517,7 +541,24 @@ export class CanvasService {
       this._fontSizeCache.clear();
     }
     this._fontSizeCache.set(cacheKey, maxFontSize);
-    return maxFontSize;
+    // Cache the raw fitted size; apply the floor on read so floored and unfloored callers share it.
+    return floorPx > 0 ? Math.max(maxFontSize, Math.round(floorPx)) : maxFontSize;
+  }
+
+  /**
+   * Strokes a background-color "halo" behind text to keep it legible where it overlaps other content.
+   * Because the stroke is the widget background color it is invisible over the empty card and only
+   * carves a clean channel around the glyphs where they sit over the value. Stroke is drawn before the
+   * fill by the caller. `maxWidth` is omitted when the text is floored so it overflows rather than squishes.
+   */
+  private strokeTextHalo(ctx: CanvasRenderingContext2D, text: string, x: number, y: number, fontSizePx: number, haloColor: string, maxWidth?: number): void {
+    ctx.save();
+    ctx.lineJoin = 'round';
+    ctx.miterLimit = 2;
+    ctx.lineWidth = Math.max(2, fontSizePx / 5);
+    ctx.strokeStyle = haloColor;
+    ctx.strokeText(text, x, y, maxWidth);
+    ctx.restore();
   }
 
   /**

--- a/src/app/core/services/canvas.service.ts
+++ b/src/app/core/services/canvas.service.ts
@@ -584,7 +584,9 @@ export class CanvasService {
     fontWeight: string,
     cssWidth: number,
     cssHeight: number,
-    titleFraction = 0.1
+    titleFraction = 0.1,
+    haloColor?: string,
+    floorPx = 0
   ): HTMLCanvasElement {
     const offscreen = document.createElement('canvas');
     offscreen.width = Math.round(cssWidth * this.scaleFactor);
@@ -597,7 +599,7 @@ export class CanvasService {
       offCtx.setTransform(this.scaleFactor, 0, 0, this.scaleFactor, 0, 0);
       // Use provided titleFraction (defaults to 0.1) for consistent appearance.
       // receive a visible bitmap even if web fonts are still loading.
-      this.drawTitleInternal(offCtx, text, color, fontWeight, cssWidth, cssHeight, titleFraction);
+      this.drawTitleInternal(offCtx, text, color, fontWeight, cssWidth, cssHeight, titleFraction, haloColor, floorPx);
       // If fonts are not yet ready, schedule a re-render when they load so
       // the offscreen bitmap updates with correct metrics. Widgets that cache
       // the returned canvas should redraw when they detect the bitmap changed.
@@ -606,7 +608,7 @@ export class CanvasService {
           try {
             // re-scale in case DPR changed
             offCtx.setTransform(this.scaleFactor, 0, 0, this.scaleFactor, 0, 0);
-            this.drawTitleInternal(offCtx, text, color, fontWeight, cssWidth, cssHeight, titleFraction);
+            this.drawTitleInternal(offCtx, text, color, fontWeight, cssWidth, cssHeight, titleFraction, haloColor, floorPx);
           } catch { /* ignore */ }
         }).catch(() => { /* ignore */ });
       }

--- a/src/app/widgets/widget-datetime/widget-datetime.component.ts
+++ b/src/app/widgets/widget-datetime/widget-datetime.component.ts
@@ -211,8 +211,6 @@ export class WidgetDatetimeComponent implements AfterViewInit, OnDestroy {
     );
 
     // Label composites last so its background-color halo can knock the value out behind it.
-    if (this.titleBitmap && this.titleBitmap.width > 0 && this.titleBitmap.height > 0) {
-      ctx.drawImage(this.titleBitmap, 0, 0, this.cssWidth, this.cssHeight);
-    }
+    this.canvas.drawTextBitmap(ctx, this.titleBitmap, this.cssWidth, this.cssHeight);
   }
 }

--- a/src/app/widgets/widget-datetime/widget-datetime.component.ts
+++ b/src/app/widgets/widget-datetime/widget-datetime.component.ts
@@ -157,6 +157,7 @@ export class WidgetDatetimeComponent implements AfterViewInit, OnDestroy {
     if (!ctx) return;
     const cfg = this.runtime.options();
     if (!cfg) return;
+    const haloColor = this.theme()?.cardColor || undefined;
     // Only recreate the title bitmap if the title text, title color, or full canvas size changes.
     // Note: the offscreen bitmap returned by createTitleBitmap is backed by
     // device pixels (width/height === css * devicePixelRatio), so compare
@@ -173,20 +174,16 @@ export class WidgetDatetimeComponent implements AfterViewInit, OnDestroy {
         titleColor,
         'normal',
         this.cssWidth,
-        this.cssHeight
+        this.cssHeight,
+        0.1,
+        haloColor,
+        this.canvas.MIN_LABEL_PX
       );
       this.titleBitmapText = `${cfg.displayName}-${cfg.color}`;
       this.titleBitmapColor = titleColor;
     }
 
     this.canvas.clearCanvas(ctx, this.cssWidth, this.cssHeight);
-
-    // Draw the title bitmap at the top. Request an explicit target size in
-    // CSS pixels to avoid any ambiguity with device-pixel intrinsic sizes.
-    // Ensure canvas is not size 0
-    if (this.titleBitmap && this.titleBitmap.width > 0 && this.titleBitmap.height > 0) {
-      ctx.drawImage(this.titleBitmap, 0, 0, this.cssWidth, this.cssHeight);
-    }
 
     let valueText: string;
 
@@ -212,5 +209,10 @@ export class WidgetDatetimeComponent implements AfterViewInit, OnDestroy {
       'bold',
       this.valueColor
     );
+
+    // Label composites last so its background-color halo can knock the value out behind it.
+    if (this.titleBitmap && this.titleBitmap.width > 0 && this.titleBitmap.height > 0) {
+      ctx.drawImage(this.titleBitmap, 0, 0, this.cssWidth, this.cssHeight);
+    }
   }
 }

--- a/src/app/widgets/widget-numeric/widget-numeric.component.spec.ts
+++ b/src/app/widgets/widget-numeric/widget-numeric.component.spec.ts
@@ -27,8 +27,12 @@ interface NumericInternals {
  *
  * The component is driven headless: onNumericValue (the stream callback that sets dataValue +
  * effectiveUnit) is invoked directly, and getValueText (the smallest seam producing the drawn text)
- * is read back. Effects are never flushed (no TestBed.tick()) so the required `theme` input is never
- * read, and ignoreZones:true keeps onNumericValue out of the zone branch that also reads theme().
+ * is read back. onNumericValue calls drawWidget(), which now reads the required `theme()` input (for
+ * the halo card color) — but drawWidget bails at its `if (!canvasCtx) return` guard here, because the
+ * component is constructed via `new` without ngOnInit so the canvas context is never set and theme()
+ * is never reached. ignoreZones:true likewise keeps onNumericValue out of the zone branch that reads
+ * theme(). Adding ngOnInit/detectChanges to this spec would make drawWidget reach this.theme() and
+ * throw NG0950 (required input not set).
  */
 describe('WidgetNumericComponent value text (crash-fix ddfb377c)', () => {
   let component: WidgetNumericComponent;

--- a/src/app/widgets/widget-numeric/widget-numeric.component.ts
+++ b/src/app/widgets/widget-numeric/widget-numeric.component.ts
@@ -68,8 +68,8 @@ export class WidgetNumericComponent implements OnInit, AfterViewInit, OnDestroy 
   private canvasCtx: CanvasRenderingContext2D | null;
   private cssWidth = 0;
   private cssHeight = 0;
-  private backgroundBitmap: HTMLCanvasElement | null = null;
-  private backgroundBitmapText: string | null = null;
+  private foregroundBitmap: HTMLCanvasElement | null = null;
+  private foregroundBitmapText: string | null = null;
 
   private dataValue: number | null = null;
   private effectiveUnit = signal<string>('');
@@ -257,8 +257,8 @@ export class WidgetNumericComponent implements OnInit, AfterViewInit, OnDestroy 
     if (!cfg || !theme) return;
     this.labelColor.set(getColors(cfg.color ?? 'contrast', theme).dim);
     this.valueStateColor = this.valueColor = getColors(cfg.color ?? 'contrast', theme).color;
-    this.backgroundBitmap = null;
-    this.backgroundBitmapText = null;
+    this.foregroundBitmap = null;
+    this.foregroundBitmapText = null;
   }
 
   private drawWidget(): void {
@@ -270,13 +270,16 @@ export class WidgetNumericComponent implements OnInit, AfterViewInit, OnDestroy 
     const marginX = 10 * this.canvas.scaleFactor;
     const marginY = 5 * this.canvas.scaleFactor;
     const displayName = cfg.displayName ?? 'Gauge Label';
-    const bgText = displayName + '|' + unit;
+    // Background-color halo: invisible over the empty card, carves the value out only where the
+    // floored label/unit overlap it. Requires the label/unit to be composited above the value below.
+    const haloColor = this.theme()?.cardColor || undefined;
+    const fgText = displayName + '|' + unit;
 
-    if (!this.backgroundBitmap ||
-        this.backgroundBitmap.width !== this.canvasElement.width ||
-        this.backgroundBitmap.height !== this.canvasElement.height ||
-        this.backgroundBitmapText !== bgText) {
-      this.backgroundBitmap = this.canvas.renderStaticToBitmap(
+    if (!this.foregroundBitmap ||
+        this.foregroundBitmap.width !== this.canvasElement.width ||
+        this.foregroundBitmap.height !== this.canvasElement.height ||
+        this.foregroundBitmapText !== fgText) {
+      this.foregroundBitmap = this.canvas.renderStaticToBitmap(
         ctx,
         this.cssWidth,
         this.cssHeight,
@@ -288,7 +291,9 @@ export class WidgetNumericComponent implements OnInit, AfterViewInit, OnDestroy 
             'normal',
             this.cssWidth,
             this.cssHeight,
-            0.1
+            0.1,
+            haloColor,
+            this.canvas.MIN_LABEL_PX
           );
           if (unit && !['unitless', 'percent', 'percentraw', 'ratio', 'latitudeSec', 'latitudeMin', 'longitudeSec', 'longitudeMin'].includes(unit)) {
             this.canvas.drawText(
@@ -301,22 +306,24 @@ export class WidgetNumericComponent implements OnInit, AfterViewInit, OnDestroy 
               'bold',
               this.valueColor,
               'end',
-              'bottom'
+              'bottom',
+              haloColor,
+              this.canvas.MIN_UNIT_PX
             );
           }
         }
       );
-      this.backgroundBitmapText = bgText;
+      this.foregroundBitmapText = fgText;
     }
 
     this.canvas.clearCanvas(ctx, this.cssWidth, this.cssHeight);
-    if (this.backgroundBitmap && this.backgroundBitmap.width > 0 && this.backgroundBitmap.height > 0) {
-      ctx.drawImage(this.backgroundBitmap, 0, 0, this.cssWidth, this.cssHeight);
-    }
-
     this.drawValue(ctx);
     if (cfg.showMax || cfg.showMin) {
       this.drawMinMax(ctx);
+    }
+    // Label + unit composite last so the background-color halo can knock the value out behind them.
+    if (this.foregroundBitmap && this.foregroundBitmap.width > 0 && this.foregroundBitmap.height > 0) {
+      ctx.drawImage(this.foregroundBitmap, 0, 0, this.cssWidth, this.cssHeight);
     }
   }
 

--- a/src/app/widgets/widget-numeric/widget-numeric.component.ts
+++ b/src/app/widgets/widget-numeric/widget-numeric.component.ts
@@ -322,9 +322,7 @@ export class WidgetNumericComponent implements OnInit, AfterViewInit, OnDestroy 
       this.drawMinMax(ctx);
     }
     // Label + unit composite last so the background-color halo can knock the value out behind them.
-    if (this.foregroundBitmap && this.foregroundBitmap.width > 0 && this.foregroundBitmap.height > 0) {
-      ctx.drawImage(this.foregroundBitmap, 0, 0, this.cssWidth, this.cssHeight);
-    }
+    this.canvas.drawTextBitmap(ctx, this.foregroundBitmap, this.cssWidth, this.cssHeight);
   }
 
   private drawValue(ctx: CanvasRenderingContext2D): void {

--- a/src/app/widgets/widget-position/widget-position.component.ts
+++ b/src/app/widgets/widget-position/widget-position.component.ts
@@ -166,6 +166,7 @@ export class WidgetPositionComponent implements AfterViewInit, OnDestroy {
     if (!this.ctx || !this.canvasElement) return;
     const cfg = this.runtime.options();
     if (!cfg) return;
+    const haloColor = this.theme()?.cardColor || undefined;
     const name = cfg.displayName || 'Position';
     const titleColor = this.labelColor();
     if (
@@ -175,17 +176,11 @@ export class WidgetPositionComponent implements AfterViewInit, OnDestroy {
       this.titleBitmapText !== name ||
       this.titleBitmapColor !== titleColor
     ) {
-      this.titleBitmap = this.canvas.createTitleBitmap(name, titleColor, 'normal', this.cssWidth, this.cssHeight);
+      this.titleBitmap = this.canvas.createTitleBitmap(name, titleColor, 'normal', this.cssWidth, this.cssHeight, 0.1, haloColor, this.canvas.MIN_LABEL_PX);
       this.titleBitmapText = name;
       this.titleBitmapColor = titleColor;
     }
     this.canvas.clearCanvas(this.ctx, this.cssWidth, this.cssHeight);
-    // Draw the title bitmap at the top. Request an explicit target size in
-    // CSS pixels to avoid any ambiguity with device-pixel intrinsic sizes.
-    // Ensure canvas is not size 0
-    if (this.titleBitmap && this.titleBitmap.width > 0 && this.titleBitmap.height > 0) {
-      this.ctx.drawImage(this.titleBitmap, 0, 0, this.cssWidth, this.cssHeight);
-    }
     // Latitude
     this.canvas.drawText(
       this.ctx,
@@ -212,6 +207,11 @@ export class WidgetPositionComponent implements AfterViewInit, OnDestroy {
       'center',
       'top'
     );
+
+    // Label composites last so its background-color halo can knock the values out behind it.
+    if (this.titleBitmap && this.titleBitmap.width > 0 && this.titleBitmap.height > 0) {
+      this.ctx.drawImage(this.titleBitmap, 0, 0, this.cssWidth, this.cssHeight);
+    }
   }
 
   ngOnDestroy(): void {

--- a/src/app/widgets/widget-position/widget-position.component.ts
+++ b/src/app/widgets/widget-position/widget-position.component.ts
@@ -209,9 +209,7 @@ export class WidgetPositionComponent implements AfterViewInit, OnDestroy {
     );
 
     // Label composites last so its background-color halo can knock the values out behind it.
-    if (this.titleBitmap && this.titleBitmap.width > 0 && this.titleBitmap.height > 0) {
-      this.ctx.drawImage(this.titleBitmap, 0, 0, this.cssWidth, this.cssHeight);
-    }
+    this.canvas.drawTextBitmap(this.ctx, this.titleBitmap, this.cssWidth, this.cssHeight);
   }
 
   ngOnDestroy(): void {

--- a/src/app/widgets/widget-racer-line/widget-racer-line.component.ts
+++ b/src/app/widgets/widget-racer-line/widget-racer-line.component.ts
@@ -470,9 +470,7 @@ export class WidgetRacerLineComponent implements AfterViewInit, OnDestroy {
     );
 
     // Label composites last so its background-color halo can knock the values out behind it.
-    if (this.titleBitmap && this.titleBitmap.width > 0 && this.titleBitmap.height > 0) {
-      this.ctx.drawImage(this.titleBitmap, 0, 0, this.cssWidth, this.cssHeight);
-    }
+    this.canvas.drawTextBitmap(this.ctx, this.titleBitmap, this.cssWidth, this.cssHeight);
 
     this.setLenBias();
   }

--- a/src/app/widgets/widget-racer-line/widget-racer-line.component.ts
+++ b/src/app/widgets/widget-racer-line/widget-racer-line.component.ts
@@ -380,14 +380,14 @@ export class WidgetRacerLineComponent implements AfterViewInit, OnDestroy {
     if (!this.ctx || !this.canvasElement) return;
     const cfg = this.runtime.options();
     const name = cfg?.displayName || 'DTS';
+    const haloColor = this.theme()?.cardColor || undefined;
     const titleColor = this.labelColor();
     if (!this.titleBitmap || !cfg || this.titleBitmap.width !== this.canvasElement.width || this.titleBitmap.height !== this.canvasElement.height || this.titleBitmapText !== name || this.titleBitmapColor !== titleColor) {
-      this.titleBitmap = this.canvas.createTitleBitmap(name, titleColor, 'normal', this.cssWidth, this.cssHeight);
+      this.titleBitmap = this.canvas.createTitleBitmap(name, titleColor, 'normal', this.cssWidth, this.cssHeight, 0.1, haloColor, this.canvas.MIN_LABEL_PX);
       this.titleBitmapText = name;
       this.titleBitmapColor = titleColor;
     }
     this.canvas.clearCanvas(this.ctx, this.cssWidth, this.cssHeight);
-    if (this.titleBitmap) this.ctx.drawImage(this.titleBitmap, 0, 0, this.cssWidth, this.cssHeight);
 
     this.canvas.drawText(
       this.ctx,
@@ -412,7 +412,9 @@ export class WidgetRacerLineComponent implements AfterViewInit, OnDestroy {
       'normal',
       this.dtsColor,
       'right',
-      'bottom'
+      'bottom',
+      haloColor,
+      this.canvas.MIN_UNIT_PX
     );
 
     this.canvas.drawText(
@@ -466,6 +468,11 @@ export class WidgetRacerLineComponent implements AfterViewInit, OnDestroy {
       'left',
       'bottom'
     );
+
+    // Label composites last so its background-color halo can knock the values out behind it.
+    if (this.titleBitmap && this.titleBitmap.width > 0 && this.titleBitmap.height > 0) {
+      this.ctx.drawImage(this.titleBitmap, 0, 0, this.cssWidth, this.cssHeight);
+    }
 
     this.setLenBias();
   }

--- a/src/app/widgets/widget-racer-timer/widget-racer-timer.component.ts
+++ b/src/app/widgets/widget-racer-timer/widget-racer-timer.component.ts
@@ -295,9 +295,7 @@ export class WidgetRacerTimerComponent implements AfterViewInit, OnDestroy {
     );
 
     // Label composites last so its background-color halo can knock the value out behind it.
-    if (this.titleBitmap && this.titleBitmap.width > 0 && this.titleBitmap.height > 0) {
-      this.ctx.drawImage(this.titleBitmap, 0, 0, this.cssWidth, this.cssHeight);
-    }
+    this.canvas.drawTextBitmap(this.ctx, this.titleBitmap, this.cssWidth, this.cssHeight);
   }
 
   private beep(frequency = 440, duration = 100) {

--- a/src/app/widgets/widget-racer-timer/widget-racer-timer.component.ts
+++ b/src/app/widgets/widget-racer-timer/widget-racer-timer.component.ts
@@ -273,14 +273,14 @@ export class WidgetRacerTimerComponent implements AfterViewInit, OnDestroy {
     if (!this.ctx || !this.canvasElement) return;
     const cfg = this.runtime.options();
     const name = cfg?.displayName || 'TTS';
+    const haloColor = this.theme()?.cardColor || undefined;
     const titleColor = this.labelColor();
     if (!this.titleBitmap || this.titleBitmap.width !== this.canvasElement.width || this.titleBitmap.height !== this.canvasElement.height || this.titleBitmapText !== name || this.titleBitmapColor !== titleColor) {
-      this.titleBitmap = this.canvas.createTitleBitmap(name, titleColor, 'normal', this.cssWidth, this.cssHeight);
+      this.titleBitmap = this.canvas.createTitleBitmap(name, titleColor, 'normal', this.cssWidth, this.cssHeight, 0.1, haloColor, this.canvas.MIN_LABEL_PX);
       this.titleBitmapText = name;
       this.titleBitmapColor = titleColor;
     }
     this.canvas.clearCanvas(this.ctx, this.cssWidth, this.cssHeight);
-    if (this.titleBitmap) this.ctx.drawImage(this.titleBitmap, 0, 0, this.cssWidth, this.cssHeight);
     this.canvas.drawText(
       this.ctx,
       this.getValueText(),
@@ -293,6 +293,11 @@ export class WidgetRacerTimerComponent implements AfterViewInit, OnDestroy {
       'center',
       'middle'
     );
+
+    // Label composites last so its background-color halo can knock the value out behind it.
+    if (this.titleBitmap && this.titleBitmap.width > 0 && this.titleBitmap.height > 0) {
+      this.ctx.drawImage(this.titleBitmap, 0, 0, this.cssWidth, this.cssHeight);
+    }
   }
 
   private beep(frequency = 440, duration = 100) {

--- a/src/app/widgets/widget-text/widget-text.component.ts
+++ b/src/app/widgets/widget-text/widget-text.component.ts
@@ -185,8 +185,6 @@ export class WidgetTextComponent implements AfterViewInit, OnInit, OnDestroy {
     );
 
     // Label composites last so its background-color halo can knock the value out behind it.
-    if (this.titleBitmap && this.titleBitmap.width > 0 && this.titleBitmap.height > 0) {
-      this.canvasCtx.drawImage(this.titleBitmap, 0, 0, this.cssWidth, this.cssHeight);
-    }
+    this.canvas.drawTextBitmap(this.canvasCtx, this.titleBitmap, this.cssWidth, this.cssHeight);
   }
 }

--- a/src/app/widgets/widget-text/widget-text.component.ts
+++ b/src/app/widgets/widget-text/widget-text.component.ts
@@ -141,6 +141,7 @@ export class WidgetTextComponent implements AfterViewInit, OnInit, OnDestroy {
     const titleHeight = Math.floor(this.cssHeight * 0.1);
     const cfg = this.runtime.options();
     if (!cfg) return;
+    const haloColor = this.theme()?.cardColor || undefined;
     const bgText = cfg.displayName + '|' + this.labelColor();
 
     if (!this.titleBitmap ||
@@ -152,15 +153,15 @@ export class WidgetTextComponent implements AfterViewInit, OnInit, OnDestroy {
         this.labelColor(),
         'normal',
         this.cssWidth,
-        this.cssHeight
+        this.cssHeight,
+        0.1,
+        haloColor,
+        this.canvas.MIN_LABEL_PX
       );
       this.titleBitmapText = cfg.displayName + '|' + this.labelColor();
     }
 
     this.canvas.clearCanvas(this.canvasCtx, this.cssWidth, this.cssHeight);
-    if (this.titleBitmap && this.titleBitmap.width > 0 && this.titleBitmap.height > 0) {
-      this.canvasCtx.drawImage(this.titleBitmap, 0, 0, this.cssWidth, this.cssHeight);
-    }
 
     const valueText = this.dataValue === null ? '--' : this.dataValue;
     const edge = this.canvas.EDGE_BUFFER || 10;
@@ -182,5 +183,10 @@ export class WidgetTextComponent implements AfterViewInit, OnInit, OnDestroy {
       'center',
       'middle'
     );
+
+    // Label composites last so its background-color halo can knock the value out behind it.
+    if (this.titleBitmap && this.titleBitmap.width > 0 && this.titleBitmap.height > 0) {
+      this.canvasCtx.drawImage(this.titleBitmap, 0, 0, this.cssWidth, this.cssHeight);
+    }
   }
 }


### PR DESCRIPTION
## Why

On small dashboard tiles — and in bright daylight or at a distance — a widget's **label** and **unit** text shrink below legibility while the main value stays readable. They're auto-fit to a box whose height is a fixed fraction of the tile (label ~10%, unit ~15%, value ~70%) with no lower bound, so they cross the legibility threshold long before the number does.

Addresses the **canvas-substrate scope** of #408 (the library/SVG/chart widgets and the reflow fallback remain tracked there as follow-ups).

## How

Three coupled parts, all opt-in via new optional args on `CanvasService` (existing callers unchanged):

1. **Legibility floor (absolute CSS px).** `calculateOptimalFontSize` gains an optional `floorPx`, applied on read so floored and unfloored callers share one memo entry. Floored text drops its `maxWidth` cap so it overflows rather than horizontally squishing. `MIN_LABEL_PX = 16`, `MIN_UNIT_PX = 12`.
2. **Always-on background-color halo (knockout).** A new `strokeText` pass under the fill, stroked with the widget card background (`theme.cardColor`). Because it's the background color it's **invisible over the empty card** and only carves a clean channel where the text overlaps the value — self-nullifying, so it's always-on at zero cost until overlap happens.
3. **Composite label/unit above the value.** The knockout only works if the text is painted after the value, so each widget's cached label/unit bitmap moves from a background layer to a foreground layer blitted last. The bitmap stays cached (rebuilt only on size/text/theme change), so per-frame cost is unchanged.

## Scope

All six **canvas-text** widgets: `numeric` (label + unit), `text`, `datetime`, `position`, `racer-timer`, `racer-line` (label + DTS unit). Widgets that render label/unit through libraries (canvas-gauges, steelseries), SVG templates, or chart.js are untouched and remain follow-ups in #408.

## Assumption

The knockout relies on a flat `theme.cardColor` widget background (true today: `widget-host2` fills a solid `--skip-widget-card-background-color`, canvas transparent over it). A future gradient/image widget background would need revisiting.

## Verification

- `snc` clean, lint clean, full unit suite **1558/1558** (one run hit the known order-dependent `minichart` flake — passes isolated and on re-run; untouched by this change).
- Built and deployed to a live boat Signal K (`./run deploy-halos local`), tuned and confirmed on the Numeric widget across tile sizes; floor values settled interactively (label 16, unit 12).
- Perf-neutral by construction: same per-frame draw-call count (one cached-bitmap blit + value draw), blit merely reordered.

## Follow-ups (tracked in #408)

Reflow fallback for the pathological long-label-on-tiny-tile case; per-substrate treatment for the library/SVG/chart widgets.
