### PR TITLE
fix: dial animations track updateInterval (and interpolate linearly)

### DIFF
--- a/src/app/core/utils/svg-animate.util.spec.ts
+++ b/src/app/core/utils/svg-animate.util.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { effectiveAnimationDuration } from './svg-animate.util';
+import { DEFAULT_WIDGET_UPDATE_INTERVAL_MS } from '../interfaces/widgets-interface';
+
+describe('effectiveAnimationDuration', () => {
+  it('returns the update interval unchanged when it is below the cap', () => {
+    expect(effectiveAnimationDuration(100)).toBe(100);
+    expect(effectiveAnimationDuration(500)).toBe(500);
+  });
+
+  it('caps the duration at the default update interval', () => {
+    expect(effectiveAnimationDuration(DEFAULT_WIDGET_UPDATE_INTERVAL_MS + 1)).toBe(DEFAULT_WIDGET_UPDATE_INTERVAL_MS);
+    expect(effectiveAnimationDuration(5000)).toBe(DEFAULT_WIDGET_UPDATE_INTERVAL_MS);
+  });
+
+  it('returns the cap at exactly the default interval', () => {
+    expect(effectiveAnimationDuration(DEFAULT_WIDGET_UPDATE_INTERVAL_MS)).toBe(DEFAULT_WIDGET_UPDATE_INTERVAL_MS);
+  });
+
+  it('never animates longer than one update interval, so a tween completes within the sample period', () => {
+    for (const interval of [50, 100, 200, 333, 500, 750, 1000, 1500, 3000]) {
+      expect(effectiveAnimationDuration(interval)).toBeLessThanOrEqual(interval);
+    }
+  });
+
+  it('is monotonic non-decreasing in the update interval (smaller cadence never yields more motion)', () => {
+    const intervals = [50, 100, 200, 333, 500, 750, 1000, 1500, 3000];
+    let previous = -Infinity;
+    for (const interval of intervals) {
+      const duration = effectiveAnimationDuration(interval);
+      expect(duration).toBeGreaterThanOrEqual(previous);
+      previous = duration;
+    }
+  });
+
+  it('falls back to the default for non-positive or non-finite input', () => {
+    expect(effectiveAnimationDuration(0)).toBe(DEFAULT_WIDGET_UPDATE_INTERVAL_MS);
+    expect(effectiveAnimationDuration(-100)).toBe(DEFAULT_WIDGET_UPDATE_INTERVAL_MS);
+    expect(effectiveAnimationDuration(Number.NaN)).toBe(DEFAULT_WIDGET_UPDATE_INTERVAL_MS);
+    expect(effectiveAnimationDuration(Number.POSITIVE_INFINITY)).toBe(DEFAULT_WIDGET_UPDATE_INTERVAL_MS);
+  });
+});

--- a/src/app/core/utils/svg-animate.util.spec.ts
+++ b/src/app/core/utils/svg-animate.util.spec.ts
@@ -39,4 +39,11 @@ describe('effectiveAnimationDuration', () => {
     expect(effectiveAnimationDuration(Number.NaN)).toBe(DEFAULT_WIDGET_UPDATE_INTERVAL_MS);
     expect(effectiveAnimationDuration(Number.POSITIVE_INFINITY)).toBe(DEFAULT_WIDGET_UPDATE_INTERVAL_MS);
   });
+
+  it('coerces string and undefined updateInterval from a persisted config', () => {
+    expect(effectiveAnimationDuration(undefined)).toBe(DEFAULT_WIDGET_UPDATE_INTERVAL_MS);
+    expect(effectiveAnimationDuration('500' as unknown as number)).toBe(500);
+    expect(effectiveAnimationDuration('5000' as unknown as number)).toBe(DEFAULT_WIDGET_UPDATE_INTERVAL_MS);
+    expect(effectiveAnimationDuration('abc' as unknown as number)).toBe(DEFAULT_WIDGET_UPDATE_INTERVAL_MS);
+  });
 });

--- a/src/app/core/utils/svg-animate.util.spec.ts
+++ b/src/app/core/utils/svg-animate.util.spec.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { effectiveAnimationDuration } from './svg-animate.util';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { animateRotation, effectiveAnimationDuration } from './svg-animate.util';
 import { DEFAULT_WIDGET_UPDATE_INTERVAL_MS } from '../interfaces/widgets-interface';
 
 describe('effectiveAnimationDuration', () => {
@@ -45,5 +45,29 @@ describe('effectiveAnimationDuration', () => {
     expect(effectiveAnimationDuration('500' as unknown as number)).toBe(500);
     expect(effectiveAnimationDuration('5000' as unknown as number)).toBe(DEFAULT_WIDGET_UPDATE_INTERVAL_MS);
     expect(effectiveAnimationDuration('abc' as unknown as number)).toBe(DEFAULT_WIDGET_UPDATE_INTERVAL_MS);
+  });
+});
+
+describe('animateRotation interpolation', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('interpolates linearly between angles, not with an ease curve', () => {
+    let transform: string | null = null;
+    const el = {
+      getAttribute: (name: string) => (name === 'transform' ? transform : null),
+      setAttribute: (name: string, value: string) => { if (name === 'transform') transform = value; }
+    } as unknown as SVGGElement;
+
+    const frames: FrameRequestCallback[] = [];
+    vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation(cb => { frames.push(cb); return 1; });
+    vi.spyOn(performance, 'now').mockReturnValue(1000);
+
+    animateRotation(el, 0, 100, 1000);
+    expect(frames.length).toBeGreaterThan(0);
+
+    frames[0](1250); // 25% through a 1000ms tween
+
+    // Linear: 0 + 100 * 0.25 = 25. An ease-in-out-cubic curve would give 6.25.
+    expect(transform).toBe('rotate(25 500 500)');
   });
 });

