### PR TITLE
Position widget: one editable location path (fix broken lat/long settings)

### DIFF
--- a/perf-harness/lib/skip-config.mjs
+++ b/perf-harness/lib/skip-config.mjs
@@ -8,7 +8,7 @@
  *
  * Three distinct version spaces (all from src/app/core/constants/config-versions.const.ts):
  *  - applicationData URL path segment 11 (REMOTE_CONFIG_FILE_VERSION)
- *  - app.configVersion 14 (LATEST_APP_CONFIG_VERSION)
+ *  - app.configVersion 15 (LATEST_APP_CONFIG_VERSION)
  *  - connectionConfig.configVersion 13 (CONNECTION_CONFIG_VERSION)
  */
 export const SELF_URN = 'vessels.urn:mrn:signalk:uuid:11111111-1111-4111-8111-111111111111';
@@ -22,12 +22,12 @@ const DEFAULT_NOTIF = {
 };
 
 export function appConfig(extra = {}) {
-  // configVersion at LATEST (14): a genuine current config, so the boot skips
+  // configVersion at LATEST (15): a genuine current config, so the boot skips
   // ConfigurationUpgradeService's migration toast/reload entirely inside the
   // measurement window. Bump this in lockstep with LATEST_APP_CONFIG_VERSION, or
   // the boot triggers an upgrade+reload and the boot-assert fails.
   return {
-    configVersion: 14, autoNightMode: false, redNightMode: false, nightModeBrightness: 0.27,
+    configVersion: 15, autoNightMode: false, redNightMode: false, nightModeBrightness: 0.27,
     widgetHistoryDisabled: false,
     notificationConfig: DEFAULT_NOTIF, browserTabTitle: 'Skip', ...extra,
   };

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -542,6 +542,11 @@ describe('AppComponent — embed read-only invariants (#216 E6)', () => {
     expect(runUpgradeSpy).toHaveBeenCalledWith(13);
   });
 
+  it('runs the config migration in the full app for an upgradeable v14 config (the position-collapse gate)', async () => {
+    const { runUpgradeSpy } = await render({ embed: false, configUpgrade: true, configVersion: 14 });
+    expect(runUpgradeSpy).toHaveBeenCalledWith(14);
+  });
+
   it('does NOT show the missing-shared-config create prompt under embed', async () => {
     const { toast, bootstrapIssue$ } = await render({ embed: true });
     toast.show.mockClear();

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -106,7 +106,7 @@ export class AppComponent implements AfterViewInit, OnDestroy {
       if (this.settings.configUpgrade()) {
         const liveVersion = this.settings.getConfigVersion();
 
-        if (liveVersion === 11 || liveVersion === 12 || liveVersion === 13) {
+        if (liveVersion === 11 || liveVersion === 12 || liveVersion === 13 || liveVersion === 14) {
           this.upgrade.runUpgrade(liveVersion);
         }
 

--- a/src/app/core/constants/config-versions.const.ts
+++ b/src/app/core/constants/config-versions.const.ts
@@ -21,7 +21,7 @@ export const REMOTE_CONFIG_FILE_VERSION = 11;
  * its legacy transforms pin their own MIGRATION_OUTPUT_VERSION so that bumping this constant
  * cannot silently re-label old migration output as current — add a chained migration instead.
  */
-export const LATEST_APP_CONFIG_VERSION = 14;
+export const LATEST_APP_CONFIG_VERSION = 15;
 
 /**
  * Per-device connectionConfig schema version (its own version space, decoupled from the app config

--- a/src/app/core/interfaces/widgets-interface.ts
+++ b/src/app/core/interfaces/widgets-interface.ts
@@ -31,10 +31,11 @@ export interface IDimensions {
  * - 'number'
  * - 'string'
  * - 'boolean'
+ * - 'object' (a whole compound leaf, e.g. navigation.position — the widget reads its sub-fields)
  * - 'Date'
  * - null
  */
-export type TWidgetPathType = 'number' | 'string' | 'boolean' | 'Date' | 'multiple' | null;
+export type TWidgetPathType = 'number' | 'string' | 'boolean' | 'object' | 'Date' | 'multiple' | null;
 
 /**
  * Skip Dynamic Widgets interface.

--- a/src/app/core/services/configuration-upgrade.service.spec.ts
+++ b/src/app/core/services/configuration-upgrade.service.spec.ts
@@ -248,7 +248,7 @@ describe('ConfigurationUpgradeService', () => {
         await service.runUpgrade(13);
 
         const written = mockStorage.setConfig.mock.calls.at(-1)![2];
-        expect(written.app.configVersion).toBe(14); // still stamped current
+        expect(written.app.configVersion).toBe(14); // still advanced one step to the v13->v14 output
         const numeric = written.dashboards[0].configuration[0].input.widgetProperties.config.paths.numericPath;
         expect(numeric.path).toBe('self.navigation.attitude.pitch'); // path left on the inert child (clean no-data), not collapsed
         expect(numeric.isPathConfigurable).toBe(true);
@@ -307,6 +307,132 @@ describe('ConfigurationUpgradeService', () => {
         const written = mockStorage.setConfig.mock.calls.at(-1)![2];
         expect(written.dashboards[0].configuration[0].input.widgetProperties.config.paths.angle.path)
             .toBe('self.navigation.attitude');
+    });
+
+    it('v14 upgrade collapses a position widget to a single object-typed positionPath and stamps v15', async () => {
+        mockStorage.listConfigs.mockResolvedValueOnce([{ scope: 'user', name: 'default' }]);
+        mockStorage.getConfig.mockResolvedValue({
+            app: { configVersion: 14 },
+            theme: { themeName: '' },
+            dashboards: [
+                { id: 'd0', configuration: [
+                    { input: { widgetProperties: { type: 'widget-position', config: { paths: {
+                        longPath: { path: 'self.navigation.position.longitude', pathType: 'number', isPathConfigurable: true, source: 'gps.0', sampleTime: 1000 },
+                        latPath: { path: 'self.navigation.position.latitude', pathType: 'number', isPathConfigurable: true, source: 'gps.0', sampleTime: 1000 }
+                    } } } } }
+                ] }
+            ]
+        });
+
+        await service.runUpgrade(14);
+
+        const written = mockStorage.setConfig.mock.calls.at(-1)![2];
+        expect(written.app.configVersion).toBe(15);
+        const paths = written.dashboards[0].configuration[0].input.widgetProperties.config.paths;
+        // The two dead coordinate entries are gone, replaced by a single object-typed location path.
+        expect(Object.keys(paths)).toEqual(['positionPath']);
+        expect(paths.positionPath.path).toBe('self.navigation.position');
+        expect(paths.positionPath.pathType).toBe('object');
+        expect(paths.positionPath.isPathConfigurable).toBe(true);
+        // A user-pinned source / sampleTime carries across the collapse.
+        expect(paths.positionPath.source).toBe('gps.0');
+        expect(paths.positionPath.sampleTime).toBe(1000);
+    });
+
+    it('v14 upgrade leaves a non-position widget untouched (scoped rewrite), still stamps v15', async () => {
+        mockStorage.listConfigs.mockResolvedValueOnce([{ scope: 'user', name: 'default' }]);
+        mockStorage.getConfig.mockResolvedValue({
+            app: { configVersion: 14 },
+            theme: { themeName: '' },
+            dashboards: [
+                { id: 'd0', configuration: [
+                    { input: { widgetProperties: { type: 'widget-numeric', config: { paths: {
+                        numericPath: { path: 'self.navigation.speedOverGround', pathType: 'number', isPathConfigurable: true }
+                    } } } } }
+                ] }
+            ]
+        });
+
+        await service.runUpgrade(14);
+
+        const written = mockStorage.setConfig.mock.calls.at(-1)![2];
+        expect(written.app.configVersion).toBe(15);
+        const paths = written.dashboards[0].configuration[0].input.widgetProperties.config.paths;
+        expect(Object.keys(paths)).toEqual(['numericPath']);
+        expect(paths.numericPath.path).toBe('self.navigation.speedOverGround');
+    });
+
+    it('v14 upgrade skips a slot that is not at version 14 (no re-stamp)', async () => {
+        mockStorage.listConfigs.mockResolvedValueOnce([{ scope: 'user', name: 'default' }]);
+        mockStorage.getConfig.mockResolvedValue({
+            app: { configVersion: 15 },
+            theme: { themeName: '' },
+            dashboards: []
+        });
+
+        await service.runUpgrade(14);
+
+        expect(mockStorage.setConfig).not.toHaveBeenCalled();
+    });
+
+    it('v14 upgrade fills default source/sampleTime and handles empty, array, and missing paths without throwing', async () => {
+        mockStorage.listConfigs.mockResolvedValueOnce([{ scope: 'user', name: 'default' }]);
+        mockStorage.getConfig.mockResolvedValue({
+            app: { configVersion: 14 },
+            theme: { themeName: '' },
+            dashboards: [
+                { id: 'd0', configuration: [
+                    // legacy record entry with no source/sampleTime -> both fall back to defaults
+                    { input: { widgetProperties: { type: 'widget-position', config: { paths: {
+                        longPath: { path: 'self.navigation.position.longitude', pathType: 'number' }
+                    } } } } },
+                    // array form of paths still collapses to the single object entry
+                    { input: { widgetProperties: { type: 'widget-position', config: { paths: [
+                        { path: 'self.navigation.position.latitude', pathType: 'number' }
+                    ] } } } },
+                    // empty paths object
+                    { input: { widgetProperties: { type: 'widget-position', config: { paths: {} } } } },
+                    // a widget with no widgetProperties is skipped, not crashed on
+                    { input: {} }
+                ] }
+            ]
+        });
+
+        await service.runUpgrade(14);
+
+        const written = mockStorage.setConfig.mock.calls.at(-1)![2];
+        expect(written.app.configVersion).toBe(15);
+        const cfgs = written.dashboards[0].configuration;
+        for (const i of [0, 1, 2]) {
+            const paths = cfgs[i].input.widgetProperties.config.paths;
+            expect(Object.keys(paths)).toEqual(['positionPath']);
+            expect(paths.positionPath.path).toBe('self.navigation.position');
+            expect(paths.positionPath.pathType).toBe('object');
+            expect(paths.positionPath.source).toBe('default');
+            expect(paths.positionPath.sampleTime).toBe(500);
+        }
+    });
+
+    it('v14 upgrade collapses every position widget across multiple dashboards', async () => {
+        const positionWidget = () => ({ input: { widgetProperties: { type: 'widget-position', config: { paths: {
+            longPath: { path: 'self.navigation.position.longitude', pathType: 'number' },
+            latPath: { path: 'self.navigation.position.latitude', pathType: 'number' }
+        } } } } });
+        mockStorage.listConfigs.mockResolvedValueOnce([{ scope: 'user', name: 'default' }]);
+        mockStorage.getConfig.mockResolvedValue({
+            app: { configVersion: 14 },
+            theme: { themeName: '' },
+            dashboards: [
+                { id: 'd0', configuration: [positionWidget()] },
+                { id: 'd1', configuration: [positionWidget()] }
+            ]
+        });
+
+        await service.runUpgrade(14);
+
+        const written = mockStorage.setConfig.mock.calls.at(-1)![2];
+        expect(Object.keys(written.dashboards[0].configuration[0].input.widgetProperties.config.paths)).toEqual(['positionPath']);
+        expect(Object.keys(written.dashboards[1].configuration[0].input.widgetProperties.config.paths)).toEqual(['positionPath']);
     });
 
     it('startFresh retires BOTH global and user legacy configs via an awaited write before resetting', async () => {

--- a/src/app/core/services/configuration-upgrade.service.ts
+++ b/src/app/core/services/configuration-upgrade.service.ts
@@ -22,6 +22,7 @@ const V13_MIGRATION_OUTPUT_VERSION = 13;
 
 // The v13 -> v14 transform output. Pinned to a fixed 14 for the same reason as the constants above.
 const V14_MIGRATION_OUTPUT_VERSION = 14;
+const V15_MIGRATION_OUTPUT_VERSION = 15;
 
 // SK-02 / #21: the delta parser stopped fabricating dotted child paths for compound leaves, so a
 // stored widget path pointing at a sub-field of one of these leaves must be rewritten to the whole
@@ -236,6 +237,30 @@ export class ConfigurationUpgradeService {
         this.upgrading.set(false);
       }
 
+    } else if (version === 14) {
+      // Remote (Signal K) configs. v14 slots live in the same active file version as v11/v12/v13.
+      try {
+        const configsList: Config[] = await this._storage.listConfigs(REMOTE_CONFIG_FILE_VERSION);
+
+        for (const item of configsList) {
+          try {
+            const config = await this._storage.getConfig(item.scope, item.name, REMOTE_CONFIG_FILE_VERSION);
+            this.pushMsg(`[Upgrade] ${item.scope}/${item.name} -> v${V15_MIGRATION_OUTPUT_VERSION}.`);
+            const migratedConfig = this.migrateOneAppVersion(config, 14);
+            if (!migratedConfig) continue; // skip if not a v14 slot
+
+            await this._storage.setConfig(item.scope, item.name, migratedConfig);
+          } catch (error) {
+            this.pushError(`[Upgrade] Error upgrading ${item.scope}/${item.name}: ${(error as Error).message}`);
+          }
+        }
+        this.pushMsg(`[Upgrade] Reloading app to finalize upgrade...`);
+        setTimeout(() => this._settings.reloadApp(), 1500);
+      } catch (error) {
+        this.pushError('Error fetching configuration data. Aborting upgrade. Details: ' + (error as Error).message);
+        this.upgrading.set(false);
+      }
+
     } else {
       // LocalStorage upgrade path for config version 10
       const localStorageConfig: v10IConfig = {
@@ -365,6 +390,7 @@ export class ConfigurationUpgradeService {
       case 11: return this.upgradeConfig(config);
       case 12: return this.upgradeConfigV12toV13(config);
       case 13: return this.upgradeConfigV13toV14(config);
+      case 14: return this.upgradeConfigV14toV15(config);
       default: return null;
     }
   }
@@ -599,6 +625,69 @@ export class ConfigurationUpgradeService {
       return { app: appConfig, theme: config.theme, dashboards: config.dashboards };
     } catch (error) {
       this.pushError(`[Upgrade Service] Error upgrading v13->v14: ${(error as Error).message}`);
+      return null;
+    }
+  }
+
+  /**
+   * v14 -> v15 (#414): the position widget rendered latitude and longitude from two independently
+   * configurable path entries. After the compound leaves stopped being flattened (#21) a numeric
+   * path can no longer point at `navigation.position.latitude`/`.longitude`, and configuring the two
+   * coordinates separately never made sense. Collapse a position widget's paths to a single
+   * object-typed `positionPath` pointing at the whole `navigation.position` leaf; the widget reads
+   * both coordinates off it. The whole `paths` object is replaced (not field-patched) so no stale
+   * `longPath`/`latPath` siblings survive the runtime default-merge. Scoped to `widget-position`
+   * only — a generic widget handed the whole object would render garbage.
+   */
+  private upgradeConfigV14toV15(config: IConfig): IConfig | null {
+    try {
+      const appConfig = config.app;
+      if (!appConfig || appConfig.configVersion !== 14) {
+        this.pushError(`[Upgrade Service] Config version ${appConfig?.configVersion} is not an upgradable v14 config. Skipping...`);
+        return null;
+      }
+
+      let rewritten = 0;
+      if (Array.isArray(config.dashboards)) {
+        for (const dash of config.dashboards) {
+          if (!dash || !Array.isArray(dash.configuration)) continue;
+          for (const widget of dash.configuration) {
+            const wp = (widget as { input?: { widgetProperties?: {
+              type?: unknown;
+              config?: { paths?: unknown };
+            } } })?.input?.widgetProperties;
+            if (!wp || wp.type !== 'widget-position') continue;
+            const cfg = wp.config;
+            if (!cfg || typeof cfg !== 'object') continue;
+            // Preserve a user-pinned source / sampleTime from whichever legacy coordinate entry exists.
+            const oldPaths = cfg.paths as Record<string, { source?: unknown; sampleTime?: unknown }> | undefined;
+            const donor = oldPaths && typeof oldPaths === 'object'
+              ? Object.values(oldPaths).find(p => p && typeof p === 'object')
+              : undefined;
+            cfg.paths = {
+              positionPath: {
+                description: 'Position',
+                path: 'self.navigation.position',
+                source: typeof donor?.source === 'string' ? donor.source : 'default',
+                pathType: 'object',
+                isPathConfigurable: true,
+                showPathSkUnitsFilter: false,
+                pathSkUnitsFilter: null,
+                sampleTime: typeof donor?.sampleTime === 'number' ? donor.sampleTime : 500
+              }
+            };
+            rewritten++;
+          }
+        }
+      }
+      if (rewritten) {
+        this.pushMsg(`[Upgrade] Collapsed ${rewritten} position widget(s) to a single location path.`);
+      }
+
+      appConfig.configVersion = V15_MIGRATION_OUTPUT_VERSION;
+      return { app: appConfig, theme: config.theme, dashboards: config.dashboards };
+    } catch (error) {
+      this.pushError(`[Upgrade Service] Error upgrading v14->v15: ${(error as Error).message}`);
       return null;
     }
   }

--- a/src/app/core/services/data.service.spec.ts
+++ b/src/app/core/services/data.service.spec.ts
@@ -768,10 +768,31 @@ describe('DataService', () => {
       .subscribe(update => updates.push(update));
 
     const countBefore = updates.length;
-    service.timeoutPathObservable('self.navigation.position', 'default', 'object', 5000);
+    service.timeoutPathObservable('self.navigation.position', 'default', 'boolean', 5000);
 
     expect(updates.length).toBe(countBefore);
     expect(updates.every(update => update !== undefined)).toBe(true);
+  });
+
+  it('resets an object-typed path (navigation.position) to null on timeout', () => {
+    let latest: IPathUpdate | undefined;
+    service
+      .subscribePath('self.navigation.position', 'default')
+      .subscribe(update => (latest = update));
+
+    dataPathUpdates$.next({
+      context: 'self',
+      path: 'navigation.position',
+      source: 'test-source',
+      timestamp: '2026-01-01T00:00:01.000Z',
+      value: { latitude: 59.5, longitude: 22.5 },
+    });
+    expect(latest!.data.value).toEqual({ latitude: 59.5, longitude: 22.5 });
+
+    // The position widget's path is object-typed; a user-enabled data timeout must still blank it.
+    service.timeoutPathObservable('self.navigation.position', 'default', 'object', 5000);
+
+    expect(latest!.data.value).toBeNull();
   });
 
   describe('timeout liveness-gated cross-clear (#254)', () => {

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -924,7 +924,7 @@ export class DataService implements OnDestroy {
    * @memberof SignalKDataService
    */
   public timeoutPathObservable(path: string, source: string, pathType: string, dataTimeoutMs: number): void {
-    if (!['string', 'Date', 'number', 'multiple'].includes(pathType)) return;
+    if (!['string', 'Date', 'number', 'multiple', 'object'].includes(pathType)) return;
     const registrations = this._pathRegisterByPath.get(path);
     if (!registrations) return;
 

--- a/src/app/widgets/widget-position/widget-position.component.spec.ts
+++ b/src/app/widgets/widget-position/widget-position.component.spec.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { WidgetPositionComponent } from './widget-position.component';
+import { IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
+import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
+import { WidgetStreamsDirective } from '../../core/directives/widget-streams.directive';
+import { UnitsService } from '../../core/services/units.service';
+import { CanvasService } from '../../core/services/canvas.service';
+import type { ITheme } from '../../core/services/app-service';
+import type { IPathUpdate } from '../../core/services/data.service';
+
+// Any color property the theme palette builder reads resolves to a valid string.
+const themeMock = new Proxy({}, { get: () => '#000000' }) as unknown as ITheme;
+
+describe('WidgetPositionComponent', () => {
+  it('exposes exactly one configurable location path — no separate latitude/longitude entries', () => {
+    const paths = WidgetPositionComponent.DEFAULT_CONFIG.paths ?? {};
+    // The whole point of the redesign: position is one location object, one path setting.
+    expect(Object.keys(paths)).toEqual(['positionPath']);
+    const p = paths['positionPath'];
+    expect(p.path).toBe('self.navigation.position');
+    expect(p.pathType).toBe('object');
+    expect(p.isPathConfigurable).toBe(true);
+  });
+
+  describe('rendering', () => {
+    let fixture: ComponentFixture<WidgetPositionComponent>;
+
+    const runtimeMock = { options: vi.fn() };
+    const streamsMock = { observe: vi.fn() };
+    // Echo the measure and value so the test can prove both coordinates were drawn from the object.
+    const unitsMock = { convertToUnit: (measure: string, value: number) => `${measure}:${value}` };
+    const drawText = vi.fn();
+    const canvasMock = {
+      registerCanvas: vi.fn(),
+      unregisterCanvas: vi.fn(),
+      releaseCanvas: vi.fn(),
+      calculateOptimalFontSize: vi.fn().mockReturnValue(20),
+      createTitleBitmap: vi.fn().mockReturnValue(document.createElement('canvas')),
+      clearCanvas: vi.fn(),
+      drawText,
+      drawTextBitmap: vi.fn(),
+      MIN_LABEL_PX: 10
+    };
+
+    const makeConfig = (): IWidgetSvcConfig => ({ ...WidgetPositionComponent.DEFAULT_CONFIG, color: 'contrast' });
+
+    const setup = async (): Promise<void> => {
+      runtimeMock.options.mockReturnValue(makeConfig());
+      await TestBed.configureTestingModule({
+        imports: [WidgetPositionComponent],
+        providers: [
+          { provide: WidgetRuntimeDirective, useValue: runtimeMock },
+          { provide: WidgetStreamsDirective, useValue: streamsMock },
+          { provide: UnitsService, useValue: unitsMock },
+          { provide: CanvasService, useValue: canvasMock }
+        ]
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(WidgetPositionComponent);
+      fixture.componentRef.setInput('id', 'w1');
+      fixture.componentRef.setInput('type', 'widget-position');
+      fixture.componentRef.setInput('theme', themeMock);
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+    };
+
+    beforeEach(() => {
+      vi.spyOn(HTMLCanvasElement.prototype, 'getContext')
+        .mockReturnValue({} as unknown as CanvasRenderingContext2D);
+      runtimeMock.options.mockReset();
+      streamsMock.observe.mockReset();
+      drawText.mockReset();
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+      TestBed.resetTestingModule();
+    });
+
+    it('observes the whole position object under one path key with no per-coordinate sub-field', async () => {
+      await setup();
+
+      expect(streamsMock.observe).toHaveBeenCalledTimes(1);
+      const [pathKey, , subField] = streamsMock.observe.mock.calls[0];
+      expect(pathKey).toBe('positionPath');
+      // A third sub-field argument would mean per-coordinate extraction — the old two-path design.
+      expect(subField).toBeUndefined();
+    });
+
+    it('renders both latitude and longitude from the single position object', async () => {
+      await setup();
+      const callback = streamsMock.observe.mock.calls[0][1] as (u: IPathUpdate) => void;
+      drawText.mockReset();
+
+      callback({ data: { value: { latitude: 59.5, longitude: 22.5 } } } as unknown as IPathUpdate);
+
+      const drawn = drawText.mock.calls.map(c => c[1]);
+      expect(drawn).toContain('latitudeMin:59.5');
+      expect(drawn).toContain('longitudeMin:22.5');
+    });
+
+    it('renders blank coordinates when no position value is present', async () => {
+      await setup();
+      const callback = streamsMock.observe.mock.calls[0][1] as (u: IPathUpdate) => void;
+      drawText.mockReset();
+
+      callback({ data: { value: null } } as unknown as IPathUpdate);
+
+      const drawn = drawText.mock.calls.map(c => c[1]);
+      expect(drawn).toContain('');
+      expect(drawn.some(s => typeof s === 'string' && s.includes(':'))).toBe(false);
+    });
+
+    it('renders only the present coordinate when the position object is partial (GPS acquiring)', async () => {
+      await setup();
+      const callback = streamsMock.observe.mock.calls[0][1] as (u: IPathUpdate) => void;
+      drawText.mockReset();
+
+      callback({ data: { value: { latitude: 59.5 } } } as unknown as IPathUpdate);
+
+      const drawn = drawText.mock.calls.map(c => c[1]);
+      expect(drawn).toContain('latitudeMin:59.5');
+      // The absent longitude must blank, never render 'undefined'/'NaN' text.
+      expect(drawn).toContain('');
+      expect(drawn.some(s => typeof s === 'string' && s.startsWith('longitudeMin'))).toBe(false);
+    });
+
+    it('blanks a non-finite coordinate rather than formatting NaN', async () => {
+      await setup();
+      const callback = streamsMock.observe.mock.calls[0][1] as (u: IPathUpdate) => void;
+      drawText.mockReset();
+
+      callback({ data: { value: { latitude: NaN, longitude: 22.5 } } } as unknown as IPathUpdate);
+
+      const drawn = drawText.mock.calls.map(c => c[1]);
+      expect(drawn).toContain('longitudeMin:22.5');
+      expect(drawn.some(s => typeof s === 'string' && s.startsWith('latitudeMin'))).toBe(false);
+    });
+
+    it('blanks both coordinates for a non-object scalar value (guards against +value coercion)', async () => {
+      await setup();
+      const callback = streamsMock.observe.mock.calls[0][1] as (u: IPathUpdate) => void;
+      drawText.mockReset();
+
+      callback({ data: { value: 42 } } as unknown as IPathUpdate);
+
+      const drawn = drawText.mock.calls.map(c => c[1]);
+      expect(drawn.some(s => typeof s === 'string' && s.includes(':'))).toBe(false);
+    });
+  });
+});

--- a/src/app/widgets/widget-position/widget-position.component.ts
+++ b/src/app/widgets/widget-position/widget-position.component.ts
@@ -4,6 +4,7 @@ import { CanvasService } from '../../core/services/canvas.service';
 import { getColors } from '../../core/utils/themeColors.utils';
 import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
 import { WidgetStreamsDirective } from '../../core/directives/widget-streams.directive';
+import { UnitsService } from '../../core/services/units.service';
 import { IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
 import { ITheme } from '../../core/services/app-service';
 
@@ -24,6 +25,7 @@ export class WidgetPositionComponent implements AfterViewInit, OnDestroy {
   protected readonly runtime = inject(WidgetRuntimeDirective);
   private readonly streams = inject(WidgetStreamsDirective);
   private readonly canvas = inject(CanvasService);
+  private readonly units = inject(UnitsService);
 
   // Canvas refs
   private canvasRef = viewChild.required<ElementRef<HTMLCanvasElement>>('canvasMainRef');
@@ -48,33 +50,18 @@ export class WidgetPositionComponent implements AfterViewInit, OnDestroy {
   protected labelColor = signal<string>('');
   private valueColor = '';
 
-  // Static default config cloned from legacy implementation
   public static readonly DEFAULT_CONFIG: IWidgetSvcConfig = {
     supportAutomaticHistoricalSeries: false,
     displayName: 'Position',
     filterSelfPaths: true,
     paths: {
-      longPath: {
-        description: 'Longitude',
+      positionPath: {
+        description: 'Position',
         path: 'self.navigation.position',
         source: 'default',
-        pathType: 'number',
-        isPathConfigurable: false,
-        convertUnitTo: 'longitudeMin',
-        showConvertUnitTo: false,
-        showPathSkUnitsFilter: true,
-        pathSkUnitsFilter: null,
-        sampleTime: 500
-      },
-      latPath: {
-        description: 'Latitude',
-        path: 'self.navigation.position',
-        source: 'default',
-        pathType: 'number',
-        isPathConfigurable: false,
-        convertUnitTo: 'latitudeMin',
-        showConvertUnitTo: false,
-        showPathSkUnitsFilter: true,
+        pathType: 'object',
+        isPathConfigurable: true,
+        showPathSkUnitsFilter: false,
         pathSkUnitsFilter: null,
         sampleTime: 500
       }
@@ -98,36 +85,29 @@ export class WidgetPositionComponent implements AfterViewInit, OnDestroy {
       });
     });
 
-    // Observe longitude path
+    // Observe the whole position object and render both coordinates from it. Signal K emits
+    // navigation.position as a single {latitude, longitude} object (in degrees), so one path
+    // drives both values — latitude and longitude are never independent paths.
     effect(() => {
       const cfg = this.runtime.options();
       if (!cfg) return;
-      const pathCfg = cfg.paths?.['longPath'];
+      const pathCfg = cfg.paths?.['positionPath'];
       if (!pathCfg?.path) return;
-      untracked(() => this.streams.observe('longPath', pkt => {
-        const val = pkt?.data?.value as number | null;
-        if (val === null || val === undefined) this.longPos = '';
-        else if (pathCfg.convertUnitTo === 'pdeg') this.longPos = (val as number).toFixed(6) + '°';
-        else this.longPos = String(val);
+      untracked(() => this.streams.observe('positionPath', pkt => {
+        const pos = pkt?.data?.value as { latitude?: number | null; longitude?: number | null } | null;
+        this.latPos = this.formatCoordinate('latitudeMin', pos?.latitude);
+        this.longPos = this.formatCoordinate('longitudeMin', pos?.longitude);
         this.calculateFontSizeAndPositions();
         this.draw();
-      }, 'longitude'));
+      }));
     });
+  }
 
-    // Observe latitude path
-    effect(() => {
-      const cfg = this.runtime.options(); if (!cfg) return;
-      const pathCfg = cfg.paths?.['latPath'];
-      if (!pathCfg?.path) return;
-      untracked(() => this.streams.observe('latPath', pkt => {
-        const val = pkt?.data?.value as number | null;
-        if (val === null || val === undefined) this.latPos = '';
-        else if (pathCfg.convertUnitTo === 'pdeg') this.latPos = (val as number).toFixed(7) + '°';
-        else this.latPos = String(val);
-        this.calculateFontSizeAndPositions();
-        this.draw();
-      }, 'latitude'));
-    });
+  private formatCoordinate(measure: 'latitudeMin' | 'longitudeMin', value: number | null | undefined): string {
+    if (value === null || value === undefined || !Number.isFinite(value)) return '';
+    // The latitudeMin/longitudeMin conversions return a preformatted DMS string despite convertToUnit's
+    // number|null signature, so the String() coercion is load-bearing — do not drop it or reformat here.
+    return String(this.units.convertToUnit(measure, value) ?? '');
   }
 
   // Canvas lifecycle

--- a/src/assets/skip-dashboard-schema.json
+++ b/src/assets/skip-dashboard-schema.json
@@ -541,7 +541,7 @@
   },
   "meta": {
     "configFileVersion": 11,
-    "configVersion": 14,
+    "configVersion": 15,
     "schemaVersion": 1,
     "skipVersion": "1.0.4"
   },
@@ -1761,28 +1761,14 @@
         "enableTimeout": false,
         "filterSelfPaths": true,
         "paths": {
-          "latPath": {
-            "convertUnitTo": "latitudeMin",
-            "description": "Latitude",
-            "isPathConfigurable": false,
+          "positionPath": {
+            "description": "Position",
+            "isPathConfigurable": true,
             "path": "self.navigation.position",
             "pathSkUnitsFilter": null,
-            "pathType": "number",
+            "pathType": "object",
             "sampleTime": 500,
-            "showConvertUnitTo": false,
-            "showPathSkUnitsFilter": true,
-            "source": "default"
-          },
-          "longPath": {
-            "convertUnitTo": "longitudeMin",
-            "description": "Longitude",
-            "isPathConfigurable": false,
-            "path": "self.navigation.position",
-            "pathSkUnitsFilter": null,
-            "pathType": "number",
-            "sampleTime": 500,
-            "showConvertUnitTo": false,
-            "showPathSkUnitsFilter": true,
+            "showPathSkUnitsFilter": false,
             "source": "default"
           }
         },
@@ -1797,27 +1783,15 @@
       "name": "Position",
       "pathSlots": [
         {
-          "defaultConvertUnitTo": "longitudeMin",
+          "defaultConvertUnitTo": null,
           "defaultPath": "self.navigation.position",
-          "description": "Longitude",
+          "description": "Position",
           "expectedSkUnit": null,
-          "isPathConfigurable": false,
+          "isPathConfigurable": true,
           "pathRequired": false,
-          "pathType": "number",
+          "pathType": "object",
           "sampleTime": 500,
-          "slot": "longPath",
-          "source": "default"
-        },
-        {
-          "defaultConvertUnitTo": "latitudeMin",
-          "defaultPath": "self.navigation.position",
-          "description": "Latitude",
-          "expectedSkUnit": null,
-          "isPathConfigurable": false,
-          "pathRequired": false,
-          "pathType": "number",
-          "sampleTime": 500,
-          "slot": "latPath",
+          "slot": "positionPath",
           "source": "default"
         }
       ],

--- a/src/default-config/config.blank.dashboard.spec.ts
+++ b/src/default-config/config.blank.dashboard.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { DefaultDashboard } from './config.blank.dashboard';
+import { WidgetPositionComponent } from '../app/widgets/widget-position/widget-position.component';
+
+// The shipped seed is stamped at LATEST_APP_CONFIG_VERSION, so config migrations never run on a
+// fresh install/profile. A widget whose path shape drifts from its DEFAULT_CONFIG therefore ships
+// its old shape forever. Guard the position widget specifically — its two-path shape was the #414
+// bug — so a future re-export of the seed can't silently reintroduce longPath/latPath.
+describe('DefaultDashboard seed', () => {
+  interface SeedWidget { input?: { widgetProperties?: { type?: string; config?: { paths?: Record<string, unknown> } } } }
+
+  const seededWidgetsOfType = (type: string): SeedWidget[] =>
+    DefaultDashboard.flatMap(dash => (dash.configuration ?? []) as SeedWidget[])
+      .filter(w => w.input?.widgetProperties?.type === type);
+
+  it('seeds every position widget with the single object-typed path from its DEFAULT_CONFIG', () => {
+    const expectedKeys = Object.keys(WidgetPositionComponent.DEFAULT_CONFIG.paths ?? {});
+    const positionWidgets = seededWidgetsOfType('widget-position');
+    expect(positionWidgets.length).toBeGreaterThan(0);
+
+    for (const widget of positionWidgets) {
+      const paths = widget.input?.widgetProperties?.config?.paths ?? {};
+      expect(Object.keys(paths)).toEqual(expectedKeys);
+      const positionPath = paths['positionPath'] as { pathType?: string } | undefined;
+      expect(positionPath?.pathType).toBe('object');
+    }
+  });
+});

--- a/src/default-config/config.blank.dashboard.ts
+++ b/src/default-config/config.blank.dashboard.ts
@@ -1405,25 +1405,13 @@ export const DefaultDashboard: Dashboard[] = [
               "displayName": "Position",
               "filterSelfPaths": true,
               "paths": {
-                "longPath": {
-                  "description": "Longitude",
+                "positionPath": {
+                  "description": "Position",
                   "path": "self.navigation.position",
                   "source": "default",
-                  "pathType": "number",
-                  "isPathConfigurable": false,
-                  "convertUnitTo": "longitudeMin",
-                  "showPathSkUnitsFilter": true,
-                  "pathSkUnitsFilter": null,
-                  "sampleTime": 500
-                },
-                "latPath": {
-                  "description": "Latitude",
-                  "path": "self.navigation.position",
-                  "source": "default",
-                  "pathType": "number",
-                  "isPathConfigurable": false,
-                  "convertUnitTo": "latitudeMin",
-                  "showPathSkUnitsFilter": true,
+                  "pathType": "object",
+                  "isPathConfigurable": true,
+                  "showPathSkUnitsFilter": false,
                   "pathSkUnitsFilter": null,
                   "sampleTime": 500
                 }


### PR DESCRIPTION
## Problem

On the boat the **Position widget** is broken in its settings: it shows **two separate path pickers** (Latitude, Longitude) and neither can be set.

The widget was built with two independently-configurable path settings, each pointing at a *synthetic flattened* path (`navigation.position.latitude` / `.longitude`). Object flattening (SK-02 / #21) removed those synthetic scalar paths, so:

- The pickers list only `pathType: 'number'` paths (`DataService.getPathsAndMetaByType` filters on the value's runtime `typeof`). `navigation.position` is an **object**, so it never appears.
- Stored configs still hold the `.longitude`/`.latitude` paths, which no longer resolve to any live SK path, so both rows validate as dead and their fields disable.

Configuring latitude and longitude as two separate paths never made sense — they're one location object. The #21 adaptation (`1fcc9cf8`) hid the pickers (`isPathConfigurable: false`) but kept two entries, and the v13→v14 migration does **not** re-run on configs already stamped v14 — so a real boat config still shows the two dead, configurable pickers.

## Fix

- **Widget** — collapse `paths` to a single object-typed `positionPath` → `self.navigation.position`, `isPathConfigurable: true`. One `observe('positionPath')` (no sub-field) receives the whole `{latitude, longitude}` object; the widget formats each coordinate via `UnitsService` (`latitudeMin` / `longitudeMin`), unchanged minutes format. `pathType: 'object'` bypasses the streams pipeline's number-only unit stage, so the object reaches the callback intact. `'object'` is added to `TWidgetPathType` so the path picker offers the whole leaf (all `pathType` consumers are equality checks — no exhaustiveness break; the two `!== 'number'` guards correctly skip an object path).

- **Migration v14 → v15** — a *fresh* version is required because affected configs are already at v14 and won't re-run the v14 step. `upgradeConfigV14toV15`, scoped to `widget-position` only, replaces the widget's `paths` with the single canonical `positionPath` (carrying over a user-pinned `source`/`sampleTime`). Replacing the whole `paths` object means no stale `longPath`/`latPath` siblings survive the runtime default-merge.

- **Version-bump couplings** (per the known checklist) — `LATEST_APP_CONFIG_VERSION → 15`; boot gate adds `liveVersion === 14`; `case 14` in the dispatch switch + a `version === 14` remote-slot branch; CI-invisible `perf-harness/lib/skip-config.mjs` seed bumped to 15; `src/assets/skip-dashboard-schema.json` regenerated via `npm run gen:mcp-schema`.

## Verification

- `npm run snc` + `npm run lint` green; full unit suite **1573 passed** (incl. a new `widget-position` spec, three v14→v15 migration tests, and a v14 boot-gate test); `test:mcp-schema` green with the regenerated schema.
- Deployed to the boat (`./run deploy-halos local`); served bundle confirmed to carry `positionPath`. Reloading a dashboard migrates the stored v14 config to v15 (single `positionPath`) and the widget shows one editable Position path row.

Closes #414
