### PR TITLE
Add rudder-angle bar to the WindSteer widget

### DIFF
--- a/src/app/core/interfaces/widgets-interface.ts
+++ b/src/app/core/interfaces/widgets-interface.ts
@@ -396,6 +396,10 @@ export interface IWidgetSvcConfig {
   twaEnable?: boolean;
   /** Used by wind Widget: enable/disable sailSetup UI feature */
   sailSetupEnable?: boolean;
+  /** Used by wind Widget: enable/disable rudder-angle bar UI feature */
+  rudderEnable?: boolean;
+  /** Used by wind Widget: flip the rudder-angle bar so it grows toward the side the boat turns */
+  invertRudder?: boolean;
 
   /** Used by autopilot Widget to configure autopilot settings */
   autopilot?: IAutopilotConfig,

--- a/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.html
+++ b/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.html
@@ -325,6 +325,16 @@
                   Drift
                 </mat-checkbox>
               }
+              @if ((widgetConfig?.rudderEnable !== undefined)) {
+                <mat-checkbox name="rudderEnable" formControlName="rudderEnable">
+                  Rudder Angle
+                </mat-checkbox>
+              }
+              @if ((widgetConfig?.invertRudder !== undefined)) {
+                <mat-checkbox name="invertRudder" formControlName="invertRudder">
+                  Invert Rudder
+                </mat-checkbox>
+              }
               @if ((widgetConfig?.minValue !== undefined) &&
                 !formMaster.get('displayScale')) {
                 <mat-form-field>

--- a/src/app/widgets/svg-windsteer/svg-windsteer.component.scss
+++ b/src/app/widgets/svg-windsteer/svg-windsteer.component.scss
@@ -102,3 +102,22 @@ svg {
   stroke-linecap: round;
   opacity: 0.38;
 }
+
+.rudder-stbd,
+.rudder-port {
+  fill: none;
+  stroke-width: 39.6875;
+  stroke-linecap: butt;
+  stroke-dasharray: 100 100;
+  // The dial's port/starboard band colours are too dark to read on this thin bar; lift them
+  // per-theme without disturbing the shared band/sector colours.
+  filter: brightness(1.8);
+}
+
+.rudder-stbd {
+  stroke: var(--skip-starboard-color);
+}
+
+.rudder-port {
+  stroke: var(--skip-port-color);
+}

--- a/src/app/widgets/svg-windsteer/svg-windsteer.component.spec.ts
+++ b/src/app/widgets/svg-windsteer/svg-windsteer.component.spec.ts
@@ -324,4 +324,60 @@ describe('SvgWindsteerComponent', () => {
 
         expect(component['cogIndicator']().nativeElement.getAttribute('display')).toBe('inline');
     });
+
+    // Rudder bar (#435): the reveal is stroke-dashoffset over a static per-side arc (pathLength 100).
+    // offset 100 = empty, 0 = full; the fraction is 1:1 with the angle, capped at 35 degrees.
+    const stbdOffset = (): number => component['rudderStbdOffset']();
+    const portOffset = (): number => component['rudderPortOffset']();
+
+    it('hides both rudder arcs (offset 100) when the feature is disabled', () => {
+        setRequiredInputs({ rudderEnabled: false, rudderAngle: 20 });
+        fixture.detectChanges();
+        expect(stbdOffset()).toBe(100);
+        expect(portOffset()).toBe(100);
+        expect(fixture.nativeElement.querySelector('#layerRudder').style.display).toBe('none');
+    });
+
+    it('hides both rudder arcs when there is no rudder data (null)', () => {
+        setRequiredInputs({ rudderEnabled: true, rudderAngle: null });
+        fixture.detectChanges();
+        expect(stbdOffset()).toBe(100);
+        expect(portOffset()).toBe(100);
+        expect(fixture.nativeElement.querySelector('#layerRudder').style.display).toBe('inline');
+    });
+
+    it('reveals the starboard arc for a positive angle and keeps port empty', () => {
+        setRequiredInputs({ rudderEnabled: true, rudderAngle: 17.5 });
+        fixture.detectChanges();
+        expect(stbdOffset()).toBeCloseTo(50);   // 17.5/35 = 0.5 revealed
+        expect(portOffset()).toBe(100);
+    });
+
+    it('reveals the port arc for a negative angle and keeps starboard empty', () => {
+        setRequiredInputs({ rudderEnabled: true, rudderAngle: -35 });
+        fixture.detectChanges();
+        expect(portOffset()).toBe(0);           // full reveal at hard-over
+        expect(stbdOffset()).toBe(100);
+    });
+
+    it('caps the reveal at 35 degrees for over-range angles', () => {
+        setRequiredInputs({ rudderEnabled: true, rudderAngle: 70 });
+        fixture.detectChanges();
+        expect(stbdOffset()).toBe(0);
+    });
+
+    it('ties the rudder reveal transition to the update interval', () => {
+        setRequiredInputs({ rudderEnabled: true, rudderAngle: 10, updateInterval: 100 });
+        fixture.detectChanges();
+        expect(component['rudderTransition']()).toBe('stroke-dashoffset 100ms linear');
+    });
+
+    it('binds the reveal to the correct per-side arc element (starboard = green/right)', () => {
+        setRequiredInputs({ rudderEnabled: true, rudderAngle: 17.5 });
+        fixture.detectChanges();
+        const stbd = fixture.nativeElement.querySelector('.rudder-stbd') as SVGPathElement;
+        const port = fixture.nativeElement.querySelector('.rudder-port') as SVGPathElement;
+        expect(parseFloat(stbd.style.strokeDashoffset)).toBeCloseTo(50);
+        expect(parseFloat(port.style.strokeDashoffset)).toBeCloseTo(100);
+    });
 });