--- a/src/app/core/utils/svg-animate.util.ts
+++ b/src/app/core/utils/svg-animate.util.ts
@@ -1,4 +1,5 @@
 import type { NgZone } from '@angular/core';
+import { DEFAULT_WIDGET_UPDATE_INTERVAL_MS } from '../interfaces/widgets-interface';
 
 /**
  * SVG Animation Utilities
@@ -33,6 +34,21 @@ import type { NgZone } from '@angular/core';
  *  const frames = new WeakMap<SVGGElement, number>();
  *  animateRotation(el, oldAngle, newAngle, 900, () => console.log('done'), frames, undefined, ngZone);
  */
+
+/**
+ * Tween duration (ms) for a per-sample needle/indicator animation, derived from the
+ * widget's updateInterval. Capped at the default cadence and never longer than one sample
+ * period, so a tween completes before the next value arrives. Passing the fixed durations
+ * these helpers used before made the animation a low-pass filter whose lag was decoupled
+ * from (and could invert) updateInterval (#466). Monotonic in the interval: a shorter
+ * cadence never yields a slower tween.
+ */
+export function effectiveAnimationDuration(updateInterval: number): number {
+  if (!Number.isFinite(updateInterval) || updateInterval <= 0) {
+    return DEFAULT_WIDGET_UPDATE_INTERVAL_MS;
+  }
+  return Math.min(updateInterval, DEFAULT_WIDGET_UPDATE_INTERVAL_MS);
+}
 
 /**
  * Smoothly animates the rotation of an SVG <g> element from a starting angle to a target angle.

--- a/src/app/core/utils/svg-animate.util.ts
+++ b/src/app/core/utils/svg-animate.util.ts
@@ -22,7 +22,8 @@ import { DEFAULT_WIDGET_UPDATE_INTERVAL_MS } from '../interfaces/widgets-interfa
  *  - For custom callers of animateAngleTransition / animateSectorTransition keep and cancel the returned id manually.
  *
  * Performance notes:
- *  - Easing function is cubic in/out to match existing widget feel.
+ *  - Interpolation is linear: consumers track a continuously-updating value, and an ease that
+ *    decelerates to a stop at each sample would read as stepping rather than smooth motion (#466).
  *  - Angle interpolation normalizes shortest path (avoids >180° spins) where relevant.
  *  - No setTimeout fallbacks; if you need reduced frame rate sampling, throttle at the call site.
  *
@@ -127,9 +128,6 @@ export function animateRotation(
   if (delta > 180) delta -= 360;
   if (delta < -180) delta += 360;
 
-  const easeInOutCubic = (t: number) =>
-    t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
-
   const runOutside = (fn: () => void) => ngZone ? ngZone.runOutsideAngular(fn) : fn();
   const runInside = (fn: () => void) => ngZone ? ngZone.run(fn) : fn();
 
@@ -139,7 +137,7 @@ export function animateRotation(
     const animate = (now: number) => {
       const elapsed = now - start;
       const progress = Math.min(elapsed / duration, 1);
-      const eased = easeInOutCubic(progress);
+      const eased = progress;
       const current = from + delta * eased;
       element.setAttribute('transform', `rotate(${current} ${center[0]} ${center[1]})`);
       if (progress < 1) {
@@ -211,13 +209,11 @@ export function animateRudderWidth(
   runOutside(() => {
     const start = performance.now();
     const delta = to - from;
-    const easeInOutCubic = (t: number) =>
-      t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
 
     const animate = (now: number) => {
       const elapsed = now - start;
       const progress = Math.min(elapsed / duration, 1);
-      const eased = easeInOutCubic(progress);
+      const eased = progress;
       const current = from + delta * eased;
       element.setAttribute('width', current.toString());
       if (progress < 1) {
@@ -235,9 +231,6 @@ export function animateRudderWidth(
 }
 
 // ---- Generic path animation helpers (laylines & sectors) ----
-
-/** Internal easing identical to other helpers */
-const _easeInOutCubic = (t: number) => t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
 
 /** Normalize angle to [0,360) */
 const _norm = (a: number) => (a % 360 + 360) % 360;
