### PR TITLE
feat: Event-driven page switching (PoC)

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -21,6 +21,7 @@ import { EmbedModeService } from './core/services/embed-mode.service';
 import { NotificationsService } from './core/services/notifications.service';
 import { ConfigurationUpgradeService } from './core/services/configuration-upgrade.service';
 import { RemoteDashboardsService } from './core/services/remote-dashboards.service';
+import { PageSwitchService } from './core/services/page-switch.service';
 import { ToastService } from './core/services/toast.service';
 import { ReloadService } from './core/services/reload.service';
 import { AppNetworkInitService, IBootstrapIssue } from './core/services/app-initNetwork.service';
@@ -49,6 +50,7 @@ export class AppComponent implements AfterViewInit, OnDestroy {
 
   private readonly _dashboard = inject(DashboardService);
   private readonly _remoteControl = inject(RemoteDashboardsService);
+  private readonly _pageSwitch = inject(PageSwitchService);
   private readonly toast = inject(ToastService);
   private readonly _reload = inject(ReloadService);
   private readonly _notifications = inject(NotificationsService);

--- a/src/app/core/components/dashboards-editor/dashboards-editor.component.spec.ts
+++ b/src/app/core/components/dashboards-editor/dashboards-editor.component.spec.ts
@@ -30,7 +30,7 @@ describe('DashboardsEditorComponent', () => {
   };
   let confirm$: Subject<boolean>;
   /** Result the (mocked) page-editor dialog emits on close; null = cancelled. */
-  let editorResult: { name: string; icon: string } | null;
+  let editorResult: { name: string; icon: string; trigger?: { path: string; value: string } | null } | null;
   let open: ReturnType<typeof vi.spyOn>;
 
   beforeEach(async () => {
@@ -102,9 +102,27 @@ describe('DashboardsEditorComponent', () => {
     call('onTileTap', 0, clickAt({ x: 0, y: 0 }));
     call('onPageAction', 'edit');
     expect(dialog.openDashboardPageEditorDialog).toHaveBeenCalledWith(
-      expect.objectContaining({ title: 'Page Options', name: 'Sailing' })
+      expect.objectContaining({ title: 'Page Options', name: 'Sailing', enableTrigger: true })
     );
-    expect(dashboard.update).toHaveBeenCalledWith(0, 'Sailing (renamed)', 'dashboard-map');
+    // No trigger returned -> cleared (null), preserving the four-arg update contract.
+    expect(dashboard.update).toHaveBeenCalledWith(0, 'Sailing (renamed)', 'dashboard-map', null);
+  });
+
+  it('forwards an auto-show trigger returned by the editor to update()', () => {
+    const trigger = { path: 'self.navigation.state', value: 'sailing' };
+    editorResult = { name: 'Sailing', icon: 'dashboard-sailing', trigger };
+    call('onTileTap', 0, clickAt({ x: 0, y: 0 }));
+    call('onPageAction', 'edit');
+    expect(dashboard.update).toHaveBeenCalledWith(0, 'Sailing', 'dashboard-sailing', trigger);
+  });
+
+  it('passes the existing trigger into the editor dialog', () => {
+    dashboard.dashboards.set([{ ...pages[0], trigger: { path: 'self.navigation.state', value: 'sailing' } }, pages[1]]);
+    call('onTileTap', 0, clickAt({ x: 0, y: 0 }));
+    call('onPageAction', 'edit');
+    expect(dialog.openDashboardPageEditorDialog).toHaveBeenCalledWith(
+      expect.objectContaining({ trigger: { path: 'self.navigation.state', value: 'sailing' } })
+    );
   });
 
   it('routes the duplicate action and applies the result', () => {

--- a/src/app/core/components/dashboards-editor/dashboards-editor.component.ts
+++ b/src/app/core/components/dashboards-editor/dashboards-editor.component.ts
@@ -90,11 +90,13 @@ export class DashboardsEditorComponent {
       title: 'Page Options',
       name: dashboard.name ?? '',
       icon: dashboard.icon || 'dashboard-dashboard',
+      enableTrigger: true,
+      trigger: dashboard.trigger ?? null,
       confirmBtnText: 'Save',
       cancelBtnText: 'Cancel'
     }).afterClosed().subscribe(data => {
       if (!data) { return } //clicked cancel
-      this._dashboard.update(itemIndex, data.name, data.icon);
+      this._dashboard.update(itemIndex, data.name, data.icon, data.trigger ?? null);
     });
   }
 

--- a/src/app/core/components/dialog-dashboard-page-editor/dialog-dashboard-page-editor.component.html
+++ b/src/app/core/components/dialog-dashboard-page-editor/dialog-dashboard-page-editor.component.html
@@ -21,6 +21,41 @@
         <select-icon [iconFile]="'assets/svg/icons.svg'" [currentIcon]="data.icon" (selectedIcon)="onIconSelected($event)"></select-icon>
       </div>
     </div>
+    @if (data.enableTrigger) {
+      <div class="field-margin trigger-section">
+        <mat-checkbox name="triggerEnabled" [(ngModel)]="triggerEnabled">
+          Auto-show this page on a Signal K value
+        </mat-checkbox>
+        @if (triggerEnabled) {
+          <div class="field-wrapper">
+            <mat-form-field class="field-flex">
+              <mat-label>Signal K path</mat-label>
+              <input matInput name="triggerPath" [(ngModel)]="triggerPath" (ngModelChange)="onPathChange()"
+                     [matAutocomplete]="pathAuto" aria-label="Auto-show Signal K path"/>
+              <mat-autocomplete #pathAuto="matAutocomplete">
+                @for (path of filteredPaths; track path) {
+                  <mat-option [value]="path">{{ path }}</mat-option>
+                }
+              </mat-autocomplete>
+              <mat-hint>e.g. self.navigation.state</mat-hint>
+            </mat-form-field>
+          </div>
+          <div class="field-wrapper">
+            <mat-form-field class="field-flex">
+              <mat-label>Value</mat-label>
+              <input matInput name="triggerValue" [(ngModel)]="triggerValue"
+                     [matAutocomplete]="valueAuto" aria-label="Auto-show trigger value"/>
+              <mat-autocomplete #valueAuto="matAutocomplete">
+                @for (option of filteredValueOptions; track option.value) {
+                  <mat-option [value]="option.value">{{ option.label }}</mat-option>
+                }
+              </mat-autocomplete>
+              <mat-hint>e.g. sailing</mat-hint>
+            </mat-form-field>
+          </div>
+        }
+      </div>
+    }
   </mat-dialog-content>
   <mat-dialog-actions align="end">
     <button mat-flat-button [mat-dialog-close]="false">{{data.cancelBtnText}}</button>

--- a/src/app/core/components/dialog-dashboard-page-editor/dialog-dashboard-page-editor.component.scss
+++ b/src/app/core/components/dialog-dashboard-page-editor/dialog-dashboard-page-editor.component.scss
@@ -43,3 +43,14 @@ max-height: max-content;
     font-weight: 400;
   }
 }
+
+.trigger-section {
+  mat-checkbox {
+    display: block;
+    margin-bottom: 8px;
+  }
+
+  .field-wrapper + .field-wrapper {
+    margin-top: 12px;
+  }
+}

--- a/src/app/core/components/dialog-dashboard-page-editor/dialog-dashboard-page-editor.component.spec.ts
+++ b/src/app/core/components/dialog-dashboard-page-editor/dialog-dashboard-page-editor.component.spec.ts
@@ -1,23 +1,159 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { DialogDashboardPageEditorComponent } from './dialog-dashboard-page-editor.component';
+import { DataService } from '../../services/data.service';
+import { DialogDashboardPageEditorData } from '../../interfaces/dialog-data';
+import { ISkMetadata } from '../../interfaces/signalk-interfaces';
+
+interface Testable {
+  triggerEnabled: boolean;
+  triggerPath: string;
+  triggerValue: string;
+  filteredPaths: string[];
+  filteredValueOptions: { value: string; label: string }[];
+  onPathChange(): void;
+  save(): void;
+}
 
 describe('DialogDashboardPageEditorComponent', () => {
-  let component: DialogDashboardPageEditorComponent;
   let fixture: ComponentFixture<DialogDashboardPageEditorComponent>;
+  let dialogRef: { close: ReturnType<typeof vi.fn> };
+  let data: Partial<DialogDashboardPageEditorData>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [DialogDashboardPageEditorComponent]
-    })
-    .compileComponents();
-
+  function setup(
+    dialogData: Partial<DialogDashboardPageEditorData>,
+    meta: ISkMetadata | null = null,
+    cachedPaths: string[] = []
+  ): Testable {
+    data = dialogData;
+    dialogRef = { close: vi.fn() };
+    const dataService = { getCachedPaths: () => cachedPaths, getPathMeta: () => meta };
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [DialogDashboardPageEditorComponent],
+      providers: [
+        { provide: MAT_DIALOG_DATA, useValue: data },
+        { provide: MatDialogRef, useValue: dialogRef },
+        { provide: DataService, useValue: dataService }
+      ]
+    });
     fixture = TestBed.createComponent(DialogDashboardPageEditorComponent);
-    component = fixture.componentInstance;
     fixture.detectChanges();
+    return fixture.componentInstance as unknown as Testable;
+  }
+
+  const meta = (values: { value: string | number | boolean; title?: string }[]): ISkMetadata =>
+    ({ possibleValues: values } as ISkMetadata);
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('creates with the trigger editor hidden in the plain (New Page) flow', () => {
+    setup({ title: 'New Page', name: 'Page 1', cancelBtnText: 'Cancel' });
+    expect(fixture.componentInstance).toBeTruthy();
+    expect((fixture.nativeElement as HTMLElement).querySelector('.trigger-section')).toBeNull();
+  });
+
+  it('prefills the trigger fields from an existing trigger', () => {
+    const c = setup({
+      title: 'Page Options', name: 'Sailing', cancelBtnText: 'Cancel',
+      enableTrigger: true, trigger: { path: 'self.navigation.state', value: 'sailing' }
+    });
+    expect(c.triggerEnabled).toBe(true);
+    expect(c.triggerPath).toBe('self.navigation.state');
+    expect(c.triggerValue).toBe('sailing');
+    expect((fixture.nativeElement as HTMLElement).querySelector('.trigger-section')).not.toBeNull();
+  });
+
+  it('maps possibleValues to option value (String) + label, storing the value not the title', () => {
+    const c = setup(
+      { title: 'Page Options', name: 'x', cancelBtnText: 'Cancel', enableTrigger: true, trigger: { path: 'self.navigation.state', value: '' } },
+      meta([{ value: 'sailing', title: 'Sailing' }, { value: 'motoring' }])
+    );
+    expect(c.filteredValueOptions).toEqual([
+      { value: 'sailing', label: 'Sailing' },
+      { value: 'motoring', label: 'motoring' }
+    ]);
+  });
+
+  it('coerces non-string possibleValues to strings', () => {
+    const c = setup(
+      { title: 'Page Options', name: 'x', cancelBtnText: 'Cancel', enableTrigger: true, trigger: { path: 'self.some.flag', value: '' } },
+      meta([{ value: true }, { value: 0 }])
+    );
+    expect(c.filteredValueOptions).toEqual([
+      { value: 'true', label: 'true' },
+      { value: '0', label: '0' }
+    ]);
+  });
+
+  it('keeps the entered value when the path changes', () => {
+    const c = setup(
+      { title: 'Page Options', name: 'x', cancelBtnText: 'Cancel', enableTrigger: true, trigger: { path: 'self.navigation.state', value: 'sailing' } },
+      meta([{ value: 'sailing' }])
+    );
+    c.triggerPath = 'self.some.other.path';
+    c.onPathChange();
+    expect(c.triggerValue).toBe('sailing');
+  });
+
+  it('closes with the entered trigger on save', () => {
+    const c = setup({
+      title: 'Page Options', name: 'Sailing', cancelBtnText: 'Cancel',
+      enableTrigger: true, trigger: { path: 'self.navigation.state', value: 'sailing' }
+    });
+    c.save();
+    expect(dialogRef.close).toHaveBeenCalledOnce();
+    expect(data.trigger).toEqual({ path: 'self.navigation.state', value: 'sailing' });
+  });
+
+  it('closes with a null trigger when the section is disabled', () => {
+    const c = setup({
+      title: 'Page Options', name: 'x', cancelBtnText: 'Cancel',
+      enableTrigger: true, trigger: { path: 'self.navigation.state', value: 'sailing' }
+    });
+    c.triggerEnabled = false;
+    c.save();
+    expect(data.trigger).toBeNull();
+  });
+
+  it('clears the trigger when path or value is left empty', () => {
+    const c = setup({
+      title: 'Page Options', name: 'x', cancelBtnText: 'Cancel',
+      enableTrigger: true, trigger: { path: 'self.navigation.state', value: 'sailing' }
+    });
+    c.triggerValue = '   ';
+    c.save();
+    expect(data.trigger).toBeNull();
+  });
+
+  it('does not touch the trigger in the New Page flow (enableTrigger off)', () => {
+    const c = setup({ title: 'New Page', name: 'Page 1', cancelBtnText: 'Cancel' });
+    c.save();
+    expect(data.trigger).toBeUndefined();
+  });
+
+  it('sorts the path suggestions alphabetically', () => {
+    const c = setup(
+      { title: 'Page Options', name: 'x', cancelBtnText: 'Cancel', enableTrigger: true, trigger: { path: '', value: '' } },
+      null, ['self.navigation.state', 'self.environment.depth', 'self.electrical.batteries.house.voltage']
+    );
+    expect(c.filteredPaths).toEqual([
+      'self.electrical.batteries.house.voltage',
+      'self.environment.depth',
+      'self.navigation.state'
+    ]);
+  });
+
+  it('filters and caps path suggestions to the typed substring', () => {
+    const paths = Array.from({ length: 60 }, (_, i) => `self.navigation.item${i}`);
+    paths.push('self.environment.depth');
+    const c = setup(
+      { title: 'Page Options', name: 'x', cancelBtnText: 'Cancel', enableTrigger: true, trigger: { path: 'environment', value: '' } },
+      null, paths
+    );
+    expect(c.filteredPaths).toEqual(['self.environment.depth']);
   });
 });

