### PR TITLE
fix(charts): thin trend-chart points to ~1/pixel to stop horizontal scroll jitter

### DIFF
--- a/src/app/widgets/widget-data-chart/widget-data-chart.component.spec.ts
+++ b/src/app/widgets/widget-data-chart/widget-data-chart.component.spec.ts
@@ -182,4 +182,42 @@ describe('WidgetDataChartComponent', () => {
     expect(title).toContain('knots');
     expect(title).not.toContain('celsius');
   });
+
+  // A 91-sample batch spanning 90s of the default 600s window. Reused by the thinning tests below.
+  const denseBatch = (): IDatasetServiceDatapoint[] => {
+    const batch: IDatasetServiceDatapoint[] = [];
+    for (let t = 0; t <= 90_000; t += 1_000) batch.push({ timestamp: t, data: { value: t / 1_000 } });
+    return batch;
+  };
+  const drawnCount = (): number => fixture.componentInstance.lineChartData.datasets[0].data.length;
+
+  it('thins a dense batch to about one point per pixel on a narrow plot', async () => {
+    const emissions$ = new Subject<IDatasetServiceDatapoint[]>();
+    historyMock.getBackfillThenLive.mockReturnValue(emissions$);
+    await setup(makeConfig({ showAverageData: false }));
+
+    // A measured 20px plot over the 600s window buckets to 30s, so the 91-sample / 90s batch
+    // collapses to one evenly spaced point per bucket instead of shimmering at ~2.6 samples/px.
+    (fixture.componentInstance as unknown as { chart: { chartArea: unknown } }).chart.chartArea =
+      { width: 20, height: 20, left: 0, right: 20, top: 0, bottom: 20 };
+
+    const batch = denseBatch();
+    emissions$.next(batch);
+
+    expect(drawnCount()).toBeLessThan(batch.length);
+    expect(drawnCount()).toBeGreaterThanOrEqual(3);
+    expect(drawnCount()).toBeLessThanOrEqual(5);
+  });
+
+  it('draws every sample when the plot has not been measured (thinning is inert)', async () => {
+    const emissions$ = new Subject<IDatasetServiceDatapoint[]>();
+    historyMock.getBackfillThenLive.mockReturnValue(emissions$);
+    await setup(makeConfig({ showAverageData: false }));
+
+    // No chartArea on the mock chart -> displayBucketMs stays 0 -> every sample is drawn.
+    const batch = denseBatch();
+    emissions$.next(batch);
+
+    expect(drawnCount()).toBe(batch.length);
+  });
 });

