### PR TITLE
Night mode: force a dark base regardless of selected theme (#443)

### DIFF
--- a/src/app/core/services/app-service.spec.ts
+++ b/src/app/core/services/app-service.spec.ts
@@ -145,22 +145,39 @@ describe('AppService', () => {
       expect(document.body.style.getPropertyValue('--skip-nightModeFilters')).toContain('sepia(0.5)');
     });
 
-    it('keeps the light-theme class in night mode when the theme is light', () => {
+    it('forces a dark base (removes light-theme) in night mode even when the theme is light', () => {
       settings.themeName.set('light-theme');
       const service = createService();
       service.isNightMode.set(true);
       service.toggleDayNightMode();
-      expect(document.body.classList.contains('light-theme')).toBe(true);
+      expect(document.body.classList.contains('light-theme')).toBe(false);
     });
 
     it('applies the red night theme at full brightness when red night mode is on', () => {
+      settings.themeName.set('light-theme');
       settings.redNightMode.set(true);
       const service = createService();
       service.isNightMode.set(true);
       service.toggleDayNightMode();
       expect(document.body.classList.contains('night-theme')).toBe(true);
+      expect(document.body.classList.contains('light-theme')).toBe(false);
       expect(document.body.style.getPropertyValue('--skip-nightModeBrightness')).toBe('1');
       expect(document.body.style.getPropertyValue('--skip-nightModeFilters')).toBe('');
+    });
+
+    it('keeps the dark base when the theme is switched to light while night mode is active', () => {
+      const service = createService();
+      service.isNightMode.set(true);
+      service.toggleDayNightMode();
+      expect(document.body.classList.contains('light-theme')).toBe(false);
+
+      settings.themeName.set('light-theme');
+      TestBed.tick();
+      expect(document.body.classList.contains('light-theme')).toBe(false);
+
+      service.isNightMode.set(false);
+      service.toggleDayNightMode();
+      expect(document.body.classList.contains('light-theme')).toBe(true);
     });
 
     it('publishes a fresh theme color snapshot on each toggle', () => {

--- a/src/app/core/services/app-service.ts
+++ b/src/app/core/services/app-service.ts
@@ -90,12 +90,9 @@ export class AppService {
     );
 
     effect(() => {
-      if (this._theme() === 'light-theme') {
-        document.body.classList.toggle('light-theme', this._theme() === 'light-theme');
-      } else {
-        // Remove the light theme class if it exists
-        document.body.classList.remove('light-theme');
-      }
+      // Night mode forces a dark base, so light-theme only applies outside it.
+      const applyLight = this._theme() === 'light-theme' && !this.isNightMode();
+      document.body.classList.toggle('light-theme', applyLight);
       // Re-snapshot the theme CSS custom properties so widgets (which draw from the
       // JS snapshot, not live CSS) recolor without a reload. getComputedStyle here
       // forces a synchronous style recalc, so the class change above is reflected.
@@ -207,17 +204,14 @@ export class AppService {
 
   public toggleDayNightMode(): void {
     if (this.isNightMode()) {
+      // Night mode always uses a dark base, regardless of the selected theme.
+      document.body.classList.remove('light-theme');
       if (this._redNightMode()) {
         document.body.classList.toggle('night-theme', true);
         this.setBrightness(1, false);
       } else {
         this.setBrightness(this._settings.getNightModeBrightness(), true);
         document.body.classList.remove('night-theme');
-        if (this._theme() === 'light-theme') {
-          document.body.classList.toggle('light-theme', this._theme() === 'light-theme');
-        } else {
-          document.body.classList.remove('light-theme');
-        }
       }
 
     } else {


### PR DESCRIPTION
Closes #443.

Night mode is meant to layer its adjustments (red `night-theme`, or dimming + sepia) over a **dark base**, but it kept the light base when the user's selected theme was light.

## Root cause & fix
Two managers of the `light-theme` class both had to respect night mode:
1. `toggleDayNightMode()` — the non-red **dim** branch re-added `light-theme` when the theme was light (so night mode just *dimmed* light); the **red** branch never removed it. → Now a single `document.body.classList.remove('light-theme')` is hoisted to the top of the night-mode branch, forcing a dark base in both sub-branches.
2. The **theme-change effect** — toggled `light-theme` purely from the theme signal, so switching the base theme to light *while night mode was active* re-added it. → Now gated: `applyLight = theme === 'light-theme' && !isNightMode()`.

Both keep `light-theme` off whenever night mode is active, and restore it (idempotently, order-independent) when night ends. The #438 live-recolor snapshot re-read is preserved in the effect. Reading `isNightMode()` in the effect adds no infinite-loop risk (`readThemeCssRoleVariables` reads no signals).

## Verification
- `npm run ci` green (1638 unit + 7 plugin + 33 mcp-schema).
- Tests: rewrote the night-mode test to assert the dark base (was asserting the old kept-light behavior), added a `light-theme`-removed assertion to the red-night test, and **added an interaction test** (switch base theme to light mid-night → stays dark; night off → restored). All three were empirically confirmed to fail on the old code.
- Deployed to the boat and confirmed: with base theme **Light**, night mode (dimming and red) renders on a dark base; turning night mode off returns to Light.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Funf1XbakER2phRLQYdW5
