### PR TITLE
Make night-mode toasts legible (dark-on-dark text + close icon) (#450)

### DIFF
--- a/src/app/core/components/toast-snackbar/toast-snackbar.component.html
+++ b/src/app/core/components/toast-snackbar/toast-snackbar.component.html
@@ -6,7 +6,7 @@
      @if (severity() !== "message") {
       <div class="toast-title">{{ title() }}</div>
      }
-    <div matSnackBarLabel>{{ data.message }}</div>
+    <div matSnackBarLabel class="toast-message">{{ data.message }}</div>
     @if (hasAction()) {
       <div class="button-group">
         <button matButton="tonal" matSnackBarAction (click)="onActionClick()">{{ data.action }}</button>

--- a/src/app/core/components/toast-snackbar/toast-snackbar.component.scss
+++ b/src/app/core/components/toast-snackbar/toast-snackbar.component.scss
@@ -85,3 +85,14 @@
     height: 18px;
   }
 }
+
+// The night palette's inverse-on-surface is dark and doubles as a background fill in other
+// components, so it can't be brightened globally — re-point it for the toast subtree only.
+// .toast-message is needed because matSnackBarLabel carries its own colour resolved above this scope.
+:host-context(.night-theme) {
+  --mat-sys-inverse-on-surface: #ffdad4;
+  .toast,
+  .toast-message {
+    color: var(--mat-sys-inverse-on-surface);
+  }
+}

--- a/src/app/core/components/toast-snackbar/toast-snackbar.component.spec.ts
+++ b/src/app/core/components/toast-snackbar/toast-snackbar.component.spec.ts
@@ -36,6 +36,14 @@ describe('ToastSnackbarComponent', () => {
         expect((actionButton.nativeElement as HTMLButtonElement).textContent?.trim()).toBe('Enable Plugin');
     });
 
+    it('renders the message on the toast-message styling hook (anchors the night-mode override)', () => {
+        createComponent({ message: 'Saved', severity: 'success' });
+
+        const label = fixture.debugElement.query(By.css('div[matSnackBarLabel].toast-message'));
+        expect(label).toBeTruthy();
+        expect((label.nativeElement as HTMLElement).textContent?.trim()).toBe('Saved');
+    });
+
     it('does not render action button when action is missing', () => {
         createComponent({ message: 'Saved', severity: 'success' });
 


### PR DESCRIPTION
Closes #450.

In **red night mode** the snackbar container is `inverse-surface` (dark red, `#831d1d`) but the night palette leaves the paired `inverse-on-surface` dark (`#3a2e2c`) — so the toast **title, message, and close icon were dark-on-dark** (~1.35:1). `inverse-on-surface` also doubles as a *background fill* in ~4 other components, so it can't be brightened globally (why #448's blunt approach was split out here).

## Fix (component-scoped, red-night only)
Within `:host-context(.night-theme)`:
- Re-point `--mat-sys-inverse-on-surface` to a light tone (`#ffdad4`) for the toast subtree — fixes the **close icon** (which reads the token) without touching the 4 background consumers (they're outside the toast).
- Colour the **title** (inherited via `.toast`) and the **message** (a new `.toast-message` class that beats `matSnackBarLabel`'s own colour — custom-property substitution resolves the Material label token *above* this scope, so the token re-point alone doesn't reach it).

Only red night mode (`.night-theme` class) is affected; dim night mode uses the dark palette and was already fine.

## Verification
- `npm run ci` green (SCSS compiles; 1650 unit + 7 plugin + 33 mcp-schema).
- **Cascade verified in real Chromium** (two earlier reasoned cascades were wrong — the message label needed the explicit class): title / message / close-icon all resolve to `rgb(255,218,212)` (~7.5:1) on the `#831d1d` container.
- Deployed to the boat for on-device confirmation (trigger a night-mode toast).

## Noted (out of scope)
The severity **accent icon** (`--toast-color`) is dark for `error` (`#93000a`) and `success` (`#005500`) on the night toast — a separate accent-colour concern from the reported text/close-icon bug. The message text (the important part) is now legible; can tune the accent icons in a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Funf1XbakER2phRLQYdW5
