### PR TITLE
Make the Cancel FAB icon legible in night mode (#448)

### DIFF
--- a/src/app/core/components/dashboard/dashboard.component.scss
+++ b/src/app/core/components/dashboard/dashboard.component.scss
@@ -49,6 +49,12 @@
     container-color: var(--mat-sys-primary),
     foreground-color: var(--mat-sys-on-primary),
   ));
+  // The night theme sets a global dark --mat-icon-color that would otherwise win over
+  // the FAB foreground for the glyph; pin the icon to on-primary so it stays legible on
+  // the (dark-red, in night) primary container. No-op in light/dark where they match.
+  @include mat.icon-overrides((
+    color: var(--mat-sys-on-primary),
+  ));
 }
 
 .save {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -190,6 +190,7 @@ html {
     on-surface-variant: #831d1d,
     inverse-surface: #831d1d,
     primary: #831d1d,
+    on-primary: #ffdad4,
     outline: #831d1d,
     tertiary-fixed: var(--skip-contrast-color),
     tertiary-fixed-dim: var(--skip-contrast-color),


### PR DESCRIPTION
Closes #448.

The Cancel FAB's close icon was dark-red on dark-red (~1.6:1) in night mode.

## Root cause (two layers)
1. The `night-theme` overrides `--mat-sys-primary` to a dark red (`#831d1d`) but left the paired `--mat-sys-on-primary` at the generated dark value (`#640d06`) — a half-overridden role pair.
2. Even with the pair completed, the night theme sets a **global** `--mat-icon-color` (dark red, via `mat.icon-overrides`) that colours the actual `<mat-icon>` glyph and **wins over** the FAB's `on-primary` foreground. So fixing only the palette token would leave the glyph unchanged (the "correct attribute overridden downstream still ships a bug" trap).

## Fix (both parts)
- Complete the pair: night `on-primary` → `#ffdad4` (also fixes the notification badge's text-on-primary).
- Pin the `.cancel` FAB's icon colour to `on-primary` (`mat.icon-overrides`) so the **glyph** is light-on-dark. No change in light/dark, where `--mat-icon-color` isn't set and the icon already inherits `on-primary`.

`.save` was unaffected (its container is the light `primary-fixed`, so the global dark icon colour already reads on it).

## Verification
- `npm run ci` green (SCSS compiles; 1650 unit + 7 plugin + 33 mcp-schema).
- **Glyph colour confirmed in real Chromium** (the review caught that the token-only fix left the glyph dark): before = `rgb(82,0,0)` on `rgb(131,29,29)` (~1.6:1); after = `rgb(255,218,212)` (~7.5:1).
- Deployed to the boat for on-device confirmation of the Cancel icon in night mode.

The audit also found a **separate** night dark-on-dark bug in toasts/snackbars (`inverse-surface` half-overridden) that needs a component-scoped fix (its paired token doubles as a background elsewhere) — filed as #450, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Funf1XbakER2phRLQYdW5
