### PR TITLE
Stop a failed night-mode dependency check from discarding Display settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * The Connectivity settings show your Signal K session identity in same-origin mode (including a read-only-session indicator) instead of a credential form.
 * Security: the Signal K login password is no longer stored in the browser; it is used only in memory to obtain a session token.
 ## Fixes
+* Saving Display settings no longer discards your changes when Automatic Night Mode cannot be enabled. Previously, if that feature was switched on while the Signal K Derived Data plugin was missing or unreachable, the failed dependency check abandoned the whole save — theme, browser tab title, brightness and the rest were silently lost, and the error message mentioned only night mode. Everything unrelated to the plugin now saves as asked; only automatic night mode is held back, and its stored value is left as it was. Fixes #498
 * OIDC/SSO users could not sign in to KIP because it required a server-local password they do not have; same-origin SSO mode resolves this.
 ## Behavior changes
 * Cross-origin token sign-in: the Signal K server provides no token-refresh endpoint, so the stored password is no longer re-sent to renew a session. The session token still persists across browser reloads until it expires; when it expires you are prompted to sign in again.

--- a/src/app/core/components/settings/display/display.component.spec.ts
+++ b/src/app/core/components/settings/display/display.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { EMPTY, of } from 'rxjs';
+import { EMPTY, Subject, of } from 'rxjs';
 import { signal } from '@angular/core';
 import { BreakpointObserver } from '@angular/cdk/layout';
 import { ToastService } from '../../../services/toast.service';
