### PR TITLE
Three-way theme selector: Follow system / Light / Dark, default Light (#439)

### DIFF
--- a/src/app/core/components/settings/display/display.component.html
+++ b/src/app/core/components/settings/display/display.component.html
@@ -45,15 +45,19 @@
           </mat-panel-title>
           @if (!isPhonePortrait().matches) {
             <mat-panel-description>
-              Choose your preferred high-contrast theme.
+              Choose light, dark, or follow the device theme.
             </mat-panel-description>
           }
         </mat-expansion-panel-header>
-        <mat-slide-toggle class="full-width"
-          [(ngModel)]="isLightTheme"
-          name="isLightTheme">
-            Enable light theme for brighter display settings.
-        </mat-slide-toggle>
+        <mat-button-toggle-group class="full-width theme-toggle"
+          [(ngModel)]="themeMode"
+          name="themeMode"
+          aria-label="Theme"
+          hideSingleSelectionIndicator>
+          @for (mode of themeModes; track mode.value) {
+            <mat-button-toggle [value]="mode.value">{{ mode.label }}</mat-button-toggle>
+          }
+        </mat-button-toggle-group>
       </mat-expansion-panel>
       <mat-expansion-panel>
         <mat-expansion-panel-header>

--- a/src/app/core/components/settings/display/display.component.scss
+++ b/src/app/core/components/settings/display/display.component.scss
@@ -5,6 +5,10 @@
   margin-top: 10px;
 }
 
+.theme-toggle mat-button-toggle {
+  flex: 1 1 0;
+}
+
 .sliders {
   margin: 5px 0px 5px 0px;
 }

--- a/src/app/core/components/settings/display/display.component.spec.ts
+++ b/src/app/core/components/settings/display/display.component.spec.ts
@@ -102,6 +102,29 @@ describe('SettingsNotificationsComponent', () => {
         expect(component).toBeTruthy();
     });
 
