### PR TITLE
Fix video camera v2 URL fallback

### DIFF
--- a/src/app/core/utils/signalk-plugin-url.util.spec.ts
+++ b/src/app/core/utils/signalk-plugin-url.util.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveSignalKPluginBaseUrl } from './signalk-plugin-url.util';
+import { resolveSignalKPluginBaseUrl, resolveSignalKV2ApiBaseUrl } from './signalk-plugin-url.util';
 
 describe('resolveSignalKPluginBaseUrl', () => {
   const HTTP_V1 = 'http://host:3000/signalk/v1/api/';
@@ -49,5 +49,65 @@ describe('resolveSignalKPluginBaseUrl', () => {
     expect(resolveSignalKPluginBaseUrl('../evil', HTTP_V1)).toBeNull();
     expect(resolveSignalKPluginBaseUrl('sk video', HTTP_V1)).toBeNull();
     expect(resolveSignalKPluginBaseUrl('SK-Video', HTTP_V1)).toBeNull();
+  });
+
+  it('strips a /signalk suffix from the configured URL', () => {
+    expect(resolveSignalKPluginBaseUrl('sk-video', null, 'http://my.boat:3000/signalk/'))
+      .toBe('http://my.boat:3000/plugins/sk-video/');
+  });
+});
+
+describe('resolveSignalKV2ApiBaseUrl', () => {
+  const HTTP_V1 = 'http://host:3000/signalk/v1/api/';
+
+  it('uses the advertised v2 endpoint when the server publishes one', () => {
+    expect(resolveSignalKV2ApiBaseUrl('http://v2.host:3000/signalk/v2/api', HTTP_V1))
+      .toBe('http://v2.host:3000/signalk/v2/api');
+  });
+
+  it('strips a trailing slash from the advertised v2 endpoint', () => {
+    expect(resolveSignalKV2ApiBaseUrl('http://host:3000/signalk/v2/api/', null))
+      .toBe('http://host:3000/signalk/v2/api');
+  });
+
+  it('derives the URL from the v1 endpoint when v2 is not advertised', () => {
+    expect(resolveSignalKV2ApiBaseUrl(undefined, HTTP_V1))
+      .toBe('http://host:3000/signalk/v2/api');
+  });
+
+  // The endpoint shapes the plugin resolver already accepts must not fall through to a
+  // non-v2 URL: every one of them has to yield the v2 API base.
+  it('derives the URL from endpoint shapes other than /signalk/v1/api', () => {
+    expect(resolveSignalKV2ApiBaseUrl(null, 'https://boat.local/signalk'))
+      .toBe('https://boat.local/signalk/v2/api');
+    expect(resolveSignalKV2ApiBaseUrl(null, 'https://boat.local/signalk/v1'))
+      .toBe('https://boat.local/signalk/v2/api');
+    expect(resolveSignalKV2ApiBaseUrl(null, 'https://boat.local/signalk/v2'))
+      .toBe('https://boat.local/signalk/v2/api');
+  });
+
+  it('preserves a reverse-proxy path prefix', () => {
+    expect(resolveSignalKV2ApiBaseUrl(null, 'https://halos.local/sk/signalk/v1/api/'))
+      .toBe('https://halos.local/sk/signalk/v2/api');
+  });
+
+  it('prefers the configured Signal K URL over the discovered endpoint', () => {
+    expect(resolveSignalKV2ApiBaseUrl(null, HTTP_V1, 'http://my.boat:3000'))
+      .toBe('http://my.boat:3000/signalk/v2/api');
+  });
+
+  it('does not double the /signalk segment of a configured URL', () => {
+    expect(resolveSignalKV2ApiBaseUrl(null, null, 'http://my.boat:3000/signalk/'))
+      .toBe('http://my.boat:3000/signalk/v2/api');
+  });
+
+  it('ignores a blank configured URL and falls back to the endpoint', () => {
+    expect(resolveSignalKV2ApiBaseUrl(null, HTTP_V1, '   '))
+      .toBe('http://host:3000/signalk/v2/api');
+  });
+
+  it('returns null when no URL is available', () => {
+    expect(resolveSignalKV2ApiBaseUrl(null, null)).toBeNull();
+    expect(resolveSignalKV2ApiBaseUrl(undefined, undefined, null)).toBeNull();
   });
 });