@@ -24,10 +24,22 @@ class AppServiceMock {
 }
 
 class ToastServiceMock {
+    // Prompts resolve as "dismissed without action" (the user declined) unless a test pushes to
+    // `action$` first. Without a live action stream the accept-the-prompt path is unreachable, and
+    // with it the only route that ever stores autoNightMode = true.
+    public readonly action$ = new Subject<void>();
     public show = vi.fn().mockReturnValue({
-        onAction: () => EMPTY,
+        onAction: () => this.action$,
         afterDismissed: () => of({ dismissedByAction: false })
     });
+
+    /** Answer the next prompt with its action button instead of a dismissal. */
+    public acceptNextPrompt(): void {
+        this.show.mockReturnValueOnce({
+            onAction: () => of(undefined),
+            afterDismissed: () => EMPTY
+        });
+    }
 }
 
 class SettingsServiceMock {
@@ -227,22 +239,52 @@ describe('SettingsNotificationsComponent', () => {
             expect(setBrowserTabTitle).toHaveBeenCalledWith('Helm');
         });
 
-        it('leaves the stored automatic night mode untouched rather than writing the reset toggle', async () => {
+        it('writes back the stored night mode rather than the refused request', async () => {
             withMissingPlugin();
             const settings = TestBed.inject(SettingsService) as unknown as SettingsServiceMock;
             const setAutoNightMode = vi.spyOn(settings, 'setAutoNightMode');
+            const setRedNightMode = vi.spyOn(settings, 'setRedNightMode');
 
             await saveWithNightModeRequested();
 
-            expect(setAutoNightMode).not.toHaveBeenCalled();
+            expect(setRedNightMode).toHaveBeenCalled(); // the save ran at all
+            expect(setAutoNightMode).toHaveBeenCalledWith(false); // stored value, not the request
             expect(component['autoNightMode']()).toBe(false);
+        });
+
+        it('keeps a working night-mode setup on through a transient plugin-API failure', async () => {
+            // The scenario the refusal path exists for: night mode is already on and stored, and
+            // the check fails for a reason that says nothing about the requirement being unmet.
+            const settings = TestBed.inject(SettingsService) as unknown as SettingsServiceMock;
+            vi.spyOn(settings, 'getAutoNightMode').mockReturnValue(true);
+            const pluginService = TestBed.inject(PluginConfigClientService) as unknown as PluginConfigClientServiceMock;
+            pluginService.getPlugin.mockResolvedValue({
+                ok: false,
+                error: { reason: 'server-error', message: 'upstream timeout' }
+            });
+            const fx = TestBed.createComponent(SettingsDisplayComponent);
+            fx.detectChanges();
+            const setAutoNightMode = vi.spyOn(settings, 'setAutoNightMode');
+
+            fx.componentInstance['saveAllSettings']();
+            await flushPromises();
+            await flushPromises();
+
+            // Neither this save nor the next one may turn it off: the toggle still agrees with the
+            // store, so a following save re-runs the check instead of writing an off state.
+            expect(setAutoNightMode).toHaveBeenCalledWith(true);
+            expect(setAutoNightMode).not.toHaveBeenCalledWith(false);
+            expect(fx.componentInstance['autoNightMode']()).toBe(true);
         });
 
         it('leaves the refusal on screen instead of replacing it with a success toast', async () => {
             withMissingPlugin();
+            const settings = TestBed.inject(SettingsService) as unknown as SettingsServiceMock;
+            const setThemeName = vi.spyOn(settings, 'setThemeName');
 
             await saveWithNightModeRequested();
 
+            expect(setThemeName).toHaveBeenCalled(); // the save ran at all
             // MatSnackBar shows one at a time, so a success toast would dismiss the persistent
             // explanation of what was refused and then vanish on its own timer.
             expect(toast.show).toHaveBeenCalledWith(expect.stringContaining('Derived Data'), 0, false, 'error');
@@ -259,6 +301,56 @@ describe('SettingsNotificationsComponent', () => {
             await saveWithNightModeRequested();
 
             expect(setThemeName).toHaveBeenCalledWith('system');
+        });
+
+        it('confirms the save when the prompt was merely declined, since nothing else is on screen', async () => {
+            // Declining closes the prompt snackbar, so unlike a failure there is no persistent
+            // message left to protect — suppressing the confirmation would leave no feedback at all.
+            await saveWithNightModeRequested();
+
+            expect(toast.show).toHaveBeenCalledWith('Configuration saved', 1000, true, 'message');
+        });
+    });
+
+    describe('an accepted automatic-night-mode prompt', () => {
+        it('stores night mode on once the plugin has been enabled and configured', async () => {
+            toast.acceptNextPrompt();
+            const settings = TestBed.inject(SettingsService) as unknown as SettingsServiceMock;
+            const pluginService = TestBed.inject(PluginConfigClientService) as unknown as PluginConfigClientServiceMock;
+            const setAutoNightMode = vi.spyOn(settings, 'setAutoNightMode');
+
+            component['isAutoNightModeSupported']({ checked: true, source: {} as MatSlideToggle });
+            component['saveAllSettings']();
+            await flushPromises();
+            await flushPromises();
+
+            expect(pluginService.savePluginConfig).toHaveBeenCalledWith('derived-data', {
+                configuration: { sun: true },
+                enabled: true
+            });
+            expect(setAutoNightMode).toHaveBeenCalledWith(true);
+        });
+
+        it('holds night mode back, but still saves the rest, when enabling the plugin fails', async () => {
+            toast.acceptNextPrompt();
+            const settings = TestBed.inject(SettingsService) as unknown as SettingsServiceMock;
+            const pluginService = TestBed.inject(PluginConfigClientService) as unknown as PluginConfigClientServiceMock;
+            pluginService.savePluginConfig.mockResolvedValue({
+                ok: false,
+                error: { reason: 'server-error', message: 'write rejected' }
+            });
+            const setAutoNightMode = vi.spyOn(settings, 'setAutoNightMode');
+            const setBrowserTabTitle = vi.spyOn(settings, 'setBrowserTabTitle');
+            component['browserTabTitle'].set('Helm');
+
+            component['isAutoNightModeSupported']({ checked: true, source: {} as MatSlideToggle });
+            component['saveAllSettings']();
+            await flushPromises();
+            await flushPromises();
+
+            expect(setBrowserTabTitle).toHaveBeenCalledWith('Helm');
+            expect(setAutoNightMode).toHaveBeenCalledWith(false);
+            expect(toast.show).not.toHaveBeenCalledWith('Configuration saved', 1000, true, 'message');
         });
     });
 

--- a/src/app/core/components/settings/display/display.component.spec.ts
+++ b/src/app/core/components/settings/display/display.component.spec.ts
@@ -196,6 +196,72 @@ describe('SettingsNotificationsComponent', () => {
         expect(toast.show).toHaveBeenCalledWith('Configuration saved', 1000, true, 'message');
     });
 
+    describe('a refused automatic-night-mode request (#498)', () => {
+        // The plugin is absent, so the dependency check fails outright.
+        function withMissingPlugin(): void {
+            const pluginService = TestBed.inject(PluginConfigClientService) as unknown as PluginConfigClientServiceMock;
+            pluginService.getPlugin.mockResolvedValue({
+                ok: false,
+                error: { reason: 'not-found', message: 'Plugin derived-data not found' }
+            });
+        }
+
+        async function saveWithNightModeRequested(): Promise<void> {
+            component['isAutoNightModeSupported']({ checked: true, source: {} as MatSlideToggle });
+            component['saveAllSettings']();
+            await flushPromises();
+            await flushPromises();
+        }
+
+        it('still persists the settings the check has no bearing on', async () => {
+            withMissingPlugin();
+            const settings = TestBed.inject(SettingsService) as unknown as SettingsServiceMock;
+            const setThemeName = vi.spyOn(settings, 'setThemeName');
+            const setBrowserTabTitle = vi.spyOn(settings, 'setBrowserTabTitle');
+            component['themeMode'].set('system');
+            component['browserTabTitle'].set('Helm');
+
+            await saveWithNightModeRequested();
+
+            expect(setThemeName).toHaveBeenCalledWith('system');
+            expect(setBrowserTabTitle).toHaveBeenCalledWith('Helm');
+        });
+
+        it('leaves the stored automatic night mode untouched rather than writing the reset toggle', async () => {
+            withMissingPlugin();
+            const settings = TestBed.inject(SettingsService) as unknown as SettingsServiceMock;
+            const setAutoNightMode = vi.spyOn(settings, 'setAutoNightMode');
+
+            await saveWithNightModeRequested();
+
+            expect(setAutoNightMode).not.toHaveBeenCalled();
+            expect(component['autoNightMode']()).toBe(false);
+        });
+
+        it('leaves the refusal on screen instead of replacing it with a success toast', async () => {
+            withMissingPlugin();
+
+            await saveWithNightModeRequested();
+
+            // MatSnackBar shows one at a time, so a success toast would dismiss the persistent
+            // explanation of what was refused and then vanish on its own timer.
+            expect(toast.show).toHaveBeenCalledWith(expect.stringContaining('Derived Data'), 0, false, 'error');
+            expect(toast.show).not.toHaveBeenCalledWith('Configuration saved', 1000, true, 'message');
+        });
+
+        it('persists the unrelated settings when the user declines the enable prompt', async () => {
+            // Plugin present but not configured -> prompt; the toast mock reports a dismissal
+            // without action, so the request is declined rather than failed.
+            const settings = TestBed.inject(SettingsService) as unknown as SettingsServiceMock;
+            const setThemeName = vi.spyOn(settings, 'setThemeName');
+            component['themeMode'].set('system');
+
+            await saveWithNightModeRequested();
+
+            expect(setThemeName).toHaveBeenCalledWith('system');
+        });
+    });
+
     it('shows prompt for configuring sun flag only when plugin is enabled but sun flag is false', async () => {
         const pluginService = TestBed.inject(PluginConfigClientService) as unknown as PluginConfigClientServiceMock;
         pluginService.getPlugin.mockResolvedValue({

--- a/src/app/core/components/settings/display/display.component.ts
+++ b/src/app/core/components/settings/display/display.component.ts
@@ -1,5 +1,5 @@
-import { Component, inject, OnInit, viewChild, signal, Signal, model } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, inject, OnInit, viewChild, signal, Signal, model } from '@angular/core';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { BreakpointObserver, Breakpoints, BreakpointState } from '@angular/cdk/layout';
 import { AppService } from '../../../services/app-service';
 import { ToastService } from '../../../services/toast.service';
@@ -16,6 +16,13 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSlideToggleModule, MatSlideToggleChange } from '@angular/material/slide-toggle';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { ThemeMode, THEME_MODES } from '../../../constants/themes.const';
+
+/**
+ * What the Automatic Night Mode dependency check concluded. The two refusals differ only in what
+ * the user can already see: 'explained' left a persistent snackbar on screen, 'declined' means the
+ * user dismissed the prompt and nothing is showing.
+ */
+type AutoNightOutcome = 'granted' | 'explained' | 'declined';
 
 
 @Component({
@@ -43,6 +50,7 @@ export class SettingsDisplayComponent implements OnInit {
   protected readonly uiEvent = inject(uiEventService);
   private readonly responsive = inject(BreakpointObserver);
   private readonly pluginConfig = inject(PluginConfigClientService);
+  private readonly destroyRef = inject(DestroyRef);
   protected isPhonePortrait: Signal<BreakpointState>;
   protected nightBrightness = signal<number>(0.27);
   protected autoNightMode = model<boolean>(false);
@@ -82,9 +90,12 @@ export class SettingsDisplayComponent implements OnInit {
       return;
     }
 
+    // Any save supersedes a check still in flight, whether or not it starts one of its own —
+    // otherwise a stale check resolves later and writes this form's state a second time.
+    const seq = ++this._pluginCheckSeq;
+
     // If auto night mode is enabled, validate plugin requirements before saving
     if (this.autoNightMode()) {
-      const seq = ++this._pluginCheckSeq;
       void this.validateAndSaveSettings(seq);
       return;
     }
@@ -93,17 +104,12 @@ export class SettingsDisplayComponent implements OnInit {
   }
 
   /**
-   * @param autoNightRefused True when the dependency check turned the night-mode request down. The
-   * rest of the page is unrelated to that plugin, so it still saves (#498); only automatic night
-   * mode is held back — and its *stored* value is left as it was rather than overwritten with the
-   * reset toggle, so a transient plugin-API failure cannot quietly disable a working setup. The
-   * success toast is held back too: the refusal is on screen as a persistent snackbar, and
-   * MatSnackBar shows one at a time.
+   * @param announce Whether to confirm the save. Suppressed when a persistent snackbar is already
+   * explaining what was turned down: MatSnackBar shows one at a time, so the confirmation would
+   * dismiss the explanation and then vanish on its own timer.
    */
-  private applyAndSaveSettings(autoNightRefused = false): void {
-    if (!autoNightRefused) {
-      this.settings.setAutoNightMode(this.autoNightMode());
-    }
+  private applyAndSaveSettings(announce = true): void {
+    this.settings.setAutoNightMode(this.autoNightMode());
     this.settings.setRedNightMode(this.isRedNightMode());
     this.settings.setNightModeBrightness(this.nightBrightness());
     this.settings.setIsRemoteControl(this.isRemoteControl());
@@ -123,22 +129,23 @@ export class SettingsDisplayComponent implements OnInit {
     this.settings.setKeepScreenAwake(this.keepScreenAwake());
     this.settings.setAutoRevealToolbar(this.autoRevealToolbar());
     this.displayForm()?.form.markAsPristine();
-    if (!autoNightRefused) {
+    if (announce) {
       this.toast.show("Configuration saved", 1000, true, 'message');
     }
   }
 
   private async validateAndSaveSettings(seq: number): Promise<void> {
-    const isValid = await this.validateAndHandleAutoNightRequirement(seq);
+    const outcome = await this.validateAndHandleAutoNightRequirement(seq);
     if (seq !== this._pluginCheckSeq) return;
 
-    if (isValid) {
-      this.applyAndSaveSettings();
-      return;
+    if (outcome !== 'granted') {
+      // Show what is stored, not the request that was turned down. Forcing the toggle off instead
+      // would put the form, the stored config and AppService's live night-mode effect into three
+      // different states, and the next save — which skips the check entirely once the toggle reads
+      // off — would write that off state anyway.
+      this.autoNightMode.set(this.settings.getAutoNightMode());
     }
-
-    this.autoNightMode.set(false);
-    this.applyAndSaveSettings(true);
+    this.applyAndSaveSettings(outcome !== 'explained');
   }
 
   protected isAutoNightModeSupported(e: MatSlideToggleChange): void {
@@ -146,9 +153,9 @@ export class SettingsDisplayComponent implements OnInit {
     this.autoNightMode.set(e.checked);
   }
 
-  private async validateAndHandleAutoNightRequirement(seq: number): Promise<boolean> {
+  private async validateAndHandleAutoNightRequirement(seq: number): Promise<AutoNightOutcome> {
     const pluginResult = await this.pluginConfig.getPlugin(this.DERIVED_DATA_PLUGIN_ID);
-    if (seq !== this._pluginCheckSeq) return false;
+    if (seq !== this._pluginCheckSeq) return 'declined';
 
     if (!pluginResult.ok) {
       const pluginFailure = pluginResult as IPluginApiFailure;
@@ -159,7 +166,7 @@ export class SettingsDisplayComponent implements OnInit {
           false,
           'error'
         );
-        return false;
+        return 'explained';
       }
 
       this.toast.show(
@@ -168,7 +175,7 @@ export class SettingsDisplayComponent implements OnInit {
         false,
         'error'
       );
-      return false;
+      return 'explained';
     }
 
     const plugin = pluginResult.data;
@@ -176,7 +183,7 @@ export class SettingsDisplayComponent implements OnInit {
     const isSunFlagEnabled = this.readBooleanByPath(plugin.state.configuration, sunFlagPath) === true;
 
     if (plugin.state.enabled && isSunFlagEnabled) {
-      return true;
+      return 'granted';
     }
 
     // Build precise message based on what needs to be changed
@@ -192,22 +199,28 @@ export class SettingsDisplayComponent implements OnInit {
       message = "To enable Automatic Night Mode, the environment.sun path in the Derived Data plugin must be activated. Do you wish to activate the path?";
     }
 
-    return new Promise<boolean>((resolve) => {
+    return new Promise<AutoNightOutcome>((resolve) => {
       const promptRef = this.toast.show(message, 0, false, 'warn', 'Ok');
 
-      promptRef.onAction().subscribe(() => {
-        void this.enableAndConfigureAutoNight(plugin, sunFlagPath, seq, resolve);
-      });
+      // Tied to the component: leaving /settings with the prompt open must not resolve later and
+      // write a destroyed form's state over whatever the user has saved since.
+      promptRef.onAction()
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe(() => {
+          void this.enableAndConfigureAutoNight(plugin, sunFlagPath, seq, resolve);
+        });
 
-      promptRef.afterDismissed().subscribe((dismissal) => {
-        if (!dismissal.dismissedByAction) {
-          resolve(false);
-        }
-      });
+      promptRef.afterDismissed()
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe((dismissal) => {
+          if (!dismissal.dismissedByAction) {
+            resolve('declined');
+          }
+        });
     });
   }
 
-  private async enableAndConfigureAutoNight(plugin: ISignalkPlugin, sunFlagPath: string[], seq: number, resolve: (value: boolean) => void): Promise<void> {
+  private async enableAndConfigureAutoNight(plugin: ISignalkPlugin, sunFlagPath: string[], seq: number, resolve: (value: AutoNightOutcome) => void): Promise<void> {
     const nextConfiguration = this.cloneConfig(plugin.state.configuration);
     this.writeBooleanByPath(nextConfiguration, sunFlagPath, true);
 
@@ -217,7 +230,7 @@ export class SettingsDisplayComponent implements OnInit {
     });
 
     if (seq !== this._pluginCheckSeq) {
-      resolve(false);
+      resolve('declined');
       return;
     }
 
@@ -229,12 +242,12 @@ export class SettingsDisplayComponent implements OnInit {
         false,
         'error'
       );
-      resolve(false);
+      resolve('explained');
       return;
     }
 
     this.toast.show('Automatic Night Mode dependency enabled and configured.', 3000, true, 'success');
-    resolve(true);
+    resolve('granted');
   }
 
   private resolveEnvironmentSunFlagPath(configuration: Record<string, unknown>): string[] {

--- a/src/app/core/components/settings/display/display.component.ts
+++ b/src/app/core/components/settings/display/display.component.ts
@@ -92,8 +92,18 @@ export class SettingsDisplayComponent implements OnInit {
     this.applyAndSaveSettings();
   }
 
-  private applyAndSaveSettings(): void {
-    this.settings.setAutoNightMode(this.autoNightMode());
+  /**
+   * @param autoNightRefused True when the dependency check turned the night-mode request down. The
+   * rest of the page is unrelated to that plugin, so it still saves (#498); only automatic night
+   * mode is held back — and its *stored* value is left as it was rather than overwritten with the
+   * reset toggle, so a transient plugin-API failure cannot quietly disable a working setup. The
+   * success toast is held back too: the refusal is on screen as a persistent snackbar, and
+   * MatSnackBar shows one at a time.
+   */
+  private applyAndSaveSettings(autoNightRefused = false): void {
+    if (!autoNightRefused) {
+      this.settings.setAutoNightMode(this.autoNightMode());
+    }
     this.settings.setRedNightMode(this.isRedNightMode());
     this.settings.setNightModeBrightness(this.nightBrightness());
     this.settings.setIsRemoteControl(this.isRemoteControl());
@@ -113,7 +123,9 @@ export class SettingsDisplayComponent implements OnInit {
     this.settings.setKeepScreenAwake(this.keepScreenAwake());
     this.settings.setAutoRevealToolbar(this.autoRevealToolbar());
     this.displayForm()?.form.markAsPristine();
-    this.toast.show("Configuration saved", 1000, true, 'message');
+    if (!autoNightRefused) {
+      this.toast.show("Configuration saved", 1000, true, 'message');
+    }
   }
 
   private async validateAndSaveSettings(seq: number): Promise<void> {
@@ -122,10 +134,11 @@ export class SettingsDisplayComponent implements OnInit {
 
     if (isValid) {
       this.applyAndSaveSettings();
-    } else {
-      // Reset toggle and abort save
-      this.autoNightMode.set(false);
+      return;
     }
+
+    this.autoNightMode.set(false);
+    this.applyAndSaveSettings(true);
   }
 
   protected isAutoNightModeSupported(e: MatSlideToggleChange): void {


### PR DESCRIPTION
Fixes #498.

## Why

A profile with Automatic Night Mode switched on routes *every* Display save through a Signal K plugin check. When that check fails — the Derived Data plugin is missing, the API errors, or the user declines the enable prompt — `validateAndSaveSettings` reset the toggle and returned without calling `applyAndSaveSettings` at all.

So a user who came to change their browser tab title, theme, brightness, keep-awake or (as of #497) the toolbar preference lost all of it, silently. The only feedback was an error toast about a night-mode plugin dependency, and the toggle still read as changed. Pressing Save a second time worked, because the failed attempt had already reset `autoNightMode` — but nothing said so.

## What

Refuse only what was actually refused. The rest of the page has no bearing on the plugin and now saves as asked.

Two deliberate details on the refusal path:

- **The stored night-mode value is left as it was**, rather than overwritten with the reset toggle. The same check fails on a transient API error, and persisting the reset there would quietly disable a working setup. The toggle still resets in the UI, so the refusal is visible; the stored intent survives.
- **The success toast is held back.** The refusal is a persistent snackbar and `MatSnackBar` shows one at a time, so announcing the save would dismiss the explanation and then disappear on its own 1s timer. The form going pristine is the save's feedback there.

## Verification

`npm run lint`, `npm run snc`, `npm test` — 1808 passed, plus the one pre-existing local `localStorage` failure that reproduces on main and passes in CI.

Four new tests, written first and confirmed red: two failed before the fix (unrelated settings not persisted, via both the plugin-missing and the declined-prompt paths). The other two guard against the naive fix rather than the bug — mutating `applyAndSaveSettings(true)` to `applyAndSaveSettings()` makes both fail, which is what pins the stored-value and toast decisions above.

No `VERSION` bump: the cycle is already open at 1.3.0 from #497, and a patch-level fix does not raise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