+    it('maps a legacy empty stored theme to Dark in the picker', () => {
+        // SettingsServiceMock.getThemeName() returns '' (legacy dark)
+        expect(component['themeMode']()).toBe('dark-theme');
+    });
+
+    it('loads a stored system theme into the picker unchanged', () => {
+        const settings = TestBed.inject(SettingsService) as unknown as SettingsServiceMock;
+        vi.spyOn(settings, 'getThemeName').mockReturnValue('system');
+        const fx = TestBed.createComponent(SettingsDisplayComponent);
+        fx.detectChanges();
+        expect(fx.componentInstance['themeMode']()).toBe('system');
+    });
+
+    it('saves the selected theme mode verbatim', async () => {
+        const settings = TestBed.inject(SettingsService) as unknown as SettingsServiceMock;
+        const setThemeName = vi.spyOn(settings, 'setThemeName');
+        component['themeMode'].set('system');
+        component['saveAllSettings']();
+        await flushPromises();
+        await flushPromises();
+        expect(setThemeName).toHaveBeenCalledWith('system');
+    });
+
     it('shows single warning prompt with Ok action when plugin is installed but not enabled/configured', async () => {
         // Toggle auto night mode on
         component['isAutoNightModeSupported']({ checked: true, source: {} as MatSlideToggle });

--- a/src/app/core/components/settings/display/display.component.ts
+++ b/src/app/core/components/settings/display/display.component.ts
@@ -14,6 +14,8 @@ import { MatSliderModule } from '@angular/material/slider';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatInputModule } from '@angular/material/input';
 import { MatSlideToggleModule, MatSlideToggleChange } from '@angular/material/slide-toggle';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
+import { ThemeMode, THEME_MODES } from '../../../constants/themes.const';
 
 
 @Component({
@@ -27,12 +29,13 @@ import { MatSlideToggleModule, MatSlideToggleChange } from '@angular/material/sl
         MatSliderModule,
         MatExpansionModule,
         MatInputModule,
-        MatSlideToggleModule
+        MatSlideToggleModule,
+        MatButtonToggleModule
     ],
 })
 export class SettingsDisplayComponent implements OnInit {
   private readonly DERIVED_DATA_PLUGIN_ID = 'derived-data';
-  private readonly LIGHT_THEME_NAME = "light-theme";
+  protected readonly themeModes = THEME_MODES;
   private readonly displayForm = viewChild<NgForm>('displayForm');
   private readonly app = inject(AppService);
   private readonly toast = inject(ToastService);
@@ -44,7 +47,7 @@ export class SettingsDisplayComponent implements OnInit {
   protected nightBrightness = signal<number>(0.27);
   protected autoNightMode = model<boolean>(false);
   protected isRedNightMode = model<boolean>(false);
-  protected isLightTheme = model<boolean>(false);
+  protected themeMode = model<ThemeMode>('dark-theme');
   protected isRemoteControl = model<boolean>(false);
   protected instanceName = model<string>('');
   protected browserTabTitle = model<string>('Skip');
@@ -60,7 +63,8 @@ export class SettingsDisplayComponent implements OnInit {
   ngOnInit() {
     this.nightBrightness.set(this.settings.getNightModeBrightness());
     this.autoNightMode.set(this.settings.getAutoNightMode());
-    this.isLightTheme.set(this.settings.getThemeName() === this.LIGHT_THEME_NAME);
+    const storedTheme = this.settings.getThemeName();
+    this.themeMode.set(storedTheme === 'light-theme' || storedTheme === 'system' ? storedTheme : 'dark-theme');
     this.isRedNightMode.set(this.settings.getRedNightMode());
     this.isRemoteControl.set(this.settings.getIsRemoteControl());
     this.instanceName.set(this.settings.getInstanceName());
@@ -101,11 +105,7 @@ export class SettingsDisplayComponent implements OnInit {
     if (!this.app.isNightMode()) {
       this.app.setBrightness(1);
     }
-    if (this.isLightTheme()) {
-    this.settings.setThemeName(this.LIGHT_THEME_NAME);
-    } else {
-      this.settings.setThemeName("");
-    }
+    this.settings.setThemeName(this.themeMode());
     this.settings.setBrowserTabTitle(this.browserTabTitle());
     this.settings.setDisablePathValidation(this.isPathValidationDisabled());
     this.settings.setKeepScreenAwake(this.keepScreenAwake());

--- a/src/app/core/constants/themes.const.ts
+++ b/src/app/core/constants/themes.const.ts
@@ -1,0 +1,12 @@
+/**
+ * User-selectable theme choice. `'system'` follows the OS `prefers-color-scheme`;
+ * `'light-theme'` / `'dark-theme'` are explicit. Legacy configs store `''` (dark) —
+ * the resolver in AppService treats any non-light, non-system value as dark.
+ */
+export type ThemeMode = 'system' | 'light-theme' | 'dark-theme';
+
+export const THEME_MODES: readonly { readonly value: ThemeMode; readonly label: string }[] = [
+  { value: 'system', label: 'System' },
+  { value: 'light-theme', label: 'Light' },
+  { value: 'dark-theme', label: 'Dark' },
+];

--- a/src/app/core/services/app-service.spec.ts
+++ b/src/app/core/services/app-service.spec.ts
@@ -23,6 +23,31 @@ const modeUpdate = (value: string): IPathUpdate => ({
   state: States.Normal
 });
 
+// Installs a controllable prefers-color-scheme matchMedia fake and returns a setter
+// that flips `matches` and emits a `change` event, so 'system' theme re-resolution
+// can be exercised (the global test.ts stub is static with no working change events).
+function installPrefersDarkMatchMedia(matches: boolean): { setMatches: (m: boolean) => void } {
+  let current = matches;
+  const listeners = new Set<(e: MediaQueryListEvent) => void>();
+  const mql = {
+    get matches() { return current; },
+    media: '(prefers-color-scheme: dark)',
+    onchange: null,
+    addEventListener: (_: string, cb: (e: MediaQueryListEvent) => void) => { listeners.add(cb); },
+    removeEventListener: (_: string, cb: (e: MediaQueryListEvent) => void) => { listeners.delete(cb); },
+    addListener: () => undefined,
+    removeListener: () => undefined,
+    dispatchEvent: () => false,
+  };
+  Object.defineProperty(window, 'matchMedia', { configurable: true, value: () => mql });
+  return {
+    setMatches: (m: boolean) => {
+      current = m;
+      listeners.forEach(cb => cb({ matches: m } as MediaQueryListEvent));
+    }
+  };
+}
+
 describe('AppService', () => {
   let settings: SettingsServiceMock;
   let envMode$: BehaviorSubject<IPathUpdate>;
@@ -91,6 +116,18 @@ describe('AppService', () => {
       expect(document.body.classList.contains('light-theme')).toBe(true);
     });
 
+    it('resolves a legacy empty theme name to dark (no light-theme class)', () => {
+      settings.themeName.set(''); // legacy stored value — the no-migration back-compat invariant
+      createService();
+      expect(document.body.classList.contains('light-theme')).toBe(false);
+    });
+
+    it('resolves an explicit dark-theme to dark (no light-theme class)', () => {
+      settings.themeName.set('dark-theme');
+      createService();
+      expect(document.body.classList.contains('light-theme')).toBe(false);
+    });
+
     it('removes the light-theme class when the theme changes away from light-theme', () => {
       settings.themeName.set('light-theme');
       createService();
@@ -107,6 +144,77 @@ describe('AppService', () => {
       const after = service.cssThemeColorRoles$.getValue();
       expect(after).not.toBe(before);
       expect(service.cssThemeColors).toBe(after);
+    });
+  });
+
+  describe('system theme (prefers-color-scheme)', () => {
+    let originalMatchMedia: typeof window.matchMedia;
+    beforeEach(() => { originalMatchMedia = window.matchMedia; });
+    afterEach(() => {
+      Object.defineProperty(window, 'matchMedia', { configurable: true, value: originalMatchMedia });
+    });
+
+    it('resolves the system theme to light when the OS prefers light', () => {
+      installPrefersDarkMatchMedia(false);
+      settings.themeName.set('system');
+      createService();
+      expect(document.body.classList.contains('light-theme')).toBe(true);
+    });
+
+    it('resolves the system theme to dark when the OS prefers dark', () => {
+      installPrefersDarkMatchMedia(true);
+      settings.themeName.set('system');
+      createService();
+      expect(document.body.classList.contains('light-theme')).toBe(false);
+    });
+
+    it('re-resolves the system theme live when the OS colour-scheme changes', () => {
+      const mm = installPrefersDarkMatchMedia(false);
+      settings.themeName.set('system');
+      createService();
+      expect(document.body.classList.contains('light-theme')).toBe(true);
+
+      mm.setMatches(true);
+      TestBed.tick();
+      expect(document.body.classList.contains('light-theme')).toBe(false);
+    });
+
+    it('keeps a dark base for the system theme in night mode regardless of OS preference', () => {
+      installPrefersDarkMatchMedia(false); // OS prefers light...
+      settings.themeName.set('system');
+      const service = createService();
+      service.isNightMode.set(true);
+      service.toggleDayNightMode();
+      expect(document.body.classList.contains('light-theme')).toBe(false); // ...but night forces dark
+    });
+
+    it('stops following the OS after switching from system to an explicit theme', () => {
+      const mm = installPrefersDarkMatchMedia(false); // OS light -> system resolves light
+      settings.themeName.set('system');
+      createService();
+      expect(document.body.classList.contains('light-theme')).toBe(true);
+
+      settings.themeName.set('dark-theme');
+      TestBed.tick();
+      expect(document.body.classList.contains('light-theme')).toBe(false);
+
+      // OS colour-scheme changes must be ignored now that an explicit theme is selected.
+      mm.setMatches(true);
+      TestBed.tick();
+      expect(document.body.classList.contains('light-theme')).toBe(false);
+      mm.setMatches(false);
+      TestBed.tick();
+      expect(document.body.classList.contains('light-theme')).toBe(false);
+    });
+
+    it('constructs without crashing when MediaQueryList lacks addEventListener (legacy WebView)', () => {
+      Object.defineProperty(window, 'matchMedia', {
+        configurable: true,
+        value: () => ({ matches: true, media: '', addListener: () => undefined, removeListener: () => undefined })
+      });
+      settings.themeName.set('system');
+      expect(() => createService()).not.toThrow();
+      expect(document.body.classList.contains('light-theme')).toBe(false); // matches:true -> dark
     });
   });
 

--- a/src/app/core/services/app-service.ts
+++ b/src/app/core/services/app-service.ts
@@ -1,4 +1,4 @@
-import { effect, inject, Injectable, signal, untracked } from '@angular/core';
+import { DestroyRef, effect, inject, Injectable, signal, untracked } from '@angular/core';
 import { MatIconRegistry } from '@angular/material/icon';
 import { DomSanitizer } from '@angular/platform-browser';
 import { BehaviorSubject } from 'rxjs';
@@ -70,9 +70,12 @@ export class AppService {
   private readonly _data = inject(DataService);
   private readonly _iconRegistry = inject(MatIconRegistry);
   private readonly _sanitizer = inject(DomSanitizer);
+  private readonly _destroyRef = inject(DestroyRef);
   public isNightMode = signal<boolean>(false);
   private _useAutoNightMode = this._settings.autoNightMode;
   private _theme = this._settings.themeName;
+  // Tracks the OS colour-scheme so the 'system' theme choice can follow it live.
+  private readonly _prefersDark = signal<boolean>(false);
   private _redNightMode = this._settings.redNightMode;
   private _environmentMode = toSignal(this._data.subscribePath(this.MODE_PATH, 'default'));
 
@@ -89,9 +92,24 @@ export class AppService {
       this._sanitizer.bypassSecurityTrustResourceUrl('assets/svg/icons.svg')
     );
 
+    if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+      this._prefersDark.set(prefersDark.matches);
+      const onSchemeChange = (e: MediaQueryListEvent) => this._prefersDark.set(e.matches);
+      // Legacy Safari/WebView return a MediaQueryList that isn't an EventTarget (no
+      // addEventListener) — fall back to the deprecated addListener rather than crash boot.
+      if (typeof prefersDark.addEventListener === 'function') {
+        prefersDark.addEventListener('change', onSchemeChange);
+        this._destroyRef.onDestroy(() => prefersDark.removeEventListener('change', onSchemeChange));
+      } else if (typeof prefersDark.addListener === 'function') {
+        prefersDark.addListener(onSchemeChange);
+        this._destroyRef.onDestroy(() => prefersDark.removeListener(onSchemeChange));
+      }
+    }
+
     effect(() => {
       // Night mode forces a dark base, so light-theme only applies outside it.
-      const applyLight = this._theme() === 'light-theme' && !this.isNightMode();
+      const applyLight = this.resolveIsLightTheme() && !this.isNightMode();
       document.body.classList.toggle('light-theme', applyLight);
       // Re-snapshot the theme CSS custom properties so widgets (which draw from the
       // JS snapshot, not live CSS) recolor without a reload. getComputedStyle here
@@ -216,12 +234,21 @@ export class AppService {
 
     } else {
       document.body.classList.remove('night-theme');
-      if (this._theme() === 'light-theme') {
-        document.body.classList.toggle('light-theme', this._theme() === 'light-theme');
-      }
+      document.body.classList.toggle('light-theme', this.resolveIsLightTheme());
       this.setBrightness(1, false);
     }
     this._cssThemeColorRoles = this.readThemeCssRoleVariables();
+  }
+
+  /**
+   * Resolves the selected theme choice to whether the light theme applies.
+   * 'system' follows the OS colour-scheme; legacy '' and 'dark-theme' are dark.
+   */
+  private resolveIsLightTheme(): boolean {
+    const theme = this._theme();
+    if (theme === 'light-theme') return true;
+    if (theme === 'system') return !this._prefersDark();
+    return false;
   }
 
   /**

--- a/src/app/core/services/settings.service.spec.ts
+++ b/src/app/core/services/settings.service.spec.ts
@@ -485,8 +485,14 @@ describe('SettingsService — hydration (pushSettings) characterization', () => 
     expect(patchSpy).not.toHaveBeenCalled();
   });
 
-  it('a null loaded theme is not applied: the default (empty) theme name stays', () => {
+  it('a null loaded theme is not applied: the default (light) theme name stays', () => {
     const { service, patchSpy } = setupHydrated({ app: loadedAppConfig(), theme: null, dashboards: [] });
+    expect(service.getThemeName()).toBe('light-theme');
+    expect(patchSpy).not.toHaveBeenCalled();
+  });
+
+  it('a stored legacy empty theme is preserved (dark), not flipped to the light default', () => {
+    const { service, patchSpy } = setupHydrated({ app: loadedAppConfig(), theme: { themeName: '' }, dashboards: [] });
     expect(service.getThemeName()).toBe('');
     expect(patchSpy).not.toHaveBeenCalled();
   });
@@ -601,7 +607,7 @@ describe('SettingsService — resetSettings (characterization)', () => {
     expect(scope).toBe('user');
     expect(name).toBe('profileA');
     expect(cfg.app).toEqual({ ...DefaultAppConfig });
-    expect(cfg.theme).toEqual({ themeName: '' });
+    expect(cfg.theme).toEqual({ themeName: 'light-theme' });
     expect(cfg.dashboards).toEqual([]);
   });
 
@@ -716,7 +722,7 @@ describe('SettingsService — getDefault* localStorage side effects (characteriz
     const theme = service.loadConfigFromLocalStorage('themeConfig');
 
     expect(theme).not.toBe(DefaultThemeConfig);
-    expect(theme).toEqual({ themeName: '' });
+    expect(theme).toEqual({ themeName: 'light-theme' });
     expect(localStorage.getItem('skip.themeConfig')).toBeNull();
   });
 });

--- a/src/app/core/services/settings.service.ts
+++ b/src/app/core/services/settings.service.ts
@@ -19,7 +19,7 @@ import { LOCAL_CONFIG_KEYS, localConfigKey } from '../constants/config-storage.c
 import { REMOTE_CONFIG_FILE_VERSION, LATEST_APP_CONFIG_VERSION, CONNECTION_CONFIG_VERSION, SUPPORTED_CONNECTION_CONFIG_VERSIONS } from '../constants/config-versions.const';
 
 
-const defaultTheme = '';
+const defaultTheme = 'light-theme';
 @Injectable({
   providedIn: 'root'
 })

--- a/src/default-config/config.blank.const.ts
+++ b/src/default-config/config.blank.const.ts
@@ -15,7 +15,7 @@ export const DefaultAppConfig: Readonly<IAppConfig> = {
 }
 
 export const DefaultThemeConfig: IThemeConfig = {
-  "themeName": ""
+  "themeName": "light-theme"
 }
 
 export const defaultConfig: IConfig = {


### PR DESCRIPTION
Closes #439.

Adds a third theme option — **Follow system** — alongside Light and Dark, and makes **Light** the default for new users. Builds on #438 (live recolor) and #443 (night mode dark).

## Model
`SettingsService.themeName` becomes a tri-state choice: `'system' | 'light-theme' | 'dark-theme'` (legacy `''` still means dark). A single resolver in `AppService` maps the choice to a light/dark base:
- `'light-theme'` → light
- `'system'` → follows a **live** `prefers-color-scheme` signal (`matchMedia` + `change` listener, cleaned up via `DestroyRef`)
- legacy `''` / `'dark-theme'` → dark

The resolver is shared by the theme-change effect **and** `toggleDayNightMode`, so: night mode still forces dark regardless of choice (#443), the effect re-resolves **live** when the OS flips (only while `'system'` is selected — the `prefersDark` signal is read lazily), and the #438 snapshot re-read still fires so widgets recolor without a reload.

## UI
`Settings > Display` swaps the light on/off slide-toggle for a segmented `mat-button-toggle-group` (System / Light / Dark). Load maps legacy `''` → Dark; save writes the chosen mode verbatim.

## Default & migration
Default flips to `'light-theme'` (`settings.service` `defaultTheme` + `DefaultThemeConfig`). **No config migration needed**: `themeName` lives in the *unversioned* `IThemeConfig` blob (passed through every migration untouched), and the resolver treats legacy `''` as dark — so existing users are unaffected (`''` stays dark, `'light-theme'` stays light); only new-user seeds change.

## Verification
- `npm run ci` green (1644 unit + 7 plugin + 33 mcp-schema; lint + snc clean). TDD: 4 new `AppService` `system` tests (OS-light→light, OS-dark→dark, **live re-resolve on OS change**, night-forces-dark) written red-first; 2 new display-component mapping tests; 3 `settings.service` default assertions updated to Light.
- Deployed to the boat and confirmed all three modes apply live, Follow-system tracks the device, and existing dark/light users are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Funf1XbakER2phRLQYdW5