--- a/src/app/widgets/svg-windsteer/svg-windsteer.component.svg
+++ b/src/app/widgets/svg-windsteer/svg-windsteer.component.svg
@@ -608,6 +608,17 @@
     <path class="crosshair"
       d="M 48,500 L 360,500 M 640,500 L 952,500" />
   </g>
+  <g id="layerRudder"
+     [style.display]="rudderEnabled() ? 'inline' : 'none'">
+    <path class="rudder-stbd" pathLength="100"
+      [style.stroke-dashoffset]="rudderStbdOffset()"
+      [style.transition]="rudderTransition()"
+      d="M 500,969.635 A 469.635,469.635 0 0 0 769.376,884.703" />
+    <path class="rudder-port" pathLength="100"
+      [style.stroke-dashoffset]="rudderPortOffset()"
+      [style.transition]="rudderTransition()"
+      d="M 500,969.635 A 469.635,469.635 0 0 1 230.624,884.703" />
+  </g>
   <g id="layerCounter">
     <g id="twsCounter"
       [style.display]="twsEnabled() ? 'inline' : 'none'">

--- a/src/app/widgets/svg-windsteer/svg-windsteer.component.ts
+++ b/src/app/widgets/svg-windsteer/svg-windsteer.component.ts
@@ -54,6 +54,9 @@ export class SvgWindsteerComponent implements OnDestroy {
   protected readonly trueWindMinHistoric = input<number | undefined>(undefined);
   protected readonly trueWindMidHistoric = input<number | undefined>(undefined);
   protected readonly trueWindMaxHistoric = input<number | undefined>(undefined);
+  // Rudder-angle bar: signed degrees, +ve = starboard (right). null hides the bar.
+  protected readonly rudderAngle = input<number | null>(null);
+  protected readonly rudderEnabled = input<boolean>(false);
 
   protected compass: ISVGRotationObject = { oldValue: 0, newValue: 0 };
   protected twa: ISVGRotationObject = { oldValue: 0, newValue: 0 };
@@ -98,6 +101,22 @@ export class SvgWindsteerComponent implements OnDestroy {
   private readonly RADIUS = 350;
   private readonly animationDuration = computed(() => effectiveAnimationDuration(this.updateInterval()));
   private readonly EPS_ANGLE = 1.0; // degrees, gate tiny animations
+
+  // Rudder bar: the SVG holds a static 35 arc per side (pathLength 100); the reveal is the
+  // stroke-dashoffset. offset 100 = empty, 0 = full; fraction is 1:1 with the rudder angle.
+  private readonly RUDDER_MAX_DEG = 35;
+  protected readonly rudderStbdOffset = computed(() => this.rudderDashOffset(true));
+  protected readonly rudderPortOffset = computed(() => this.rudderDashOffset(false));
+  protected readonly rudderTransition = computed(() => `stroke-dashoffset ${this.animationDuration()}ms linear`);
+
+  private rudderDashOffset(starboard: boolean): number {
+    if (!this.rudderEnabled()) return 100;
+    const angle = this.rudderAngle();
+    if (angle == null || !Number.isFinite(angle)) return 100;
+    const magnitude = starboard ? Math.max(angle, 0) : Math.max(-angle, 0);
+    const fraction = Math.min(magnitude, this.RUDDER_MAX_DEG) / this.RUDDER_MAX_DEG;
+    return 100 * (1 - fraction);
+  }
 
   private readonly ngZone = inject(NgZone);
 

--- a/src/app/widgets/widget-windsteer/widget-windsteer.component.html
+++ b/src/app/widgets/widget-windsteer/widget-windsteer.component.html
@@ -29,4 +29,6 @@
   [trueWindMidHistoric]="trueWindMidHistoric()"
   [trueWindMaxHistoric]="trueWindMaxHistoric()"
   [sailSetupEnabled]="runtime.options()?.sailSetupEnable ?? false"
+  [rudderAngle]="rudderAngle()"
+  [rudderEnabled]="runtime.options()?.rudderEnable ?? true"
 ></svg-windsteer>

--- a/src/app/widgets/widget-windsteer/widget-windsteer.component.spec.ts
+++ b/src/app/widgets/widget-windsteer/widget-windsteer.component.spec.ts
@@ -265,6 +265,91 @@ describe('WidgetWindComponent waypoint presence (#441)', () => {
 });
 
 /**
+ * #435: rudder angle drives a bar on the windsteer dial. steering.rudderAngle is +ve to starboard,
+ * and a rudder to starboard turns the boat to starboard, so the raw sign already matches the
+ * boat-turn side; invertRudder flips it for a reversed sensor. Absence (null) hides the bar
+ * entirely rather than drawing a centred zero.
+ */
+describe('WidgetWindComponent rudder angle (#435)', () => {
+  let component: WidgetWindComponent;
+  let options: WritableSignal<IWidgetSvcConfig | undefined>;
+  let callbacks: Map<string, (u: IPathUpdate) => void>;
+
+  const update = (value: number | null): IPathUpdate => ({ data: { value, timestamp: null }, state: 'normal' });
+  const rudder = (): number | null =>
+    (component as unknown as { rudderAngle: () => number | null }).rudderAngle();
+
+  const build = (cfg: Partial<IWidgetSvcConfig> = {}) => {
+    options = signal<IWidgetSvcConfig | undefined>({ ...WidgetWindComponent.DEFAULT_CONFIG, ...cfg });
+    callbacks = new Map<string, (u: IPathUpdate) => void>();
+    const streamsMock = {
+      observe: (pathName: string, next: (u: IPathUpdate) => void) => { callbacks.set(pathName, next); }
+    };
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: WidgetRuntimeDirective, useValue: { options } },
+        { provide: WidgetStreamsDirective, useValue: streamsMock },
+        { provide: UnitsService, useValue: unitsServiceStub }
+      ]
+    });
+    component = TestBed.runInInjectionContext(() => new WidgetWindComponent());
+    TestBed.tick();
+  };
+
+  it('registers the rudder stream on a configurable, degree-converted path', () => {
+    build();
+    expect(callbacks.has('rudderAngle')).toBe(true);
+    const path = WidgetWindComponent.DEFAULT_CONFIG.paths?.['rudderAngle'];
+    expect(path?.isPathConfigurable).toBe(true);
+    expect(path?.convertUnitTo).toBe('deg');
+    expect(path?.path).toBe('self.steering.rudderAngle');
+  });
+
+  it('passes the raw value through by default (starboard rudder = boat turns starboard)', () => {
+    build();
+    callbacks.get('rudderAngle')!(update(10));
+    expect(rudder()).toBe(10);
+  });
+
+  it('flips the sign when invertRudder is enabled (reversed sensor)', () => {
+    build({ invertRudder: true });
+    callbacks.get('rudderAngle')!(update(10));
+    expect(rudder()).toBe(-10);
+  });
+
+  it('hides the bar (null) when the rudder value goes away', () => {
+    build();
+    callbacks.get('rudderAngle')!(update(10));
+    expect(rudder()).toBe(10);
+    callbacks.get('rudderAngle')!(update(null));
+    expect(rudder()).toBeNull();
+  });
+
+  it('re-signs the cached sample on a live invertRudder toggle (no new sample)', () => {
+    build();
+    callbacks.get('rudderAngle')!(update(10));
+    expect(rudder()).toBe(10);
+    options.set({ ...WidgetWindComponent.DEFAULT_CONFIG, invertRudder: true });
+    TestBed.tick();
+    expect(rudder()).toBe(-10);
+  });
+
+  it('keeps a centred (0) rudder present rather than coercing it to null', () => {
+    build();
+    callbacks.get('rudderAngle')!(update(0));
+    expect(rudder()).toBe(0);
+  });
+
+  it('hides the bar on a non-finite value so a NaN sample cannot stick', () => {
+    build();
+    callbacks.get('rudderAngle')!(update(NaN));
+    expect(rudder()).toBeNull();
+    callbacks.get('rudderAngle')!(update(12));
+    expect(rudder()).toBe(12);
+  });
+});
+
+/**
  * #442: the COG arrow hides at rest. That needs a speed-over-ground value the widget doesn't
  * otherwise use — plumbed as a hidden, source-linked path and tracked in `sog`.
  */

