### PR TITLE
fix(audio): play alarms via Web Audio to drop the Android media card

### DIFF
--- a/src/app/core/services/notifications.service.spec.ts
+++ b/src/app/core/services/notifications.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { signal, WritableSignal } from '@angular/core';
+import { signal, Signal, WritableSignal } from '@angular/core';
 import { Subject } from 'rxjs';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { INotification, INotificationInfo, NotificationsService } from './notifications.service';
@@ -7,6 +7,7 @@ import { DataService } from './data.service';
 import { SettingsService } from './settings.service';
 import { SignalkRequestsService } from './signalk-requests.service';
 import { ConnectionState, ConnectionStateMachine } from './connection-state-machine.service';
+import { SoundService } from './sound.service';
 import { INotificationConfig } from '../interfaces/app-settings.interfaces';
 import { ISignalKDataValueUpdate, ISignalKNotification, ISkMetadata, Methods, States, TMethod, TState } from '../interfaces/signalk-interfaces';
 import { IMeta } from '../interfaces/app-interfaces';
@@ -54,6 +55,12 @@ describe('NotificationsService', () => {
   let connectionState$: Subject<ConnectionState>;
   let putRequest: ReturnType<typeof vi.fn>;
   let service: NotificationsService;
+  let sound: {
+    playLoop: ReturnType<typeof vi.fn>;
+    stopLoop: ReturnType<typeof vi.fn>;
+    playOnce: ReturnType<typeof vi.fn>;
+    blocked: Signal<boolean>;
+  };
 
   function setup(initialConfig: INotificationConfig = makeConfig()): void {
     configSignal = signal<INotificationConfig>(initialConfig);
@@ -73,6 +80,7 @@ describe('NotificationsService', () => {
     const requestsStub: Partial<SignalkRequestsService> = {
       putRequest: putRequest as SignalkRequestsService['putRequest'],
     };
+    sound = { playLoop: vi.fn(), stopLoop: vi.fn(), playOnce: vi.fn(), blocked: signal(false) };
 
     TestBed.configureTestingModule({
       providers: [
@@ -80,6 +88,7 @@ describe('NotificationsService', () => {
         { provide: DataService, useValue: dataStub },
         { provide: SignalkRequestsService, useValue: requestsStub },
         { provide: ConnectionStateMachine, useValue: { state$: connectionState$.asObservable() } },
+        { provide: SoundService, useValue: sound as unknown as SoundService },
       ],
     });
     service = TestBed.inject(NotificationsService);
@@ -99,10 +108,6 @@ describe('NotificationsService', () => {
 
   function activeTrack(): number | null {
     return (service as unknown as { _activeAlarmSoundtrack: number | null })._activeAlarmSoundtrack;
-  }
-
-  function alarmPlayer(track: number): HTMLAudioElement {
-    return (service as unknown as { _players: Map<number, HTMLAudioElement> })._players.get(track)!;
   }
 
   describe('alarm state aggregation from deltas', () => {
@@ -401,9 +406,8 @@ describe('NotificationsService', () => {
       expect(latestNotifications()).toHaveLength(1);
       expect(activeTrack()).toBe(1003);
 
-      const player = alarmPlayer(1003);
-      const playSpy = vi.spyOn(player, 'play');
-      const pauseSpy = vi.spyOn(player, 'pause');
+      sound.playLoop.mockClear();
+      sound.stopLoop.mockClear();
 
       vi.useFakeTimers();
       // A drop must not clear; the reconnect that follows must not blank or silence the alarm.
@@ -414,15 +418,15 @@ describe('NotificationsService', () => {
       expect(activeTrack()).toBe(1003);
 
       // The snapshot re-delivers the same still-active alarm: recognised as the existing entry, not
-      // cleared-and-re-added, so the looping player is never paused/restarted.
+      // cleared-and-re-added, so the looping track is never stopped/restarted.
       notificationMsg$.next(makeDelta('notifications.bilge', makeValue(States.Alarm, [Methods.Visual, Methods.Sound])));
       vi.runOnlyPendingTimers();
 
       expect(latestNotifications()).toHaveLength(1);
       expect(latestInfo().alarmCount).toBe(1);
       expect(activeTrack()).toBe(1003);
-      expect(playSpy).not.toHaveBeenCalled();
-      expect(pauseSpy).not.toHaveBeenCalled();
+      expect(sound.playLoop).not.toHaveBeenCalled();
+      expect(sound.stopLoop).not.toHaveBeenCalled();
     });
 
     it('sweeps a notification the server no longer reports once the snapshot settles', () => {
@@ -494,7 +498,7 @@ describe('NotificationsService', () => {
       expect(latestNotifications()).toHaveLength(1);
       expect(activeTrack()).toBe(1003);
 
-      const pauseSpy = vi.spyOn(alarmPlayer(1003), 'pause');
+      sound.stopLoop.mockClear();
 
       vi.useFakeTimers();
       connectionState$.next(ConnectionState.Disconnected);
@@ -508,7 +512,7 @@ describe('NotificationsService', () => {
       expect(latestNotifications().map(n => n.path)).toContain('notifications.bilge');
       expect(latestInfo().alarmCount).toBe(1);
       expect(activeTrack()).toBe(1003);
-      expect(pauseSpy).not.toHaveBeenCalled();
+      expect(sound.stopLoop).not.toHaveBeenCalled();
     });
 
     it('does not reconcile or clear notifications while the connection stays up', () => {

--- a/src/app/core/services/notifications.service.spec.ts
+++ b/src/app/core/services/notifications.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { signal, Signal, WritableSignal } from '@angular/core';
+import { signal, WritableSignal } from '@angular/core';
 import { Subject } from 'rxjs';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { INotification, INotificationInfo, NotificationsService } from './notifications.service';
@@ -8,6 +8,7 @@ import { SettingsService } from './settings.service';
 import { SignalkRequestsService } from './signalk-requests.service';
 import { ConnectionState, ConnectionStateMachine } from './connection-state-machine.service';
 import { SoundService } from './sound.service';
+import { ToastService } from './toast.service';
 import { INotificationConfig } from '../interfaces/app-settings.interfaces';
 import { ISignalKDataValueUpdate, ISignalKNotification, ISkMetadata, Methods, States, TMethod, TState } from '../interfaces/signalk-interfaces';
 import { IMeta } from '../interfaces/app-interfaces';
@@ -59,8 +60,9 @@ describe('NotificationsService', () => {
     playLoop: ReturnType<typeof vi.fn>;
     stopLoop: ReturnType<typeof vi.fn>;
     playOnce: ReturnType<typeof vi.fn>;
-    blocked: Signal<boolean>;
+    blocked: WritableSignal<boolean>;
   };
+  let toast: { show: ReturnType<typeof vi.fn>; dismiss: ReturnType<typeof vi.fn> };
 
   function setup(initialConfig: INotificationConfig = makeConfig()): void {
     configSignal = signal<INotificationConfig>(initialConfig);
@@ -81,6 +83,9 @@ describe('NotificationsService', () => {
       putRequest: putRequest as SignalkRequestsService['putRequest'],
     };
     sound = { playLoop: vi.fn(), stopLoop: vi.fn(), playOnce: vi.fn(), blocked: signal(false) };
+    const dismiss = vi.fn();
+    const show = vi.fn().mockReturnValue({ afterDismissed: () => new Subject<void>().asObservable(), dismiss });
+    toast = { show, dismiss };
 
     TestBed.configureTestingModule({
       providers: [
@@ -89,6 +94,7 @@ describe('NotificationsService', () => {
         { provide: SignalkRequestsService, useValue: requestsStub },
         { provide: ConnectionStateMachine, useValue: { state$: connectionState$.asObservable() } },
         { provide: SoundService, useValue: sound as unknown as SoundService },
+        { provide: ToastService, useValue: { show } as unknown as ToastService },
       ],
     });
     service = TestBed.inject(NotificationsService);
@@ -316,6 +322,37 @@ describe('NotificationsService', () => {
 
       service.mutePlayer(false);
       expect(latestInfo()).toMatchObject({ audioSev: 4, isMuted: false });
+    });
+  });
+
+  describe('SoundService delegation', () => {
+    it('plays the mapped alarm track through SoundService, and stops on clear', () => {
+      setup();
+      notificationMsg$.next(makeDelta('notifications.a', makeValue(States.Alarm, [Methods.Visual, Methods.Sound])));
+      expect(sound.playLoop).toHaveBeenCalledWith('alarm', 1);
+
+      notificationMsg$.next(makeDelta('notifications.a', makeValue(States.Emergency, [Methods.Visual, Methods.Sound])));
+      expect(sound.playLoop).toHaveBeenCalledWith('emergency', 1);
+
+      sound.stopLoop.mockClear();
+      notificationMsg$.next(makeDelta('notifications.a', null));
+      expect(sound.stopLoop).toHaveBeenCalled();
+    });
+  });
+
+  describe('audio-blocked prompt', () => {
+    it('shows the prompt when audio is blocked and dismisses it on unblock', () => {
+      setup();
+      expect(toast.show).not.toHaveBeenCalled();
+
+      sound.blocked.set(true);
+      TestBed.tick();
+      expect(toast.show).toHaveBeenCalledTimes(1);
+      expect(String(toast.show.mock.calls[0][0])).toContain('blocked');
+
+      sound.blocked.set(false);
+      TestBed.tick();
+      expect(toast.dismiss).toHaveBeenCalled();
     });
   });
 

--- a/src/app/core/services/notifications.service.ts
+++ b/src/app/core/services/notifications.service.ts
@@ -5,6 +5,7 @@ import { Injectable, OnDestroy, effect, inject } from '@angular/core';
 import { BehaviorSubject, map, Observable, Subscription } from 'rxjs';
 import { SettingsService } from "./settings.service";
 import { ToastService } from './toast.service';
+import { SoundService } from './sound.service';
 import { INotificationConfig } from '../interfaces/app-settings.interfaces';
 import { DefaultNotificationConfig } from '../../../default-config/config.blank.notification.const';
 import { SignalkRequestsService } from './signalk-requests.service';
@@ -55,6 +56,7 @@ export class NotificationsService implements OnDestroy {
   private data = inject(DataService);
   private requests = inject(SignalkRequestsService);
   private connectionStateMachine = inject(ConnectionStateMachine);
+  private sound = inject(SoundService);
 
   private static readonly ALARM_SEVERITIES: IAlarmSeverities = {
     normal: { sound: 0, visual: 0 },
@@ -83,9 +85,6 @@ export class NotificationsService implements OnDestroy {
   private _notifications$ = new BehaviorSubject<INotification[]>([]);
   private _alarmsInfo$ = new BehaviorSubject<IAlarmInfo>({ audioSev: 0, visualSev: 0, alarmCount: 0, isMuted: false });
 
-  // --- HTMLAudioElement (audio) state ----------------------------------------
-  // Cache one player per track id and reuse across switches.
-  private _players = new Map<number, HTMLAudioElement>();
   private _activeAlarmSoundtrack: number | null = null;
   private _isMuted = false;
 
@@ -109,8 +108,9 @@ export class NotificationsService implements OnDestroy {
       this._wasConnected = connected;
     });
 
-    // Pre-cache silent track player
-    this.getPlayer(1000);
+    effect(() => {
+      if (this.sound.blocked()) this.showAudioBlockedPrompt();
+    });
   }
 
   private applyNotificationConfig(config: INotificationConfig): void {
@@ -393,80 +393,42 @@ export class NotificationsService implements OnDestroy {
     );
   }
 
-  private getPlayer(track: number): HTMLAudioElement {
-    const existing = this._players.get(track);
-    if (existing) return existing;
-    const name = alarmTrack[track];
-    if (!name) {
-      console.warn('[Notification Service] Unknown track id', track);
-      return this.getPlayer(1000);
-    }
-    const player = new Audio(`assets/${name}.mp3`);
-    player.preload = 'auto';
-    player.loop = true;
-    player.muted = this._isMuted;
-    this._players.set(track, player);
-    return player;
-  }
-
   /**
-   * Mutes/unmutes the currently playing alarm sound (if any).
-   *
-   * Also updates the emitted alarm summary (`isMuted`) and may influence computed audio severity.
+   * Mutes/unmutes alarm sound. Mute is severity-driven: with `_isMuted` set, `getNotificationSeverity`
+   * zeroes audio severity, so `updateNotificationsState` stops the active track via `playAlarm(1000)`.
    */
   mutePlayer(state: boolean) {
-    if (this._activeAlarmSoundtrack != null && this._activeAlarmSoundtrack !== 1000) {
-      const p = this._players.get(this._activeAlarmSoundtrack);
-      if (p) p.muted = state;
-    }
     this._isMuted = state;
     this.updateNotificationsState();
   }
 
   /**
-   * Switches the active looping alarm track.
+   * Switches the active looping alarm track through the SoundService.
    *
    * Track ids map to: 1000=stop/silent, 1001=alert, 1002=warn, 1003=alarm, 1004=emergency.
-   * This stops the previously active audio player (but keeps it cached for reuse).
+   * Re-selecting the active track is a no-op, so an unchanged alarm never restarts its tone.
    */
   playAlarm(trackId: number) {
     if (this._activeAlarmSoundtrack === trackId) return;
+    this._activeAlarmSoundtrack = trackId;
 
-    // Stop previous track (do not unload to allow reuse)
-    if (this._activeAlarmSoundtrack != null) {
-      const prev = this._players.get(this._activeAlarmSoundtrack);
-      if (prev) {
-        prev.pause();
-        prev.currentTime = 0;
-      }
-    }
-
-    if (trackId === 1000) {
-      this._activeAlarmSoundtrack = 1000;
+    const name = alarmTrack[trackId];
+    if (!name || trackId === 1000) {
+      this.sound.stopLoop();
       return;
     }
+    this.sound.playLoop(name, 1);
+  }
 
-    const player = this.getPlayer(trackId);
-    this._activeAlarmSoundtrack = trackId;
-    player.muted = this._isMuted;
-    player.currentTime = 0;
-    player.play().catch(err => {
-      // Autoplay blocked by browser policy - requires user interaction first
-      console.debug('Alarm audio playback blocked:', err.message);
-      if (!this.audioBlockedNotificationShown) {
-        this.audioBlockedNotificationShown = true;
-        // Show persistent toast requiring user interaction to dismiss
-        const blockRef = this.toastService.show(
-          'Alarm sounds blocked by browser. Closing this message will enable audio.',
-          0, // No timeout - requires user to close
-          true, // Silent to avoid recursion
-          'warn'
-        );
-        // Reset flag when user dismisses, allowing audio to work after interaction
-        blockRef.afterDismissed().subscribe(() => {
-          this.audioBlockedNotificationShown = false;
-        });
-      }
+  private showAudioBlockedPrompt(): void {
+    if (this.audioBlockedNotificationShown) return;
+    this.audioBlockedNotificationShown = true;
+    const blockRef = this.toastService.show(
+      'Alarm sounds blocked by browser. Tap anywhere to enable audio.',
+      0, true, 'warn'
+    );
+    blockRef.afterDismissed().subscribe(() => {
+      this.audioBlockedNotificationShown = false;
     });
   }
 
@@ -488,16 +450,7 @@ export class NotificationsService implements OnDestroy {
     this._notifications$.complete();
     this._alarmsInfo$.complete();
 
-    // Stop and release all cached audio players
-    for (const p of this._players.values()) {
-      try {
-        p.pause();
-        p.currentTime = 0;
-        p.src = '';
-      } catch {
-        // ignore audio cleanup errors
-      }
-    }
-    this._players.clear();
+    // Stop this service's alarm track only; the shared SoundService context is not ours to close.
+    this.sound.stopLoop();
   }
 }

--- a/src/app/core/services/notifications.service.ts
+++ b/src/app/core/services/notifications.service.ts
@@ -17,7 +17,6 @@ import { TMethod, ISignalKDataValueUpdate, ISkMetadata, ISignalKNotification, St
 import { IMeta } from '../interfaces/app-interfaces';
 
 const alarmTrack = {
-  1000: 'notification', // filler / silent (stop)
   1001: 'alert',
   1002: 'warn',
   1003: 'alarm',
@@ -53,6 +52,7 @@ export class NotificationsService implements OnDestroy {
   private settings = inject(SettingsService);
   private toastService = inject(ToastService);
   private audioBlockedNotificationShown = false;
+  private _audioBlockedRef: ReturnType<ToastService['show']> | null = null;
   private data = inject(DataService);
   private requests = inject(SignalkRequestsService);
   private connectionStateMachine = inject(ConnectionStateMachine);
@@ -110,6 +110,7 @@ export class NotificationsService implements OnDestroy {
 
     effect(() => {
       if (this.sound.blocked()) this.showAudioBlockedPrompt();
+      else this.dismissAudioBlockedPrompt();
     });
   }
 
@@ -412,8 +413,9 @@ export class NotificationsService implements OnDestroy {
     if (this._activeAlarmSoundtrack === trackId) return;
     this._activeAlarmSoundtrack = trackId;
 
+    // trackId 1000 (silent) has no asset, so the guard stops the loop for it and any unmapped id.
     const name = alarmTrack[trackId];
-    if (!name || trackId === 1000) {
+    if (!name) {
       this.sound.stopLoop();
       return;
     }
@@ -423,13 +425,18 @@ export class NotificationsService implements OnDestroy {
   private showAudioBlockedPrompt(): void {
     if (this.audioBlockedNotificationShown) return;
     this.audioBlockedNotificationShown = true;
-    const blockRef = this.toastService.show(
-      'Alarm sounds blocked by browser. Tap anywhere to enable audio.',
+    this._audioBlockedRef = this.toastService.show(
+      'Sounds blocked by the browser. Tap anywhere to enable audio.',
       0, true, 'warn'
     );
-    blockRef.afterDismissed().subscribe(() => {
+    this._audioBlockedRef.afterDismissed().subscribe(() => {
       this.audioBlockedNotificationShown = false;
+      this._audioBlockedRef = null;
     });
+  }
+
+  private dismissAudioBlockedPrompt(): void {
+    this._audioBlockedRef?.dismiss();
   }
 
   /**

--- a/src/app/core/services/sound.service.spec.ts
+++ b/src/app/core/services/sound.service.spec.ts
@@ -20,6 +20,7 @@ class FakeGain {
 class FakeAudioContext {
   static instances: FakeAudioContext[] = [];
   static autoResume = true;
+  static decodeFailures = 0; // number of initial decodeAudioData calls that reject
 
   state: 'suspended' | 'running' | 'closed' = 'suspended';
   currentTime = 0;
@@ -31,7 +32,10 @@ class FakeAudioContext {
 
   createBufferSource(): FakeSource { const s = new FakeSource(); this.sources.push(s); return s; }
   createGain(): FakeGain { return new FakeGain(); }
-  decodeAudioData = vi.fn(async () => ({} as AudioBuffer));
+  decodeAudioData = vi.fn(async () => {
+    if (FakeAudioContext.decodeFailures > 0) { FakeAudioContext.decodeFailures--; throw new Error('decode failed'); }
+    return {} as AudioBuffer;
+  });
   resume = vi.fn(async () => {
     if (FakeAudioContext.autoResume) { this.state = 'running'; this.onstatechange?.(); }
   });
@@ -52,6 +56,7 @@ describe('SoundService', () => {
     vi.unstubAllGlobals();
     FakeAudioContext.instances = [];
     FakeAudioContext.autoResume = true;
+    FakeAudioContext.decodeFailures = 0;
   });
 
   describe('without Web Audio support', () => {
@@ -125,6 +130,26 @@ describe('SoundService', () => {
       const source = ctx().sources.at(-1)!;
       svc.stopLoop();
       expect(source.stop).toHaveBeenCalled();
+    });
+
+    it('retries a transient decode failure and eventually starts the loop', async () => {
+      stubWebAudio();
+      FakeAudioContext.decodeFailures = 1; // first decode rejects; the retry must recover
+      const svc = new SoundService();
+      svc.playLoop('alarm');
+      await vi.waitFor(() => expect(ctx().sources.at(-1)?.start).toHaveBeenCalled(), { timeout: 2000 });
+      expect(ctx().sources.at(-1)!.loop).toBe(true);
+    });
+
+    it('plays a one-shot that does not loop and disconnects when it ends', async () => {
+      stubWebAudio();
+      const svc = new SoundService();
+      svc.playOnce('notification', 0.3);
+      await vi.waitFor(() => expect(ctx().sources.at(-1)?.start).toHaveBeenCalled());
+      const source = ctx().sources.at(-1)!;
+      expect(source.loop).toBe(false);
+      source.onended?.();
+      expect(source.disconnect).toHaveBeenCalled();
     });
   });
 });

--- a/src/app/core/services/sound.service.spec.ts
+++ b/src/app/core/services/sound.service.spec.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SoundService } from './sound.service';
+
+class FakeSource {
+  buffer: AudioBuffer | null = null;
+  loop = false;
+  onended: (() => void) | null = null;
+  start = vi.fn();
+  stop = vi.fn();
+  disconnect = vi.fn();
+  connect = vi.fn((node: unknown) => node);
+}
+
+class FakeGain {
+  gain = { value: 1 };
+  connect = vi.fn((node: unknown) => node);
+  disconnect = vi.fn();
+}
+
+class FakeAudioContext {
+  static instances: FakeAudioContext[] = [];
+  static autoResume = true;
+
+  state: 'suspended' | 'running' | 'closed' = 'suspended';
+  currentTime = 0;
+  destination = {};
+  onstatechange: (() => void) | null = null;
+  sources: FakeSource[] = [];
+
+  constructor() { FakeAudioContext.instances.push(this); }
+
+  createBufferSource(): FakeSource { const s = new FakeSource(); this.sources.push(s); return s; }
+  createGain(): FakeGain { return new FakeGain(); }
+  decodeAudioData = vi.fn(async () => ({} as AudioBuffer));
+  resume = vi.fn(async () => {
+    if (FakeAudioContext.autoResume) { this.state = 'running'; this.onstatechange?.(); }
+  });
+  close = vi.fn();
+}
+
+function stubWebAudio(): void {
+  FakeAudioContext.instances = [];
+  FakeAudioContext.autoResume = true;
+  vi.stubGlobal('AudioContext', FakeAudioContext as unknown as typeof AudioContext);
+  vi.stubGlobal('fetch', vi.fn(async () => ({ arrayBuffer: async () => new ArrayBuffer(8) } as Response)));
+}
+
+function ctx(): FakeAudioContext { return FakeAudioContext.instances[0]; }
+
+describe('SoundService', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    FakeAudioContext.instances = [];
+    FakeAudioContext.autoResume = true;
+  });
+
+  describe('without Web Audio support', () => {
+    it('is inert: no context, no throw', () => {
+      const svc = new SoundService();
+      expect(() => { svc.playLoop('alarm'); svc.playOnce('notification', 0.3); svc.stopLoop(); }).not.toThrow();
+      expect(FakeAudioContext.instances).toHaveLength(0);
+      expect(svc.blocked()).toBe(false);
+    });
+  });
+
+  describe('with Web Audio', () => {
+    it('decodes and starts a looping source', async () => {
+      stubWebAudio();
+      const svc = new SoundService();
+      svc.playLoop('alarm', 1);
+      await vi.waitFor(() => expect(ctx().sources.at(-1)?.start).toHaveBeenCalled());
+      const source = ctx().sources.at(-1)!;
+      expect(source.loop).toBe(true);
+      expect(fetch).toHaveBeenCalledWith('assets/alarm.mp3');
+    });
+
+    it('is a no-op when the same key is already looping', async () => {
+      stubWebAudio();
+      const svc = new SoundService();
+      svc.playLoop('alarm');
+      await vi.waitFor(() => expect(ctx().sources.at(-1)?.start).toHaveBeenCalled());
+      const countAfterFirst = ctx().sources.length;
+      svc.playLoop('alarm');
+      expect(ctx().sources.length).toBe(countAfterFirst);
+    });
+
+    it('replaces the current loop when the key changes', async () => {
+      stubWebAudio();
+      const svc = new SoundService();
+      svc.playLoop('alarm');
+      await vi.waitFor(() => expect(ctx().sources.at(-1)?.start).toHaveBeenCalled());
+      const first = ctx().sources.at(-1)!;
+      svc.playLoop('emergency');
+      await vi.waitFor(() => expect(ctx().sources.length).toBe(2));
+      expect(first.stop).toHaveBeenCalled();
+      expect(ctx().sources.at(-1)!.start).toHaveBeenCalled();
+    });
+
+    it('starts the source even while the context is suspended, and flags blocked', async () => {
+      stubWebAudio();
+      FakeAudioContext.autoResume = false; // gesture has not unlocked the context yet
+      const svc = new SoundService();
+      svc.playLoop('alarm');
+      expect(svc.blocked()).toBe(true);
+      await vi.waitFor(() => expect(ctx().sources.at(-1)?.start).toHaveBeenCalled());
+      expect(ctx().state).toBe('suspended');
+    });
+
+    it('clears blocked when the context resumes', async () => {
+      stubWebAudio();
+      FakeAudioContext.autoResume = false;
+      const svc = new SoundService();
+      svc.playLoop('alarm');
+      expect(svc.blocked()).toBe(true);
+      ctx().state = 'running';
+      ctx().onstatechange?.();
+      expect(svc.blocked()).toBe(false);
+    });
+
+    it('stopLoop stops the active source', async () => {
+      stubWebAudio();
+      const svc = new SoundService();
+      svc.playLoop('alarm');
+      await vi.waitFor(() => expect(ctx().sources.at(-1)?.start).toHaveBeenCalled());
+      const source = ctx().sources.at(-1)!;
+      svc.stopLoop();
+      expect(source.stop).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/core/services/sound.service.ts
+++ b/src/app/core/services/sound.service.ts
@@ -14,6 +14,8 @@ type AudioContextCtor = new () => AudioContext;
 @Injectable({ providedIn: 'root' })
 export class SoundService {
   private static readonly PRELOAD = ['alert', 'warn', 'alarm', 'emergency'];
+  private static readonly LOOP_DECODE_RETRIES = 3;
+  private static readonly RETRY_DELAY_MS = 500;
 
   private ctx: AudioContext | null = null;
   private readonly buffers = new Map<string, AudioBuffer>();
@@ -47,8 +49,21 @@ export class SoundService {
     this.stopLoop();
     const token = ++this.loopToken;
     this.resume(ctx);
+    this.startLoop(key, gain, token, SoundService.LOOP_DECODE_RETRIES);
+  }
+
+  private startLoop(key: string, gain: number, token: number, retriesLeft: number): void {
     void this.getBuffer(key).then(buffer => {
-      if (token !== this.loopToken || !buffer || !this.ctx) return;
+      if (token !== this.loopToken || !this.ctx) return; // superseded by a newer stop/switch
+      if (!buffer) {
+        // A transient fetch/decode failure must not leave a safety alarm permanently silent.
+        if (retriesLeft > 0) {
+          setTimeout(() => {
+            if (token === this.loopToken) this.startLoop(key, gain, token, retriesLeft - 1);
+          }, SoundService.RETRY_DELAY_MS);
+        }
+        return;
+      }
       const source = this.play(buffer, gain, true);
       this.current = { key, source };
     });

--- a/src/app/core/services/sound.service.ts
+++ b/src/app/core/services/sound.service.ts
@@ -1,0 +1,138 @@
+import { Injectable, Signal, signal } from '@angular/core';
+
+type AudioContextCtor = new () => AudioContext;
+
+/**
+ * Owns all app audio through the Web Audio API. Web Audio playback — unlike an
+ * `HTMLAudioElement` — never spawns an Android media-session notification, which is why alarm and
+ * toast sounds route through here.
+ *
+ * The context is created lazily on the first user gesture (or first playback) and feature-detected,
+ * so in environments without Web Audio (e.g. jsdom under test) every method is an inert no-op and
+ * construction never throws.
+ */
+@Injectable({ providedIn: 'root' })
+export class SoundService {
+  private static readonly PRELOAD = ['alert', 'warn', 'alarm', 'emergency'];
+
+  private ctx: AudioContext | null = null;
+  private readonly buffers = new Map<string, AudioBuffer>();
+  private readonly decoding = new Map<string, Promise<AudioBuffer | null>>();
+  private current: { key: string; source: AudioBufferSourceNode } | null = null;
+  private loopToken = 0;
+  private unlockInstalled = false;
+
+  private readonly _blocked = signal(false);
+  /** True while a play was attempted against a suspended context (browser autoplay gate). */
+  readonly blocked: Signal<boolean> = this._blocked.asReadonly();
+
+  constructor() {
+    if (this.audioCtor) this.installUnlock();
+  }
+
+  private get audioCtor(): AudioContextCtor | undefined {
+    const w = window as typeof window & { webkitAudioContext?: AudioContextCtor };
+    return w.AudioContext ?? w.webkitAudioContext;
+  }
+
+  /**
+   * Loop `assets/<key>.mp3`. Replaces any currently looping sound; a repeat of the already-active
+   * key is a no-op (guarded by the caller too). The source is started even while the context is
+   * suspended so it becomes audible the moment a user gesture resumes it.
+   */
+  playLoop(key: string, gain = 1): void {
+    const ctx = this.ensureContext();
+    if (!ctx) return;
+    if (this.current?.key === key) return;
+    this.stopLoop();
+    const token = ++this.loopToken;
+    this.resume(ctx);
+    void this.getBuffer(key).then(buffer => {
+      if (token !== this.loopToken || !buffer || !this.ctx) return;
+      const source = this.play(buffer, gain, true);
+      this.current = { key, source };
+    });
+  }
+
+  /** Stop the active looping sound, if any. */
+  stopLoop(): void {
+    this.loopToken++;
+    if (this.current) {
+      try { this.current.source.stop(); } catch { /* already stopped */ }
+      this.current.source.disconnect();
+      this.current = null;
+    }
+  }
+
+  /** Play `assets/<key>.mp3` once (fire-and-forget) at the given gain. */
+  playOnce(key: string, gain = 1): void {
+    const ctx = this.ensureContext();
+    if (!ctx) return;
+    this.resume(ctx);
+    void this.getBuffer(key).then(buffer => {
+      if (!buffer || !this.ctx) return;
+      const source = this.play(buffer, gain, false);
+      source.onended = () => source.disconnect();
+    });
+  }
+
+  private play(buffer: AudioBuffer, gain: number, loop: boolean): AudioBufferSourceNode {
+    const ctx = this.ctx as AudioContext;
+    const source = ctx.createBufferSource();
+    source.buffer = buffer;
+    source.loop = loop;
+    const gainNode = ctx.createGain();
+    gainNode.gain.value = gain;
+    source.connect(gainNode).connect(ctx.destination);
+    source.start();
+    return source;
+  }
+
+  private ensureContext(): AudioContext | null {
+    const Ctor = this.audioCtor;
+    if (!Ctor) return null;
+    if (!this.ctx) {
+      this.ctx = new Ctor();
+      this.ctx.onstatechange = () => {
+        if (this.ctx) this._blocked.set(this.ctx.state === 'suspended');
+      };
+      SoundService.PRELOAD.forEach(key => void this.getBuffer(key));
+      this.installUnlock();
+    }
+    return this.ctx;
+  }
+
+  private resume(ctx: AudioContext): void {
+    if (ctx.state === 'suspended') {
+      this._blocked.set(true);
+      void ctx.resume().catch(() => undefined);
+    }
+  }
+
+  private getBuffer(key: string): Promise<AudioBuffer | null> {
+    const cached = this.buffers.get(key);
+    if (cached) return Promise.resolve(cached);
+    const pending = this.decoding.get(key);
+    if (pending) return pending;
+    const ctx = this.ctx;
+    if (!ctx) return Promise.resolve(null);
+    const p = fetch(`assets/${key}.mp3`)
+      .then(res => res.arrayBuffer())
+      .then(data => ctx.decodeAudioData(data))
+      .then(buffer => { this.buffers.set(key, buffer); this.decoding.delete(key); return buffer; })
+      .catch(() => { this.decoding.delete(key); return null; });
+    this.decoding.set(key, p);
+    return p;
+  }
+
+  private installUnlock(): void {
+    if (this.unlockInstalled) return;
+    this.unlockInstalled = true;
+    const handler = () => {
+      const ctx = this.ensureContext();
+      if (ctx?.state === 'suspended') void ctx.resume().catch(() => undefined);
+    };
+    ['pointerdown', 'keydown', 'touchstart'].forEach(ev =>
+      window.addEventListener(ev, handler, { passive: true }));
+  }
+}

--- a/src/app/core/services/toast.service.spec.ts
+++ b/src/app/core/services/toast.service.spec.ts
@@ -1,11 +1,12 @@
 import { TestBed } from '@angular/core/testing';
-import { signal } from '@angular/core';
+import { signal, WritableSignal } from '@angular/core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { BehaviorSubject } from 'rxjs';
 import { MatSnackBar, MatSnackBarRef } from '@angular/material/snack-bar';
 
 import { ToastService } from './toast.service';
 import { SettingsService } from './settings.service';
+import { SoundService } from './sound.service';
 import { ToastSnackbarComponent } from '../components/toast-snackbar/toast-snackbar.component';
 
 class MatSnackBarMock {
@@ -14,20 +15,21 @@ class MatSnackBarMock {
     } as unknown as MatSnackBarRef<ToastSnackbarComponent>));
 }
 
-class SettingsServiceMock {
-    public readonly notificationConfig = signal({ sound: { disableSound: true } });
-}
-
 describe('ToastService', () => {
     let service: ToastService;
     let snackBar: MatSnackBarMock;
+    let sound: { playOnce: ReturnType<typeof vi.fn> };
+    let config: WritableSignal<{ sound: { disableSound: boolean } }>;
 
     beforeEach(() => {
+        config = signal({ sound: { disableSound: false } });
+        sound = { playOnce: vi.fn() };
         TestBed.configureTestingModule({
             providers: [
                 ToastService,
                 { provide: MatSnackBar, useClass: MatSnackBarMock },
-                { provide: SettingsService, useClass: SettingsServiceMock }
+                { provide: SettingsService, useValue: { notificationConfig: config } },
+                { provide: SoundService, useValue: sound }
             ]
         });
         service = TestBed.inject(ToastService);
@@ -56,5 +58,21 @@ describe('ToastService', () => {
         expect(lastSnack).toBeTruthy();
         expect(lastSnack?.action).toBe('Enable Plugin');
         expect(lastSnack?.severity).toBe('warn');
+    });
+
+    it('plays the notification sound once when not silent and sound is enabled', () => {
+        service.show('Anchor dragging', 5000, false, 'warn');
+        expect(sound.playOnce).toHaveBeenCalledWith('notification', 0.3);
+    });
+
+    it('does not play sound when silent', () => {
+        service.show('Saved', 1000, true);
+        expect(sound.playOnce).not.toHaveBeenCalled();
+    });
+
+    it('does not play sound when sound is disabled', () => {
+        config.set({ sound: { disableSound: true } });
+        service.show('Anchor dragging', 5000, false, 'warn');
+        expect(sound.playOnce).not.toHaveBeenCalled();
     });
 });

--- a/src/app/core/services/toast.service.ts
+++ b/src/app/core/services/toast.service.ts
@@ -57,6 +57,7 @@ export class ToastService {
 
     this.lastSnack.set(snack);
     if (silent || this.soundDisabled()) return ref;
+    // If the browser blocks playback, SoundService raises `blocked`; the prompt is surfaced by NotificationsService.
     this.sound.playOnce('notification', 0.3);
     return ref;
   }

--- a/src/app/core/services/toast.service.ts
+++ b/src/app/core/services/toast.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, computed, signal, inject } from '@angular/core';
 import { MatSnackBar, MatSnackBarRef } from '@angular/material/snack-bar';
 import { SettingsService } from './settings.service';
+import { SoundService } from './sound.service';
 import { ToastSnackbarComponent, type ToastSeverity, type ToastSnackbarData } from '../components/toast-snackbar/toast-snackbar.component';
 
 export interface SnackItem {
@@ -15,9 +16,8 @@ export interface SnackItem {
 export class ToastService {
   private readonly snackBar = inject(MatSnackBar);
   private readonly app = inject(SettingsService);
+  private readonly sound = inject(SoundService);
   private readonly soundDisabled = computed(() => this.app.notificationConfig().sound.disableSound);
-  private toastAudio: HTMLAudioElement | null = null;
-  private audioBlockedNotificationShown = false;
 
   // last snack for diagnostics/other UI (not a queue)
   public readonly lastSnack = signal<SnackItem | null>(null);
@@ -57,33 +57,7 @@ export class ToastService {
 
     this.lastSnack.set(snack);
     if (silent || this.soundDisabled()) return ref;
-    if (!this.toastAudio) {
-      this.toastAudio = new Audio('assets/notification.mp3');
-      this.toastAudio.preload = 'auto';
-      this.toastAudio.volume = 0.3;
-    }
-    // restart sound for rapid successive notifications
-    this.toastAudio.currentTime = 0;
-    this.toastAudio.play().catch(err => {
-      // Autoplay blocked by browser policy - requires user interaction first
-      console.debug('Toast audio playback blocked:', err.message);
-      if (!this.audioBlockedNotificationShown) {
-        this.audioBlockedNotificationShown = true;
-        // Show persistent toast requiring user interaction to dismiss
-        const blockRef = this.snackBar.openFromComponent(ToastSnackbarComponent, {
-          duration: 0, // No timeout - requires user to close
-          verticalPosition: 'top',
-          data: {
-            message: 'Sound notifications blocked by browser. Closing this message will enable audio.',
-            severity: 'warn'
-          } as ToastSnackbarData
-        });
-        // Reset flag when user dismisses, allowing audio to work after interaction
-        blockRef.afterDismissed().subscribe(() => {
-          this.audioBlockedNotificationShown = false;
-        });
-      }
-    });
+    this.sound.playOnce('notification', 0.3);
     return ref;
   }
 }


### PR DESCRIPTION
## Why

Installed as an Android PWA, Skip's looping alarm plays through a `HTMLAudioElement`, which makes Chrome show (and leave lingering) a media-player card in the notification drawer — play/pause, seek slider, app logo — so an alarm looks like a music app. Fixes #479.

## What

Route all notification audio through the Web Audio API, which never spawns a media-session card.

- **New `SoundService`** (`providedIn: 'root'`) owns a lazily created, feature-detected `AudioContext` (inert no-op when absent, so the ~30 real-service jsdom specs stay safe), a decoded-buffer cache with the four alarm tracks pre-decoded, looping + one-shot playback, and gesture-based unlock exposing a `blocked` signal.
- **`NotificationsService`** plays alarm loops via `SoundService`; the same-key guard keeps a reconnect from restarting the tone. Mute stays severity-driven (a muted alarm zeroes `audioSev` and stops via `playAlarm(1000)`); the vestigial per-player `.muted` is dropped. The autoplay-blocked prompt is consolidated here, driven off `blocked`.
- **`ToastService`** plays its chime one-shot via `SoundService` (0.3 gain); alarms play full volume.

## Verification

- `npm run ci` (lint + snc): clean. Full unit suite: all pass except one **pre-existing** failure (`app.component.spec.ts`, a local `localStorage` env artifact that reproduces on clean `main` and is unrelated to this change).
- New `SoundService` spec covers: inert-when-unsupported, decode+loop start, same-key no-op, key replacement, start-while-suspended, and the `blocked` transitions. The two reconnect specs now assert against a spec-local `SoundService` fake.
- **Premise verified on-device:** an audible Web Audio loop keeps playing when the Android PWA is backgrounded, so removing the card does not silence a backgrounded/locked alarm.

## Before merge — manual device acceptance (per #479)

Unit specs use a fake `AudioContext` and cannot cover platform audio. On the Android PWA, confirm: (1) a cold emergency alarm sounds within ~1 s; (2) it keeps sounding with the screen locked ≥ 60 s; (3) the media card no longer appears; (4) in-app mute silences it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDtPDenpQ64FybWqpKiYoc