### PR TITLE
Light-theme color legibility: paired on-role tokens + transparent chart label (#440)

### DIFF
--- a/src/app/core/components/dashboard/dashboard.component.scss
+++ b/src/app/core/components/dashboard/dashboard.component.scss
@@ -47,14 +47,14 @@
 .cancel {
   @include mat.fab-overrides((
     container-color: var(--mat-sys-primary),
-    foreground-color: var(--mat-sys-background),
+    foreground-color: var(--mat-sys-on-primary),
   ));
 }
 
 .save {
   @include mat.fab-overrides((
     container-color: var(--mat-sys-primary-fixed),
-    foreground-color: var(--mat-sys-background),
+    foreground-color: var(--mat-sys-on-primary-fixed),
   ));
 }
 

--- a/src/app/widget-config/path-control-config/path-control-config.component.html
+++ b/src/app/widget-config/path-control-config/path-control-config.component.html
@@ -1,6 +1,6 @@
 <div [formGroup]="pathFormGroup()" class="flex-container rounded-card rounded-card-color">
   <div class="flex-field-100">
-    <span [style.color]="pathFormGroup().controls['path'].disabled ? 'rgba(255,255,255,0.5)' : ''">{{pathFormGroup().value.description}}</span>
+    <span [style.color]="pathFormGroup().controls['path'].disabled ? 'var(--mat-sys-on-surface-variant)' : ''">{{pathFormGroup().value.description}}</span>
   </div>
 
   @if (pathFormGroup().value.pathOptions?.length) {

--- a/src/app/widget-config/path-control-config/path-control-config.component.scss
+++ b/src/app/widget-config/path-control-config/path-control-config.component.scss
@@ -1,16 +1,3 @@
-@use 'sass:map';
-@use '@angular/material' as mat;
-
-@mixin modal-path-selector-theme($theme) {
-
-  $themeForeground: map-get($theme, foreground);
-
-  .pathMetaDescription {
-    font: small-caption;
-    color: mat.m2-get-color-from-palette($themeForeground, disabled-text);
-  }
-}
-
 .pathGroup {
   width: 100%;
 }

--- a/src/app/widgets/widget-data-chart/widget-data-chart.component.ts
+++ b/src/app/widgets/widget-data-chart/widget-data-chart.component.ts
@@ -458,7 +458,7 @@ export class WidgetDataChartComponent implements OnDestroy {
               position: "start",
               padding: 4,
               color: this.getThemeColors().chartValue,
-              backgroundColor: 'rgba(63,63,63,0.7)'
+              backgroundColor: 'rgba(63,63,63,0.0)'
             }
           }
         }


### PR DESCRIPTION
Closes #440.

Three light-theme color-legibility regressions found during on-boat testing — each a hardcoded or mismatched color that only breaks in light theme.

## Fixes
1. **Edit-mode FABs** (`dashboard.component.scss`) — `.save`/`.cancel` used `--mat-sys-background` as the icon foreground (near-white in light theme → illegible glyph). Now use the on-role paired with each container: `.save` (container `primary-fixed`) → `on-primary-fixed`, `.cancel` (container `primary`) → `on-primary`.
2. **Data-chart average label** (`widget-data-chart.component.ts`) — the `averageLine` label had a hardcoded dark box `rgba(63,63,63,0.7)` (dark-on-dark in light theme). Now transparent `rgba(63,63,63,0.0)`, matching the sibling min/max labels exactly.
3. **Widget-config path label** (`path-control-config.component.html`) — the disabled path description used hardcoded translucent white `rgba(255,255,255,0.5)` (white-on-light). Now `var(--mat-sys-on-surface-variant)` (the theme's secondary/disabled text role).

Also removes the never-`@include`d dead `modal-path-selector-theme` SCSS mixin (M2 leftover) and its two now-orphaned `@use` imports.

## Verification
- `npm run ci` green (1638 unit + 7 plugin + 33 mcp-schema, lint + snc clean).
- Deployed to the boat and confirmed the three spots are legible in light theme; the new on-role tokens also contrast correctly in dark theme.

### Known follow-up (out of scope)
The `.cancel` FAB uses `on-primary` on a `primary` container; the `night-theme` overrides `--mat-sys-primary` (dark red) but not `--mat-sys-on-primary`, so its icon has low contrast in **night mode** — a night-palette token-completeness gap, separate from this light-theme fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Funf1XbakER2phRLQYdW5
