### PR TITLE
fix(help): Help page scrolls long docs (bounded flex layout)

### DIFF
--- a/src/app/core/components/app-help/app-help.component.scss
+++ b/src/app/core/components/app-help/app-help.component.scss
@@ -33,10 +33,6 @@
   letter-spacing: var(--mat-dialog-subhead-tracking, var(--mat-sys-headline-small-tracking, 0.03125em));
 }
 
-.mat-mdc-dialog-content {
-  max-height: max-content;
-}
-
 .dialog-close-icon {
   display: flex;
   flex-direction: row;
@@ -55,7 +51,7 @@
   background: var(--mat-sys-surface-container-high);
 }
 
-::ng-deep .markdown-content {
+.markdown-content {
   display: block;
   flex: 1 1 auto;
   min-height: 0;

--- a/src/app/core/components/app-help/app-help.component.scss
+++ b/src/app/core/components/app-help/app-help.component.scss
@@ -1,7 +1,15 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
 .fullpage-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  flex: 0 0 auto;
 }
 
 .page-icon {
@@ -49,9 +57,10 @@
 
 ::ng-deep .markdown-content {
   display: block;
-  height: calc(100% - 75px);
+  flex: 1 1 auto;
+  min-height: 0;
   width: 100%;
-  overflow-x: scroll;
+  overflow: auto;
   padding: 25px;
   font-size: 1.1rem;
   line-height: 1.7;


### PR DESCRIPTION
## Motivation

On the Help full-page view, long docs scrolled only a few pixels — unreadable past the first screenful (reported on a Samsung tablet, #437). `.markdown-content` used `height: calc(100% - 75px)`, but the routed Help host had **no `:host` rule** setting a definite height, so `100%` resolved to `auto` and the content collapsed to ~content-height — almost nothing to scroll. (Settings scrolls fine only because *its* host sets `height: 100%`.)

## Approach

Give the Help host the bounded flex column the shell already provides for routed content (`.skip-app-shell > *:not(app-toolbar) { flex: 1 1 auto; min-height: 0 }`):

- `:host { display: flex; flex-direction: column; height: 100%; min-height: 0 }`
- header pinned with `flex: 0 0 auto`
- `.markdown-content { flex: 1 1 auto; min-height: 0; overflow: auto }` — dropping the `height: calc(100% - 75px)` magic number and the `overflow-x: scroll` hack (Chromium was only promoting `overflow-y → auto` off it).

Single-file SCSS change; mirrors the Settings page's working layout.

## Verification

Deployed to the boat and confirmed on the tablet: long help docs now scroll through the entire document via touch. Settings-parity layout, so desktop wheel scrolling follows.

Closes #437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