--- a/src/app/widgets/widget-windsteer/widget-windsteer.component.ts
+++ b/src/app/widgets/widget-windsteer/widget-windsteer.component.ts
@@ -163,6 +163,18 @@ export class WidgetWindComponent implements OnDestroy {
         showPathSkUnitsFilter: false,
         pathSkUnitsFilter: 'm/s',
         convertUnitTo: 'knots'
+      },
+      rudderAngle: {
+        description: 'Rudder Angle',
+        path: 'self.steering.rudderAngle',
+        source: 'default',
+        pathType: 'number',
+        isPathConfigurable: true,
+        pathRequired: false,
+        showPathSkUnitsFilter: false,
+        pathSkUnitsFilter: 'rad',
+        convertUnitTo: 'deg',
+        showConvertUnitTo: false
       }
     },
     compassModeEnabled: true,
@@ -177,6 +189,8 @@ export class WidgetWindComponent implements OnDestroy {
     twsEnable: true,
     twaEnable: true,
     sailSetupEnable: false,
+    rudderEnable: true,
+    invertRudder: false,
     updateInterval: 1000,
     enableTimeout: false,
     dataTimeout: 5
@@ -199,6 +213,7 @@ export class WidgetWindComponent implements OnDestroy {
   private hasWPT = false;
   private hasSOG = false;
   private lastRawTrueWindAngle: number | null = null;
+  private lastRawRudder: number | null = null;
 
   protected currentHeading = signal(0);
   protected courseOverGroundAngle = signal(0);
@@ -226,6 +241,8 @@ export class WidgetWindComponent implements OnDestroy {
     return s == null || s >= this.speedInDisplayUnit(this.sogMeasure(), SOG_HIDE_LIMIT_MS);
   });
   protected waypointAngle = signal<number | undefined>(undefined);
+  // Signed degrees, +ve = starboard (after invertRudder). null = no rudder data (bar hidden).
+  protected rudderAngle = signal<number | null>(null);
   protected historicalWindDirection: { timestamp: number; windDirection: number; }[] = [];
   protected trueWindMinHistoric = signal<number | undefined>(undefined);
   protected trueWindMidHistoric = signal<number | undefined>(undefined);
@@ -256,6 +273,8 @@ export class WidgetWindComponent implements OnDestroy {
         // offset until the next sample arrives (#73). currentHeading is read untracked to avoid
         // re-running this effect on every heading tick.
         this.applyTrueWindBase();
+        // A live invertRudder toggle must re-sign the cached sample without a new stream tick.
+        this.applyRudder();
       });
     });
   }