--- a/src/app/core/components/dialog-dashboard-page-editor/dialog-dashboard-page-editor.component.ts
+++ b/src/app/core/components/dialog-dashboard-page-editor/dialog-dashboard-page-editor.component.ts
@@ -6,31 +6,98 @@ import type { DialogDashboardPageEditorData } from '../../interfaces/dialog-data
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatInputModule } from '@angular/material/input';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
+import { MatCheckboxModule } from '@angular/material/checkbox';
 import { SelectIconComponent } from '../select-icon/select-icon.component';
+import { DataService } from '../../services/data.service';
+import { IPageSwitchTrigger } from '../../services/dashboard.service';
+
+/** A path value the user can pick as a trigger: the string we store plus a friendly label. */
+interface ValueOption {
+  value: string;
+  label: string;
+}
+
+const MAX_PATH_SUGGESTIONS = 50;
 
 @Component({
   selector: 'dialog-dashboard-page-editor',
   standalone: true,
-  imports: [ MatDialogModule, MatIconModule, MatFormFieldModule, MatInputModule, MatButtonModule, FormsModule, SelectIconComponent ],
+  imports: [MatDialogModule, MatIconModule, MatFormFieldModule, MatInputModule, MatButtonModule, MatAutocompleteModule, MatCheckboxModule, FormsModule, SelectIconComponent],
   templateUrl: './dialog-dashboard-page-editor.component.html',
   styleUrl: './dialog-dashboard-page-editor.component.scss'
 })
 export class DialogDashboardPageEditorComponent {
   protected dialogRef = inject<MatDialogRef<DialogDashboardPageEditorComponent>>(MatDialogRef);
   protected data = inject<DialogDashboardPageEditorData>(MAT_DIALOG_DATA);
+  private readonly _data = inject(DataService);
+
+  protected triggerEnabled = false;
+  protected triggerPath = '';
+  protected triggerValue = '';
+  private readonly _pathOptions: string[] = [];
+  private _valueOptions: ValueOption[] = [];
 
   constructor() {
-    // Set default icon if not provided
     if (!this.data.icon) {
       this.data.icon = 'dashboard-dashboard';
     }
+    const trigger = this.data.trigger;
+    if (trigger) {
+      this.triggerEnabled = true;
+      this.triggerPath = trigger.path;
+      this.triggerValue = trigger.value;
+    }
+    this._pathOptions = this._data.getCachedPaths(true).slice().sort((a, b) => a.localeCompare(b));
+    this.refreshValueOptions();
   }
 
-  protected save(): void {
-    this.dialogRef.close(this.data);
+  /** Paths matching the current input; capped so the list stays usable. */
+  protected get filteredPaths(): string[] {
+    const needle = this.triggerPath.trim().toLowerCase();
+    const matches = needle ? this._pathOptions.filter(p => p.toLowerCase().includes(needle)) : this._pathOptions;
+    return matches.slice(0, MAX_PATH_SUGGESTIONS);
+  }
+
+  /** Known values for the chosen path, filtered by what the user has typed. */
+  protected get filteredValueOptions(): ValueOption[] {
+    const needle = this.triggerValue.trim().toLowerCase();
+    if (!needle) return this._valueOptions;
+    return this._valueOptions.filter(o => o.value.toLowerCase().includes(needle) || o.label.toLowerCase().includes(needle));
+  }
+
+  /** Re-read the chosen path's possibleValues, but keep whatever value the user already entered. */
+  protected onPathChange(): void {
+    this.refreshValueOptions();
   }
 
   protected onIconSelected(icon: string): void {
     this.data.icon = icon;
+  }
+
+  protected save(): void {
+    // Only touch the trigger when this dialog is in the trigger-editing flow, so the
+    // New Page / Duplicate flows leave it untouched.
+    if (this.data.enableTrigger) {
+      this.data.trigger = this.buildTrigger();
+    }
+    this.dialogRef.close(this.data);
+  }
+
+  private refreshValueOptions(): void {
+    const meta = this.triggerPath.trim() ? this._data.getPathMeta(this.triggerPath.trim()) : null;
+    // Store the String()-coerced value (never the human title) so it matches the live path value.
+    this._valueOptions = (meta?.possibleValues ?? []).map(pv => ({
+      value: String(pv.value),
+      label: pv.title ?? String(pv.value)
+    }));
+  }
+
+  private buildTrigger(): IPageSwitchTrigger | null {
+    if (!this.triggerEnabled) return null;
+    const path = this.triggerPath.trim();
+    const value = this.triggerValue.trim();
+    if (!path || !value) return null;
+    return { path, value };
   }
 }

--- a/src/app/core/interfaces/dialog-data.ts
+++ b/src/app/core/interfaces/dialog-data.ts
@@ -1,4 +1,5 @@
 import { ComponentType } from "@angular/cdk/portal";
+import type { IPageSwitchTrigger } from "../services/dashboard.service";
 
 export interface DialogConfirmationData {
   title: string;
@@ -28,6 +29,10 @@ export interface DialogDashboardPageEditorData {
   title: string;
   name: string;
   icon?: string;
+  /** When true, the dialog shows the auto-show trigger editor (edit flow only). */
+  enableTrigger?: boolean;
+  /** Current auto-show trigger for the edit flow; null/undefined = none. Read back on save. */
+  trigger?: IPageSwitchTrigger | null;
   confirmBtnText?: string;
   cancelBtnText: string;
 }

--- a/src/app/core/services/dashboard.service.spec.ts
+++ b/src/app/core/services/dashboard.service.spec.ts
@@ -6,7 +6,7 @@ import { ActivatedRouteSnapshot, convertToParamMap, NavigationEnd, Router } from
 import { NgGridStackWidget } from 'gridstack/dist/angular';
 import { DefaultDashboard } from '../../../default-config/config.blank.dashboard';
 import { SettingsService } from './settings.service';
-import { Dashboard, DashboardService, widgetOperation } from './dashboard.service';
+import { Dashboard, DashboardService, IPageSwitchTrigger, widgetOperation } from './dashboard.service';
 import { EmbedModeService } from './embed-mode.service';
 import { StorageService } from './storage.service';
 
@@ -233,6 +233,60 @@ describe('DashboardService', () => {
       expect(updated.id).toBe('d-0');
       expect(updated.configuration).toBe(config);
       expect(service.dashboards()[1].name).toBe('Two');
+    });
+  });
+
+  describe('page-switch trigger', () => {
+    const trigger: IPageSwitchTrigger = { path: 'self.navigation.state', value: 'sailing' };
+
+    it('sets a trigger on the target page only when update is given one', () => {
+      setup([makeDashboard('d-0', 'One'), makeDashboard('d-1', 'Two')]);
+      service.update(0, 'One', 'dashboard-dashboard', trigger);
+      expect(service.dashboards()[0].trigger).toEqual(trigger);
+      expect(service.dashboards()[1].trigger).toBeUndefined();
+    });
+
+    it('leaves an existing trigger untouched when update omits the argument', () => {
+      setup([makeDashboard('d-0', 'One')]);
+      service.update(0, 'One', 'icon', trigger);
+      service.update(0, 'Renamed', 'icon-2');
+      expect(service.dashboards()[0].name).toBe('Renamed');
+      expect(service.dashboards()[0].trigger).toEqual(trigger);
+    });
+
+    it('clears the trigger when update is given null', () => {
+      setup([makeDashboard('d-0', 'One')]);
+      service.update(0, 'One', 'icon', trigger);
+      service.update(0, 'One', 'icon', null);
+      expect(service.dashboards()[0].trigger).toBeUndefined();
+    });
+
+    it('clears the trigger when given an empty path or value', () => {
+      setup([makeDashboard('d-0', 'One')]);
+      service.update(0, 'One', 'icon', trigger);
+      service.update(0, 'One', 'icon', { path: '', value: '' });
+      expect(service.dashboards()[0].trigger).toBeUndefined();
+    });
+
+    it('does not copy the trigger onto a duplicated page', () => {
+      setup([{ ...makeDashboard('d-src', 'Source', [makeWidget('w-src')]), trigger }]);
+      service.duplicate(0, 'Copy', 'icon');
+      expect(service.dashboards()[0].trigger).toEqual(trigger);
+      expect(service.dashboards()[1].trigger).toBeUndefined();
+    });
+
+    it('adds new pages without a trigger', () => {
+      setup();
+      service.add('Fresh', []);
+      expect(service.dashboards().at(-1)!.trigger).toBeUndefined();
+    });
+
+    it('persists the trigger through the save effect', () => {
+      setup([makeDashboard('d-0', 'One')]);
+      service.update(0, 'One', 'icon', trigger);
+      TestBed.tick();
+      const lastSaved = settings.saveDashboards.mock.lastCall![0];
+      expect(lastSaved[0].trigger).toEqual(trigger);
     });
   });
 

