### PR TITLE
fix(pwa): don't lock the installed app to landscape orientation

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -8,7 +8,7 @@
   "name": "Skip",
   "short_name": "Skip",
   "description": "An advanced and versatile marine instrumentation package to display Signal K data.",
-  "orientation": "landscape",
+  "orientation": "any",
   "icons": [
     {
       "src": "assets/manifest-icon-192.maskable.png",


### PR DESCRIPTION
## Motivation

Installing Skip as a PWA in Brave ("Install and create shortcut" → "Install") forced the app into **landscape**. The web-app manifest set `orientation: "landscape"`, which installed PWAs obey as an orientation **lock**.

The only other orientation references are the `apple-touch-startup-image` splash media queries in `index.html` (which select a splash image *by* orientation — they don't lock), and there is no `screen.orientation.lock()` anywhere in the app, so the manifest field was the sole cause.

## Approach

`src/manifest.json`: `orientation: "landscape"` → `"any"` — the installed app now follows the device orientation. `display: fullscreen` and `id` / `scope` / `start_url` are unchanged.

## Verification

Deployed to the boat; confirmed the **served** manifest reports `orientation: "any"`, then re-installed the PWA in Brave and confirmed it no longer forces landscape (rotates with the device).

Note for existing installs: the manifest is read at install time, so an already-installed shortcut keeps the old lock until it is uninstalled and re-installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
