### PR TITLE
fix(charts): round line joins to stop miter-spike flicker on narrow viewports

### DIFF
--- a/src/app/core/utils/chart-registration.util.spec.ts
+++ b/src/app/core/utils/chart-registration.util.spec.ts
@@ -6,7 +6,8 @@ import { describe, it, expect, vi } from 'vitest';
 // registry inside the test and re-import fresh so the guard starts clean regardless of run order.
 // Each mocked component is a distinct sentinel string so the assertion can name the exact set.
 vi.mock('chart.js', () => ({
-  Chart: { register: vi.fn() },
+  // defaults.elements.line: registerChartComponents() writes the round join default onto it.
+  Chart: { register: vi.fn(), defaults: { elements: { line: {} } } },
   LineController: 'LineController',
   LineElement: 'LineElement',
   PointElement: 'PointElement',
@@ -46,5 +47,15 @@ describe('registerChartComponents', () => {
       'annotationPlugin',
       'ChartStreaming'
     );
+  });
+
+  it('sets the line-element default join to round to prevent miter-spike flicker', async () => {
+    vi.resetModules();
+    const { Chart } = await import('chart.js');
+    const { registerChartComponents } = await import('./chart-registration.util');
+
+    registerChartComponents();
+
+    expect(Chart.defaults.elements.line.borderJoinStyle).toBe('round');
   });
 });

--- a/src/app/core/utils/chart-registration.util.ts
+++ b/src/app/core/utils/chart-registration.util.ts
@@ -24,6 +24,8 @@ let registered = false;
  * set is present. Registering the explicit union rather than every registerable lets the
  * bundler drop the unused controllers/scales on this Pi-class target. The `realtime`
  * scale used by the live-tail charts is contributed by the streaming plugin registration.
+ * It also sets the app-wide line-join default to round here, once alongside registration,
+ * so thick chart lines never render the miter spikes that flicker as a chart scrolls.
  */
 export function registerChartComponents(): void {
   if (registered) {
@@ -44,4 +46,12 @@ export function registerChartComponents(): void {
     annotationPlugin,
     ChartStreaming
   );
+
+  // Round line joins instead of Chart.js's default miter. At a sharp corner a miter juts to a
+  // point until its length crosses the canvas miterLimit, at which point the browser flips it to
+  // a bevel. As a realtime chart scrolls, each vertex's sub-pixel geometry shifts and vertices
+  // near that threshold flicker spike<->bevel frame to frame — most visibly on narrow viewports,
+  // where points pack into fewer pixels and corners are sharpest. Round joins have no miter point,
+  // so nothing spikes and nothing flips.
+  Chart.defaults.elements.line.borderJoinStyle = 'round';
 }

--- a/src/app/widgets/minichart/minichart.component.spec.ts
+++ b/src/app/widgets/minichart/minichart.component.spec.ts
@@ -6,6 +6,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 vi.mock('chart.js', () => {
   class MockChart {
     public static register(): void { /* noop */ }
+    // registerChartComponents() sets a line-element default join style on this.
+    public static defaults = { elements: { line: {} } };
     public ctx = {};
     public data: { datasets: { data: unknown[] }[] };
     public options: unknown;

--- a/src/app/widgets/widget-data-chart/widget-data-chart.component.spec.ts
+++ b/src/app/widgets/widget-data-chart/widget-data-chart.component.spec.ts
@@ -7,6 +7,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 vi.mock('chart.js', () => {
   class MockChart {
     public static register(): void { /* noop */ }
+    // registerChartComponents() sets a line-element default join style on this.
+    public static defaults = { elements: { line: {} } };
     public data: unknown;
     public options: unknown;
     constructor(_ctx: unknown, config: { data: unknown; options: unknown }) {

--- a/src/app/widgets/widget-windtrends-chart/widget-windtrends-chart.component.spec.ts
+++ b/src/app/widgets/widget-windtrends-chart/widget-windtrends-chart.component.spec.ts
@@ -5,6 +5,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 vi.mock('chart.js', () => {
   class MockChart {
     public static register(): void { /* noop */ }
+    // registerChartComponents() sets a line-element default join style on this.
+    public static defaults = { elements: { line: {} } };
     public ctx = {};
     public data: { datasets: { data: unknown[] }[] };
     public options: { plugins?: Record<string, unknown>; scales?: Record<string, unknown> } = {};


### PR DESCRIPTION
## Problem

On mobile phones and any narrow viewport, Skip's time-series graph widgets flicker/jitter as they scroll. Instead of the line simply scrolling left, the thick polyline's corners are drawn as sharp, tall **spikes** that appear and disappear frame-to-frame.

## Root cause

Chart.js strokes line datasets with its element-default `lineJoin: 'miter'` and never sets `ctx.miterLimit`, so the canvas default (`10`) applies. At a sharp corner a miter juts out to a point whose length grows as the angle sharpens; when it crosses the miter limit the browser **discretely** switches the join from a drawn spike to a cut-off bevel. A realtime/streaming chart shifts every vertex's sub-pixel geometry each frame, so vertices sitting near the threshold flip spike↔bevel independently — the flicker.

It's a narrow-viewport problem specifically because the same point count packs into far fewer horizontal pixels, so segments get steeper and corners sharper — many more vertices land near the threshold. The worst offender is `widget-data-chart`'s Value line (`tension: 0` straight-segment polyline, `borderWidth: 3`).

## Fix

Set the line-element default join to `round` once, in the shared `chart-registration.util` hub. Round joins have no miter point — nothing spikes and nothing flips, so the line is stable under sub-pixel motion. One property, in the one place every chart widget (data-chart, minichart, windtrends) already routes through. Caps are left at the default — the artifact is joins (corners), not line ends.

## Verification

- Rendered the **real chart.js** with `widget-data-chart`'s exact Value-line options at phone width (DPR 2), before (miter) vs after (round): the spikes are present, then gone.
- `npm run snc` + `npm run lint` green; all four chart-widget specs pass (25 tests), plus a new round-join regression assertion in the registration-util spec.
- Deployed the prod build to the live boat (`halpi`) and confirmed the served bundle carries `borderJoinStyle="round"` (fetched from Signal K over HTTPS, not just an HTTP-200).

## Test-mock note

The hub now *writes* `Chart.defaults.elements.line`, so all four self-contained `chart.js` spec mocks were completed with that shape (else the register body throws under the mock).

## Out of scope

Chart.js's `fastPathSegment` collapses points sharing an integer-x column into a min/max vertical stroke; that envelope still shifts as the chart scrolls, but that's the real data being drawn, not spikes. Round joins are the correct, complete fix for the reported flicker.