--- a/src/app/core/utils/signalk-plugin-url.util.ts
+++ b/src/app/core/utils/signalk-plugin-url.util.ts
@@ -1,11 +1,41 @@
 /**
+ * Resolves the Signal K server root (no trailing slash) that every API and plugin URL hangs off.
+ *
+ * A user-configured Signal K URL takes precedence over the discovered HTTP service endpoint.
+ * Either input may already carry a `/signalk[/vN[/api]]` suffix, so both go through the same
+ * suffix strip — a path prefix ahead of it (reverse proxy) is preserved.
+ *
+ * @param httpServiceUrl the server's discovered v1/v2 API URL (e.g. `http://host:3000/signalk/v1/api/`)
+ * @param configuredUrl  the user-configured Signal K URL, if any (takes precedence)
+ * @returns the server root without a trailing slash, or `null` if it cannot be resolved
+ */
+function resolveSignalKServerRoot(
+  httpServiceUrl: string | null | undefined,
+  configuredUrl?: string | null
+): string | null {
+  const source = configuredUrl?.trim() || httpServiceUrl;
+  if (!source) {
+    return null;
+  }
+
+  const normalized = source.endsWith('/') ? source.slice(0, -1) : source;
+  const root = normalized
+    .replace(/\/signalk\/v2\/api$/, '')
+    .replace(/\/signalk\/v1\/api$/, '')
+    .replace(/\/signalk\/v2$/, '')
+    .replace(/\/signalk\/v1$/, '')
+    .replace(/\/signalk$/, '');
+
+  return root || null;
+}
+
+/**
  * Resolves the base URL of a Signal K server plugin (`<server>/plugins/<pluginId>/`) from the
  * active connection endpoint.
  *
  * Generalises the per-plugin logic used by the `sk-video` and other plugin clients so every
  * plugin client agrees on how the base URL is derived. Pass the plugin
- * id (e.g. `'kip'`, `'sk-video'`); a user-configured Signal K URL takes precedence over the
- * discovered HTTP service endpoint.
+ * id (e.g. `'kip'`, `'sk-video'`).
  *
  * @param pluginId       the Signal K plugin id (lower-case kebab; e.g. `'sk-video'`)
  * @param httpServiceUrl the server's discovered v1/v2 API URL (e.g. `http://host:3000/signalk/v1/api/`)
@@ -23,24 +53,33 @@ export function resolveSignalKPluginBaseUrl(
     return null;
   }
 
-  // A user-configured Signal K URL wins over the discovered endpoint.
-  const configured = configuredUrl?.trim();
-  if (configured) {
-    const base = configured.endsWith('/') ? configured.slice(0, -1) : configured;
-    return `${base}/plugins/${pluginId}/`;
+  const root = resolveSignalKServerRoot(httpServiceUrl, configuredUrl);
+  return root ? `${root}/plugins/${pluginId}/` : null;
+}
+
+/**
+ * Resolves the base URL of the Signal K v2 REST API (`<server>/signalk/v2/api`).
+ *
+ * The endpoint the server advertises wins when present. A server can serve the v2 API and still
+ * omit `endpoints.v2` from its `/signalk` document, which leaves the advertised value unset; the
+ * URL is then derived from the same server root the plugin clients use, so both address the same
+ * host.
+ *
+ * @param httpServiceUrlV2 the server's advertised v2 API URL, if any
+ * @param httpServiceUrl   the server's discovered v1/v2 API URL
+ * @param configuredUrl    the user-configured Signal K URL, if any
+ * @returns the v2 API base URL without a trailing slash, or `null` if it cannot be resolved
+ */
+export function resolveSignalKV2ApiBaseUrl(
+  httpServiceUrlV2: string | null | undefined,
+  httpServiceUrl: string | null | undefined,
+  configuredUrl?: string | null
+): string | null {
+  const advertised = httpServiceUrlV2?.trim();
+  if (advertised) {
+    return advertised.endsWith('/') ? advertised.slice(0, -1) : advertised;
   }
 
-  if (!httpServiceUrl) {
-    return null;
-  }
-
-  const normalized = httpServiceUrl.endsWith('/') ? httpServiceUrl.slice(0, -1) : httpServiceUrl;
-  const root = normalized
-    .replace(/\/signalk\/v2\/api$/, '')
-    .replace(/\/signalk\/v1\/api$/, '')
-    .replace(/\/signalk\/v2$/, '')
-    .replace(/\/signalk\/v1$/, '')
-    .replace(/\/signalk$/, '');
-
-  return `${root}/plugins/${pluginId}/`;
+  const root = resolveSignalKServerRoot(httpServiceUrl, configuredUrl);
+  return root ? `${root}/signalk/v2/api` : null;
 }

