### PR TITLE
fix(charts): stop Data Chart scroll shimmer by drawing the value line off the fast path

### DIFF
--- a/src/app/widgets/widget-data-chart/widget-data-chart.component.spec.ts
+++ b/src/app/widgets/widget-data-chart/widget-data-chart.component.spec.ts
@@ -182,4 +182,16 @@ describe('WidgetDataChartComponent', () => {
     expect(title).toContain('knots');
     expect(title).not.toContain('celsius');
   });
+
+  it('draws the value line with a hair of tension so it avoids the fast pixel-bucketing path', async () => {
+    await setup(makeConfig());
+
+    // tension 0 routes the line onto Chart.js fastPathSegment, whose per-pixel-column collapse
+    // shimmers under the streaming plugin's per-frame re-path. A tiny non-zero tension keeps it on
+    // the exact-position path; it must stay non-zero (and visually straight) to avoid a regression.
+    const valueDataset = fixture.componentInstance.lineChartData.datasets[0];
+    expect(valueDataset.label).toBe('Value');
+    expect(valueDataset.tension ?? 0).toBeGreaterThan(0);
+    expect(valueDataset.tension ?? 1).toBeLessThan(0.01);
+  });
 });

--- a/src/app/widgets/widget-data-chart/widget-data-chart.component.ts
+++ b/src/app/widgets/widget-data-chart/widget-data-chart.component.ts
@@ -39,6 +39,15 @@ interface IChartColors {
 }
 interface IDataSetRow { x: number | null, y: number | null }
 
+// A hair of curvature — visually a straight line — that routes the value line off Chart.js's fast
+// integer-pixel-bucketing draw path onto the exact-position path. The streaming plugin re-paths the
+// line every animation frame from sub-pixel-shifted points; on the fast path that re-buckets dense
+// points into per-pixel-column min/max strokes whose x jumps as points cross pixel boundaries, so
+// features shimmer independently as the chart scrolls. The exact-position path draws every point
+// where it is and translates the whole line as one. Bezier control points at this tension sit far
+// below a pixel from the vertices, so the rendered line is indistinguishable from straight segments.
+const NON_FAST_PATH_TENSION = 1e-6;
+
 @Component({
   selector: 'widget-data-chart',
   templateUrl: './widget-data-chart.component.html',
@@ -489,7 +498,7 @@ export class WidgetDataChartComponent implements OnDestroy {
         data: [],
         order: cfg.trackAgainstAverage ? 1 : 0,
         parsing: false,
-        tension: 0,
+        tension: NON_FAST_PATH_TENSION,
         pointRadius: cfg.showDataPoints ? (cfg.trackAgainstAverage ? 0 : 1.5) : 0,
         pointHoverRadius: 0,
         pointHitRadius: 0,


### PR DESCRIPTION
## Problem

On narrow/mobile viewports the Data Chart's polyline jitters horizontally as it scrolls — **individual features shimmer independently** (not the whole line hitching as one). This is the horizontal-jitter half of the scroll-jitter report; the vertical miter spikes were fixed separately in #410.

## Root cause (traced in the streaming plugin's source)

`@aziham/chartjs-plugin-streaming`'s `realtime` scale, in its per-frame rAF loop, shifts every point's pixel by a sub-pixel amount and **`delete`s the dataset's cached path** — forcing Chart.js to re-path the line *every frame*. Chart.js's fast line path (`fastPathSegment`, used for `tension: 0` lines) buckets points by `truncX = x | 0` and collapses each integer-pixel column to a min/max stroke at the column's **average x**. As points slide sub-pixel, which points share a column churns frame-to-frame, so those collapsed features jump around independently → the shimmer.

## Fix

Give the value line a hair of tension (`1e-6`, visually a straight line) so `_getSegmentMethod` returns the exact-position (`pathSegment`) path instead of the fast bucketing one. Every point then draws where it is and the whole line **translates as one** each frame — no per-column churn to shimmer, at any density or width. Bezier control points at this tension sit far below a pixel from the vertices, so the rendered line is indistinguishable from straight segments. The average line already used tension and was never affected.

One line of behavior change, plus a regression test asserting the value line's tension stays non-zero (a reset to 0 silently reintroduces the fast path).

## Verification

- **User-verified on the live boat** ("perfect") after deploying a combined build (this + #410).
- Full data-chart spec passes (incl. the new tension guard); `npm run snc` + `npm run lint` green; prod build (AOT) succeeds via the deploy.
- The exact-position path is confirmed in the source frame loop, not inferred from a repro — a simplified panned-axis repro is *not* faithful to the streaming scale (see below).

## Note: supersedes #411

My first attempt (#411) was width-aware density thinning, validated on a repro that panned a plain linear axis — which doesn't model the streaming scale's per-frame re-path. On the real scale, thinning cleans up the line spatially but does nothing for the scroll shimmer. #411 is the wrong lever and should be closed; this PR is the actual fix.

Independent of #410 (branched from main; #410 touches `chart-registration.util`, this touches `widget-data-chart`) — they compose and can merge in either order.