@@ -316,6 +335,12 @@ export class WidgetWindComponent implements OnDestroy {
       this.waypointAngle.set(next); this.hasWPT = true;
     }
   };
+  private onRudderUpdate = (u: IPathUpdate) => {
+    // A non-finite or absent value hides the bar; a real 0 keeps it present but draws nothing.
+    // Cache the raw value so a live invertRudder toggle can re-sign it without a new sample.
+    this.lastRawRudder = Number.isFinite(u.data.value) ? u.data.value : null;
+    this.applyRudder();
+  };
   private onAppWindAngle = (u: IPathUpdate) => {
     if (u.data.value == null) u.data.value = 0;
     const raw = u.data.value;
@@ -375,6 +400,22 @@ export class WidgetWindComponent implements OnDestroy {
     this.trueWindAngle.set(this.normalizeAngle(this.computeTrueWindBase(this.lastRawTrueWindAngle)));
   }
 
+  // Resolve the signed rudder angle from the last raw sample. steering.rudderAngle is +ve to
+  // starboard, and a rudder to starboard turns the boat to starboard, so the raw sign already
+  // matches the side the boat turns (green to the right); invertRudder corrects a reversed sensor.
+  private applyRudder() {
+    const raw = this.lastRawRudder;
+    if (raw == null) {
+      if (this.rudderAngle() !== null) this.rudderAngle.set(null);
+      return;
+    }
+    const signed = (this.runtime.options()?.invertRudder ?? false) ? -raw : raw;
+    const cur = this.rudderAngle();
+    if (cur == null || Math.abs(cur - signed) >= this.DEG_EPSILON) {
+      this.rudderAngle.set(signed);
+    }
+  }
+
   private registerStreams() {
     const cfg = this.runtime.options();
     if (!cfg) return;
@@ -388,6 +429,7 @@ export class WidgetWindComponent implements OnDestroy {
     this.stream.observe('appWindSpeed', this.onAppWindSpeed);
     this.stream.observe('trueWindSpeed', this.onTrueWindSpeed);
     this.stream.observe('trueWindAngle', this.onTrueWindAngle);
+    this.stream.observe('rudderAngle', this.onRudderUpdate);
   }
 
   ngOnDestroy() {

--- a/src/assets/skip-dashboard-schema.json
+++ b/src/assets/skip-dashboard-schema.json
@@ -2804,6 +2804,7 @@
         "driftEnable": true,
         "enableTimeout": false,
         "filterSelfPaths": true,
+        "invertRudder": false,
         "laylineAngle": 40,
         "laylineEnable": true,
         "paths": {
@@ -2897,6 +2898,18 @@
             "showPathSkUnitsFilter": false,
             "source": "default"
           },
+          "rudderAngle": {
+            "convertUnitTo": "deg",
+            "description": "Rudder Angle",
+            "isPathConfigurable": true,
+            "path": "self.steering.rudderAngle",
+            "pathRequired": false,
+            "pathSkUnitsFilter": "rad",
+            "pathType": "number",
+            "showConvertUnitTo": false,
+            "showPathSkUnitsFilter": false,
+            "source": "default"
+          },
           "set": {
             "convertUnitTo": "deg",
             "description": "True Drift Set",
@@ -2955,6 +2968,7 @@
             "source": "default"
           }
         },
+        "rudderEnable": true,
         "sailSetupEnable": false,
         "supportAutomaticHistoricalSeries": false,
         "twaEnable": true,
@@ -3127,6 +3141,19 @@
           "pathRequired": false,
           "pathType": "number",
           "slot": "drift",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "deg",
+          "defaultPath": "self.steering.rudderAngle",
+          "description": "Rudder Angle",
+          "expectedSkUnit": "rad",
+          "hideFromConfig": false,
+          "isPathConfigurable": true,
+          "pathOptions": null,
+          "pathRequired": false,
+          "pathType": "number",
+          "slot": "rudderAngle",
           "source": "default"
         }
       ],


