### PR TITLE
fix(templates): ask for Skip version, not KIP, in bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -44,10 +44,10 @@ body:
       required: true
   
   - type: input
-    id: kip-version
+    id: skip-version
     attributes:
-      label: KIP Version
-      description: What version of Kip are you using (Found in Settings -> Options -> Connectivity)?
+      label: Skip Version
+      description: What version of Skip are you using (Found in Settings -> Options -> Connectivity)?
       placeholder: e.g., v2.5.1
     validations:
       required: true


### PR DESCRIPTION
## Why

Every filed bug report asks for **"KIP Version"** — the bug-report issue template still carried the upstream Kip naming after the Kip→Skip fork rename. Visible in recent reports (#404, #405, #437 all show a `### KIP Version` field). Fixes #405.

## What

Rename the version field in `.github/ISSUE_TEMPLATE/bug_report.yml` to Skip — `label`, `description`, and `id` (`kip-version` → `skip-version`). YAML re-validated.

`feature_request.yml` was checked and has no Kip references. Deliberately **not** touched: the many other `kip` references in the codebase are correct historical ones (the old `kip` applicationData namespace, pre-fork config paths shown to users for migration, and "older KIP" in migration messages) — they name the actual pre-fork app/config and renaming them would break their meaning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDtPDenpQ64FybWqpKiYoc