### PR TITLE
Fix theme change requiring a reload for widget colors (#438)

### DIFF
--- a/src/app/core/services/app-service.spec.ts
+++ b/src/app/core/services/app-service.spec.ts
@@ -98,6 +98,16 @@ describe('AppService', () => {
       TestBed.tick();
       expect(document.body.classList.contains('light-theme')).toBe(false);
     });
+
+    it('publishes a fresh theme color snapshot when the theme changes', () => {
+      const service = createService();
+      const before = service.cssThemeColorRoles$.getValue();
+      settings.themeName.set('light-theme');
+      TestBed.tick();
+      const after = service.cssThemeColorRoles$.getValue();
+      expect(after).not.toBe(before);
+      expect(service.cssThemeColors).toBe(after);
+    });
   });
 
   describe('setBrightness', () => {

--- a/src/app/core/services/app-service.ts
+++ b/src/app/core/services/app-service.ts
@@ -96,6 +96,10 @@ export class AppService {
         // Remove the light theme class if it exists
         document.body.classList.remove('light-theme');
       }
+      // Re-snapshot the theme CSS custom properties so widgets (which draw from the
+      // JS snapshot, not live CSS) recolor without a reload. getComputedStyle here
+      // forces a synchronous style recalc, so the class change above is reflected.
+      this._cssThemeColorRoles = this.readThemeCssRoleVariables();
     });
 
     effect(() => {


### PR DESCRIPTION
Fixes #438.

## Symptom
After switching the theme (light ⇄ dark), Material chrome and CSS-driven surfaces recolored immediately, but **widget colors stayed on the old theme until a full page reload** — gauges, the D3 wind radar, Chart.js trend charts and the SVG steer widgets.

## Root cause
Widgets don't read theme CSS live. `AppService` snapshots the `--skip-*` / `--mat-sys-background` custom properties into a plain JS `ITheme` object and publishes it on `cssThemeColorRoles$`; widgets consume that snapshot (via `widget-host2`'s `inputBinding('theme', …)`) and draw from it.

That snapshot was only (re)read in the constructor (startup) and inside `toggleDayNightMode()` (night mode). The **light/dark theme-switch effect toggled the `body.light-theme` class but never re-published the snapshot**, so widgets kept the stale startup values until a reload re-ran the constructor.

## Fix
Re-read and re-publish the snapshot inside the theme-change effect, right after the class toggle — exactly what `toggleDayNightMode()` already does. `getComputedStyle` forces a synchronous style recalc, so the just-applied class is reflected in the new snapshot. No new signal dependencies are read, so the effect doesn't self-trigger.

## Verification
- `npm run ci` green (1637 unit + 7 plugin + 33 mcp-schema). Added a spec asserting the theme-change effect publishes a **fresh** snapshot (mirrors the existing night-toggle snapshot test); it fails before the fix (same object reference) and passes after.
- Deployed to the boat and confirmed light ⇄ dark recolors gauges, trend charts, and the windsteer widget **without** a reload.

This is the basis for the theme cluster: it's also a prerequisite for a live "Follow system" option (#439) recoloring widgets on OS-theme changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Funf1XbakER2phRLQYdW5
