### PR TITLE
fix(widget-config): unhide stacked Display-tab controls

### DIFF
--- a/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.scss
+++ b/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.scss
@@ -9,8 +9,10 @@
 }
 
 .display-content {
+  // Content height, not 100%: a tab can stack several .display-content blocks
+  // (e.g. the update-interval block plus the main options block). Forcing each to
+  // full height makes the first fill the scroll area and pushes the rest off-screen.
   display: block;
-  height: 100%;
   width: 100%;
   padding-top: 15px;
   padding-bottom: 10px;

--- a/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.scss
+++ b/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.scss
@@ -23,7 +23,6 @@
 }
 
 .tab-group-content {
-  // height: calc(100% - 63px);
   overflow: hidden;
   width: 100%;
 }


### PR DESCRIPTION
## Problem

Opening a Compact Linear (and other) widget's **Settings → Display** tab showed only *Display update interval* and the stale-timeout checkbox. Widget Label, Color, Scale Start/End, Integer/Decimal Places, Unit Label, and Ignore Zones were all missing — on phones and on landscape tablets alike (not a width issue). The saved config was complete; the controls simply weren't visible.

## Root cause

The Display tab renders **two stacked `.display-content` blocks**: the update-interval block (added in `450a3333`) and the main options block. `.display-content` had `height: 100%` (from `eef85d73`, back when a tab held only one such block). With two stacked inside the scrollable, definite-height tab body, the first block — whose real content is tiny — expands to the full tab height and pushes the second block (all the real controls) entirely below the fold.

Confirmed by measuring the live dialog: the tab body was 552px tall, the first `.display-content` was 552px, and the second started at exactly y=898 (the bottom edge), with every control below it.

## Fix

Drop `height: 100%` from `.display-content` so each block sizes to its content and the tab body scrolls normally.

## Verification

- Reproduced against the **live dashboard** in a headless browser (real config + session): the controls were present in the DOM but positioned below the visible tab body.
- Injecting `height: auto` on the live dialog brought every control into view.
- Rebuilt production bundle: the compiled `.display-content` rule no longer carries `height:100%`, and the controls render in view.

No automated test accompanies this — it's a layout regression jsdom can't observe (no real layout/scroll), and the perf-harness dialog is content-sized so it doesn't hit the definite-height path. Verification was via the live headless repro above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tcpPFSkxPhYdBhBCrQ4Nn