### PR TITLE
Heel-gauge & horizon: repair stranded attitude path settings (v15→v16)

### DIFF
--- a/perf-harness/lib/skip-config.mjs
+++ b/perf-harness/lib/skip-config.mjs
@@ -8,7 +8,7 @@
  *
  * Three distinct version spaces (all from src/app/core/constants/config-versions.const.ts):
  *  - applicationData URL path segment 11 (REMOTE_CONFIG_FILE_VERSION)
- *  - app.configVersion 15 (LATEST_APP_CONFIG_VERSION)
+ *  - app.configVersion 16 (LATEST_APP_CONFIG_VERSION)
  *  - connectionConfig.configVersion 13 (CONNECTION_CONFIG_VERSION)
  */
 export const SELF_URN = 'vessels.urn:mrn:signalk:uuid:11111111-1111-4111-8111-111111111111';
@@ -22,12 +22,12 @@ const DEFAULT_NOTIF = {
 };
 
 export function appConfig(extra = {}) {
-  // configVersion at LATEST (15): a genuine current config, so the boot skips
+  // configVersion at LATEST (16): a genuine current config, so the boot skips
   // ConfigurationUpgradeService's migration toast/reload entirely inside the
   // measurement window. Bump this in lockstep with LATEST_APP_CONFIG_VERSION, or
   // the boot triggers an upgrade+reload and the boot-assert fails.
   return {
-    configVersion: 15, autoNightMode: false, redNightMode: false, nightModeBrightness: 0.27,
+    configVersion: 16, autoNightMode: false, redNightMode: false, nightModeBrightness: 0.27,
     widgetHistoryDisabled: false,
     notificationConfig: DEFAULT_NOTIF, browserTabTitle: 'Skip', ...extra,
   };

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -547,6 +547,11 @@ describe('AppComponent — embed read-only invariants (#216 E6)', () => {
     expect(runUpgradeSpy).toHaveBeenCalledWith(14);
   });
 
+  it('runs the config migration in the full app for an upgradeable v15 config (the attitude-path gate)', async () => {
+    const { runUpgradeSpy } = await render({ embed: false, configUpgrade: true, configVersion: 15 });
+    expect(runUpgradeSpy).toHaveBeenCalledWith(15);
+  });
+
   it('does NOT show the missing-shared-config create prompt under embed', async () => {
     const { toast, bootstrapIssue$ } = await render({ embed: true });
     toast.show.mockClear();

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -106,7 +106,7 @@ export class AppComponent implements AfterViewInit, OnDestroy {
       if (this.settings.configUpgrade()) {
         const liveVersion = this.settings.getConfigVersion();
 
-        if (liveVersion === 11 || liveVersion === 12 || liveVersion === 13 || liveVersion === 14) {
+        if (liveVersion === 11 || liveVersion === 12 || liveVersion === 13 || liveVersion === 14 || liveVersion === 15) {
           this.upgrade.runUpgrade(liveVersion);
         }
 

--- a/src/app/core/constants/config-versions.const.ts
+++ b/src/app/core/constants/config-versions.const.ts
@@ -21,7 +21,7 @@ export const REMOTE_CONFIG_FILE_VERSION = 11;
  * its legacy transforms pin their own MIGRATION_OUTPUT_VERSION so that bumping this constant
  * cannot silently re-label old migration output as current — add a chained migration instead.
  */
-export const LATEST_APP_CONFIG_VERSION = 15;
+export const LATEST_APP_CONFIG_VERSION = 16;
 
 /**
  * Per-device connectionConfig schema version (its own version space, decoupled from the app config

--- a/src/app/core/services/configuration-upgrade.service.spec.ts
+++ b/src/app/core/services/configuration-upgrade.service.spec.ts
@@ -435,6 +435,144 @@ describe('ConfigurationUpgradeService', () => {
         expect(Object.keys(written.dashboards[1].configuration[0].input.widgetProperties.config.paths)).toEqual(['positionPath']);
     });
 
+    it('v15 upgrade resets heel-gauge/horizon paths to the fixed default, enables the timeout, and stamps v16', async () => {
+        mockStorage.listConfigs.mockResolvedValueOnce([{ scope: 'user', name: 'default' }]);
+        mockStorage.getConfig.mockResolvedValue({
+            app: { configVersion: 15 },
+            theme: { themeName: '' },
+            dashboards: [
+                { id: 'd0', configuration: [
+                    // the stranded boat shape: whole leaf, still configurable, with a stale unit override
+                    { input: { widgetProperties: { type: 'widget-heel-gauge', config: {
+                        paths: { angle: { path: 'self.navigation.attitude', pathType: 'number', isPathConfigurable: true, convertUnitTo: 'rad' } },
+                        enableTimeout: false, dataTimeout: 5
+                    } } } },
+                    // stale sub-field paths must be reset back to the whole leaf
+                    { input: { widgetProperties: { type: 'widget-horizon', config: {
+                        paths: {
+                            gaugePitchPath: { path: 'self.navigation.attitude.pitch', pathType: 'number', isPathConfigurable: true },
+                            gaugeRollPath: { path: 'self.navigation.attitude.roll', pathType: 'number', isPathConfigurable: true }
+                        },
+                        enableTimeout: false, dataTimeout: 5
+                    } } } }
+                ] }
+            ]
+        });
+
+        await service.runUpgrade(15);
+
+        const written = mockStorage.setConfig.mock.calls.at(-1)![2];
+        expect(written.app.configVersion).toBe(16);
+        const heelWp = written.dashboards[0].configuration[0].input.widgetProperties;
+        expect(heelWp.config.paths.angle.path).toBe('self.navigation.attitude');
+        expect(heelWp.config.paths.angle.isPathConfigurable).toBe(false);
+        expect(heelWp.config.paths.angle.pathType).toBe('number'); // pipeline extracts sub-field then converts rad->deg
+        expect(heelWp.config.paths.angle.convertUnitTo).toBe('deg'); // stale 'rad' override discarded
+        // The Paths tab (and its timeout control) is gone, so the timeout defaults on.
+        expect(heelWp.config.enableTimeout).toBe(true);
+        expect(heelWp.config.dataTimeout).toBe(5);
+        const horizon = written.dashboards[0].configuration[1].input.widgetProperties.config.paths;
+        expect(horizon.gaugePitchPath.path).toBe('self.navigation.attitude');
+        expect(horizon.gaugeRollPath.path).toBe('self.navigation.attitude');
+        expect(horizon.gaugePitchPath.isPathConfigurable).toBe(false);
+        expect(horizon.gaugeRollPath.isPathConfigurable).toBe(false);
+        expect(written.dashboards[0].configuration[1].input.widgetProperties.config.enableTimeout).toBe(true);
+    });
+
+    it('v15 upgrade handles empty, array, and missing paths without throwing (still enables timeout, stamps v16)', async () => {
+        mockStorage.listConfigs.mockResolvedValueOnce([{ scope: 'user', name: 'default' }]);
+        mockStorage.getConfig.mockResolvedValue({
+            app: { configVersion: 15 },
+            theme: { themeName: '' },
+            dashboards: [
+                { id: 'd0', configuration: [
+                    { input: { widgetProperties: { type: 'widget-heel-gauge', config: { paths: {
+                        angle: { path: 'self.navigation.attitude.roll', pathType: 'number', isPathConfigurable: true }
+                    } } } } },
+                    // array-form paths
+                    { input: { widgetProperties: { type: 'widget-horizon', config: { paths: [
+                        { path: 'self.navigation.attitude', pathType: 'number', isPathConfigurable: true }
+                    ] } } } },
+                    // empty paths object — still enables the timeout, does not throw
+                    { input: { widgetProperties: { type: 'widget-heel-gauge', config: { paths: {} } } } },
+                    // a widget with no widgetProperties is skipped, not crashed on
+                    { input: {} }
+                ] }
+            ]
+        });
+
+        await service.runUpgrade(15);
+
+        const written = mockStorage.setConfig.mock.calls.at(-1)![2];
+        expect(written.app.configVersion).toBe(16);
+        const cfgs = written.dashboards[0].configuration;
+        expect(cfgs[0].input.widgetProperties.config.paths.angle.path).toBe('self.navigation.attitude');
+        expect(cfgs[1].input.widgetProperties.config.paths[0].isPathConfigurable).toBe(false);
+        // empty-paths widget still gets the timeout default and no throw
+        expect(cfgs[2].input.widgetProperties.config.enableTimeout).toBe(true);
+    });
+
+    it('v15 upgrade enables the timeout on racer widgets without resetting their (scalar) paths', async () => {
+        mockStorage.listConfigs.mockResolvedValueOnce([{ scope: 'user', name: 'default' }]);
+        mockStorage.getConfig.mockResolvedValue({
+            app: { configVersion: 15 },
+            theme: { themeName: '' },
+            dashboards: [
+                { id: 'd0', configuration: [
+                    { input: { widgetProperties: { type: 'widget-racer-timer', config: {
+                        paths: { ttsPath: { path: 'self.navigation.racing.timeToStart', pathType: 'number', isPathConfigurable: false } },
+                        enableTimeout: false, dataTimeout: 5
+                    } } } }
+                ] }
+            ]
+        });
+
+        await service.runUpgrade(15);
+
+        const wp = mockStorage.setConfig.mock.calls.at(-1)![2].dashboards[0].configuration[0].input.widgetProperties;
+        // Paths tab (and its timeout toggle) is suppressed for this all-fixed-path widget → timeout defaults on.
+        expect(wp.config.enableTimeout).toBe(true);
+        expect(wp.config.dataTimeout).toBe(5);
+        // Its scalar path is already fixed — left untouched (only attitude widgets get the path reset).
+        expect(wp.config.paths.ttsPath.path).toBe('self.navigation.racing.timeToStart');
+    });
+
+    it('v15 upgrade leaves a non-attitude widget untouched (scoped), still stamps v16', async () => {
+        mockStorage.listConfigs.mockResolvedValueOnce([{ scope: 'user', name: 'default' }]);
+        mockStorage.getConfig.mockResolvedValue({
+            app: { configVersion: 15 },
+            theme: { themeName: '' },
+            dashboards: [
+                { id: 'd0', configuration: [
+                    { input: { widgetProperties: { type: 'widget-numeric', config: { paths: {
+                        numericPath: { path: 'self.navigation.speedOverGround', pathType: 'number', isPathConfigurable: true }
+                    } } } } }
+                ] }
+            ]
+        });
+
+        await service.runUpgrade(15);
+
+        const written = mockStorage.setConfig.mock.calls.at(-1)![2];
+        expect(written.app.configVersion).toBe(16);
+        const numeric = written.dashboards[0].configuration[0].input.widgetProperties.config.paths.numericPath;
+        expect(numeric.path).toBe('self.navigation.speedOverGround');
+        expect(numeric.isPathConfigurable).toBe(true);
+    });
+
+    it('v15 upgrade skips a slot that is not at version 15 (no re-stamp)', async () => {
+        mockStorage.listConfigs.mockResolvedValueOnce([{ scope: 'user', name: 'default' }]);
+        mockStorage.getConfig.mockResolvedValue({
+            app: { configVersion: 16 },
+            theme: { themeName: '' },
+            dashboards: []
+        });
+
+        await service.runUpgrade(15);
+
+        expect(mockStorage.setConfig).not.toHaveBeenCalled();
+    });
+
     it('startFresh retires BOTH global and user legacy configs via an awaited write before resetting', async () => {
         mockStorage.initConfig = null; // remote (Signal K) path
         mockStorage.listConfigs.mockResolvedValueOnce([

--- a/src/app/core/services/configuration-upgrade.service.ts
+++ b/src/app/core/services/configuration-upgrade.service.ts
@@ -23,6 +23,7 @@ const V13_MIGRATION_OUTPUT_VERSION = 13;
 // The v13 -> v14 transform output. Pinned to a fixed 14 for the same reason as the constants above.
 const V14_MIGRATION_OUTPUT_VERSION = 14;
 const V15_MIGRATION_OUTPUT_VERSION = 15;
+const V16_MIGRATION_OUTPUT_VERSION = 16;
 
 // SK-02 / #21: the delta parser stopped fabricating dotted child paths for compound leaves, so a
 // stored widget path pointing at a sub-field of one of these leaves must be rewritten to the whole
@@ -261,6 +262,30 @@ export class ConfigurationUpgradeService {
         this.upgrading.set(false);
       }
 
+    } else if (version === 15) {
+      // Remote (Signal K) configs. v15 slots live in the same active file version as v11..v14.
+      try {
+        const configsList: Config[] = await this._storage.listConfigs(REMOTE_CONFIG_FILE_VERSION);
+
+        for (const item of configsList) {
+          try {
+            const config = await this._storage.getConfig(item.scope, item.name, REMOTE_CONFIG_FILE_VERSION);
+            this.pushMsg(`[Upgrade] ${item.scope}/${item.name} -> v${V16_MIGRATION_OUTPUT_VERSION}.`);
+            const migratedConfig = this.migrateOneAppVersion(config, 15);
+            if (!migratedConfig) continue; // skip if not a v15 slot
+
+            await this._storage.setConfig(item.scope, item.name, migratedConfig);
+          } catch (error) {
+            this.pushError(`[Upgrade] Error upgrading ${item.scope}/${item.name}: ${(error as Error).message}`);
+          }
+        }
+        this.pushMsg(`[Upgrade] Reloading app to finalize upgrade...`);
+        setTimeout(() => this._settings.reloadApp(), 1500);
+      } catch (error) {
+        this.pushError('Error fetching configuration data. Aborting upgrade. Details: ' + (error as Error).message);
+        this.upgrading.set(false);
+      }
+
     } else {
       // LocalStorage upgrade path for config version 10
       const localStorageConfig: v10IConfig = {
@@ -391,6 +416,7 @@ export class ConfigurationUpgradeService {
       case 12: return this.upgradeConfigV12toV13(config);
       case 13: return this.upgradeConfigV13toV14(config);
       case 14: return this.upgradeConfigV14toV15(config);
+      case 15: return this.upgradeConfigV15toV16(config);
       default: return null;
     }
   }
@@ -688,6 +714,73 @@ export class ConfigurationUpgradeService {
       return { app: appConfig, theme: config.theme, dashboards: config.dashboards };
     } catch (error) {
       this.pushError(`[Upgrade Service] Error upgrading v14->v15: ${(error as Error).message}`);
+      return null;
+    }
+  }
+
+  /**
+   * v15 -> v16 (#416): widgets whose paths are all fixed (heel-gauge, horizon, racer-timer,
+   * racer-line) no longer show the widget-settings Paths tab — with it goes the data-timeout
+   * control, so those widgets default to a 5 s data timeout instead. heel-gauge/horizon additionally
+   * carried a stranded dead path picker (a stored entry left at `pathType: 'number'` +
+   * `isPathConfigurable: true`, which a number picker can't resolve against the object leaf — the
+   * bug #414 fixed for position; the v14->v15 step only rewrote position). This enables the timeout
+   * on all four types and, for the two attitude widgets, resets every path entry to its canonical
+   * fixed shape (`self.navigation.attitude`, `pathType: 'number'` so the pipeline's sub-field extract
+   * + rad->deg conversion still runs, `isPathConfigurable: false`, `convertUnitTo: 'deg'`), discarding
+   * stale stored overrides. Racer paths are already scalar/fixed, so only their timeout changes.
+   */
+  private upgradeConfigV15toV16(config: IConfig): IConfig | null {
+    try {
+      const appConfig = config.app;
+      if (!appConfig || appConfig.configVersion !== 15) {
+        this.pushError(`[Upgrade Service] Config version ${appConfig?.configVersion} is not an upgradable v15 config. Skipping...`);
+        return null;
+      }
+
+      const ATTITUDE_WIDGET_TYPES = new Set(['widget-heel-gauge', 'widget-horizon']);
+      // All-fixed-path widgets whose Paths tab (and its timeout control) is now suppressed.
+      const TIMEOUT_DEFAULT_WIDGET_TYPES = new Set([
+        'widget-heel-gauge', 'widget-horizon', 'widget-racer-timer', 'widget-racer-line'
+      ]);
+      let rewritten = 0;
+      if (Array.isArray(config.dashboards)) {
+        for (const dash of config.dashboards) {
+          if (!dash || !Array.isArray(dash.configuration)) continue;
+          for (const widget of dash.configuration) {
+            const wp = (widget as { input?: { widgetProperties?: {
+              type?: unknown;
+              config?: { paths?: unknown; enableTimeout?: boolean; dataTimeout?: number };
+            } } })?.input?.widgetProperties;
+            if (!wp || typeof wp.type !== 'string' || !TIMEOUT_DEFAULT_WIDGET_TYPES.has(wp.type) || !wp.config) continue;
+            if (ATTITUDE_WIDGET_TYPES.has(wp.type)) {
+              const paths = wp.config.paths;
+              if (paths && typeof paths === 'object') {
+                for (const pathCfg of Object.values(paths as Record<string, Record<string, unknown>>)) {
+                  if (!pathCfg || typeof pathCfg !== 'object') continue;
+                  // Discard stale overrides — the fixed attitude path is not user-configurable.
+                  pathCfg.path = 'self.navigation.attitude';
+                  pathCfg.pathType = 'number';
+                  pathCfg.isPathConfigurable = false;
+                  pathCfg.convertUnitTo = 'deg';
+                  rewritten++;
+                }
+              }
+            }
+            // The Paths tab (and its timeout control) is gone — default the timeout on.
+            wp.config.enableTimeout = true;
+            wp.config.dataTimeout = 5;
+          }
+        }
+      }
+      if (rewritten) {
+        this.pushMsg(`[Upgrade] Reset ${rewritten} attitude path(s) to the fixed hidden default.`);
+      }
+
+      appConfig.configVersion = V16_MIGRATION_OUTPUT_VERSION;
+      return { app: appConfig, theme: config.theme, dashboards: config.dashboards };
+    } catch (error) {
+      this.pushError(`[Upgrade Service] Error upgrading v15->v16: ${(error as Error).message}`);
       return null;
     }
   }

--- a/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.html
+++ b/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.html
@@ -758,7 +758,7 @@
         </mat-tab>
       }
       <!-- Paths stuff -->
-      @if ((widgetConfig?.paths !== undefined)) {
+      @if ((widgetConfig?.paths !== undefined) && hasConfigurablePaths) {
         <mat-tab label="Paths">
           <div class="tab-content">
             <div>

--- a/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.spec.ts
+++ b/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.spec.ts
@@ -162,6 +162,57 @@ describe('ModalWidgetComponent title composition (#180)', () => {
   });
 });
 
+// The Paths tab is suppressed when a widget has no user-configurable path (#416): all-fixed-path
+// widgets (heel-gauge/horizon) would otherwise show an empty/irrelevant tab.
+describe('ModalWidgetComponent Paths tab visibility (#416)', () => {
+  const unitsServiceStub: Pick<UnitsService, 'getConversionsForPath'> = {
+    getConversionsForPath: (): IConversionPathList => ({ base: 'unitless', conversions: [] }),
+  };
+  const appServiceStub: Pick<AppService, 'configurableThemeColors'> = { configurableThemeColors: [] };
+
+  beforeEach(() => TestBed.resetTestingModule());
+
+  function createComponentWithData(data: object): RootModalWidgetConfigComponent {
+    TestBed.configureTestingModule({
+      imports: [RootModalWidgetConfigComponent],
+      providers: [
+        { provide: UnitsService, useValue: unitsServiceStub },
+        { provide: AppService, useValue: appServiceStub },
+        { provide: MAT_DIALOG_DATA, useValue: data },
+        { provide: MatDialogRef, useValue: { close: vi.fn() } },
+      ],
+    });
+    ensureTestIconsReady();
+    return TestBed.createComponent(RootModalWidgetConfigComponent).componentInstance;
+  }
+
+  it('suppresses the Paths tab when every path is fixed (isPathConfigurable:false)', () => {
+    const component = createComponentWithData({ paths: {
+      angle: { path: 'self.navigation.attitude', pathType: 'number', isPathConfigurable: false }
+    } });
+    expect(component.hasConfigurablePaths).toBe(false);
+  });
+
+  it('shows the Paths tab when at least one path is user-configurable', () => {
+    const component = createComponentWithData({ paths: {
+      a: { path: 'self.foo', pathType: 'number', isPathConfigurable: false },
+      b: { path: 'self.bar', pathType: 'number', isPathConfigurable: true }
+    } });
+    expect(component.hasConfigurablePaths).toBe(true);
+  });
+
+  it('treats a path with no explicit isPathConfigurable flag as configurable', () => {
+    const component = createComponentWithData({ paths: { p: { path: 'self.foo', pathType: 'number' } } });
+    expect(component.hasConfigurablePaths).toBe(true);
+  });
+
+  it('keeps the tab for an array-form (multiChildCtrls) widget even with empty paths', () => {
+    // widget-boolean-switch / widget-zones-state-panel ship paths:[] and add paths via this tab.
+    const component = createComponentWithData({ paths: [], multiChildCtrls: [] });
+    expect(component.hasConfigurablePaths).toBe(true);
+  });
+});
+
 // Characterization of the two closed leaf shapes built reflectively by the widget-config
 // form generator: the multiChildCtrls control group and the array-mode path group. Locks the
 // exact control tree + required validators so the typed-factory refactor cannot drift them.

--- a/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.ts
+++ b/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.ts
@@ -300,6 +300,17 @@ export class RootModalWidgetConfigComponent implements OnInit {
     return this.configControl('filterSelfPaths') as FormControl<boolean>;
   }
 
+  /** True when the Paths tab has something to configure. Array-form widgets (multiChildCtrls) build
+   * their paths through that tab, so it must stay even while their path collection is empty. A
+   * non-array widget whose every path is fixed (isPathConfigurable:false) has nothing to edit there,
+   * so the tab is suppressed (its per-path picker was already hidden by path-control-config). */
+  get hasConfigurablePaths(): boolean {
+    if (this.widgetConfig?.multiChildCtrls !== undefined) return true;
+    const entries = Object.values((this.widgetConfig?.paths ?? {}) as Record<string, { isPathConfigurable?: boolean }>);
+    if (entries.length === 0) return false;
+    return entries.some(p => p?.isPathConfigurable !== false);
+  }
+
   get dataTimeoutToControl(): UntypedFormControl {
     return this.configControl('dataTimeout') as UntypedFormControl;
   }

--- a/src/app/widgets/widget-heel-gauge/widget-heel-gauge.component.ts
+++ b/src/app/widgets/widget-heel-gauge/widget-heel-gauge.component.ts
@@ -75,6 +75,10 @@ export class WidgetHeelGaugeComponent implements AfterViewInit {
     displayName: 'Heel',
     filterSelfPaths: true,
     paths: {
+      // pathType stays 'number' though the path is the whole navigation.attitude object: the
+      // streams pipeline extracts the 'roll' sub-field (observe below) BEFORE the number-type
+      // conversion runs, so it converts the scalar rad->deg. Switching to 'object' would skip that
+      // conversion and render radians. The path is fixed (isPathConfigurable:false) — no Paths tab.
       angle: {
         description: 'Heel / Roll Angle',
         path: 'self.navigation.attitude',
@@ -95,7 +99,7 @@ export class WidgetHeelGaugeComponent implements AfterViewInit {
     numInt: 2,
     numDecimal: 0,
     color: 'contrast',
-    enableTimeout: false,
+    enableTimeout: true,
     dataTimeout: 5
   };
 

--- a/src/app/widgets/widget-horizon/widget-horizon.component.ts
+++ b/src/app/widgets/widget-horizon/widget-horizon.component.ts
@@ -64,6 +64,10 @@ export class WidgetHorizonComponent implements AfterViewInit, OnDestroy {
     displayName: 'Horizon',
     filterSelfPaths: true,
     paths: {
+      // pathType stays 'number' though the path is the whole navigation.attitude object: the
+      // streams pipeline extracts the pitch/roll sub-field (observe below) BEFORE the number-type
+      // conversion runs, so it converts the scalar rad->deg. Switching to 'object' would skip that
+      // conversion and render radians. Both paths are fixed (isPathConfigurable:false) — no Paths tab.
       gaugePitchPath: {
         description: 'Attitude Pitch Data',
         path: 'self.navigation.attitude',
@@ -98,7 +102,7 @@ export class WidgetHorizonComponent implements AfterViewInit, OnDestroy {
       invertPitch: false,
       invertRoll: false
     },
-    enableTimeout: false,
+    enableTimeout: true,
     dataTimeout: 5
   };
 

--- a/src/app/widgets/widget-racer-line/widget-racer-line.component.ts
+++ b/src/app/widgets/widget-racer-line/widget-racer-line.component.ts
@@ -57,7 +57,7 @@ export class WidgetRacerLineComponent implements AfterViewInit, OnDestroy {
     numDecimal: 0,
     ignoreZones: true,
     color: 'contrast',
-    enableTimeout: false,
+    enableTimeout: true,
     dataTimeout: 5,
     paths: {
       dtsPath: {

--- a/src/app/widgets/widget-racer-timer/widget-racer-timer.component.ts
+++ b/src/app/widgets/widget-racer-timer/widget-racer-timer.component.ts
@@ -54,7 +54,7 @@ export class WidgetRacerTimerComponent implements AfterViewInit, OnDestroy {
       dtsPath: { description: 'Distance to Start Line path, used to determine OCS', path: 'self.navigation.racing.distanceStartline', source: 'default', pathType: 'number', pathRequired: false, isPathConfigurable: false, convertUnitTo: 'm', showConvertUnitTo: false, showPathSkUnitsFilter: false, pathSkUnitsFilter: 'm', sampleTime: 500 }
     },
     color: 'contrast',
-    enableTimeout: false,
+    enableTimeout: true,
     dataTimeout: 5,
     ignoreZones: true
   };

--- a/src/assets/skip-dashboard-schema.json
+++ b/src/assets/skip-dashboard-schema.json
@@ -541,7 +541,7 @@
   },
   "meta": {
     "configFileVersion": 11,
-    "configVersion": 15,
+    "configVersion": 16,
     "schemaVersion": 1,
     "skipVersion": "1.0.4"
   },
@@ -1427,7 +1427,7 @@
         "color": "contrast",
         "dataTimeout": 5,
         "displayName": "Heel",
-        "enableTimeout": false,
+        "enableTimeout": true,
         "filterSelfPaths": true,
         "gauge": {
           "invertAngle": false,
@@ -1500,7 +1500,7 @@
       "defaultConfig": {
         "dataTimeout": 5,
         "displayName": "Horizon",
-        "enableTimeout": false,
+        "enableTimeout": true,
         "filterSelfPaths": true,
         "gauge": {
           "faceColor": "anthracite",
@@ -1806,7 +1806,7 @@
         "color": "contrast",
         "dataTimeout": 5,
         "displayName": "DTS",
-        "enableTimeout": false,
+        "enableTimeout": true,
         "filterSelfPaths": true,
         "ignoreZones": true,
         "numDecimal": 0,
@@ -2007,7 +2007,7 @@
         "color": "contrast",
         "dataTimeout": 5,
         "displayName": "TTS",
-        "enableTimeout": false,
+        "enableTimeout": true,
         "filterSelfPaths": true,
         "ignoreZones": true,
         "nextDashboard": 0,

--- a/src/default-config/config.blank.dashboard.spec.ts
+++ b/src/default-config/config.blank.dashboard.spec.ts
@@ -7,7 +7,7 @@ import { WidgetPositionComponent } from '../app/widgets/widget-position/widget-p
 // its old shape forever. Guard the position widget specifically — its two-path shape was the #414
 // bug — so a future re-export of the seed can't silently reintroduce longPath/latPath.
 describe('DefaultDashboard seed', () => {
-  interface SeedWidget { input?: { widgetProperties?: { type?: string; config?: { paths?: Record<string, unknown> } } } }
+  interface SeedWidget { input?: { widgetProperties?: { type?: string; config?: { paths?: Record<string, unknown>; enableTimeout?: boolean; dataTimeout?: number } } } }
 
   const seededWidgetsOfType = (type: string): SeedWidget[] =>
     DefaultDashboard.flatMap(dash => (dash.configuration ?? []) as SeedWidget[])
@@ -25,4 +25,27 @@ describe('DefaultDashboard seed', () => {
       expect(positionPath?.pathType).toBe('object');
     }
   });
+
+  // Attitude widgets read a sub-field off navigation.attitude; their path must stay hidden
+  // (isPathConfigurable:false) — else the settings show a dead 'number' picker on an object leaf and
+  // no Paths tab is suppressed (#416) — and their data timeout defaults on. Each type is asserted
+  // separately so dropping one on a future re-export can't hide behind the other's presence.
+  for (const type of ['widget-heel-gauge', 'widget-horizon']) {
+    it(`seeds ${type} with a hidden fixed attitude path and the timeout enabled`, () => {
+      const widgets = seededWidgetsOfType(type);
+      expect(widgets.length).toBeGreaterThan(0);
+
+      for (const widget of widgets) {
+        const cfg = widget.input?.widgetProperties?.config;
+        const paths = Object.values(cfg?.paths ?? {}) as { path?: string; isPathConfigurable?: boolean }[];
+        expect(paths.length).toBeGreaterThan(0);
+        for (const pathCfg of paths) {
+          expect(pathCfg.path).toBe('self.navigation.attitude');
+          expect(pathCfg.isPathConfigurable).toBe(false);
+        }
+        expect(cfg?.enableTimeout).toBe(true);
+        expect(cfg?.dataTimeout).toBe(5);
+      }
+    });
+  }
 });

--- a/src/default-config/config.blank.dashboard.ts
+++ b/src/default-config/config.blank.dashboard.ts
@@ -1325,7 +1325,7 @@ export const DefaultDashboard: Dashboard[] = [
               "numInt": 2,
               "numDecimal": 0,
               "color": "contrast",
-              "enableTimeout": false,
+              "enableTimeout": true,
               "dataTimeout": 5
             }
           }
@@ -1381,7 +1381,7 @@ export const DefaultDashboard: Dashboard[] = [
                 "invertPitch": false,
                 "invertRoll": false
               },
-              "enableTimeout": false,
+              "enableTimeout": true,
               "dataTimeout": 5
             }
           }


### PR DESCRIPTION
## Problem

Widgets whose paths are all fixed showed a widget-settings **Paths tab** with nothing useful to edit. `widget-heel-gauge` / `widget-horizon` additionally had a dead `pathType: 'number'` picker on the `navigation.attitude` object leaf (the position bug #414 class) — the boat's heel-gauge was stranded at v15 (`isPathConfigurable: true`) after #415, which rewrote only position.

## Fix

- **Config dialog** — suppress the Paths tab when a widget has **no user-configurable path** (`hasConfigurablePaths`). Array-form widgets (`multiChildCtrls`: `widget-boolean-switch`, `widget-zones-state-panel`) build their paths *through* that tab, so they're explicitly kept.
- **Default TTL on** — the Paths tab also hosted the data-timeout control, so the four all-fixed-path widgets (`heel-gauge`, `horizon`, `racer-timer`, `racer-line`) now default `enableTimeout: true` / `dataTimeout: 5`; stale data blanks the gauge/readout. Attitude widgets keep `pathType: 'number'` so the pipeline extracts the roll/pitch sub-field then converts rad→deg (documented at the defaults).
- **Migration v15 → v16** — enables the timeout on all four types, and for the two attitude widgets resets every stored path to the fixed default (`self.navigation.attitude`, `pathType: 'number'`, `isPathConfigurable: false`, `convertUnitTo: 'deg'`), discarding stale overrides. Racer paths are already scalar/fixed, so only their timeout changes. Bumps `LATEST_APP_CONFIG_VERSION → 16` with the usual couplings (boot gate `liveVersion === 15`, dispatch `case 15`, `version === 15` branch, perf-harness seed, regenerated schema, fixed `V16_MIGRATION_OUTPUT_VERSION`).
- **Seed** — heel-gauge/horizon set to `enableTimeout: true` (racers aren't seeded); seed guard test extended per-type.

## Review (two rounds, findings fixed)

- **P1 (fixed):** the first cut of `hasConfigurablePaths` hid the tab for array-form widgets (`paths: []`), breaking control creation for fresh boolean-switch/zones-panel instances — now excluded via `multiChildCtrls`, with a dialog test.
- **P2 (resolved):** the rule also caught the racer widgets; per the maintainer's decision they're included in the "hide the tab" rule and get the TTL-on default (not left stuck off).
- Migration correctness (gate/scope/guards/idempotency), boot-gate chaining to v16, and the rad→deg pipeline after the reset were confirmed by the reviewers.

## Verification

`npm run ci` green (lint + snc + full suite + plugin + `test:mcp-schema`); schema diff is the four `enableTimeout` flips + `configVersion 16`. Deployed to the boat.

## Note (release)

Like #415, this does not bump `VERSION` — the boat runs the dev deploy. A `./run bumpversion` is needed to ship the accumulated config migrations (v14→v16) to app-store/npm users.

Closes #416