--- a/src/app/widget-config/video-camera-setup/video-camera-setup.component.spec.ts
+++ b/src/app/widget-config/video-camera-setup/video-camera-setup.component.spec.ts
@@ -128,8 +128,7 @@ describe('VideoCameraSetupComponent — camera mode', () => {
           provide: SignalKConnectionService,
           useValue: {
             serverServiceEndpoint$: of({
-              httpServiceUrl: 'http://h:3000/signalk/v1/api/',
-              httpServiceUrlV2: 'http://h:3000/signalk/v2/api'
+              httpServiceUrl: 'http://h:3000/signalk/v1/api/'
             }),
             signalKURL: { url: null }
           }

--- a/src/app/widget-config/video-camera-setup/video-camera-setup.component.spec.ts
+++ b/src/app/widget-config/video-camera-setup/video-camera-setup.component.spec.ts
@@ -323,6 +323,76 @@ describe('VideoCameraSetupComponent — camera mode', () => {
   });
 });
 
+// The camera-mode block above runs against a server that advertises no v2 endpoint, so the
+// resource URL there is derived from the v1 one. This block pins the other side: an advertised
+// endpoint is used as-is. Its host differs from anything the derivation could produce, so the
+// assertions fail if the advertised value stops winning.
+describe('VideoCameraSetupComponent — camera mode, advertised v2 endpoint', () => {
+  const ADVERTISED_V2 = 'http://v2.h:3000/signalk/v2/api';
+  const resources = {
+    list: vi.fn().mockResolvedValue([]),
+    save: vi.fn().mockResolvedValue(undefined),
+    remove: vi.fn().mockResolvedValue(undefined)
+  };
+  const discovery = { scan: vi.fn().mockResolvedValue([]) };
+  const creds = {
+    set: vi.fn().mockResolvedValue(undefined),
+    clear: vi.fn().mockResolvedValue(undefined),
+    presence: vi.fn().mockResolvedValue({ hasUsername: false, hasPassword: false })
+  };
+  const ptz = { move: vi.fn().mockResolvedValue(undefined), stop: vi.fn().mockResolvedValue(undefined) };
+
+  let fixture: ComponentFixture<HostComponent>;
+  let cmp: { manualForm: UntypedFormGroup; addCamera: () => Promise<void> };
+
+  beforeEach(async () => {
+    resources.list.mockClear();
+    resources.save.mockClear();
+
+    await TestBed.configureTestingModule({
+      imports: [HostComponent],
+      providers: [
+        { provide: CamerasResourceClient, useValue: resources },
+        { provide: CameraDiscoveryClient, useValue: discovery },
+        { provide: CameraCredentialsClient, useValue: creds },
+        { provide: PtzClient, useValue: ptz },
+        {
+          provide: SignalKConnectionService,
+          useValue: {
+            serverServiceEndpoint$: of({
+              httpServiceUrl: 'http://h:3000/signalk/v1/api/',
+              httpServiceUrlV2: ADVERTISED_V2
+            }),
+            signalKURL: { url: null }
+          }
+        }
+      ]
+    }).compileComponents();
+    fixture = TestBed.createComponent(HostComponent);
+    const videoGroup = fixture.componentInstance.root.get('video') as UntypedFormGroup;
+    fixture.detectChanges(); // ngOnInit
+    videoGroup.get('sourceKind')?.setValue('camera');
+    await Promise.resolve(); // refreshCameras
+    fixture.detectChanges();
+    cmp = fixture.debugElement.query(By.directive(VideoCameraSetupComponent))
+      .componentInstance as typeof cmp;
+  });
+
+  it('lists cameras from the advertised v2 endpoint, not the one derived from v1', () => {
+    expect(resources.list).toHaveBeenCalledWith(ADVERTISED_V2);
+  });
+
+  it('saves a camera to the advertised v2 endpoint', async () => {
+    cmp.manualForm.patchValue({ name: 'Bow Cam', scheme: 'rtsp', host: '10.0.0.9' });
+    await cmp.addCamera();
+    expect(resources.save).toHaveBeenCalledWith(ADVERTISED_V2, 'bow-cam', {
+      name: 'Bow Cam',
+      enabled: true,
+      source: { scheme: 'rtsp', host: '10.0.0.9' }
+    });
+  });
+});
+
 describe('VideoCameraSetupComponent — upload mode', () => {
   const assets = {
     list: vi.fn(),

--- a/src/app/widget-config/video-camera-setup/video-camera-setup.component.ts
+++ b/src/app/widget-config/video-camera-setup/video-camera-setup.component.ts
@@ -16,7 +16,7 @@ import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { mapPreset, type TVideoPreset } from '../../widgets/widget-video/playback-presets.util';
 import { SignalKConnectionService } from '../../core/services/signalk-connection.service';
 import { PluginConfigClientService } from '../../core/services/plugin-config-client.service';
-import { resolveSignalKPluginBaseUrl } from '../../core/utils/signalk-plugin-url.util';
+import { resolveSignalKPluginBaseUrl, resolveSignalKV2ApiBaseUrl } from '../../core/utils/signalk-plugin-url.util';
 import { classifyPluginPresence, type TPluginPresence } from '../../widgets/widget-video/plugin-presence.util';
 import { CameraDiscoveryClient, DiscoveryRateLimitedError } from '../../widgets/widget-video/discovery-client';
 import { CamerasResourceClient, type ISavedCamera } from '../../widgets/widget-video/cameras-resource-client';
@@ -68,11 +68,11 @@ export class VideoCameraSetupComponent implements OnInit, OnDestroy {
     resolveSignalKPluginBaseUrl('sk-video', this.endpoint()?.httpServiceUrl ?? null, this.connection.signalKURL?.url ?? null)
   );
   private readonly v2BaseUrl = computed(() =>
-    this.endpoint()?.httpServiceUrlV2
-    ?? this.endpoint()?.httpServiceUrl?.replace(/\/signalk\/v1\/api\/?$/, '/signalk/v2/api')
-    ?? (this.connection.signalKURL?.url
-      ? `${this.connection.signalKURL.url.replace(/\/$/, '')}/signalk/v2/api`
-      : null)
+    resolveSignalKV2ApiBaseUrl(
+      this.endpoint()?.httpServiceUrlV2,
+      this.endpoint()?.httpServiceUrl ?? null,
+      this.connection.signalKURL?.url ?? null
+    )
   );
 
   protected readonly cameras = signal<ISavedCamera[]>([]);

--- a/src/app/widget-config/video-camera-setup/video-camera-setup.component.ts
+++ b/src/app/widget-config/video-camera-setup/video-camera-setup.component.ts
@@ -67,7 +67,13 @@ export class VideoCameraSetupComponent implements OnInit, OnDestroy {
   private readonly pluginBaseUrl = computed(() =>
     resolveSignalKPluginBaseUrl('sk-video', this.endpoint()?.httpServiceUrl ?? null, this.connection.signalKURL?.url ?? null)
   );
-  private readonly v2BaseUrl = computed(() => this.endpoint()?.httpServiceUrlV2 ?? null);
+  private readonly v2BaseUrl = computed(() =>
+    this.endpoint()?.httpServiceUrlV2
+    ?? this.endpoint()?.httpServiceUrl?.replace(/\/signalk\/v1\/api\/?$/, '/signalk/v2/api')
+    ?? (this.connection.signalKURL?.url
+      ? `${this.connection.signalKURL.url.replace(/\/$/, '')}/signalk/v2/api`
+      : null)
+  );
 
   protected readonly cameras = signal<ISavedCamera[]>([]);
   protected readonly candidates = signal<ICameraCandidate[]>([]);


### PR DESCRIPTION
## Summary

- Keep using `endpoint.httpServiceUrlV2` for Video camera resource calls when the server advertises it.
- Fall back to the discovered v1 API URL when `httpServiceUrlV2` is missing.
- Fall back to the configured Signal K server URL if no discovered HTTP endpoint is available.
- Cover the camera save path with a test where only the v1 endpoint is discovered.

## Root Cause

The Video widget could probe cameras through the SK Video plugin because plugin URLs already use the configured Signal K base URL as a fallback. Saving a camera uses the Signal K Resources API instead, and the component only passed `endpoint.httpServiceUrlV2`. On Signal K servers that expose the v2 API but do not advertise `endpoints.v2` in `/signalk`, that value is `null`, so saving fails before the `PUT /signalk/v2/api/resources/cameras/:id` request is made.

## Validation

- `npm run snc`
- `npm run test:headless -- --include src/app/core/utils/signalk-plugin-url.util.spec.ts --include src/app/widget-config/video-camera-setup/video-camera-setup.component.spec.ts`

Note: the targeted test run emits existing Angular extended diagnostics warnings from unrelated templates, but the selected specs pass: 35 tests passed.