--- a/src/app/core/services/dashboard.service.spec.ts
+++ b/src/app/core/services/dashboard.service.spec.ts
@@ -268,6 +268,16 @@ describe('DashboardService', () => {
       expect(service.dashboards()[0].trigger).toBeUndefined();
     });
 
+    it('clears the trigger when only one of path/value is empty (half-formed)', () => {
+      setup([makeDashboard('d-0', 'One')]);
+      service.update(0, 'One', 'icon', trigger);
+      service.update(0, 'One', 'icon', { path: 'self.navigation.state', value: '' });
+      expect(service.dashboards()[0].trigger).toBeUndefined();
+      service.update(0, 'One', 'icon', trigger);
+      service.update(0, 'One', 'icon', { path: '', value: 'sailing' });
+      expect(service.dashboards()[0].trigger).toBeUndefined();
+    });
+
     it('does not copy the trigger onto a duplicated page', () => {
       setup([{ ...makeDashboard('d-src', 'Source', [makeWidget('w-src')]), trigger }]);
       service.duplicate(0, 'Copy', 'icon');

--- a/src/app/core/services/dashboard.service.ts
+++ b/src/app/core/services/dashboard.service.ts
@@ -12,11 +12,20 @@ import { EmbedModeService } from './embed-mode.service';
 import { StorageService } from './storage.service';
 import { dashboardsRequireRemoteContexts } from '../utils/remote-context-demand.util';
 
+/** An optional rule that auto-shows a page when a Signal K path reaches a value. */
+export interface IPageSwitchTrigger {
+  /** Full self-prefixed Signal K path, e.g. `self.navigation.state`. */
+  path: string;
+  /** The value (as a string) the path must equal to switch to this page. */
+  value: string;
+}
+
 export interface Dashboard {
   id: string
   name?: string;
   icon?: string;
   configuration?: NgGridStackWidget[] | [];
+  trigger?: IPageSwitchTrigger;
 }
 
 export interface widgetOperation {
@@ -213,13 +222,29 @@ export class DashboardService {
    *  - change the dashboard id
    *  - alter the widget configuration array
    *
+   * The optional page-switch `trigger` follows three-state semantics:
+   *  - a valid `{ path, value }` (both non-empty) sets it,
+   *  - `null` or an empty path/value clears it,
+   *  - `undefined` (argument omitted) leaves any existing trigger untouched.
+   *
    * @param itemIndex Index of the dashboard to update (0-based).
    * @param name New display name.
    * @param icon New icon key (fallback to 'dashboard-dashboard').
+   * @param trigger New auto-show trigger, `null`/empty to clear, omitted to leave as-is.
    */
-  public update(itemIndex: number, name: string, icon: string): void {
-    this.dashboards.update(dashboards => dashboards.map((dashboard, i) =>
-      i === itemIndex ? { ...dashboard, name: name, icon: icon ?? 'dashboard-dashboard' } : dashboard));
+  public update(itemIndex: number, name: string, icon: string, trigger?: IPageSwitchTrigger | null): void {
+    this.dashboards.update(dashboards => dashboards.map((dashboard, i) => {
+      if (i !== itemIndex) return dashboard;
+      const next: Dashboard = { ...dashboard, name: name, icon: icon ?? 'dashboard-dashboard' };
+      if (trigger !== undefined) {
+        if (trigger && trigger.path.trim() !== '' && trigger.value.trim() !== '') {
+          next.trigger = { path: trigger.path, value: trigger.value };
+        } else {
+          delete next.trigger;
+        }
+      }
+      return next;
+    }));
   }
 
   /**
@@ -282,6 +307,9 @@ export class DashboardService {
     newDashboard.id = UUID.create();
     newDashboard.name = newName;
     newDashboard.icon = newIcon || 'dashboard-dashboard';
+    // A page's auto-show trigger is its identity, not layout: a duplicate must not
+    // silently compete for the same Signal K state.
+    delete newDashboard.trigger;
 
     if (Array.isArray(newDashboard.configuration)) {
       newDashboard.configuration.forEach((widget: NgGridStackWidget) => {

--- a/src/app/core/services/page-switch.service.spec.ts
+++ b/src/app/core/services/page-switch.service.spec.ts
@@ -23,6 +23,7 @@ class DashboardStub {
   dashboards = signal<Dashboard[]>([]);
   activeDashboard = signal<number | null>(0);
   isDashboardStatic = signal<boolean>(true);
+  isPageTransitioning = signal<boolean>(false);
   navigateTo: Mock = vi.fn();
 }
 
@@ -240,11 +241,100 @@ describe('PageSwitchService', () => {
     expect(dashboard.navigateTo).toHaveBeenCalledWith(1); // immediate startup jump
     dashboard.navigateTo.mockClear();
 
-    // User swipes to another page; the state has not changed.
+    // User swipes to another page; the state has not changed. TestBed.tick() flushes the
+    // startup effect so this actually exercises the _startupHandled once-guard, not just the
+    // absence of an armed dwell.
     dashboard.activeDashboard.set(2);
+    TestBed.tick();
     dwell(); // advance well past any dwell window
 
-    expect(dashboard.navigateTo).not.toHaveBeenCalled(); // no delayed re-switch
+    expect(dashboard.navigateTo).not.toHaveBeenCalled(); // no delayed re-switch, no re-evaluate
+  });
+
+  it('treats a late first matching value (arriving after startup) as a dwelled, cued change', () => {
+    dashboard.dashboards.set([page('p0', 'Zero'), page('p1', 'Sailing', trig(STATE, 'sailing'))]);
+    dashboard.activeDashboard.set(0);
+    create(); // startup handled; STATE has no value yet
+
+    data.push(STATE, 'sailing'); // STATE's first value, arriving after startup
+    expect(dashboard.navigateTo).not.toHaveBeenCalled(); // NOT an immediate silent jump
+
+    dwell();
+    expect(dashboard.navigateTo).toHaveBeenCalledTimes(1);
+    expect(dashboard.navigateTo).toHaveBeenCalledWith(1);
+    expect(snackBar.open).toHaveBeenCalledOnce(); // cued, like any runtime change
+  });
+
+  it('a late first value on one path never silently switches to another path\'s matching page', () => {
+    dashboard.dashboards.set([
+      page('p0', 'Zero'),
+      page('p1', 'Sailing', trig(STATE, 'sailing')),
+      page('p2', 'Shallow', trig(DEPTH, '3'))
+    ]);
+    dashboard.activeDashboard.set(0);
+    data.push(STATE, 'sailing'); // sailing already true at startup
+    create();
+    expect(dashboard.navigateTo).toHaveBeenCalledWith(1); // startup jump to Sailing
+
+    dashboard.activeDashboard.set(0); // user swipes back to page 0
+    dashboard.navigateTo.mockClear();
+    snackBar.open.mockClear();
+
+    data.push(DEPTH, '5'); // DEPTH's first value, non-matching, arriving after startup
+    dwell();
+    expect(dashboard.navigateTo).not.toHaveBeenCalled(); // must NOT re-switch to the still-matching Sailing page
+  });
+
+  it('cancels a pending dwell when the trigger path is removed mid-dwell', () => {
+    dashboard.dashboards.set([page('p0', 'Zero'), page('p1', 'Sailing', trig(STATE, 'sailing'))]);
+    create();
+    baseline(STATE, 'moored');
+    data.push(STATE, 'sailing'); // arms the dwell
+
+    dashboard.dashboards.set([page('p0', 'Zero'), page('p1', 'Plain')]); // trigger removed
+    TestBed.tick();
+    dwell();
+
+    expect(dashboard.navigateTo).not.toHaveBeenCalled();
+  });
+
+  it('cancels the pending switch when the value clears to null before the dwell', () => {
+    dashboard.dashboards.set([page('p0', 'Zero'), page('p1', 'Sailing', trig(STATE, 'sailing'))]);
+    create();
+    baseline(STATE, 'moored');
+    data.push(STATE, 'sailing');
+    vi.advanceTimersByTime(PAGE_SWITCH_DWELL_MS - 1);
+    data.push(STATE, null); // cleared before it held for the dwell
+    dwell();
+
+    expect(dashboard.navigateTo).not.toHaveBeenCalled();
+  });
+
+  it('re-fires after the value clears to null and returns', () => {
+    dashboard.dashboards.set([page('p0', 'Zero'), page('p1', 'Sailing', trig(STATE, 'sailing'))]);
+    create();
+    baseline(STATE, 'moored');
+    data.push(STATE, 'sailing');
+    dwell();
+    expect(dashboard.navigateTo).toHaveBeenCalledTimes(1);
+
+    data.push(STATE, null); // cleared
+    data.push(STATE, 'sailing'); // re-asserted
+    dwell();
+    expect(dashboard.navigateTo).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not switch or cue while a page transition is in flight', () => {
+    dashboard.dashboards.set([page('p0', 'Zero'), page('p1', 'Sailing', trig(STATE, 'sailing'))]);
+    dashboard.isPageTransitioning.set(true);
+    create();
+    baseline(STATE, 'moored');
+
+    data.push(STATE, 'sailing');
+    dwell();
+
+    expect(dashboard.navigateTo).not.toHaveBeenCalled();
+    expect(snackBar.open).not.toHaveBeenCalled();
   });
 
   it('performs the startup jump once a page becomes active when the value was seeded first', () => {

--- a/src/app/core/services/page-switch.service.spec.ts
+++ b/src/app/core/services/page-switch.service.spec.ts
@@ -1,0 +1,305 @@
+import type { Mock } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { signal } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { PageSwitchService, PAGE_SWITCH_DWELL_MS } from './page-switch.service';
+import { Dashboard, DashboardService, IPageSwitchTrigger } from './dashboard.service';
+import { DataService, IPathUpdate } from './data.service';
+import { uiEventService } from './uiEvent.service';
+import { EmbedModeService } from './embed-mode.service';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { States } from '../interfaces/signalk-interfaces';
+
+const STATE = 'self.navigation.state';
+const DEPTH = 'self.environment.depth.belowKeel';
+
+const trig = (path: string, value: string): IPageSwitchTrigger => ({ path, value });
+const page = (id: string, name: string, trigger?: IPageSwitchTrigger): Dashboard =>
+  ({ id, name, icon: 'x', configuration: [], ...(trigger ? { trigger } : {}) });
+const asUpdate = (value: unknown): IPathUpdate => ({ data: { value, timestamp: null }, state: States.Normal });
+
+class DashboardStub {
+  dashboards = signal<Dashboard[]>([]);
+  activeDashboard = signal<number | null>(0);
+  isDashboardStatic = signal<boolean>(true);
+  navigateTo: Mock = vi.fn();
+}
+
+class DataStub {
+  readonly subjects = new Map<string, BehaviorSubject<IPathUpdate>>();
+  readonly released: string[] = [];
+
+  acquirePath(path: string): { data$: Observable<IPathUpdate>; release: () => void } {
+    return { data$: this.subject(path).asObservable(), release: () => this.released.push(path) };
+  }
+  /** Set a path's value; when called before the service subscribes it becomes the replayed seed. */
+  push(path: string, value: unknown): void { this.subject(path).next(asUpdate(value)); }
+  observed(path: string): boolean { return this.subjects.get(path)?.observed ?? false; }
+
+  private subject(path: string): BehaviorSubject<IPathUpdate> {
+    let s = this.subjects.get(path);
+    if (!s) { s = new BehaviorSubject<IPathUpdate>(asUpdate(null)); this.subjects.set(path, s); }
+    return s;
+  }
+}
+
+describe('PageSwitchService', () => {
+  let dashboard: DashboardStub;
+  let data: DataStub;
+  let dragging: ReturnType<typeof signal<boolean>>;
+  let embed: boolean;
+  let snackBar: { open: Mock };
+
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    dashboard = new DashboardStub();
+    data = new DataStub();
+    dragging = signal(false);
+    embed = false;
+    snackBar = { open: vi.fn() };
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: DashboardService, useValue: dashboard },
+        { provide: DataService, useValue: data },
+        { provide: uiEventService, useValue: { isDragging: dragging } },
+        { provide: EmbedModeService, useValue: { embed: () => embed, profile: () => null } },
+        { provide: MatSnackBar, useValue: snackBar }
+      ]
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  function create(): PageSwitchService {
+    const service = TestBed.inject(PageSwitchService);
+    TestBed.tick(); // flush the subscription + startup effects
+    return service;
+  }
+  const dwell = (): void => { vi.advanceTimersByTime(PAGE_SWITCH_DWELL_MS); };
+  /** Establish a path's baseline real value (no switch, no dwell) so the next push is a change. */
+  const baseline = (path: string, value: string): void => { data.push(path, value); };
+
+  it('switches with a cue after a runtime change holds for the dwell', () => {
+    dashboard.dashboards.set([page('p0', 'Zero'), page('p1', 'Sailing', trig(STATE, 'sailing'))]);
+    create();
+    baseline(STATE, 'moored');
+
+    data.push(STATE, 'sailing');
+    expect(dashboard.navigateTo).not.toHaveBeenCalled(); // still within the dwell
+
+    dwell();
+    expect(dashboard.navigateTo).toHaveBeenCalledTimes(1);
+    expect(dashboard.navigateTo).toHaveBeenCalledWith(1);
+    expect(snackBar.open).toHaveBeenCalledOnce();
+  });
+
+  it('cancels the pending switch when the value flaps to a non-matching value before the dwell', () => {
+    dashboard.dashboards.set([page('p0', 'Zero'), page('p1', 'Sailing', trig(STATE, 'sailing'))]);
+    create();
+    baseline(STATE, 'moored');
+
+    data.push(STATE, 'sailing');
+    vi.advanceTimersByTime(PAGE_SWITCH_DWELL_MS - 1);
+    data.push(STATE, 'anchored');
+    dwell();
+
+    expect(dashboard.navigateTo).not.toHaveBeenCalled();
+  });
+
+  it('re-arms to the latest matching value when it changes before the dwell elapses', () => {
+    dashboard.dashboards.set([
+      page('p0', 'Zero'),
+      page('p1', 'Sailing', trig(STATE, 'sailing')),
+      page('p2', 'Motoring', trig(STATE, 'motoring'))
+    ]);
+    create();
+    baseline(STATE, 'anchored');
+
+    data.push(STATE, 'sailing');
+    vi.advanceTimersByTime(PAGE_SWITCH_DWELL_MS - 1);
+    data.push(STATE, 'motoring');
+    dwell();
+
+    expect(dashboard.navigateTo).toHaveBeenCalledTimes(1);
+    expect(dashboard.navigateTo).toHaveBeenCalledWith(2);
+  });
+
+  it('does not re-fire while a matching value simply persists (edge dedupe)', () => {
+    dashboard.dashboards.set([page('p0', 'Zero'), page('p1', 'Sailing', trig(STATE, 'sailing'))]);
+    create();
+    baseline(STATE, 'moored');
+
+    data.push(STATE, 'sailing');
+    dwell();
+    data.push(STATE, 'sailing'); // identical replay
+    dwell();
+
+    expect(dashboard.navigateTo).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires again when the value leaves and re-enters the trigger value', () => {
+    dashboard.dashboards.set([page('p0', 'Zero'), page('p1', 'Sailing', trig(STATE, 'sailing'))]);
+    create();
+    baseline(STATE, 'moored');
+
+    data.push(STATE, 'sailing');
+    dwell();
+    data.push(STATE, 'moored');
+    dwell();
+    data.push(STATE, 'sailing');
+    dwell();
+
+    expect(dashboard.navigateTo).toHaveBeenCalledTimes(2);
+    expect(dashboard.navigateTo).toHaveBeenLastCalledWith(1);
+  });
+
+  it('does not switch on a runtime change while the dashboard is being edited', () => {
+    dashboard.dashboards.set([page('p0', 'Zero'), page('p1', 'Sailing', trig(STATE, 'sailing'))]);
+    dashboard.isDashboardStatic.set(false);
+    create();
+    baseline(STATE, 'moored');
+
+    data.push(STATE, 'sailing');
+    dwell();
+
+    expect(dashboard.navigateTo).not.toHaveBeenCalled();
+  });
+
+  it('does not switch on a runtime change while a drag is in progress', () => {
+    dashboard.dashboards.set([page('p0', 'Zero'), page('p1', 'Sailing', trig(STATE, 'sailing'))]);
+    dragging.set(true);
+    create();
+    baseline(STATE, 'moored');
+
+    data.push(STATE, 'sailing');
+    dwell();
+
+    expect(dashboard.navigateTo).not.toHaveBeenCalled();
+  });
+
+  it('ignores a value that no page is configured for', () => {
+    dashboard.dashboards.set([page('p0', 'Zero'), page('p1', 'Sailing', trig(STATE, 'sailing'))]);
+    create();
+    baseline(STATE, 'moored');
+
+    data.push(STATE, 'anchored');
+    dwell();
+
+    expect(dashboard.navigateTo).not.toHaveBeenCalled();
+  });
+
+  it('picks the first page in order when several match the same value', () => {
+    dashboard.dashboards.set([
+      page('p0', 'Zero'),
+      page('p1', 'Sailing A', trig(STATE, 'sailing')),
+      page('p2', 'Sailing B', trig(STATE, 'sailing'))
+    ]);
+    create();
+    baseline(STATE, 'moored');
+
+    data.push(STATE, 'sailing');
+    dwell();
+
+    expect(dashboard.navigateTo).toHaveBeenCalledTimes(1);
+    expect(dashboard.navigateTo).toHaveBeenCalledWith(1);
+  });
+
+  it('does not switch when the matching page is already active', () => {
+    dashboard.dashboards.set([page('p0', 'Sailing', trig(STATE, 'sailing')), page('p1', 'Other')]);
+    dashboard.activeDashboard.set(0);
+    create();
+    baseline(STATE, 'moored');
+
+    data.push(STATE, 'sailing');
+    dwell();
+
+    expect(dashboard.navigateTo).not.toHaveBeenCalled();
+    expect(snackBar.open).not.toHaveBeenCalled();
+  });
+
+  it('jumps immediately and silently to a page whose value is already true at startup', () => {
+    dashboard.dashboards.set([page('p0', 'Zero'), page('p1', 'Sailing', trig(STATE, 'sailing')), page('p2', 'Two')]);
+    dashboard.activeDashboard.set(0);
+    data.push(STATE, 'sailing'); // already true, seeded before the service subscribes
+    create();
+
+    expect(dashboard.navigateTo).toHaveBeenCalledTimes(1);
+    expect(dashboard.navigateTo).toHaveBeenCalledWith(1);
+    expect(snackBar.open).not.toHaveBeenCalled(); // startup jump is silent
+  });
+
+  it('does not re-switch later for a value that was already true at startup (the swipe-away bug)', () => {
+    dashboard.dashboards.set([page('p0', 'Zero'), page('p1', 'Sailing', trig(STATE, 'sailing')), page('p2', 'Two')]);
+    dashboard.activeDashboard.set(0);
+    data.push(STATE, 'sailing'); // already true at startup
+    create();
+    expect(dashboard.navigateTo).toHaveBeenCalledWith(1); // immediate startup jump
+    dashboard.navigateTo.mockClear();
+
+    // User swipes to another page; the state has not changed.
+    dashboard.activeDashboard.set(2);
+    dwell(); // advance well past any dwell window
+
+    expect(dashboard.navigateTo).not.toHaveBeenCalled(); // no delayed re-switch
+  });
+
+  it('performs the startup jump once a page becomes active when the value was seeded first', () => {
+    dashboard.dashboards.set([page('p0', 'Zero'), page('p1', 'Sailing', trig(STATE, 'sailing'))]);
+    dashboard.activeDashboard.set(null);
+    data.push(STATE, 'sailing');
+    create();
+    expect(dashboard.navigateTo).not.toHaveBeenCalled(); // no page active yet
+
+    dashboard.activeDashboard.set(0);
+    TestBed.tick();
+
+    expect(dashboard.navigateTo).toHaveBeenCalledTimes(1);
+    expect(dashboard.navigateTo).toHaveBeenCalledWith(1);
+    expect(snackBar.open).not.toHaveBeenCalled();
+  });
+
+  it('tears down the subscription (unsubscribe + release) when a trigger path is removed', () => {
+    dashboard.dashboards.set([page('p0', 'Sailing', trig(STATE, 'sailing'))]);
+    create();
+    expect(data.observed(STATE)).toBe(true);
+
+    dashboard.dashboards.set([page('p0', 'Plain')]); // trigger removed
+    TestBed.tick();
+
+    expect(data.released).toContain(STATE);
+    expect(data.observed(STATE)).toBe(false);
+
+    data.push(STATE, 'sailing');
+    dwell();
+    expect(dashboard.navigateTo).not.toHaveBeenCalled();
+  });
+
+  it('rebuilds subscriptions only when the set of trigger paths changes', () => {
+    dashboard.dashboards.set([page('p0', 'Sailing', trig(STATE, 'sailing'))]);
+    create();
+    expect(data.observed(STATE)).toBe(true);
+
+    dashboard.dashboards.set([
+      page('p0', 'Sailing', trig(STATE, 'sailing')),
+      page('p1', 'Shallow', trig(DEPTH, '3'))
+    ]);
+    TestBed.tick();
+    expect(data.observed(DEPTH)).toBe(true);
+    expect(data.released).not.toContain(STATE);
+  });
+
+  it('is completely inert in embed mode', () => {
+    embed = true;
+    dashboard.dashboards.set([page('p0', 'Zero'), page('p1', 'Sailing', trig(STATE, 'sailing'))]);
+    create();
+
+    expect(data.observed(STATE)).toBe(false);
+    data.push(STATE, 'sailing');
+    dwell();
+    expect(dashboard.navigateTo).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/core/services/page-switch.service.ts
+++ b/src/app/core/services/page-switch.service.ts
@@ -92,38 +92,48 @@ export class PageSwitchService {
   }
 
   private teardown(watch: PathWatch): void {
-    if (watch.dwellTimer) clearTimeout(watch.dwellTimer);
+    this.cancelDwell(watch);
     // release() alone only decrements the shared refcount; unsubscribe stops OUR handler.
     watch.sub.unsubscribe();
     watch.release();
+  }
+
+  private cancelDwell(watch: PathWatch): void {
+    if (watch.dwellTimer) {
+      clearTimeout(watch.dwellTimer);
+      watch.dwellTimer = undefined;
+    }
   }
 
   private onUpdate(path: string, update: IPathUpdate): void {
     const watch = this._watches.get(path);
     if (!watch) return;
     const value = update.data.value;
-    if (value == null) return; // ignore the no-value seed / a path being cleared
+
+    if (value == null) {
+      // A cleared value cancels any pending switch and resets the baseline, so a later
+      // re-assertion of the same value is seen as a fresh change rather than deduped away.
+      this.cancelDwell(watch);
+      watch.value = UNSET;
+      return;
+    }
     if (Object.is(value, watch.value)) return; // dedupe replays / unchanged
+
     const firstValue = watch.value === UNSET;
     watch.value = value;
 
-    if (firstValue) {
-      // A value that was already true when we started watching is a baseline, not a change:
-      // never arm the dwell. If startup is already past (a late-arriving first value), jump to it
-      // immediately; otherwise the startup effect handles it once a page is active.
-      if (this._startupHandled) this.evaluateCurrentValues();
-      return;
-    }
+    // Before startup is handled, a path's first value is only a baseline: the startup effect
+    // performs the one-time silent jump. A first value arriving AFTER startup is a genuine
+    // (late) change and takes the normal dwell + cue path below, scoped to this path — never a
+    // global re-evaluate, which could silently switch to an unrelated already-matching page.
+    if (firstValue && !this._startupHandled) return;
 
     if (!this.hasMatchingPage(path, value)) {
-      if (watch.dwellTimer) {
-        clearTimeout(watch.dwellTimer);
-        watch.dwellTimer = undefined;
-      }
+      this.cancelDwell(watch);
       return;
     }
 
-    if (watch.dwellTimer) clearTimeout(watch.dwellTimer);
+    this.cancelDwell(watch);
     watch.dwellTimer = setTimeout(() => this.onDwellElapsed(path, value), PAGE_SWITCH_DWELL_MS);
   }
 
@@ -152,7 +162,9 @@ export class PageSwitchService {
    * passes false so opening the app lands on the right page silently.
    */
   private switchTo(idx: number, notify: boolean): void {
-    if (!this._dashboard.isDashboardStatic() || this._uiEvent.isDragging()) return;
+    // isPageTransitioning: navigateTo no-ops mid-transition, so switching then would show a
+    // "Switched to …" cue for a navigation that never happened.
+    if (!this._dashboard.isDashboardStatic() || this._uiEvent.isDragging() || this._dashboard.isPageTransitioning()) return;
     const active = this._dashboard.activeDashboard();
     if (active === null || active === idx) return;
     this._dashboard.navigateTo(idx);
@@ -163,8 +175,7 @@ export class PageSwitchService {
   }
 
   private hasMatchingPage(path: string, value: unknown): boolean {
-    return this._dashboard.dashboards().some(d =>
-      d.trigger?.path === path && this.valueMatches(value, d.trigger.value));
+    return this.matchingPageIndex(path, value) >= 0;
   }
 
   private matchingPageIndex(path: string, value: unknown): number {

--- a/src/app/core/services/page-switch.service.ts
+++ b/src/app/core/services/page-switch.service.ts
@@ -1,0 +1,178 @@
+import { effect, inject, Injectable, untracked } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { DashboardService } from './dashboard.service';
+import { DataService, IPathUpdate } from './data.service';
+import { uiEventService } from './uiEvent.service';
+import { EmbedModeService } from './embed-mode.service';
+
+/**
+ * How long a genuine value *change* must hold before an auto-switch fires — debounces a
+ * transient pass-through value during a real state transition. The value already present at
+ * startup (a path's first known value) switches immediately, without this delay.
+ */
+export const PAGE_SWITCH_DWELL_MS = 2500;
+
+/** Sentinel for "no value seen yet" so a path's first real value is recognised as its baseline. */
+const UNSET = Symbol('page-switch-unset');
+
+interface PathWatch {
+  /** Last value seen on this path (UNSET until the first non-null emission). */
+  value: unknown;
+  release: () => void;
+  sub: Subscription;
+  dwellTimer?: ReturnType<typeof setTimeout>;
+}
+
+/**
+ * Watches each page's optional auto-show trigger and navigates to a page when its Signal K
+ * value comes up.
+ *
+ * Two distinct behaviours:
+ *  - **Startup / first-known value** (the value already true when the app opens): switch
+ *    immediately and silently — no dwell, no cue. This is a one-time "boot into the right page".
+ *  - **Runtime change** (the value transitions to a trigger while the app runs): switch only
+ *    after the value holds for a short dwell, with a snackbar cue.
+ *
+ * Guarded throughout by isDashboardStatic / isDragging / an active page. Inert in embed mode.
+ */
+@Injectable({ providedIn: 'root' })
+export class PageSwitchService {
+  private readonly _dashboard = inject(DashboardService);
+  private readonly _data = inject(DataService);
+  private readonly _uiEvent = inject(uiEventService);
+  private readonly _embed = inject(EmbedModeService);
+  private readonly _snackBar = inject(MatSnackBar);
+
+  private readonly _watches = new Map<string, PathWatch>();
+  /** Becomes true the first time a page is active; the startup jump runs exactly once. */
+  private _startupHandled = false;
+
+  constructor() {
+    // A chromeless embed panel is strictly read-only: never move its page.
+    if (this._embed.embed()) return;
+
+    // Keep one subscription per distinct configured trigger path, rebuilt as pages change.
+    effect(() => {
+      const desired = new Set<string>();
+      for (const dashboard of this._dashboard.dashboards()) {
+        if (dashboard.trigger?.path) desired.add(dashboard.trigger.path);
+      }
+      untracked(() => this.syncSubscriptions(desired));
+    });
+
+    // Startup jump: the first time a page becomes active, switch to the first page whose trigger
+    // already matches its path's current value — immediately, without a cue. Runs once, so a later
+    // manual navigation is never undone.
+    effect(() => {
+      const active = this._dashboard.activeDashboard();
+      untracked(() => {
+        if (this._startupHandled || active === null) return;
+        this._startupHandled = true;
+        this.evaluateCurrentValues();
+      });
+    });
+  }
+
+  private syncSubscriptions(desired: Set<string>): void {
+    for (const [path, watch] of this._watches) {
+      if (!desired.has(path)) {
+        this.teardown(watch);
+        this._watches.delete(path);
+      }
+    }
+    for (const path of desired) {
+      if (this._watches.has(path)) continue;
+      const { data$, release } = this._data.acquirePath(path, 'default');
+      const watch: PathWatch = { value: UNSET, release, sub: Subscription.EMPTY };
+      this._watches.set(path, watch);
+      // subscribe after registering the watch so the synchronous replay finds it.
+      watch.sub = data$.subscribe(update => this.onUpdate(path, update));
+    }
+  }
+
+  private teardown(watch: PathWatch): void {
+    if (watch.dwellTimer) clearTimeout(watch.dwellTimer);
+    // release() alone only decrements the shared refcount; unsubscribe stops OUR handler.
+    watch.sub.unsubscribe();
+    watch.release();
+  }
+
+  private onUpdate(path: string, update: IPathUpdate): void {
+    const watch = this._watches.get(path);
+    if (!watch) return;
+    const value = update.data.value;
+    if (value == null) return; // ignore the no-value seed / a path being cleared
+    if (Object.is(value, watch.value)) return; // dedupe replays / unchanged
+    const firstValue = watch.value === UNSET;
+    watch.value = value;
+
+    if (firstValue) {
+      // A value that was already true when we started watching is a baseline, not a change:
+      // never arm the dwell. If startup is already past (a late-arriving first value), jump to it
+      // immediately; otherwise the startup effect handles it once a page is active.
+      if (this._startupHandled) this.evaluateCurrentValues();
+      return;
+    }
+
+    if (!this.hasMatchingPage(path, value)) {
+      if (watch.dwellTimer) {
+        clearTimeout(watch.dwellTimer);
+        watch.dwellTimer = undefined;
+      }
+      return;
+    }
+
+    if (watch.dwellTimer) clearTimeout(watch.dwellTimer);
+    watch.dwellTimer = setTimeout(() => this.onDwellElapsed(path, value), PAGE_SWITCH_DWELL_MS);
+  }
+
+  private onDwellElapsed(path: string, value: unknown): void {
+    const watch = this._watches.get(path);
+    if (!watch) return;
+    watch.dwellTimer = undefined;
+    if (!Object.is(watch.value, value)) return; // value moved on while the dwell was pending
+    const idx = this.matchingPageIndex(path, value);
+    if (idx < 0) return;
+    this.switchTo(idx, true);
+  }
+
+  private evaluateCurrentValues(): void {
+    const dashboards = this._dashboard.dashboards();
+    const idx = dashboards.findIndex(dashboard => {
+      if (!dashboard.trigger) return false;
+      const watch = this._watches.get(dashboard.trigger.path);
+      return watch !== undefined && this.valueMatches(watch.value, dashboard.trigger.value);
+    });
+    if (idx >= 0) this.switchTo(idx, false);
+  }
+
+  /**
+   * Guarded navigation. `notify` shows the snackbar cue for runtime changes; the startup jump
+   * passes false so opening the app lands on the right page silently.
+   */
+  private switchTo(idx: number, notify: boolean): void {
+    if (!this._dashboard.isDashboardStatic() || this._uiEvent.isDragging()) return;
+    const active = this._dashboard.activeDashboard();
+    if (active === null || active === idx) return;
+    this._dashboard.navigateTo(idx);
+    if (notify) {
+      const name = this._dashboard.dashboards()[idx]?.name ?? 'page';
+      this._snackBar.open(`Switched to ${name}`, undefined, { duration: 4000 });
+    }
+  }
+
+  private hasMatchingPage(path: string, value: unknown): boolean {
+    return this._dashboard.dashboards().some(d =>
+      d.trigger?.path === path && this.valueMatches(value, d.trigger.value));
+  }
+
+  private matchingPageIndex(path: string, value: unknown): number {
+    return this._dashboard.dashboards().findIndex(d =>
+      d.trigger?.path === path && this.valueMatches(value, d.trigger.value));
+  }
+
+  private valueMatches(liveValue: unknown, triggerValue: string): boolean {
+    return String(liveValue) === triggerValue;
+  }
+}


### PR DESCRIPTION
## What & why

Lets a dashboard page come up on its own when a Signal K value changes to signal a
new activity — e.g. when `navigation.state` becomes `sailing`, Skip switches to the
Sailing page. Proof-of-concept: the simplest useful shape — one path, one value,
per page.

Closes #457. Implements #458, #459, #460.

Brainstorm → plan → **independent 6-persona plan review** → build. The review
reshaped the design before any code (see the [review-outcome comment](https://github.com/halos-org/skip/issues/457#issuecomment-5122093193)).

## How it works

- **Model (#458):** an optional `trigger { path, value }` on `Dashboard`. `update()`
  gains set/clear/leave semantics; `duplicate()` drops the trigger so a copy never
  competes for the same state. Round-trips through the existing verbatim persistence
  — **no `LATEST_APP_CONFIG_VERSION` bump** (an absent field = no trigger).
- **Editor (#459):** an "Auto-show this page on a Signal K value" section in the
  page-options dialog (edit flow only), with a path autocomplete and a value
  autocomplete seeded from the path's `possibleValues` meta (free text when the
  server publishes none). Stored value is the `String()`-coerced value, never the
  display title, so it matches the live path value.
- **Evaluator (#460):** `PageSwitchService` — one subscription per distinct trigger
  path (diff-managed, torn down with `unsubscribe()` **and** `release()`), edge
  dedupe, first-match-wins, guarded by `isDashboardStatic()` / `!isDragging()` / an
  active page. Two behaviours: a value **already true at startup** switches
  **immediately and silently** (one-time boot-into-the-right-page); a genuine
  **runtime change** switches only after a short (~2.5s) **dwell**, with a
  "Switched to …" snackbar cue. Eagerly constructed in the app shell; inert in
  embed mode.

## Decisions from the plan review

- **Authority = force + cue + dwell.** Zero-touch switch kept, but a snackbar names
  the page and a short dwell debounces a transient value (addresses the silent-teleport
  and jittery-signal findings). Operator confirms `navigation.state` is stable on the vessel.
- **No global master pause** — deferred (clear a page's trigger to disable).
- **Accepted PoC limitations:** last-writer-wins if the remote-control feature and a
  local trigger disagree; multi-path near-simultaneous emissions resolve last-wins.

## Testing

- New/updated unit specs: `dashboard.service` (trigger set/clear/leave, duplicate
  strips, persistence), `page-switch.service` (16 scenarios: dwell, flap, dedupe,
  re-entry, guards, conflict, already-active, startup backstop, teardown, embed),
  `dialog-dashboard-page-editor` (value coercion, prefill, clear, path-change
  preservation), `dashboards-editor` (trigger forwarding).
- `npm run snc` + `npm run lint` clean; full headless suite green (1688 tests).
- **Live on hurma:** deployed via `./run deploy-halos local` and confirmed on-device —
  opening the app while `navigation.state` is already `moored` lands on the trigger
  page immediately with no cue, and swiping away is not re-grabbed.

## On-device refinements (post first deploy)

- Startup now switches **immediately and silently**; the earlier build let the
  already-true value both arm the dwell and fire the backstop, which re-switched the
  page ~2.5s after the user had swiped away. Fixed by treating a path's first known
  value as a baseline (never arms the dwell); the dwell + cue apply only to genuine
  runtime changes. Two regression tests cover it.
- Dialog polish: padding between the path/value fields, examples moved to muted
  field **hints** (they read as placeholders before), and the path suggestions are
  now sorted.

## Post-Deploy Monitoring & Validation

- **What to watch:** open a page's options → the "Auto-show…" section renders; set a
  trigger to `self.navigation.state = <current state>` and reload → the app lands on
  that page with a "Switched to <page>" snackbar; after an auto-switch, swiping to
  another page is not undone while the state holds.
- **Healthy signal:** page switches only on a genuine state transition (held for the
  dwell) and never while editing the layout.
- **Failure signal / mitigation:** unexpected page jumps, or a switch that fights
  manual navigation → clear the offending page's trigger (Page Options) to disable it;
  the feature is inert with no triggers configured.
- **Validation window/owner:** the operator, on the vessel, over the next few sails.