@@ -286,7 +279,7 @@ export function animateAngleTransition(
     const base = _norm(from);
     const step = (now: number) => {
       const progress = Math.min((now - start) / duration, 1);
-      const eased = _easeInOutCubic(progress);
+      const eased = progress;
       const current = base + delta * eased;
       apply(_norm(current));
       if (progress < 1) {
@@ -341,7 +334,7 @@ export function animateSectorTransition(
     const start = performance.now();
     const step = (now: number) => {
       const progress = Math.min((now - start) / duration, 1);
-      const eased = _easeInOutCubic(progress);
+      const eased = progress;
       apply(_lerpSector(from, to, eased));
       if (progress < 1) {
         frameId = requestAnimationFrame(step);

--- a/src/app/core/utils/svg-animate.util.ts
+++ b/src/app/core/utils/svg-animate.util.ts
@@ -39,22 +39,23 @@ import { DEFAULT_WIDGET_UPDATE_INTERVAL_MS } from '../interfaces/widgets-interfa
 /**
  * Tween duration (ms) for a per-sample needle/indicator animation, derived from the
  * widget's updateInterval. Capped at the default cadence and never longer than one sample
- * period, so a tween completes before the next value arrives. Passing the fixed durations
- * these helpers used before made the animation a low-pass filter whose lag was decoupled
- * from (and could invert) updateInterval (#466). Monotonic in the interval: a shorter
+ * period, so a tween completes before the next value arrives. A longer duration would make
+ * the animation a low-pass filter whose lag is decoupled from (and can invert) updateInterval
+ * (#466). Monotonic in the interval: a shorter
  * cadence never yields a slower tween.
  */
-export function effectiveAnimationDuration(updateInterval: number): number {
-  if (!Number.isFinite(updateInterval) || updateInterval <= 0) {
+export function effectiveAnimationDuration(updateInterval: number | undefined): number {
+  const ms = Number(updateInterval);
+  if (!Number.isFinite(ms) || ms <= 0) {
     return DEFAULT_WIDGET_UPDATE_INTERVAL_MS;
   }
-  return Math.min(updateInterval, DEFAULT_WIDGET_UPDATE_INTERVAL_MS);
+  return Math.min(ms, DEFAULT_WIDGET_UPDATE_INTERVAL_MS);
 }
 
 /**
  * Smoothly animates the rotation of an SVG <g> element from a starting angle to a target angle.
  *
- * The function uses requestAnimationFrame for smooth animation and cubic easing for a natural feel.
+ * The function uses requestAnimationFrame for smooth animation and linear interpolation for constant-velocity tracking.
  * It can optionally manage and cancel overlapping animations for the same element using a WeakMap.
  *
  * @param element    The SVG <g> (or other) element to rotate.
@@ -137,8 +138,7 @@ export function animateRotation(
     const animate = (now: number) => {
       const elapsed = now - start;
       const progress = Math.min(elapsed / duration, 1);
-      const eased = progress;
-      const current = from + delta * eased;
+      const current = from + delta * progress;
       element.setAttribute('transform', `rotate(${current} ${center[0]} ${center[1]})`);
       if (progress < 1) {
         const id = requestAnimationFrame(animate);
@@ -157,7 +157,7 @@ export function animateRotation(
 /**
  * Smoothly animates the width of an SVG <rect> element from a starting value to a target value.
  *
- * The function uses requestAnimationFrame for smooth animation and cubic easing for a natural feel.
+ * The function uses requestAnimationFrame for smooth animation and linear interpolation for constant-velocity tracking.
  * It can optionally manage and cancel overlapping animations for the same element using a WeakMap.
  *
  * @param element    The SVG <rect> element to animate.
@@ -213,8 +213,7 @@ export function animateRudderWidth(
     const animate = (now: number) => {
       const elapsed = now - start;
       const progress = Math.min(elapsed / duration, 1);
-      const eased = progress;
-      const current = from + delta * eased;
+      const current = from + delta * progress;
       element.setAttribute('width', current.toString());
       if (progress < 1) {
         const id = requestAnimationFrame(animate);
@@ -244,7 +243,7 @@ const _angleDeltaSigned = (from: number, to: number) => {
 };
 
 /**
- * Animates an angle value (degrees) from "from" to "to" over duration using cubic easing.
+ * Animates an angle value (degrees) from "from" to "to" over duration using linear interpolation.
  * Calls apply(currentAngle) each frame (angle already normalized to [0,360)).
  * If ngZone is provided, the loop runs outside Angular and onDone re-enters the zone.
  * Returns the requestAnimationFrame id.
@@ -279,8 +278,7 @@ export function animateAngleTransition(
     const base = _norm(from);
     const step = (now: number) => {
       const progress = Math.min((now - start) / duration, 1);
-      const eased = progress;
-      const current = base + delta * eased;
+      const current = base + delta * progress;
       apply(_norm(current));
       if (progress < 1) {
         frameId = requestAnimationFrame(step);
@@ -303,7 +301,7 @@ const _lerpSector = (a: SectorAngles, b: SectorAngles, t: number): SectorAngles 
 });
 
 /**
- * Animates sector angles (min/mid/max) with easing.
+ * Animates sector angles (min/mid/max) with linear interpolation.
  * Each frame apply(current) receives interpolated angles (not normalized for wrapping; supply original domain if needed).
  * If ngZone supplied, runs outside Angular.
  *
@@ -334,8 +332,7 @@ export function animateSectorTransition(
     const start = performance.now();
     const step = (now: number) => {
       const progress = Math.min((now - start) / duration, 1);
-      const eased = progress;
-      apply(_lerpSector(from, to, eased));
+      apply(_lerpSector(from, to, progress));
       if (progress < 1) {
         frameId = requestAnimationFrame(step);
       } else if (onDone) {

--- a/src/app/widgets/svg-autopilot/svg-autopilot.component.ts
+++ b/src/app/widgets/svg-autopilot/svg-autopilot.component.ts
@@ -1,5 +1,6 @@
 import { Component, ElementRef, input, viewChild, effect, computed, untracked, signal, NgZone, inject, OnDestroy, ChangeDetectionStrategy } from '@angular/core';
-import { animateRotation, animateRudderWidth } from '../../core/utils/svg-animate.util';
+import { animateRotation, animateRudderWidth, effectiveAnimationDuration } from '../../core/utils/svg-animate.util';
+import { DEFAULT_WIDGET_UPDATE_INTERVAL_MS } from '../../core/interfaces/widgets-interface';
 import { TApMode } from '../../core/interfaces/signalk-autopilot-interfaces';
 
 
@@ -17,6 +18,7 @@ export class SvgAutopilotComponent implements OnDestroy {
   private readonly rudderPortRect = viewChild.required<ElementRef<SVGRectElement>>('rudderPortRect');
 
   protected readonly apMode = input<TApMode>('off-line');
+  protected readonly updateInterval = input<number | undefined>(undefined);
   protected readonly targetPilotHeadingTrue = input.required<boolean>();
   protected readonly autopilotTarget = input.required<number | null>();
   protected readonly courseXte = input.required<number>();
@@ -74,7 +76,7 @@ export class SvgAutopilotComponent implements OnDestroy {
     return this.headingDirectionTrue() ? 'T' : 'M';
   });
   private animationFrames = new WeakMap<Element, number>();
-  private readonly ANIMATION_DURATION = 1000; // unified animation duration (ms)
+  private readonly animationDuration = computed(() => effectiveAnimationDuration(this.updateInterval() ?? DEFAULT_WIDGET_UPDATE_INTERVAL_MS));
   private readonly DEG_TO_PX = 16.66666667; // 30° maps to 500px, so 1° = 500/30 = 16.6667px
   private readonly ROT_CENTER: [number, number] = [500, 560.061];
   private readonly ngZone = inject(NgZone);
@@ -111,7 +113,7 @@ export class SvgAutopilotComponent implements OnDestroy {
         if (isFirst || prev === next) {
           this.setRotationImmediate(dial, -next);
         } else {
-          animateRotation(dial, -prev, -next, this.ANIMATION_DURATION, undefined, this.animationFrames, this.ROT_CENTER, this.ngZone);
+          animateRotation(dial, -prev, -next, this.animationDuration(), undefined, this.animationFrames, this.ROT_CENTER, this.ngZone);
         }
       });
     });
@@ -138,7 +140,7 @@ export class SvgAutopilotComponent implements OnDestroy {
         if (isFirst || prev === next) {
           this.setRotationImmediate(awaEl, next);
         } else {
-          animateRotation(awaEl, prev, next, this.ANIMATION_DURATION, undefined, this.animationFrames, this.ROT_CENTER, this.ngZone);
+          animateRotation(awaEl, prev, next, this.animationDuration(), undefined, this.animationFrames, this.ROT_CENTER, this.ngZone);
         }
       });
     });
@@ -238,7 +240,7 @@ export class SvgAutopilotComponent implements OnDestroy {
         starboardEl,
         this.oldRudderStbAngle,
         capped,
-        this.ANIMATION_DURATION,
+        this.animationDuration(),
         undefined,
         this.animationFrames,
         this.ngZone
@@ -247,7 +249,7 @@ export class SvgAutopilotComponent implements OnDestroy {
         portEl,
         this.oldRudderPrtAngle,
         0,
-        this.ANIMATION_DURATION,
+        this.animationDuration(),
         undefined,
         this.animationFrames,
         this.ngZone
@@ -259,7 +261,7 @@ export class SvgAutopilotComponent implements OnDestroy {
         portEl,
         this.oldRudderPrtAngle,
         capped,
-        this.ANIMATION_DURATION,
+        this.animationDuration(),
         undefined,
         this.animationFrames,
         this.ngZone
@@ -268,7 +270,7 @@ export class SvgAutopilotComponent implements OnDestroy {
         starboardEl,
         this.oldRudderStbAngle,
         0,
-        this.ANIMATION_DURATION,
+        this.animationDuration(),
         undefined,
         this.animationFrames,
         this.ngZone

--- a/src/app/widgets/svg-autopilot/svg-autopilot.component.ts
+++ b/src/app/widgets/svg-autopilot/svg-autopilot.component.ts
@@ -1,6 +1,5 @@
 import { Component, ElementRef, input, viewChild, effect, computed, untracked, signal, NgZone, inject, OnDestroy, ChangeDetectionStrategy } from '@angular/core';
 import { animateRotation, animateRudderWidth, effectiveAnimationDuration } from '../../core/utils/svg-animate.util';
-import { DEFAULT_WIDGET_UPDATE_INTERVAL_MS } from '../../core/interfaces/widgets-interface';
 import { TApMode } from '../../core/interfaces/signalk-autopilot-interfaces';
 
 
@@ -76,7 +75,7 @@ export class SvgAutopilotComponent implements OnDestroy {
     return this.headingDirectionTrue() ? 'T' : 'M';
   });
   private animationFrames = new WeakMap<Element, number>();
-  private readonly animationDuration = computed(() => effectiveAnimationDuration(this.updateInterval() ?? DEFAULT_WIDGET_UPDATE_INTERVAL_MS));
+  private readonly animationDuration = computed(() => effectiveAnimationDuration(this.updateInterval()));
   private readonly DEG_TO_PX = 16.66666667; // 30° maps to 500px, so 1° = 500/30 = 16.6667px
   private readonly ROT_CENTER: [number, number] = [500, 560.061];
   private readonly ngZone = inject(NgZone);

--- a/src/app/widgets/svg-racesteer/svg-racesteer.component.ts
+++ b/src/app/widgets/svg-racesteer/svg-racesteer.component.ts
@@ -193,7 +193,7 @@ export class SvgRacesteerComponent implements OnDestroy {
           if (this.tack.oldValue === this.tack.newValue) {
             this.setRotationImmediate(this.tackIndicator().nativeElement, this.tack.newValue);
           } else {
-            animateRotation(this.tackIndicator().nativeElement, this.tack.oldValue, this.tack.newValue, this.animationDuration(), undefined, this.animationFrameIds, [600, 620]);
+            animateRotation(this.tackIndicator().nativeElement, this.tack.oldValue, this.tack.newValue, this.animationDuration(), undefined, this.animationFrameIds, [600, 620], this.ngZone);
           }
         }
         this.updateLaylines();
@@ -226,7 +226,7 @@ export class SvgRacesteerComponent implements OnDestroy {
           if (this.wpt.oldValue === this.wpt.newValue) {
             this.setRotationImmediate(this.wptIndicator().nativeElement, this.wpt.newValue);
           } else {
-            animateRotation(this.wptIndicator().nativeElement, this.wpt.oldValue, this.wpt.newValue, this.animationDuration(), undefined, this.animationFrameIds, [600, 620]);
+            animateRotation(this.wptIndicator().nativeElement, this.wpt.oldValue, this.wpt.newValue, this.animationDuration(), undefined, this.animationFrameIds, [600, 620], this.ngZone);
           }
         }
       });

--- a/src/app/widgets/svg-racesteer/svg-racesteer.component.ts
+++ b/src/app/widgets/svg-racesteer/svg-racesteer.component.ts
@@ -1,6 +1,7 @@
 import { Component, ElementRef, input, viewChild, signal, effect, computed, untracked, OnDestroy, NgZone, inject, ChangeDetectionStrategy } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
-import { animateRotation, animateAngleTransition, animateSectorTransition, type SectorAngles } from '../../core/utils/svg-animate.util';
+import { animateRotation, animateAngleTransition, animateSectorTransition, effectiveAnimationDuration, type SectorAngles } from '../../core/utils/svg-animate.util';
+import { DEFAULT_WIDGET_UPDATE_INTERVAL_MS } from '../../core/interfaces/widgets-interface';
 
 const angle = ([a,b],[c,d],[e,f]) => (Math.atan2(f-d,e-c)-Math.atan2(b-d,a-c)+3*Math.PI)%(2*Math.PI)-Math.PI;
 
@@ -24,6 +25,7 @@ export class SvgRacesteerComponent implements OnDestroy {
   protected readonly tackIndicator = viewChild.required<ElementRef<SVGGElement>>('tackIndicator');
 
   protected readonly compassHeading = input.required<number>();
+  protected readonly updateInterval = input<number | undefined>(undefined);
   protected readonly tackTrue = input.required<number>();
   protected readonly polarSpeedRatio = input.required<number>();
   protected readonly trueWindAngle = input.required<number>();
@@ -112,7 +114,7 @@ export class SvgRacesteerComponent implements OnDestroy {
   private readonly CENTER_X = 600;
   private readonly CENTER_Y = 620;
   private readonly RADIUS = 540;
-  private readonly ANIMATION_DURATION = 1000;
+  private readonly animationDuration = computed(() => effectiveAnimationDuration(this.updateInterval() ?? DEFAULT_WIDGET_UPDATE_INTERVAL_MS));
   protected laylinePortPath = signal<string>(`M ${this.CENTER_X},${this.CENTER_Y} ${this.CENTER_X},${this.CENTER_Y}`);
   protected laylineStbdPath = signal<string>(`M ${this.CENTER_X},${this.CENTER_Y} ${this.CENTER_X},${this.CENTER_Y}`);
   //Wind Sectors
@@ -166,7 +168,7 @@ export class SvgRacesteerComponent implements OnDestroy {
           if (this.compass.oldValue === this.compass.newValue) {
             this.setRotationImmediate(this.rotatingDial().nativeElement, -this.compass.newValue);
           } else {
-            animateRotation(this.rotatingDial().nativeElement, -this.compass.oldValue, -this.compass.newValue, this.ANIMATION_DURATION, undefined, this.animationFrameIds, [600, 620], this.ngZone);
+            animateRotation(this.rotatingDial().nativeElement, -this.compass.oldValue, -this.compass.newValue, this.animationDuration(), undefined, this.animationFrameIds, [600, 620], this.ngZone);
           }
           this.updateWindSectors();
         }
@@ -192,7 +194,7 @@ export class SvgRacesteerComponent implements OnDestroy {
           if (this.tack.oldValue === this.tack.newValue) {
             this.setRotationImmediate(this.tackIndicator().nativeElement, this.tack.newValue);
           } else {
-            animateRotation(this.tackIndicator().nativeElement, this.tack.oldValue, this.tack.newValue, this.ANIMATION_DURATION, undefined, this.animationFrameIds, [600, 620]);
+            animateRotation(this.tackIndicator().nativeElement, this.tack.oldValue, this.tack.newValue, this.animationDuration(), undefined, this.animationFrameIds, [600, 620]);
           }
         }
         this.updateLaylines();
@@ -225,7 +227,7 @@ export class SvgRacesteerComponent implements OnDestroy {
           if (this.wpt.oldValue === this.wpt.newValue) {
             this.setRotationImmediate(this.wptIndicator().nativeElement, this.wpt.newValue);
           } else {
-            animateRotation(this.wptIndicator().nativeElement, this.wpt.oldValue, this.wpt.newValue, this.ANIMATION_DURATION, undefined, this.animationFrameIds, [600, 620]);
+            animateRotation(this.wptIndicator().nativeElement, this.wpt.oldValue, this.wpt.newValue, this.animationDuration(), undefined, this.animationFrameIds, [600, 620]);
           }
         }
       });
@@ -253,7 +255,7 @@ export class SvgRacesteerComponent implements OnDestroy {
           if (this.twa.oldValue === this.twa.newValue) {
             this.setRotationImmediate(this.twaIndicator().nativeElement, this.twa.newValue);
           } else {
-            animateRotation(this.twaIndicator().nativeElement, this.twa.oldValue, this.twa.newValue, this.ANIMATION_DURATION, undefined, this.animationFrameIds, [600, 620], this.ngZone);
+            animateRotation(this.twaIndicator().nativeElement, this.twa.oldValue, this.twa.newValue, this.animationDuration(), undefined, this.animationFrameIds, [600, 620], this.ngZone);
           }
           this.updateLaylines();
         }
@@ -309,7 +311,7 @@ export class SvgRacesteerComponent implements OnDestroy {
           if (this.set.oldValue === this.set.newValue) {
             this.setRotationImmediate(this.setIndicator().nativeElement, this.set.newValue);
           } else {
-            animateRotation(this.setIndicator().nativeElement, this.set.oldValue, this.set.newValue, this.ANIMATION_DURATION, undefined, this.animationFrameIds, [600, 620], this.ngZone);
+            animateRotation(this.setIndicator().nativeElement, this.set.oldValue, this.set.newValue, this.animationDuration(), undefined, this.animationFrameIds, [600, 620], this.ngZone);
           }
         }
       });
@@ -356,7 +358,7 @@ export class SvgRacesteerComponent implements OnDestroy {
     const id = animateAngleTransition(
       from,
       to,
-      this.ANIMATION_DURATION,
+      this.animationDuration(),
       angle => this.setLaylinePath(angle, isPort),
       onDone,
       this.ngZone
@@ -415,7 +417,7 @@ export class SvgRacesteerComponent implements OnDestroy {
     const id = animateSectorTransition(
       from,
       to,
-      this.ANIMATION_DURATION,
+      this.animationDuration(),
       sector => this.setWindSectorPath(sector, isPort),
       onDone,
       this.ngZone

--- a/src/app/widgets/svg-racesteer/svg-racesteer.component.ts
+++ b/src/app/widgets/svg-racesteer/svg-racesteer.component.ts
@@ -1,7 +1,6 @@
 import { Component, ElementRef, input, viewChild, signal, effect, computed, untracked, OnDestroy, NgZone, inject, ChangeDetectionStrategy } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
 import { animateRotation, animateAngleTransition, animateSectorTransition, effectiveAnimationDuration, type SectorAngles } from '../../core/utils/svg-animate.util';
-import { DEFAULT_WIDGET_UPDATE_INTERVAL_MS } from '../../core/interfaces/widgets-interface';
 
 const angle = ([a,b],[c,d],[e,f]) => (Math.atan2(f-d,e-c)-Math.atan2(b-d,a-c)+3*Math.PI)%(2*Math.PI)-Math.PI;
 
@@ -114,7 +113,7 @@ export class SvgRacesteerComponent implements OnDestroy {
   private readonly CENTER_X = 600;
   private readonly CENTER_Y = 620;
   private readonly RADIUS = 540;
-  private readonly animationDuration = computed(() => effectiveAnimationDuration(this.updateInterval() ?? DEFAULT_WIDGET_UPDATE_INTERVAL_MS));
+  private readonly animationDuration = computed(() => effectiveAnimationDuration(this.updateInterval()));
   protected laylinePortPath = signal<string>(`M ${this.CENTER_X},${this.CENTER_Y} ${this.CENTER_X},${this.CENTER_Y}`);
   protected laylineStbdPath = signal<string>(`M ${this.CENTER_X},${this.CENTER_Y} ${this.CENTER_X},${this.CENTER_Y}`);
   //Wind Sectors

--- a/src/app/widgets/svg-windsteer/svg-windsteer.component.spec.ts
+++ b/src/app/widgets/svg-windsteer/svg-windsteer.component.spec.ts
@@ -48,6 +48,20 @@ describe('SvgWindsteerComponent', () => {
         component = fixture.componentInstance;
     });
 
+    it('derives the needle animation duration from updateInterval', () => {
+        setRequiredInputs({ updateInterval: 100 });
+        fixture.detectChanges();
+        expect(component['animationDuration']()).toBe(100);
+
+        fixture.componentRef.setInput('updateInterval', 5000);
+        fixture.detectChanges();
+        expect(component['animationDuration']()).toBe(1000);
+
+        fixture.componentRef.setInput('updateInterval', undefined);
+        fixture.detectChanges();
+        expect(component['animationDuration']()).toBe(1000);
+    });
+
     it('renders first values without rotation animation', () => {
         // Set up component with initial values
         setRequiredInputs();

--- a/src/app/widgets/svg-windsteer/svg-windsteer.component.ts
+++ b/src/app/widgets/svg-windsteer/svg-windsteer.component.ts
@@ -1,6 +1,5 @@
 import { Component, ElementRef, input, viewChild, signal, computed, effect, untracked, ChangeDetectionStrategy, OnDestroy, NgZone, inject } from '@angular/core';
 import { animateRotation, animateAngleTransition, animateSectorTransition, effectiveAnimationDuration, SectorAngles } from '../../core/utils/svg-animate.util';
-import { DEFAULT_WIDGET_UPDATE_INTERVAL_MS } from '../../core/interfaces/widgets-interface';
 import { DecimalPipe } from '@angular/common';
 
 const angle = ([a, b], [c, d], [e, f]) => (Math.atan2(f - d, e - c) - Math.atan2(b - d, a - c) + 3 * Math.PI) % (2 * Math.PI) - Math.PI;
@@ -97,7 +96,7 @@ export class SvgWindsteerComponent implements OnDestroy {
 
   private readonly CENTER = 500;
   private readonly RADIUS = 350;
-  private readonly animationDuration = computed(() => effectiveAnimationDuration(this.updateInterval() ?? DEFAULT_WIDGET_UPDATE_INTERVAL_MS));
+  private readonly animationDuration = computed(() => effectiveAnimationDuration(this.updateInterval()));
   private readonly EPS_ANGLE = 1.0; // degrees, gate tiny animations
 
   private readonly ngZone = inject(NgZone);

--- a/src/app/widgets/svg-windsteer/svg-windsteer.component.ts
+++ b/src/app/widgets/svg-windsteer/svg-windsteer.component.ts
@@ -1,5 +1,6 @@
 import { Component, ElementRef, input, viewChild, signal, computed, effect, untracked, ChangeDetectionStrategy, OnDestroy, NgZone, inject } from '@angular/core';
-import { animateRotation, animateAngleTransition, animateSectorTransition, SectorAngles } from '../../core/utils/svg-animate.util';
+import { animateRotation, animateAngleTransition, animateSectorTransition, effectiveAnimationDuration, SectorAngles } from '../../core/utils/svg-animate.util';
+import { DEFAULT_WIDGET_UPDATE_INTERVAL_MS } from '../../core/interfaces/widgets-interface';
 import { DecimalPipe } from '@angular/common';
 
 const angle = ([a, b], [c, d], [e, f]) => (Math.atan2(f - d, e - c) - Math.atan2(b - d, a - c) + 3 * Math.PI) % (2 * Math.PI) - Math.PI;
@@ -26,6 +27,7 @@ export class SvgWindsteerComponent implements OnDestroy {
 
   protected readonly compassHeading = input.required<number>();
   protected readonly compassModeEnabled = input.required<boolean>();
+  protected readonly updateInterval = input<number | undefined>(undefined);
   protected readonly courseOverGroundAngle = input<number | undefined>(undefined);
   protected readonly courseOverGroundEnabled = input.required<boolean>();
   protected readonly sogActive = input<boolean>(true);
@@ -95,7 +97,7 @@ export class SvgWindsteerComponent implements OnDestroy {
 
   private readonly CENTER = 500;
   private readonly RADIUS = 350;
-  private readonly ANIMATION_DURATION = 900;
+  private readonly animationDuration = computed(() => effectiveAnimationDuration(this.updateInterval() ?? DEFAULT_WIDGET_UPDATE_INTERVAL_MS));
   private readonly EPS_ANGLE = 1.0; // degrees, gate tiny animations
 
   private readonly ngZone = inject(NgZone);
@@ -127,7 +129,7 @@ export class SvgWindsteerComponent implements OnDestroy {
           if (isFirstCompass || this.compass.oldValue === this.compass.newValue) {
             this.setRotationImmediate(this.rotatingDial().nativeElement, -this.compass.newValue);
           } else {
-            animateRotation(this.rotatingDial().nativeElement, -this.compass.oldValue, -this.compass.newValue, this.ANIMATION_DURATION, undefined, this.animationFrameIds, undefined, this.ngZone);
+            animateRotation(this.rotatingDial().nativeElement, -this.compass.oldValue, -this.compass.newValue, this.animationDuration(), undefined, this.animationFrameIds, undefined, this.ngZone);
           }
           // Heading affects dial-local geometry for laylines and sectors; refresh without animation
           this.updateCloseHauledLines(false);
@@ -158,7 +160,7 @@ export class SvgWindsteerComponent implements OnDestroy {
           if (isFirstCog || this.cog.oldValue === this.cog.newValue) {
             this.setRotationImmediate(this.cogIndicator().nativeElement, this.cog.newValue);
           } else {
-            animateRotation(this.cogIndicator().nativeElement, this.cog.oldValue, this.cog.newValue, this.ANIMATION_DURATION, undefined, this.animationFrameIds, undefined, this.ngZone);
+            animateRotation(this.cogIndicator().nativeElement, this.cog.oldValue, this.cog.newValue, this.animationDuration(), undefined, this.animationFrameIds, undefined, this.ngZone);
           }
         }
       });
@@ -184,7 +186,7 @@ export class SvgWindsteerComponent implements OnDestroy {
           if (isFirstWaypoint || this.wpt.oldValue === this.wpt.newValue) {
             this.setRotationImmediate(this.wptIndicator().nativeElement, this.wpt.newValue);
           } else {
-            animateRotation(this.wptIndicator().nativeElement, this.wpt.oldValue, this.wpt.newValue, this.ANIMATION_DURATION, undefined, this.animationFrameIds, undefined, this.ngZone);
+            animateRotation(this.wptIndicator().nativeElement, this.wpt.oldValue, this.wpt.newValue, this.animationDuration(), undefined, this.animationFrameIds, undefined, this.ngZone);
           }
         }
       });
@@ -209,7 +211,7 @@ export class SvgWindsteerComponent implements OnDestroy {
           if (isFirstAwa || this.awa.oldValue === this.awa.newValue) {
             this.setRotationImmediate(this.awaIndicator().nativeElement, this.awa.newValue);
           } else {
-            animateRotation(this.awaIndicator().nativeElement, this.awa.oldValue, this.awa.newValue, this.ANIMATION_DURATION, undefined, this.animationFrameIds, undefined, this.ngZone);
+            animateRotation(this.awaIndicator().nativeElement, this.awa.oldValue, this.awa.newValue, this.animationDuration(), undefined, this.animationFrameIds, undefined, this.ngZone);
           }
         }
       });
@@ -238,7 +240,7 @@ export class SvgWindsteerComponent implements OnDestroy {
           if (isFirstTwa || this.twa.oldValue === this.twa.newValue) {
             this.setRotationImmediate(this.twaIndicator().nativeElement, this.twa.newValue);
           } else {
-            animateRotation(this.twaIndicator().nativeElement, this.twa.oldValue, this.twa.newValue, this.ANIMATION_DURATION, undefined, this.animationFrameIds, undefined, this.ngZone);
+            animateRotation(this.twaIndicator().nativeElement, this.twa.oldValue, this.twa.newValue, this.animationDuration(), undefined, this.animationFrameIds, undefined, this.ngZone);
           }
         }
         // Laylines are centered on the true wind; recompute whenever TWA changes
@@ -272,7 +274,7 @@ export class SvgWindsteerComponent implements OnDestroy {
           if (!this.setInitialized || this.set.oldValue === this.set.newValue) {
             this.setRotationImmediate(this.setIndicator().nativeElement, this.set.newValue);
           } else {
-            animateRotation(this.setIndicator().nativeElement, this.set.oldValue, this.set.newValue, this.ANIMATION_DURATION, undefined, this.animationFrameIds, undefined, this.ngZone);
+            animateRotation(this.setIndicator().nativeElement, this.set.oldValue, this.set.newValue, this.animationDuration(), undefined, this.animationFrameIds, undefined, this.ngZone);
           }
         }
       });
@@ -347,7 +349,7 @@ export class SvgWindsteerComponent implements OnDestroy {
     const id = animateAngleTransition(
       from,
       to,
-      this.ANIMATION_DURATION,
+      this.animationDuration(),
       angle => this.drawLayline(angle, isPort),
       () => { if (isPort) this.portLaylineAnimId = null; else this.stbdLaylineAnimId = null; },
       this.ngZone
@@ -463,7 +465,7 @@ export class SvgWindsteerComponent implements OnDestroy {
     const id = animateSectorTransition(
       from as SectorAngles,
       to as SectorAngles,
-      this.ANIMATION_DURATION,
+      this.animationDuration(),
       (current) => {
         const path = this.computeSectorPath(current, isPort);
         if (isPort) this.portWindSectorPath.set(path); else this.stbdWindSectorPath.set(path);

--- a/src/app/widgets/widget-autopilot/widget-autopilot.component.html
+++ b/src/app/widgets/widget-autopilot/widget-autopilot.component.html
@@ -24,6 +24,7 @@
   <div class="ap-screen">
     <app-svg-autopilot
       [apMode]="apMode() ?? 'off-line'"
+      [updateInterval]="runtime.options()?.updateInterval"
       [targetPilotHeadingTrue]="runtime.options()?.autopilot?.courseDirectionTrue ?? false"
       [autopilotTarget]="autopilotTarget()"
       [courseXte]="crossTrackError() ?? 0"

--- a/src/app/widgets/widget-racesteer/widget-racesteer.component.html
+++ b/src/app/widgets/widget-racesteer/widget-racesteer.component.html
@@ -1,5 +1,6 @@
 <svg-racesteer
   [compassHeading]="currentHeading()"
+  [updateInterval]="runtime.options()?.updateInterval"
   [tackTrue]="tackTrue()"
   [polarSpeedRatio]="polarSpeedRatio()"
   [trueWindAngle]="trueWindAngle()"

--- a/src/app/widgets/widget-windsteer/widget-windsteer.component.html
+++ b/src/app/widgets/widget-windsteer/widget-windsteer.component.html
@@ -1,6 +1,7 @@
 <svg-windsteer
   [compassHeading]="currentHeading()"
   [compassModeEnabled]="runtime.options()?.compassModeEnabled ?? true"
+  [updateInterval]="runtime.options()?.updateInterval"
   [courseOverGroundAngle]="courseOverGroundAngle()"
   [courseOverGroundEnabled]="runtime.options()?.courseOverGroundEnable ?? true"
   [sogActive]="sogActive()"


### PR DESCRIPTION
## Motivation

The windsteer dial looked heavily filtered — the AWA/TWA needle sat nearly still while the numeric wind values swung. Root cause: the needle animation was a fixed 900/1000&nbsp;ms re-triggered `ease-in-out-cubic` tween, which behaves as a low-pass filter whose lag is **decoupled from — and inverts —** the widget's `updateInterval`. At `updateInterval = 100 ms` the needle showed only **~11%** of the real motion; the *shorter* the interval, the *less* the needle moved. Full root-cause writeup and the attenuation table are in #466.

## Approach

- **`effectiveAnimationDuration(updateInterval)`** (new pure helper): caps a tween at one sample period — `min(updateInterval, DEFAULT_WIDGET_UPDATE_INTERVAL_MS)` — so it completes before the next value arrives. Monotonic in the interval (a shorter cadence never yields less motion). Fully unit-tested.
- **Thread `updateInterval` into `svg-windsteer`, `svg-racesteer`, `svg-autopilot`** and size every needle / rudder-bar / layline / sector tween from it instead of the hardcoded constant. (racesteer and autopilot shipped a 1000&nbsp;ms tween against a 500&nbsp;ms default cadence, so they were over-animated even at their defaults.)
- **Linear interpolation instead of `ease-in-out-cubic`** in the shared animation helpers. Cubic zeros velocity at both ends of every tween, so a continuously re-triggered tween dead-stops at each sample (~0→64&nbsp;deg/s velocity pulsing) and reads as *stepping*. These helpers only ever drive continuously-updating values, so linear gives constant-velocity, smooth tracking with no added lag.

## Verification

- **Unit:** `effectiveAnimationDuration` (monotonic, `≤ interval`, cap, non-finite fallback) + a windsteer duration-wiring test. Full suite **1723/1723** green.
- **Static:** ESLint, `strictNullChecks` (`npm run snc`), and the `strictTemplates` build all clean.
- **On-boat:** deployed to halpi and confirmed on the MFD — the needle tracks at 100&nbsp;ms, motion is monotonic in cadence, and (after switching to linear) glides smoothly instead of hopping.

## Scope note

Only the three animation-driven widgets are touched here. The broader audit for *other* hardcoded time constants across widgets is tracked separately in #467.

Closes #466.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