### PR DESCRIPTION
## What

Adds a rudder-angle indicator to the WindSteer widget (closes #435), as a bar riding the bottom of the dial ring. The bar grows from dead astern (180°) toward the side the boat turns — **green to starboard, red to port** — 1:1 with the dial's own degree scale, capped at 35°. It mirrors the existing top port/starboard bands, and its zero point sits on the stern lubber line.

mairas asked for a graphical (rather than numeric) indicator in the issue; this reuses the empty stern region of the dial.

## Why this shape

- **Boat-fixed, not on the rotating card.** Rudder angle is boat-relative, so the bar is a fixed overlay (same slot as the crosshair) and stays put in both compass and simple modes while the card rotates underneath.
- **Reveal, not redraw.** Each side is a static arc (`pathLength=100`); the fill is a `stroke-dashoffset`, transitioned in step with the widget's `updateInterval` — no hidden fixed-duration low-pass.
- **Graceful absence.** Renders nothing when `steering.rudderAngle` has no data, so boats without a rudder sensor see no change. Existing WindSteer widgets pick up the new path/toggles automatically via the runtime config deep-merge — no config migration or version bump.

## Direction

`steering.rudderAngle` is +ve to starboard, and a rudder to starboard turns the boat to starboard, so the raw sign already matches the side the boat turns (green to the right). `invertRudder` defaults **off** and only flips the sign for a reversed sensor. Both the enable and invert toggles live in the widget config; the path (default `self.steering.rudderAngle`) is configurable on the Paths tab.

## Config

- New `rudderAngle` path (configurable, degree-converted).
- New `rudderEnable` (default on) and `invertRudder` (default off) flags.
- `skip-dashboard-schema.json` regenerated.

## Testing

- `npm run snc`, `npm run lint`, `npm run test:mcp-schema`, full `npm test` (1735 tests) — all green locally.
- 10 new specs cover the reveal geometry (direction, proportion, 35° cap, hidden when disabled/no-data, transition tied to updateInterval) and the orchestrator (sign, invert, null-hides-bar, stream registration).
- Geometry validated offline against the real template render; deployed to the boat (which publishes `steering.rudderAngle`) for a live look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
