### PR TITLE
Fix: toolbar tap ignored after a flick-to-reveal (browser fling suppresses the click)

### DIFF
--- a/src/app/core/directives/gesture.directive.spec.ts
+++ b/src/app/core/directives/gesture.directive.spec.ts
@@ -186,6 +186,46 @@ describe('GestureDirective', () => {
         expect(swipeLeftCount).toBe(0);
     });
 
+    it('claims touch-move only while tracking a gesture (stops the fling that swallows the next tap)', () => {
+        component.mode = 'all';
+        syncFixture();
+        const touchMovePrevented = () => {
+            const e = new Event('touchmove', { bubbles: true, cancelable: true });
+            hostEl.dispatchEvent(e);
+            return e.defaultPrevented;
+        };
+
+        // Idle (not tracking): touch-move passes through, so scrolling in dialogs/sheets is unaffected.
+        expect(touchMovePrevented()).toBe(false);
+
+        // A gesture starts on pointerdown -> subsequent touch-moves are claimed so the browser
+        // recognises no scroll/fling (a fling would make Chromium suppress the click of the tap that
+        // stops it, losing a flick-to-reveal-then-tap).
+        dispatchPointerEvent(hostEl, 'pointerdown', { clientX: 50, clientY: 20, pointerId: POINTER_ID, pointerType: 'touch' });
+        expect(touchMovePrevented()).toBe(true);
+
+        // After release, tracking ends -> touch-move passes through again.
+        dispatchPointerEvent(hostEl, 'pointerup', { clientX: 50, clientY: 20, pointerId: POINTER_ID, pointerType: 'touch' });
+        expect(touchMovePrevented()).toBe(false);
+    });
+
+    it('yields touch-move to a scrollable descendant so routed pages/lists keep touch-scrolling', () => {
+        component.mode = 'all';
+        syncFixture();
+        // A scrollable child with content overflowing (jsdom has no layout, so stub the metrics).
+        const scroller = document.createElement('div');
+        scroller.style.overflowY = 'auto';
+        Object.defineProperty(scroller, 'scrollHeight', { value: 400, configurable: true });
+        Object.defineProperty(scroller, 'clientHeight', { value: 100, configurable: true });
+        hostEl.appendChild(scroller);
+
+        // Gesture tracking, but the touch is inside the scroller -> NOT claimed, so the browser scrolls.
+        dispatchPointerEvent(hostEl, 'pointerdown', { clientX: 50, clientY: 20, pointerId: POINTER_ID, pointerType: 'touch' });
+        const onScroller = new Event('touchmove', { bubbles: true, cancelable: true });
+        scroller.dispatchEvent(onScroller);
+        expect(onScroller.defaultPrevented).toBe(false);
+    });
+
     it('emits doubletap for two taps within interval', () => {
         component.mode = 'press';
         component.enableDoubleTap = true;

--- a/src/app/core/directives/gesture.directive.ts
+++ b/src/app/core/directives/gesture.directive.ts
@@ -153,6 +153,9 @@ export class GestureDirective {
   private startY = 0;
   private startTime = 0;
   private tracking = false;
+  /** Per-gesture cache: whether to claim touch-moves (block the fling) or yield to a scrollable child. */
+  private touchClaimDecided = false;
+  private claimTouchMoves = false;
   private longPressTimer: number | null = null;
   private pressFired = false;
   // Track which lanes this instance acquired for current pointer
@@ -218,6 +221,11 @@ export class GestureDirective {
       el.addEventListener('pointerdown', this.onPointerDown, { passive: false, capture: true });
       // Movement: both pointermove and pointerrawupdate feed the same handler to keep behavior consistent.
       el.addEventListener('pointermove', this.onPointerMove, { passive: true, capture: true });
+      // Claim touch-move while a gesture is being tracked so the browser recognises no scroll/fling.
+      // touch-action:none stops the scroll but NOT the fling: a fast flick still registers a fling, and
+      // Chromium then swallows the click of the tap that stops it — so a flick-to-reveal followed by an
+      // immediate button tap loses that tap. Non-passive is required to preventDefault.
+      el.addEventListener('touchmove', this.onTouchMove, { passive: false, capture: true });
       // raw updates provide higher-fidelity movement in Chrome; ignored by other browsers
       el.addEventListener('pointerrawupdate', this.onPointerRawUpdate as EventListener, { passive: true, capture: true } as AddEventListenerOptions);
       // Use capture for touch/pen reliability; for mouse, pointerup in bubble keeps native click working
@@ -337,6 +345,7 @@ export class GestureDirective {
     this.destroyRef.onDestroy(() => {
         el.removeEventListener('pointerdown', this.onPointerDown, { capture: true } as AddEventListenerOptions);
         el.removeEventListener('pointermove', this.onPointerMove, { capture: true } as AddEventListenerOptions);
+        el.removeEventListener('touchmove', this.onTouchMove, { capture: true } as AddEventListenerOptions);
         el.removeEventListener('pointerrawupdate', this.onPointerRawUpdate as EventListener, { capture: true } as AddEventListenerOptions);
         // pointerup was added without capture; remove without capture
         el.removeEventListener('pointerup', this.onPointerUp);
@@ -544,6 +553,7 @@ export class GestureDirective {
     this.pointerId = ev.pointerId;
     ownersMap.set(ev.pointerId, owners);
     this.tracking = true;
+    this.touchClaimDecided = false;
     this.pressFired = false;
     this.currentPointerType = ev.pointerType || null;
     this.lockedAxis = null;
@@ -733,6 +743,38 @@ export class GestureDirective {
   }
 
   private onPointerMove = (ev: PointerEvent) => this.handlePointerMotion(ev, 'move');
+
+  /**
+   * While tracking a gesture, prevent the browser from turning the touch into a scroll/fling — a fast
+   * flick otherwise registers a fling even under touch-action:none, and Chromium then swallows the
+   * click of the tap that stops it (a flick-to-reveal then an immediate button tap loses that tap).
+   * But YIELD when the touch is inside a scrollable descendant so routed pages (settings/remote/help)
+   * and lists still touch-scroll — mirrors the wheel yield in scroll-nav.directive. Decided once per
+   * gesture (the touch target is stable for the sequence) to avoid per-move layout reads.
+   */
+  private onTouchMove = (ev: TouchEvent): void => {
+    if (!this.tracking || !ev.cancelable) return;
+    if (!this.touchClaimDecided) {
+      this.touchClaimDecided = true;
+      this.claimTouchMoves = !this.hasScrollableAncestor(ev.target);
+    }
+    if (this.claimTouchMoves) ev.preventDefault();
+  };
+
+  /** True if any element from `target` up to the host is a scroll container with content overflowing. */
+  private hasScrollableAncestor(target: EventTarget | null): boolean {
+    let el = target instanceof Element ? target : null;
+    const host = this.host.nativeElement;
+    while (el && el !== host) {
+      if (el instanceof HTMLElement) {
+        const style = getComputedStyle(el);
+        if ((style.overflowY === 'auto' || style.overflowY === 'scroll') && el.scrollHeight > el.clientHeight) return true;
+        if ((style.overflowX === 'auto' || style.overflowX === 'scroll') && el.scrollWidth > el.clientWidth) return true;
+      }
+      el = el.parentElement;
+    }
+    return false;
+  }
 
   // Chrome sends pointerrawupdate for high-frequency movement; mirror pointermove logic via shared handler
   private onPointerRawUpdate = (ev: PointerEvent) => this.handlePointerMotion(ev, 'raw');


### PR DESCRIPTION
## Fix: toolbar tap ignored after a flick-to-reveal (browser fling suppresses the click)

### Symptom
On touch devices, after flicking to reveal the auto-hiding toolbar, the **first** tap on the lock button was often ignored; a second tap worked. Reproduced on a Samsung tablet and a Pixel 10 XL (Brave), and Hermit.

### Root cause
The reveal-swipe, when done as a **fast flick**, is recognised by Chromium as a **fling** — even though the gesture shell has `touch-action: none`. `touch-action: none` stops the *scroll*, but not the *fling recognition*. Chromium then applies its tap-suppression-after-fling: the tap that "stops" the fling has its synthesized `click` swallowed. Since the toolbar buttons use a native `(click)`, that tap does nothing. A slow pull (no momentum) generates no fling, so it always worked — which is exactly what distinguished the failing cases.

### How it was found
Instrumented the live browser over ADB + CDP: every dead tap showed a clean `pointerdown`+`pointerup` on the button with **no `click`**, and the failure correlated with a velocity-dependent window after the reveal-swipe (dead ≲ ~800ms, click after) that only appeared for a real hardware finger (synthetic/CDP touch never reproduced it — it doesn't drive the browser's fling recogniser). A user-confirmed test settled it: **flick suppresses, slow pull doesn't.** A `preventDefault`-on-touchmove patch injected live eliminated it.

### The fix
`gesture.directive` registers a **non-passive `touchmove`** on its host that `preventDefault`s while a gesture is being tracked — so the browser recognises no scroll/fling and never arms tap-suppression. Scoped:
- gated on `this.tracking` (the active-gesture window only), **and**
- **yields (does not `preventDefault`) when the touch is inside a scrollable descendant**, so routed full-page views (settings / remote / connection / help) and lists keep touch-scrolling. This mirrors the wheel-yield already in `scroll-nav.directive`. The claim-vs-yield decision is made once per gesture (the touch target is stable for the sequence) to avoid per-move layout reads.

Pointer-event–based swipe detection is untouched (it doesn't rely on touch events).

### Verification
- `npm run ci` green (1636 unit + 7 plugin + 33 mcp-schema); added two directive unit tests: touch-move is claimed only while tracking, and is **not** claimed when the touch targets a scrollable child.
- Deployed to the boat and confirmed on a Samsung tablet: flick-to-reveal + immediate lock tap now registers on the first tap, **and** Settings/Remote/Help still touch-scroll (no scroll/swipe/page-nav regressions).

No VERSION bump (later PR in the 1.0.5 cycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Funf1XbakER2phRLQYdW5