--- a/src/app/widgets/widget-data-chart/widget-data-chart.component.ts
+++ b/src/app/widgets/widget-data-chart/widget-data-chart.component.ts
@@ -101,6 +101,11 @@ export class WidgetDataChartComponent implements OnDestroy {
   private streamSub: Subscription | null = null;
   private datasetConfig: IDatasetServiceDatasetConfig | null = null;
   private dataSourceInfo: IDatasetServiceDataSourceInfo | null = null;
+  // Display-thinning state (see updateDisplayBucket): the window's time span and the current
+  // one-point-per-pixel bucket width. displayBucketMs 0 means draw every point.
+  private windowMs = 0;
+  private displayBucketMs = 0;
+  private lastKeptTimestampBucket: number | null = null;
   private lastVerticalChart: boolean | null | undefined = null;
   // Latest finite annotation values; NaN until real data arrives, which keeps the
   // min/max/average lines and their labels hidden instead of drawing at a placeholder 0.
@@ -198,12 +203,14 @@ export class WidgetDataChartComponent implements OnDestroy {
     this.lastAverageValue = NaN;
     this.lastMinimumValue = NaN;
     this.lastMaximumValue = NaN;
+    this.lastKeptTimestampBucket = null;
     this.historyUnavailable.set(false);
 
     // Synthesize the config + cadence the axis/streaming options expect, derived from the widget's
     // display window.
     const period = cfg.period ?? 10;
     const windowMs = resolveWindowMs(cfg.timeScale as TimeScaleFormat, period);
+    this.windowMs = windowMs;
     this.dataSourceInfo = deriveDataSourceInfo(windowMs);
     this.datasetConfig = {
       uuid: this.id(),
@@ -224,8 +231,10 @@ export class WidgetDataChartComponent implements OnDestroy {
       data: this.lineChartData,
       options: this.lineChartOptions
     });
-    this.startStreaming();
+    // Lay the chart out first so updateDisplayBucket() can measure the plot before backfill arrives.
     this.ngZone.runOutsideAngular(() => this.chart?.update());
+    this.updateDisplayBucket();
+    this.startStreaming();
   }
 
   private setChartOptions(cfg: IWidgetSvcConfig): void {
@@ -806,28 +815,50 @@ export class WidgetDataChartComponent implements OnDestroy {
 
   private handleDatasetEmission(dsPointOrBatch: IDatasetServiceDatapoint[] | IDatasetServiceDatapoint, cfg: IWidgetSvcConfig): void {
     if (!this.chart) return;
-    if (Array.isArray(dsPointOrBatch)) {
-      const valueRows = this.transformDatasetRows(dsPointOrBatch, 0);
-      this.chart.data.datasets[0].data.push(...valueRows);
-      if (cfg.showAverageData && this.lineChartData.datasets[1]) {
-        const avgRows = this.transformDatasetRows(dsPointOrBatch, cfg.datasetAverageArray);
-        this.chart.data.datasets[1].data.push(...avgRows);
-      }
+    const rows = Array.isArray(dsPointOrBatch) ? dsPointOrBatch : [dsPointOrBatch];
+    if (rows.length === 0) return;
 
-      const lastBatchPoint = dsPointOrBatch[dsPointOrBatch.length - 1];
-      if (lastBatchPoint) {
-        this.applyTitleAndAnnotationValues(lastBatchPoint, cfg);
-      }
-    } else {
-      const valueRow = this.transformDatasetRows([dsPointOrBatch], 0)[0];
-      this.chart.data.datasets[0].data.push(valueRow);
+    // Recompute the per-pixel bucket from the current plot size so thinning tracks the live width
+    // (and adapts across a resize) before deciding which of this emission's samples to draw.
+    this.updateDisplayBucket();
+    const kept = rows.filter(row => this.keepForDisplay(row.timestamp));
+    if (kept.length > 0) {
+      this.chart.data.datasets[0].data.push(...this.transformDatasetRows(kept, 0));
       if (cfg.showAverageData && this.lineChartData.datasets[1]) {
-        const avgRow = this.transformDatasetRows([dsPointOrBatch], cfg.datasetAverageArray)[0];
-        this.chart.data.datasets[1].data.push(avgRow);
+        this.chart.data.datasets[1].data.push(...this.transformDatasetRows(kept, cfg.datasetAverageArray));
       }
-      this.applyTitleAndAnnotationValues(dsPointOrBatch, cfg);
     }
+
+    // Title, average, min and max always reflect the newest sample, whether or not it was drawn.
+    this.applyTitleAndAnnotationValues(rows[rows.length - 1], cfg);
     this.ngZone.runOutsideAngular(() => this.chart?.update('none'));
+  }
+
+  // A window always carries ~TARGET_POINTS_PER_WINDOW samples regardless of how wide it renders. On a
+  // narrow (phone) chart that is several samples per horizontal pixel; the sub-pixel structure can't
+  // be drawn distinctly and shimmers frame to frame as the chart scrolls. Thin the drawn points to
+  // about one per pixel along the time axis. Bucketing by timestamp keeps the kept set evenly spaced
+  // and stable under scroll (unlike min/max or chart.js decimation, which re-select shifting points
+  // and keep boiling). Wide charts, where samples already fit, keep every point (bucket 0).
+  private updateDisplayBucket(): void {
+    const chart = this.chart;
+    const info = this.dataSourceInfo;
+    if (!chart || !info || this.windowMs <= 0) {
+      this.displayBucketMs = 0;
+      return;
+    }
+    const area = chart.chartArea;
+    const axisPx = this.runtime.options()?.verticalChart ? (area?.height ?? 0) : (area?.width ?? 0);
+    const targetPoints = Math.min(info.maxDataPoints, Math.max(1, Math.round(axisPx)));
+    this.displayBucketMs = axisPx > 0 && targetPoints < info.maxDataPoints ? this.windowMs / targetPoints : 0;
+  }
+
+  private keepForDisplay(timestamp: number): boolean {
+    if (this.displayBucketMs <= 0) return true;
+    const bucket = Math.round(timestamp / this.displayBucketMs);
+    if (bucket === this.lastKeptTimestampBucket) return false;
+    this.lastKeptTimestampBucket = bucket;
+    return true;
   }
 
   private applyTitleAndAnnotationValues(point: IDatasetServiceDatapoint, cfg: IWidgetSvcConfig): void {


### PR DESCRIPTION
## Problem

On mobile phones and other narrow viewports, the time-series trend charts jitter/boil horizontally as they scroll — the polyline's features shimmer and jump left/right instead of gliding smoothly. This is the second half of the scroll-jitter report; the vertical miter spikes were fixed separately in #410, and this is what remained.

## Root cause

`deriveDataSourceInfo` (`chart-window.util.ts`) targets a **fixed ~500 samples per window** (`TARGET_POINTS_PER_WINDOW`), independent of how wide the widget actually renders. On a phone the plotting area is ~150–250px, so that's **~2–3 data points per horizontal pixel**. You can't draw more than one distinct feature per pixel, so that sub-pixel structure aliases and *boils* as the chart scrolls sub-pixel. chart.js's `fastPathSegment` (used for `tension:0` lines) amplifies it by collapsing points into shifting integer-pixel columns, but over-sampling is the disease — wide desktop charts (≤1 pt/px) are already smooth.

I confirmed this with a headless scrolling repro on the real chart.js, measuring a scroll-invariant jitter metric (mean |2nd-difference| of the line's per-column position across frames):

| Render | jitter (px) |
|---|---|
| current (~2.6 pt/px, fastPath) | 4.25 |
| tension `1e-6` (bypasses fastPath, full density) | 3.13 |
| **evenly-spaced ~1 pt/px** | **0.75** |

Two findings drove the fix: (1) reducing to ~1 pt/px is what actually matters (5.6× smoother); (2) it must be **evenly-spaced** — peak-preserving min-max and chart.js's own decimation still boil because they re-select shifting points as the window slides.

## Fix

Thin the **drawn** points to about one per pixel along the time axis, bucketing by **timestamp** so the kept set stays evenly spaced and stable under scroll. The bucket width is recomputed from the live plot size on each emission, so it adapts across a resize with **no reload**, and wide charts (samples already fit) keep every point. Rolling stats / SMA / min / max still track full-resolution upstream data — only rendering is thinned.

Deliberately *not* used: chart.js's built-in decimation. It bails on the streaming `realtime` axis (`chart.js` guards to `linear`/`time` only), and its min-max/lttb algorithms re-select shifting points, so they'd keep boiling anyway.

## Tradeoff

Inherent to any ~1 pt/px approach: a brief spike between kept samples isn't drawn (today it only surfaces *as* the jitter this removes). Preserving spikes needs a min/max band, which — per the metric above — reintroduces boiling. This chooses smooth over spike-preserving.

## Verification

- Scroll-invariant repro metric above (evenly-spaced thinning = the 0.75 result).
- Unit tests: a dense 91-sample batch thins to ~one point per 30s bucket on a measured 20px plot; an unmeasured plot draws every sample (fallback). `npm run snc` + `npm run lint` green; full data-chart spec passes.
- Deployed a combined build (this + #410) to the live boat for on-phone confirmation of the scrolling behavior.

Independent of #410 (branched from main; #410 touches `chart-registration.util`, this touches `widget-data-chart`) — they compose cleanly and can merge in either order.
