### PR TITLE
Consolidate theme-snapshot cache + publish into one method (#445)

### DIFF
--- a/src/app/core/services/app-service.ts
+++ b/src/app/core/services/app-service.ts
@@ -114,7 +114,7 @@ export class AppService {
       // Re-snapshot the theme CSS custom properties so widgets (which draw from the
       // JS snapshot, not live CSS) recolor without a reload. getComputedStyle here
       // forces a synchronous style recalc, so the class change above is reflected.
-      this._cssThemeColorRoles = this.readThemeCssRoleVariables();
+      this.refreshThemeSnapshot();
     });
 
     effect(() => {
@@ -146,7 +146,7 @@ export class AppService {
       });
     });
 
-    this._cssThemeColorRoles = this.readThemeCssRoleVariables();
+    this.refreshThemeSnapshot();
 
     this.browserVersion.set(this.getBrowserVersion());
     this.osVersion.set(this.getOSVersion());
@@ -196,8 +196,12 @@ export class AppService {
       zoneAlarm: computedStyle.getPropertyValue('--skip-zone-alarm-color').trim(),
       zoneEmergency: computedStyle.getPropertyValue('--skip-zone-emergency-color').trim(),
     };
-    this.cssThemeColorRoles$.next(cssThemeRolesColor);
     return cssThemeRolesColor;
+  }
+
+  private refreshThemeSnapshot(): void {
+    this._cssThemeColorRoles = this.readThemeCssRoleVariables();
+    this.cssThemeColorRoles$.next(this._cssThemeColorRoles);
   }
 
   public get cssThemeColors() : ITheme {
@@ -237,7 +241,7 @@ export class AppService {
       document.body.classList.toggle('light-theme', this.resolveIsLightTheme());
       this.setBrightness(1, false);
     }
-    this._cssThemeColorRoles = this.readThemeCssRoleVariables();
+    this.refreshThemeSnapshot();
   }
 
   /**


### PR DESCRIPTION
Closes #445.

A behavior-preserving refactor flagged by the maintainability reviewer on PR #444.

## Before
`readThemeCssRoleVariables()` was a mixed command/query — its name/return type read like a pure query, but it also published the snapshot internally (`cssThemeColorRoles$.next(...)`). Separately, all three call sites additionally cached the return: `this._cssThemeColorRoles = this.readThemeCssRoleVariables()` (constructor bootstrap, theme-change effect, `toggleDayNightMode`). The assignment was triplicated, and a future 4th caller that forgot the field write would leave the `cssThemeColors` getter stale while subscribers stayed current.

## After
- `readThemeCssRoleVariables()` is now a pure private query (builds and returns `ITheme`, no side effect).
- `refreshThemeSnapshot()` does both: caches the field **and** publishes.
- All three sites call `refreshThemeSnapshot()`.

Identical semantics: 3 sites × (1 cache + 1 publish), same as before.

## Verification
- `npm run ci` green (1650 unit + 7 plugin + 33 mcp-schema). No test changes — the existing publish-site tests are the guard ('publishes CSS theme color roles' at construction, '…when the theme changes', '…on each toggle'), all still pass.
- Independently verified behavior-preserving: `readThemeCssRoleVariables` has exactly one caller (`refreshThemeSnapshot`), no publish dropped/doubled, getter unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Funf1XbakER2phRLQYdW5
