### PR TITLE
Widgets with no data show the instrument, not a blank card

### DIFF
--- a/src/app/widgets/shared/electrical-card-layout.constants.ts
+++ b/src/app/widgets/shared/electrical-card-layout.constants.ts
@@ -57,3 +57,9 @@ export const ELECTRICAL_DIRECT_CARD_FULL_LAYOUT: IElectricalDirectCardLayout = {
 export const ELECTRICAL_DIRECT_CARD_COMPACT_LAYOUT: IElectricalDirectCardLayout = {
   ...ELECTRICAL_DIRECT_CARD_FULL_LAYOUT
 };
+
+/**
+ * Opacity of the all-'--' card the electrical widgets draw while nothing has reported. One value
+ * so the family's empty state cannot render at two intensities.
+ */
+export const ELECTRICAL_NO_DATA_OPACITY = 0.6;

--- a/src/app/widgets/shared/electrical-direct-card-draw.ts
+++ b/src/app/widgets/shared/electrical-direct-card-draw.ts
@@ -6,8 +6,7 @@ import {
   ELECTRICAL_DIRECT_CARD_GAP,
   ELECTRICAL_DIRECT_CARD_HEIGHT,
   ELECTRICAL_DIRECT_CARD_VIEWBOX_WIDTH,
-  ELECTRICAL_DIRECT_COMPACT_CARD_HEIGHT
-} from './electrical-card-layout.constants';
+  ELECTRICAL_DIRECT_COMPACT_CARD_HEIGHT, ELECTRICAL_NO_DATA_OPACITY } from './electrical-card-layout.constants';
 
 /**
  * The per-card display fields the shared direct-card draw reads. The trio's own
@@ -54,7 +53,6 @@ interface DirectCard<TEntity> {
 }
 
 const PLACEHOLDER_KEY = '__no-electrical-data__';
-const PLACEHOLDER_OPACITY = 0.6;
 
 /** Dimmed all-'--' card drawn while nothing has reported, so the widget keeps its card shape. */
 const PLACEHOLDER_MODEL: DirectCardDisplayModel = {
@@ -142,7 +140,7 @@ export function drawDirectCards<TEntity extends IElectricalTopologySnapshotCore>
   const merged = enter.merge(selection as Selection<SVGGElement, DirectCard<TEntity>, SVGGElement, unknown>);
 
   merged.attr('transform', item => `translate(0, ${item.y})`);
-  merged.attr('opacity', isPlaceholder ? PLACEHOLDER_OPACITY : null);
+  merged.attr('opacity', isPlaceholder ? ELECTRICAL_NO_DATA_OPACITY : null);
 
   if (includeCardBg) {
     merged.select(`rect.${classPrefix}-card-bg`)

--- a/src/app/widgets/shared/electrical-direct-card-draw.ts
+++ b/src/app/widgets/shared/electrical-direct-card-draw.ts
@@ -53,6 +53,24 @@ interface DirectCard<TEntity> {
   y: number;
 }
 
+const PLACEHOLDER_KEY = '__no-electrical-data__';
+const PLACEHOLDER_OPACITY = 0.6;
+
+/** Dimmed all-'--' card drawn while nothing has reported, so the widget keeps its card shape. */
+const PLACEHOLDER_MODEL: DirectCardDisplayModel = {
+  id: '',
+  titleText: '',
+  modeText: '--',
+  busText: '--',
+  metricsLineOne: '--',
+  metricsLineTwo: '--',
+  stateBarColor: 'var(--skip-contrast-dim-color)',
+  titleTextColor: 'var(--skip-contrast-dim-color)',
+  metaTextColor: 'var(--skip-contrast-dim-color)',
+  primaryMetricsTextColor: 'var(--skip-contrast-dim-color)',
+  secondaryMetricsTextColor: 'var(--skip-contrast-dim-color)'
+};
+
 /**
  * Select the direct-card `<svg>`, seed the shared viewBox/role/aria-label, and
  * append the stacked-card layer group. Reads the layout constants at call time
@@ -89,11 +107,18 @@ export function drawDirectCards<TEntity extends IElectricalTopologySnapshotCore>
 
   const layout = compact ? ELECTRICAL_DIRECT_CARD_COMPACT_LAYOUT : ELECTRICAL_DIRECT_CARD_FULL_LAYOUT;
   const cardHeight = compact ? ELECTRICAL_DIRECT_COMPACT_CARD_HEIGHT : ELECTRICAL_DIRECT_CARD_HEIGHT;
-  const cards: DirectCard<TEntity>[] = entities.map((entity, index) => ({
-    key: entity.deviceKey ?? entity.id,
-    entity,
-    y: index * (cardHeight + ELECTRICAL_DIRECT_CARD_GAP)
-  }));
+  // With nothing to show, draw one all-'--' card so the widget keeps its shape behind the
+  // empty-state message instead of collapsing to a bare panel and a sentence. The synthetic
+  // entity only ever reaches the id text, which the placeholder model blanks anyway.
+  const isPlaceholder = entities.length === 0;
+  const models = isPlaceholder ? { [PLACEHOLDER_KEY]: PLACEHOLDER_MODEL } : displayModels;
+  const cards: DirectCard<TEntity>[] = isPlaceholder
+    ? [{ key: PLACEHOLDER_KEY, entity: { id: '' } as TEntity, y: 0 }]
+    : entities.map((entity, index) => ({
+        key: entity.deviceKey ?? entity.id,
+        entity,
+        y: index * (cardHeight + ELECTRICAL_DIRECT_CARD_GAP)
+      }));
 
   const contentHeight = cards.length ? cards[cards.length - 1].y + cardHeight : cardHeight;
   svg.attr('viewBox', `0 0 ${ELECTRICAL_DIRECT_CARD_VIEWBOX_WIDTH} ${contentHeight}`);
@@ -117,6 +142,7 @@ export function drawDirectCards<TEntity extends IElectricalTopologySnapshotCore>
   const merged = enter.merge(selection as Selection<SVGGElement, DirectCard<TEntity>, SVGGElement, unknown>);
 
   merged.attr('transform', item => `translate(0, ${item.y})`);
+  merged.attr('opacity', isPlaceholder ? PLACEHOLDER_OPACITY : null);
 
   if (includeCardBg) {
     merged.select(`rect.${classPrefix}-card-bg`)
@@ -138,15 +164,15 @@ export function drawDirectCards<TEntity extends IElectricalTopologySnapshotCore>
     .attr('ry', layout.stateBarCornerRadius)
     .attr('width', 3)
     .attr('height', cardHeight - 3)
-    .attr('fill', item => displayModels[item.key]?.stateBarColor ?? widgetColors.dim);
+    .attr('fill', item => models[item.key]?.stateBarColor ?? widgetColors.dim);
 
   if (entities.length > 1) {
     merged.select(`text.${classPrefix}-title`)
       .attr('x', layout.titleX)
       .attr('y', layout.titleY)
       .attr('font-size', layout.titleFontSize)
-      .attr('fill', item => displayModels[item.key]?.titleTextColor ?? 'var(--skip-contrast-color)')
-      .text(item => displayModels[item.key]?.titleText ?? titleFallback(item.entity));
+      .attr('fill', item => models[item.key]?.titleTextColor ?? 'var(--skip-contrast-color)')
+      .text(item => models[item.key]?.titleText ?? titleFallback(item.entity));
   } else {
     merged.select(`text.${classPrefix}-title`).text('');
   }
@@ -164,8 +190,8 @@ export function drawDirectCards<TEntity extends IElectricalTopologySnapshotCore>
     .attr('y', layout.metaY)
     .attr('font-size', layout.metaFontSize)
     .attr('opacity', 0.8)
-    .attr('fill', item => displayModels[item.key]?.metaTextColor ?? 'var(--skip-contrast-dim-color)')
-    .text(item => displayModels[item.key]?.modeText ?? '');
+    .attr('fill', item => models[item.key]?.metaTextColor ?? 'var(--skip-contrast-dim-color)')
+    .text(item => models[item.key]?.modeText ?? '');
 
   merged.select(`text.${classPrefix}-bus`)
     .attr('x', layout.metaRightX)
@@ -173,23 +199,23 @@ export function drawDirectCards<TEntity extends IElectricalTopologySnapshotCore>
     .attr('text-anchor', 'end')
     .attr('font-size', layout.metaFontSize)
     .attr('opacity', 0.8)
-    .attr('fill', item => displayModels[item.key]?.metaTextColor ?? 'var(--skip-contrast-dim-color)')
-    .text(item => displayModels[item.key]?.busText ?? '');
+    .attr('fill', item => models[item.key]?.metaTextColor ?? 'var(--skip-contrast-dim-color)')
+    .text(item => models[item.key]?.busText ?? '');
 
   merged.select(`text.${classPrefix}-metrics-1`)
     .attr('x', layout.lineOneX)
     .attr('y', layout.lineOneY)
     .attr('font-size', layout.lineOneFontSize)
-    .attr('fill', item => displayModels[item.key]?.primaryMetricsTextColor ?? 'var(--skip-contrast-color)')
-    .text(item => displayModels[item.key]?.metricsLineOne ?? '');
+    .attr('fill', item => models[item.key]?.primaryMetricsTextColor ?? 'var(--skip-contrast-color)')
+    .text(item => models[item.key]?.metricsLineOne ?? '');
 
   merged.select(`text.${classPrefix}-metrics-2`)
     .attr('x', layout.lineTwoX)
     .attr('y', layout.lineTwoY)
     .attr('font-size', layout.lineTwoFontSize)
     .attr('opacity', 0.85)
-    .attr('fill', item => displayModels[item.key]?.secondaryMetricsTextColor ?? 'var(--skip-contrast-color)')
-    .text(item => displayModels[item.key]?.metricsLineTwo ?? '');
+    .attr('fill', item => models[item.key]?.secondaryMetricsTextColor ?? 'var(--skip-contrast-color)')
+    .text(item => models[item.key]?.metricsLineTwo ?? '');
 
   selection.exit().remove();
 }

--- a/src/app/widgets/svg-autopilot/svg-autopilot.component.spec.ts
+++ b/src/app/widgets/svg-autopilot/svg-autopilot.component.spec.ts
@@ -1,0 +1,69 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { SvgAutopilotComponent } from './svg-autopilot.component';
+
+/**
+ * The AP screen is a steering display: a reading that stops arriving has to read as absent rather
+ * than hold its last value, because a frozen dial and a live one look identical.
+ */
+describe('SvgAutopilotComponent', () => {
+  let fixture: ComponentFixture<SvgAutopilotComponent>;
+
+  interface Internals {
+    compassAngle: () => number | null;
+    apModeValue: () => string;
+  }
+
+  const set = (inputs: Record<string, unknown>) => {
+    for (const [key, value] of Object.entries(inputs)) {
+      (fixture.componentRef.setInput.bind(fixture.componentRef) as (k: string, v: unknown) => void)(key, value);
+    }
+    fixture.detectChanges();
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({ imports: [SvgAutopilotComponent] }).compileComponents();
+    fixture = TestBed.createComponent(SvgAutopilotComponent);
+    set({
+      apMode: 'auto',
+      updateInterval: 500,
+      targetPilotHeadingTrue: false,
+      autopilotTarget: null,
+      courseXte: 0,
+      compassHeading: null,
+      headingDirectionTrue: false,
+      appWindAngle: null,
+      rudderAngle: null
+    });
+  });
+
+  const internals = () => fixture.componentInstance as unknown as Internals;
+
+  it('reports no heading before one has arrived', () => {
+    expect(internals().compassAngle()).toBeNull();
+  });
+
+  it('returns the heading readout to absent when the source drops out', () => {
+    set({ compassHeading: 142 });
+    expect(internals().compassAngle()).toBe(142);
+
+    set({ compassHeading: null });
+    expect(internals().compassAngle()).toBeNull();
+  });
+
+  it('places the next heading after a dropout without sweeping from the stale angle', () => {
+    set({ compassHeading: 142 });
+    set({ compassHeading: null });
+    set({ compassHeading: 10 });
+
+    expect(internals().compassAngle()).toBe(10);
+  });
+
+  it('shows a placeholder rather than a dead-ahead 0 for a missing wind-hold angle', () => {
+    set({ apMode: 'wind', appWindAngle: null });
+    expect(internals().apModeValue()).toBe('--');
+
+    set({ appWindAngle: 35 });
+    expect(internals().apModeValue()).toBe('35°');
+  });
+});

--- a/src/app/widgets/svg-autopilot/svg-autopilot.component.ts
+++ b/src/app/widgets/svg-autopilot/svg-autopilot.component.ts
@@ -94,7 +94,16 @@ export class SvgAutopilotComponent implements OnDestroy {
   constructor() {
     effect(() => {
       const heading = this.compassHeading();
-      if (heading == null || !Number.isFinite(heading)) return;
+      // A heading that stops arriving must read as absent, not hold its last value: a frozen dial
+      // is indistinguishable from a live one. Clearing `compassInitialized` also places the next
+      // real heading without sweeping to it from a stale angle.
+      if (heading == null || !Number.isFinite(heading)) {
+        untracked(() => {
+          this.compassAngle.set(null);
+          this.compassInitialized = false;
+        });
+        return;
+      }
       const next = this.roundDeg(heading);
       untracked(() => {
         const prev = this.prevCompassAngle;
@@ -156,7 +165,7 @@ export class SvgAutopilotComponent implements OnDestroy {
     effect(() => {
       const state = this.apMode();
       const awaRaw = this.appWindAngle();
-      const awa = (awaRaw != null && Number.isFinite(awaRaw)) ? this.roundDeg(awaRaw) : 0;
+      const awa = (awaRaw != null && Number.isFinite(awaRaw)) ? this.roundDeg(awaRaw) : null;
       let xteValue = this.courseXte();
 
       untracked(() => {
@@ -195,8 +204,9 @@ export class SvgAutopilotComponent implements OnDestroy {
             this.apModeValueDirection.set('');
             break;
           case "wind":
+            // A dead vane reads '--', not a dead-ahead 0 the helm would take for a real target.
             this.apModeValueAnnotation.set(awa ? awa > 0 ? 'S' : 'P' : '');
-            this.apModeValue.set(Math.abs(awa) + '°');
+            this.apModeValue.set(awa === null ? '--' : Math.abs(awa) + '°');
             this.apModeValueDirection.set('');
             break;
           default:

--- a/src/app/widgets/svg-autopilot/svg-autopilot.component.ts
+++ b/src/app/widgets/svg-autopilot/svg-autopilot.component.ts
@@ -26,7 +26,8 @@ export class SvgAutopilotComponent implements OnDestroy {
   protected readonly appWindAngle = input.required<number | null>();
   protected readonly rudderAngle = input.required<number | null>();
 
-  protected compassAngle = signal<number>(0);
+  /** null until a heading arrives, so the readout shows '--' rather than a fabricated north. */
+  protected compassAngle = signal<number | null>(null);
   protected awaAngle = signal<number>(0);
   private prevCompassAngle = 0;
   private prevAwaAngle = 0;

--- a/src/app/widgets/widget-ac/widget-ac.component.html
+++ b/src/app/widgets/widget-ac/widget-ac.component.html
@@ -2,7 +2,9 @@
 <svg #acSvg class="ac-svg" aria-hidden="false"></svg>
 @if (!hasBuses()) {
   <div class="ac-empty">
-    <div class="ac-empty-title">No AC buses detected</div>
-    <div class="ac-empty-sub">Check Signal K AC paths or select buses in widget settings.</div>
+    <div class="ac-empty-panel">
+      <div class="ac-empty-title">No AC buses detected</div>
+      <div class="ac-empty-sub">Check Signal K AC paths or select buses in widget settings.</div>
+    </div>
   </div>
 }

--- a/src/app/widgets/widget-ac/widget-ac.component.scss
+++ b/src/app/widgets/widget-ac/widget-ac.component.scss
@@ -28,6 +28,8 @@
   justify-content: center;
   text-align: center;
   color: var(--mat-sys-on-surface);
+  // Above the card SVG, which carries z-index 20.
+  z-index: 30;
   pointer-events: none;
 }
 

--- a/src/app/widgets/widget-ac/widget-ac.component.scss
+++ b/src/app/widgets/widget-ac/widget-ac.component.scss
@@ -24,13 +24,23 @@
   inset: 0;
   margin: 10px;
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 8px;
   text-align: center;
   color: var(--mat-sys-on-surface);
-  background: color-mix(in srgb, var(--skip-widget-card-background-color) 92%, transparent);
+  pointer-events: none;
+}
+
+// The message gets its own plate rather than a full-bleed scrim, so it stays legible while the
+// placeholder card behind it still reads as the widget it belongs to.
+.ac-empty-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--skip-widget-card-border-color);
+  background: color-mix(in srgb, var(--mat-sys-surface-container-high) 88%, transparent);
 }
 
 .ac-empty-title {

--- a/src/app/widgets/widget-ac/widget-ac.component.spec.ts
+++ b/src/app/widgets/widget-ac/widget-ac.component.spec.ts
@@ -448,4 +448,19 @@ describe('WidgetAcComponent', () => {
     const normalized = (svg?.outerHTML ?? '').replace(/ _ng(content|host)-[a-z0-9-]+=""/g, '');
     expect(normalized).toMatchSnapshot();
   });
+  it('draws one dimmed all-placeholder card while no AC bus has reported', async () => {
+    // The widget must keep its card shape behind the empty-state message rather than collapsing
+    // to a bare panel carrying a sentence.
+    vi.useFakeTimers();
+    await setup([]);
+    await vi.runAllTimersAsync();
+    fixture.detectChanges();
+    await vi.runAllTimersAsync();
+
+    const host = fixture.nativeElement as HTMLElement;
+    const cards = host.querySelectorAll('g.ac-card');
+    expect(cards.length).toBe(1);
+    expect(cards[0].getAttribute('opacity')).toBe('0.6');
+    expect(host.querySelector('text.ac-metrics-1')?.textContent).toBe('--');
+  });
 });

--- a/src/app/widgets/widget-alternator/widget-alternator.component.html
+++ b/src/app/widgets/widget-alternator/widget-alternator.component.html
@@ -2,7 +2,9 @@
 <svg #alternatorSvg class="alternator-svg" aria-hidden="false"></svg>
 @if (!hasAlternators()) {
 <div class="alternator-empty">
-  <div class="alternator-empty-title">No alternators detected</div>
-  <div class="alternator-empty-sub">Check Signal K alternator paths or select alternators in widget settings.</div>
+  <div class="alternator-empty-panel">
+    <div class="alternator-empty-title">No alternators detected</div>
+    <div class="alternator-empty-sub">Check Signal K alternator paths or select alternators in widget settings.</div>
+  </div>
 </div>
 }

--- a/src/app/widgets/widget-alternator/widget-alternator.component.scss
+++ b/src/app/widgets/widget-alternator/widget-alternator.component.scss
@@ -28,6 +28,8 @@
   justify-content: center;
   text-align: center;
   color: var(--mat-sys-on-surface);
+  // Above the card SVG, which carries z-index 20.
+  z-index: 30;
   pointer-events: none;
 }
 

--- a/src/app/widgets/widget-alternator/widget-alternator.component.scss
+++ b/src/app/widgets/widget-alternator/widget-alternator.component.scss
@@ -24,13 +24,23 @@
   inset: 0;
   margin: 10px;
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 8px;
   text-align: center;
   color: var(--mat-sys-on-surface);
-  background: color-mix(in srgb, var(--skip-widget-card-background-color) 92%, transparent);
+  pointer-events: none;
+}
+
+// The message gets its own plate rather than a full-bleed scrim, so it stays legible while the
+// placeholder card behind it still reads as the widget it belongs to.
+.alternator-empty-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--skip-widget-card-border-color);
+  background: color-mix(in srgb, var(--mat-sys-surface-container-high) 88%, transparent);
 }
 
 .alternator-empty-title {

--- a/src/app/widgets/widget-alternator/widget-alternator.component.spec.ts
+++ b/src/app/widgets/widget-alternator/widget-alternator.component.spec.ts
@@ -330,4 +330,19 @@ describe('WidgetAlternatorComponent', () => {
     const normalized = (svg?.outerHTML ?? '').replace(/ _ng(content|host)-[a-z0-9-]+=""/g, '');
     expect(normalized).toMatchSnapshot();
   });
+  it('draws one dimmed all-placeholder card while no alternator has reported', async () => {
+    // The widget must keep its card shape behind the empty-state message rather than collapsing
+    // to a bare panel carrying a sentence.
+    vi.useFakeTimers();
+    await setup([]);
+    await vi.runAllTimersAsync();
+    fixture.detectChanges();
+    await vi.runAllTimersAsync();
+
+    const host = fixture.nativeElement as HTMLElement;
+    const cards = host.querySelectorAll('g.alternator-card');
+    expect(cards.length).toBe(1);
+    expect(cards[0].getAttribute('opacity')).toBe('0.6');
+    expect(host.querySelector('text.alternator-metrics-1')?.textContent).toBe('--');
+  });
 });

--- a/src/app/widgets/widget-autopilot/widget-autopilot.component.html
+++ b/src/app/widgets/widget-autopilot/widget-autopilot.component.html
@@ -1,7 +1,7 @@
 <div class="autopilot-grid-container">
   <!-- Modes row -->
   <div class="ap-modes">
-    <button mat-flat-button [disabled]="(apState() === 'off-line') || (apMode() === 'off-line')" class="ap-btn ap-btn-ctrlbar" (click)="toggleMenu()">
+    <button mat-flat-button [disabled]="!apModeKnown()" class="ap-btn ap-btn-ctrlbar" (click)="toggleMenu()">
       <span class="label label-ctrlbar">Mode {{ apMode() | titlecase }}<span aria-hidden="true">&nbsp;&vellip;</span></span>
     </button>
     <button mat-flat-button [disabled]="apEngageBtnDisabled()" [class]="!apEngaged() ? 'ap-btn ap-btn-ctrlbar ap-btn-disengage' : 'ap-btn ap-btn-ctrlbar ap-btn-engage'" (click)="buildAndSendCommand('standby')">

--- a/src/app/widgets/widget-autopilot/widget-autopilot.component.html
+++ b/src/app/widgets/widget-autopilot/widget-autopilot.component.html
@@ -1,4 +1,4 @@
-<div [style.display]="apGrid()" class="autopilot-grid-container">
+<div class="autopilot-grid-container">
   <!-- Modes row -->
   <div class="ap-modes">
     <button mat-flat-button [disabled]="(apState() === 'off-line') || (apMode() === 'off-line')" class="ap-btn ap-btn-ctrlbar" (click)="toggleMenu()">
@@ -27,11 +27,11 @@
         <text x="50%" dy="75" [style.visibility]="countDownValue >= 0 ? 'visible' : 'hidden'" style="font-size: 3em" [innerHTML]="countDownValue + 1" class="svg-element-msg" />
       </svg>
     </div>
-    <div class="ap-screen-overlay ap-error-text" [style.visibility]="errorOverlayVisibility()">
-      <span class="material-icons ap-error-icon">warning</span>
-      <svg viewBox="0 0 100 100" width="100%" height="100%" preserveAspectRatio="xMidYMid meet">
-        <text x="50%" y="25" [innerHTML]="errorOverlayText()" class="svg-element-msg svg-element-error-txt" />
-      </svg>
+    <div class="ap-screen-overlay ap-error-overlay" [style.visibility]="errorOverlayVisibility()">
+      <div class="ap-error-panel">
+        <span class="material-icons">warning</span>
+        <span class="ap-error-msg">{{ errorOverlayText() }}</span>
+      </div>
     </div>
   </div>
   <!-- -1 / +1 buttons row -->

--- a/src/app/widgets/widget-autopilot/widget-autopilot.component.scss
+++ b/src/app/widgets/widget-autopilot/widget-autopilot.component.scss
@@ -53,9 +53,9 @@
   z-index: 50;
   vertical-align: middle;
   text-align: center;
-  // Translucent so the autopilot screen stays readable behind a message: a widget that is only
-  // an opaque panel and a sentence reads as broken rather than as an autopilot with no data.
-  background-color: color-mix(in srgb, var(--mat-sys-background) 72%, transparent);
+  // Opaque by default: the countdown overlay is a confirmation prompt and must not compete with
+  // the rotating dial behind it. The error overlay opts out and carries its own plate instead.
+  background-color: var(--mat-sys-background);
 }
 
 // The message sits on its own plate rather than tinting the whole layer, matching the electrical

--- a/src/app/widgets/widget-autopilot/widget-autopilot.component.scss
+++ b/src/app/widgets/widget-autopilot/widget-autopilot.component.scss
@@ -53,15 +53,40 @@
   z-index: 50;
   vertical-align: middle;
   text-align: center;
-  background-color: var(--mat-sys-background);
+  // Translucent so the autopilot screen stays readable behind a message: a widget that is only
+  // an opaque panel and a sentence reads as broken rather than as an autopilot with no data.
+  background-color: color-mix(in srgb, var(--mat-sys-background) 72%, transparent);
 }
 
-.ap-error-icon {
-  padding-top: 15px;
+// The message sits on its own plate rather than tinting the whole layer, matching the electrical
+// widgets' empty state: error-coloured text needs a surface behind it to stay legible over the
+// autopilot screen.
+.ap-error-overlay {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 8px;
+  background-color: transparent;
 }
 
-.ap-error-text {
-  color: var(--mat-sys-error-container);
+.ap-error-panel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  border: 1px solid var(--skip-widget-card-border-color);
+  background: color-mix(in srgb, var(--mat-sys-surface-container-high) 88%, transparent);
+  color: var(--mat-sys-error);
+}
+
+.ap-error-msg {
+  font-family: Roboto;
+  font-size: 12px;
+  font-weight: bold;
+  line-height: 1.25;
 }
 
 // Each control is a size container so its label can be sized against the control's own box. A tile

--- a/src/app/widgets/widget-autopilot/widget-autopilot.component.spec.ts
+++ b/src/app/widgets/widget-autopilot/widget-autopilot.component.spec.ts
@@ -112,19 +112,42 @@ describe('WidgetAutopilotComponent', () => {
 
   const startV1 = () => (component as unknown as { startV1Subscriptions: () => void }).startV1Subscriptions();
 
-  it('disables the engage toggle while an error is on screen', () => {
+  it('disables the engage toggle while the pilot has no known mode', () => {
+    // A pilot whose paths are silent cannot be commanded, whatever the REST API would accept.
     const internals = component as unknown as {
+      apMode: { set: (value: string | null) => void };
       apEngaged: { set: (value: boolean) => void };
-      errorOverlayVisibility: { set: (value: string) => void };
       apEngageBtnDisabled: () => boolean;
     };
 
     internals.apEngaged.set(false);
-    internals.errorOverlayVisibility.set('hidden');
-    expect(internals.apEngageBtnDisabled()).toBe(false);
-
-    internals.errorOverlayVisibility.set('visible');
+    internals.apMode.set(null);
     expect(internals.apEngageBtnDisabled()).toBe(true);
+
+    internals.apMode.set('off-line');
+    expect(internals.apEngageBtnDisabled()).toBe(true);
+
+    internals.apMode.set('auto');
+    expect(internals.apEngageBtnDisabled()).toBe(false);
+  });
+
+  it('leaves the engage toggle live after a refused command', () => {
+    // The toggle reads Disengage on an engaged pilot; a rejected command must not lock the helm
+    // out of taking a misbehaving pilot off.
+    const internals = component as unknown as {
+      apMode: { set: (value: string | null) => void };
+      apEngaged: { set: (value: boolean) => void };
+      errorOverlayVisibility: { set: (value: string) => void };
+      apEngageBtnDisabled: () => boolean;
+      standbyButtonLabel: () => string;
+    };
+
+    internals.apMode.set('auto');
+    internals.apEngaged.set(true);
+    internals.errorOverlayVisibility.set('visible');
+
+    expect(internals.standbyButtonLabel()).toBe('Disengage');
+    expect(internals.apEngageBtnDisabled()).toBe(false);
   });
 
   it('keeps the control rows laid out but disabled while no autopilot mode is known', () => {
@@ -204,14 +227,14 @@ describe('WidgetAutopilotComponent', () => {
     return (clone.textContent ?? '').trim();
   };
 
-  const render = (mode: string): ComponentFixture<WidgetAutopilotComponent> => {
+  const render = (mode: string | null): ComponentFixture<WidgetAutopilotComponent> => {
     const fixture = TestBed.createComponent(WidgetAutopilotComponent);
     const set = fixture.componentRef.setInput.bind(fixture.componentRef) as (k: string, v: unknown) => void;
     set('id', 'autopilot-test');
     set('type', 'widget-autopilot');
     set('theme', null);
     const state = fixture.componentInstance as unknown as {
-      apMode: { set: (value: string) => void };
+      apMode: { set: (value: string | null) => void };
       apState: { set: (value: string) => void };
     };
     state.apMode.set(mode);
@@ -247,5 +270,19 @@ describe('WidgetAutopilotComponent', () => {
     expect(labels).toContain('Tack Stbd');
     expect(labels).toContain('Dodge');
     expect(labels).toContain('Adv Wpt');
+  });
+  it('keeps the grid and its controls on screen when no mode is known', () => {
+    // The widget went blank because [style.display]="apGrid()" collapsed this container. Assert the
+    // rendered result, not the row-visibility signals — those never fed that binding.
+    const fixture = render(null);
+    const host = fixture.nativeElement as HTMLElement;
+
+    const grid = host.querySelector<HTMLElement>('.autopilot-grid-container');
+    expect(grid).not.toBeNull();
+    expect(grid?.style.display).not.toBe('none');
+
+    const buttons = controls(fixture);
+    expect(buttons.length).toBeGreaterThan(0);
+    expect(buttons.every(b => b.disabled)).toBe(true);
   });
 });

--- a/src/app/widgets/widget-autopilot/widget-autopilot.component.spec.ts
+++ b/src/app/widgets/widget-autopilot/widget-autopilot.component.spec.ts
@@ -112,6 +112,41 @@ describe('WidgetAutopilotComponent', () => {
 
   const startV1 = () => (component as unknown as { startV1Subscriptions: () => void }).startV1Subscriptions();
 
+  it('keeps the control rows laid out but disabled while no autopilot mode is known', () => {
+    // A silent or unconfigured autopilot must still look like an autopilot, not collapse to two
+    // buttons over an empty panel.
+    const internals = component as unknown as {
+      apMode: { set: (value: string | null) => void };
+      adjustHdgBtnVisibility: () => boolean;
+      tackBtnVisibility: () => boolean;
+      apBtnDisabled: () => boolean;
+    };
+
+    internals.apMode.set(null);
+    expect(internals.adjustHdgBtnVisibility()).toBe(true);
+    expect(internals.tackBtnVisibility()).toBe(true);
+    expect(internals.apBtnDisabled()).toBe(true);
+
+    internals.apMode.set('off-line');
+    expect(internals.adjustHdgBtnVisibility()).toBe(true);
+    expect(internals.tackBtnVisibility()).toBe(true);
+    expect(internals.apBtnDisabled()).toBe(true);
+  });
+
+  it('enables the control rows once a real mode is reported', () => {
+    const internals = component as unknown as {
+      apMode: { set: (value: string | null) => void };
+      apEngaged: { set: (value: boolean) => void };
+      adjustHdgBtnVisibility: () => boolean;
+      apBtnDisabled: () => boolean;
+    };
+
+    internals.apMode.set('auto');
+    internals.apEngaged.set(true);
+    expect(internals.adjustHdgBtnVisibility()).toBe(true);
+    expect(internals.apBtnDisabled()).toBe(false);
+  });
+
   it('does not throw starting V1 subscriptions when the config has no paths object', () => {
     const spy = vi.spyOn(runtimeMock, 'options').mockReturnValue({ autopilot: runtimeOptions.autopilot } as unknown as typeof runtimeOptions);
     try {

--- a/src/app/widgets/widget-autopilot/widget-autopilot.component.spec.ts
+++ b/src/app/widgets/widget-autopilot/widget-autopilot.component.spec.ts
@@ -112,6 +112,21 @@ describe('WidgetAutopilotComponent', () => {
 
   const startV1 = () => (component as unknown as { startV1Subscriptions: () => void }).startV1Subscriptions();
 
+  it('disables the engage toggle while an error is on screen', () => {
+    const internals = component as unknown as {
+      apEngaged: { set: (value: boolean) => void };
+      errorOverlayVisibility: { set: (value: string) => void };
+      apEngageBtnDisabled: () => boolean;
+    };
+
+    internals.apEngaged.set(false);
+    internals.errorOverlayVisibility.set('hidden');
+    expect(internals.apEngageBtnDisabled()).toBe(false);
+
+    internals.errorOverlayVisibility.set('visible');
+    expect(internals.apEngageBtnDisabled()).toBe(true);
+  });
+
   it('keeps the control rows laid out but disabled while no autopilot mode is known', () => {
     // A silent or unconfigured autopilot must still look like an autopilot, not collapse to two
     // buttons over an empty panel.

--- a/src/app/widgets/widget-autopilot/widget-autopilot.component.ts
+++ b/src/app/widgets/widget-autopilot/widget-autopilot.component.ts
@@ -308,11 +308,17 @@ export class WidgetAutopilotComponent implements OnInit, OnDestroy {
 
     return "Disengage";
   });
+  /** True while the error overlay is showing, whether the error is persistent or a command failure. */
+  protected readonly errorActive = computed(() => this.errorOverlayVisibility() === 'visible');
   protected readonly apEngageBtnDisabled = computed(() => {
     const state = this.apState();
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const engaged = this.apEngaged();
     const apiVersion = this.runtime.options()?.autopilot?.apiVersion;
+
+    // Under a displayed error the pilot is either unreachable or just refused a command; engaging
+    // it is the last thing the helm should be able to do by accident.
+    if (this.errorActive()) return true;
 
     if (!apiVersion) return true;
 

--- a/src/app/widgets/widget-autopilot/widget-autopilot.component.ts
+++ b/src/app/widgets/widget-autopilot/widget-autopilot.component.ts
@@ -308,17 +308,16 @@ export class WidgetAutopilotComponent implements OnInit, OnDestroy {
 
     return "Disengage";
   });
-  /** True while the error overlay is showing, whether the error is persistent or a command failure. */
-  protected readonly errorActive = computed(() => this.errorOverlayVisibility() === 'visible');
   protected readonly apEngageBtnDisabled = computed(() => {
     const state = this.apState();
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const engaged = this.apEngaged();
     const apiVersion = this.runtime.options()?.autopilot?.apiVersion;
 
-    // Under a displayed error the pilot is either unreachable or just refused a command; engaging
-    // it is the last thing the helm should be able to do by accident.
-    if (this.errorActive()) return true;
+    // Same reachability gate as every other control: a pilot whose paths are silent is not one the
+    // helm can command, whatever the REST API would accept. A refused command is not a reason to
+    // disable this one — it is the button that takes a misbehaving pilot off.
+    if (!this.apModeKnown()) return true;
 
     if (!apiVersion) return true;
 

--- a/src/app/widgets/widget-autopilot/widget-autopilot.component.ts
+++ b/src/app/widgets/widget-autopilot/widget-autopilot.component.ts
@@ -299,8 +299,6 @@ export class WidgetAutopilotComponent implements OnInit, OnDestroy {
   // Request management
   private currentRequests = new Set<Observable<unknown>>();
 
-  // Keypad buttons & layout
-  protected apGrid = computed(() => this.apMode() ? 'grid' : 'none');
   protected readonly standbyButtonLabel = computed(() => {
     const apiVersion = this.runtime.options()?.autopilot?.apiVersion;
 
@@ -331,6 +329,8 @@ export class WidgetAutopilotComponent implements OnInit, OnDestroy {
     const engaged = this.apEngaged();
     const apiVersion = this.runtime.options()?.autopilot?.apiVersion;
 
+    if (!this.apModeKnown()) return true;
+
     if (apiVersion === "v1") {
       return this.apMode() === 'standby' ? true : false;
     }
@@ -339,8 +339,16 @@ export class WidgetAutopilotComponent implements OnInit, OnDestroy {
     }
     return true;
   });
+  /** False while no mode has been reported (never subscribed, or reported off-line). */
+  protected readonly apModeKnown = computed(() => {
+    const mode = this.apMode();
+    return mode !== null && mode !== 'off-line';
+  });
   protected readonly adjustHdgBtnVisibility = computed(() => {
     const mode = this.apMode();
+    // With no known mode the rows stay laid out but disabled, so the widget keeps its shape
+    // instead of collapsing to two buttons and an empty panel.
+    if (!this.apModeKnown()) return true;
     if ( mode !== null && ['auto', 'compass', 'gps', 'wind', 'true wind', 'standby'].includes(mode)) {
       return true;
     }
@@ -348,6 +356,7 @@ export class WidgetAutopilotComponent implements OnInit, OnDestroy {
   });
   protected readonly tackBtnVisibility = computed(() => {
     const mode = this.apMode();
+    if (!this.apModeKnown()) return true;
     if ( mode !== null && ['auto', 'compass', 'gps', 'wind', 'true wind', 'standby'].includes(mode)) {
       return true;
     }
@@ -723,8 +732,8 @@ export class WidgetAutopilotComponent implements OnInit, OnDestroy {
         console.warn('[Autopilot Widget] Autopilot V1 mode state is null or not available');
       }
     });
-    this.streams.observe('autopilotTargetHeading', newValue => this.autopilotTargetHeading.set(newValue.data.value != null ? newValue.data.value : 0));
-    this.streams.observe('autopilotTargetWindHeading', newValue => this.autopilotTargetWindHeading.set(newValue.data.value != null ? newValue.data.value : 0));
+    this.streams.observe('autopilotTargetHeading', newValue => this.autopilotTargetHeading.set(newValue.data.value));
+    this.streams.observe('autopilotTargetWindHeading', newValue => this.autopilotTargetWindHeading.set(newValue.data.value));
 
     this.startDataSubscription();
 
@@ -747,13 +756,15 @@ export class WidgetAutopilotComponent implements OnInit, OnDestroy {
       }
     );
 
+    // A missing heading or wind angle stays null so the AP screen shows '--' instead of a
+    // fabricated north / dead-ahead reading.
     if (this.runtime.options()?.autopilot?.headingDirectionTrue ?? false) {
-      this.streams.observe('headingTrue', newValue => this.heading.set(newValue.data.value != null ? newValue.data.value : 0));
+      this.streams.observe('headingTrue', newValue => this.heading.set(newValue.data.value));
     } else {
-      this.streams.observe('headingMag', newValue => this.heading.set(newValue.data.value != null ? newValue.data.value : 0));
+      this.streams.observe('headingMag', newValue => this.heading.set(newValue.data.value));
     }
 
-    this.streams.observe('windAngleApparent', newValue => this.windAngleApparent.set(newValue.data.value != null ? newValue.data.value : 0));
+    this.streams.observe('windAngleApparent', newValue => this.windAngleApparent.set(newValue.data.value));
   }
 
   private subscribePutResponse(): void {

--- a/src/app/widgets/widget-bms/widget-bms.component.html
+++ b/src/app/widgets/widget-bms/widget-bms.component.html
@@ -1,10 +1,10 @@
-@if (hasBanks()) {
 <widget-title [text]="displayLabel()" [color]="labelColor()"></widget-title>
-}
-<svg #bmsSvg class="bms-svg" [class.bms-svg--full]="!hasBanks()" aria-hidden="false"></svg>
+<svg #bmsSvg class="bms-svg" aria-hidden="false"></svg>
 @if (!hasBatteries()) {
   <div class="bms-empty">
-    <div class="bms-empty-title">No batteries detected</div>
-    <div class="bms-empty-sub">Check Signal K battery paths or select batteries in widget settings.</div>
+    <div class="bms-empty-panel">
+      <div class="bms-empty-title">No batteries detected</div>
+      <div class="bms-empty-sub">Check Signal K battery paths or select batteries in widget settings.</div>
+    </div>
   </div>
 }

--- a/src/app/widgets/widget-bms/widget-bms.component.html
+++ b/src/app/widgets/widget-bms/widget-bms.component.html
@@ -1,6 +1,6 @@
 <widget-title [text]="displayLabel()" [color]="labelColor()"></widget-title>
-<svg #bmsSvg class="bms-svg" aria-hidden="false"></svg>
-@if (!hasBatteries()) {
+<svg #bmsSvg class="bms-svg" [class.bms-svg--full]="hasBatteries() && !hasBanks()" aria-hidden="false"></svg>
+@if (nothingToShow()) {
   <div class="bms-empty">
     <div class="bms-empty-panel">
       <div class="bms-empty-title">No batteries detected</div>

--- a/src/app/widgets/widget-bms/widget-bms.component.scss
+++ b/src/app/widgets/widget-bms/widget-bms.component.scss
@@ -16,6 +16,14 @@
   width: 100%;
   overflow: hidden;
   padding: 0 10px 10px 10px;
+
+  // Batteries reported without a bank have no bank header to sit under, so the cards take the
+  // full box. The empty state keeps the inset layout: its placeholder card needs the title row.
+  &.bms-svg--full {
+    top: 0;
+    height: 100%;
+    padding-top: 10px;
+  }
 }
 
 .bms-card-metric {

--- a/src/app/widgets/widget-bms/widget-bms.component.scss
+++ b/src/app/widgets/widget-bms/widget-bms.component.scss
@@ -16,12 +16,6 @@
   width: 100%;
   overflow: hidden;
   padding: 0 10px 10px 10px;
-
-  &.bms-svg--full {
-    top: 0;
-    height: 100%;
-    padding-top: 10px;
-  }
 }
 
 .bms-card-metric {
@@ -73,13 +67,23 @@
   inset: 0;
   margin: 10px;
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 8px;
   text-align: center;
   color: var(--mat-sys-on-surface);
-  background: color-mix(in srgb, var(--skip-widget-card-background-color) 92%, transparent);
+  pointer-events: none;
+}
+
+// The message gets its own translucent panel rather than a full-bleed scrim, so it stays legible
+// while the placeholder bank behind it still reads as a battery monitor with no data.
+.bms-empty-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--skip-widget-card-border-color);
+  background: color-mix(in srgb, var(--mat-sys-surface-container-high) 88%, transparent);
 }
 
 .bms-empty-title {

--- a/src/app/widgets/widget-bms/widget-bms.component.spec.ts
+++ b/src/app/widgets/widget-bms/widget-bms.component.spec.ts
@@ -288,6 +288,22 @@ describe('WidgetBmsComponent', () => {
     // Guards #360: the layout-constant getters must yield well-formed geometry. The
     // NaN only appears when >=2 electrical specs share a test bundle, so this bites
     // in the full suite, not when this spec runs alone.
+    it('renders well-formed geometry (no NaN/undefined viewBox)', async () => {
+        vi.useFakeTimers();
+        try {
+            fixture.detectChanges();
+            await vi.runAllTimersAsync();
+            fixture.detectChanges();
+            await vi.runAllTimersAsync();
+            const svg = fixture.nativeElement.querySelector('svg') as SVGSVGElement | null;
+            const viewBox = svg?.getAttribute('viewBox') ?? '';
+            expect(viewBox).not.toBe('');
+            expect(viewBox).not.toContain('NaN');
+            expect(viewBox).not.toContain('undefined');
+        } finally {
+            vi.useRealTimers();
+        }
+    });
     it('draws one dimmed all-placeholder bank while no battery has reported', () => {
         // The widget must keep the shape of a bank behind its empty-state message rather than
         // collapsing to a bare panel carrying a sentence.
@@ -318,22 +334,5 @@ describe('WidgetBmsComponent', () => {
         expect(host.querySelector('tspan.bank-gauge-soc-value')?.textContent).toBe('--');
         // The title stays on so the card is still identifiable as the battery widget.
         expect(host.querySelector('widget-title')).not.toBeNull();
-    });
-
-    it('renders well-formed geometry (no NaN/undefined viewBox)', async () => {
-        vi.useFakeTimers();
-        try {
-            fixture.detectChanges();
-            await vi.runAllTimersAsync();
-            fixture.detectChanges();
-            await vi.runAllTimersAsync();
-            const svg = fixture.nativeElement.querySelector('svg') as SVGSVGElement | null;
-            const viewBox = svg?.getAttribute('viewBox') ?? '';
-            expect(viewBox).not.toBe('');
-            expect(viewBox).not.toContain('NaN');
-            expect(viewBox).not.toContain('undefined');
-        } finally {
-            vi.useRealTimers();
-        }
     });
 });

--- a/src/app/widgets/widget-bms/widget-bms.component.spec.ts
+++ b/src/app/widgets/widget-bms/widget-bms.component.spec.ts
@@ -288,6 +288,38 @@ describe('WidgetBmsComponent', () => {
     // Guards #360: the layout-constant getters must yield well-formed geometry. The
     // NaN only appears when >=2 electrical specs share a test bundle, so this bites
     // in the full suite, not when this spec runs alone.
+    it('draws one dimmed all-placeholder bank while no battery has reported', () => {
+        // The widget must keep the shape of a bank behind its empty-state message rather than
+        // collapsing to a bare panel carrying a sentence.
+        dataServiceMock.subscribePathTreeWithInitial.mockReturnValue({
+            initial: [],
+            live$: liveSubject.asObservable()
+        });
+
+        // The scheduler subscribes when the component is constructed, so the empty tree has to be
+        // in place before createComponent.
+        fixture = TestBed.createComponent(WidgetBmsComponent);
+        component = fixture.componentInstance;
+        fixture.componentRef.setInput('id', 'w-bms-empty');
+        fixture.componentRef.setInput('type', 'widget-bms');
+        fixture.componentRef.setInput('theme', themeMock);
+        fixture.detectChanges();
+
+        const internals = component as unknown as {
+            buildRenderSnapshot: () => unknown;
+            render: (snapshot: unknown) => void;
+        };
+        internals.render(internals.buildRenderSnapshot());
+
+        const host = fixture.nativeElement as HTMLElement;
+        expect(host.querySelectorAll('g.bank-card').length).toBe(1);
+        expect(host.querySelector('svg.bms-svg > g')?.getAttribute('opacity')).toBe('0.6');
+        expect(host.querySelector('tspan.bank-card-current-value')?.textContent).toBe('--');
+        expect(host.querySelector('tspan.bank-gauge-soc-value')?.textContent).toBe('--');
+        // The title stays on so the card is still identifiable as the battery widget.
+        expect(host.querySelector('widget-title')).not.toBeNull();
+    });
+
     it('renders well-formed geometry (no NaN/undefined viewBox)', async () => {
         vi.useFakeTimers();
         try {

--- a/src/app/widgets/widget-bms/widget-bms.component.ts
+++ b/src/app/widgets/widget-bms/widget-bms.component.ts
@@ -13,7 +13,7 @@ import { getElectricalWidgetFamilyDescriptor } from '../../core/contracts/electr
 import type { BmsBankDisplayModel, BmsBankSummary, BmsBatteryDisplayModel, BmsBatterySnapshot } from './widget.bms.types';
 import type { ElectricalCardDisplayMode } from '../../core/contracts/electrical-topology-card.contract';
 import type { ITheme } from '../../core/services/app-service';
-import { ELECTRICAL_DIRECT_CARD_HEIGHT, ELECTRICAL_DIRECT_CARD_FULL_LAYOUT, ELECTRICAL_DIRECT_CARD_VIEWBOX_WIDTH } from '../shared/electrical-card-layout.constants';
+import { ELECTRICAL_DIRECT_CARD_HEIGHT, ELECTRICAL_DIRECT_CARD_FULL_LAYOUT, ELECTRICAL_DIRECT_CARD_VIEWBOX_WIDTH, ELECTRICAL_NO_DATA_OPACITY } from '../shared/electrical-card-layout.constants';
 import { normalizeOptionalString, normalizeStringList, normalizeTrackedDevices } from '../shared/electrical-config.util';
 import { toFiniteNumber } from '../shared/electrical-apply.util';
 import { ElectricalIngestScheduler } from '../shared/electrical-ingest-scheduler';
@@ -100,7 +100,6 @@ export class WidgetBmsComponent implements AfterViewInit {
   private static readonly COMPACT_UNASSIGNED_BATTERY_SCALE = 0.82;
   private static readonly PATH_BATCH_WINDOW_MS = 500;
   private static readonly PLACEHOLDER_KEY = '__no-battery-data__';
-  private static readonly PLACEHOLDER_OPACITY = 0.6;
 
   private readonly runtime = inject(WidgetRuntimeDirective);
   private readonly data = inject(DataService);
@@ -293,6 +292,12 @@ export class WidgetBmsComponent implements AfterViewInit {
 
   protected readonly hasBatteries = computed(() => this.visibleBatteries().length > 0);
   protected readonly hasBanks = computed(() => this.bankSummaries().length > 0);
+  /**
+   * Drives both the empty-state message and the placeholder card, so the plate can never end up
+   * over live bank cards. A configured bank yields a summary before any battery reports, so
+   * hasBatteries() alone is not the same question.
+   */
+  protected readonly nothingToShow = computed(() => !this.hasBanks() && !this.hasBatteries());
 
   constructor() {
     effect(() => {
@@ -716,7 +721,7 @@ export class WidgetBmsComponent implements AfterViewInit {
 
   private render(snapshot: BmsRenderSnapshot): void {
     if (!this.bankLayer || !this.batteryLayer) return;
-    const isPlaceholder = snapshot.banks.length === 0 && snapshot.batteries.length === 0;
+    const isPlaceholder = this.nothingToShow();
     const { banks, batteries, bankDisplayModels, batteryDisplayModels } = isPlaceholder
       ? this.placeholderRenderInput(snapshot.widgetColors)
       : snapshot;
@@ -737,7 +742,7 @@ export class WidgetBmsComponent implements AfterViewInit {
     const viewBoxHeight = Math.max(WidgetBmsComponent.MIN_VIEWBOX_HEIGHT, renderLayout.contentHeight);
     this.svg?.attr('viewBox', `0 0 ${WidgetBmsComponent.VIEWBOX_WIDTH} ${viewBoxHeight}`);
     this.root?.attr('transform', null);
-    this.root?.attr('opacity', isPlaceholder ? WidgetBmsComponent.PLACEHOLDER_OPACITY : null);
+    this.root?.attr('opacity', isPlaceholder ? ELECTRICAL_NO_DATA_OPACITY : null);
 
     const bankSelection = this.bankLayer
       .selectAll<SVGGElement, BmsRenderBank>('g.bank-card')

--- a/src/app/widgets/widget-bms/widget-bms.component.ts
+++ b/src/app/widgets/widget-bms/widget-bms.component.ts
@@ -99,6 +99,8 @@ export class WidgetBmsComponent implements AfterViewInit {
   private static readonly BANK_GAUGE_VALUE_STROKE = 10;
   private static readonly COMPACT_UNASSIGNED_BATTERY_SCALE = 0.82;
   private static readonly PATH_BATCH_WINDOW_MS = 500;
+  private static readonly PLACEHOLDER_KEY = '__no-battery-data__';
+  private static readonly PLACEHOLDER_OPACITY = 0.6;
 
   private readonly runtime = inject(WidgetRuntimeDirective);
   private readonly data = inject(DataService);
@@ -660,9 +662,65 @@ export class WidgetBmsComponent implements AfterViewInit {
     };
   }
 
+  /**
+   * One all-'--' bank holding one all-'--' battery, drawn while nothing has reported so the
+   * widget keeps its shape behind the empty-state message. Text comes from the same formatters
+   * the live path uses, so the placeholders read exactly like a real card with missing values.
+   */
+  private placeholderRenderInput(widgetColors: ReturnType<typeof getColors> | null): Omit<BmsRenderSnapshot, 'widgetColors'> {
+    const id = WidgetBmsComponent.PLACEHOLDER_KEY;
+    const dim = 'var(--skip-contrast-dim-color)';
+    const dimmer = 'var(--skip-contrast-dimmer-color)';
+    return {
+      banks: [{
+        id, name: 'Bank', batteryIds: [id],
+        totalCurrent: null, totalPower: null, avgSoc: null, remainingCapacity: null, timeRemaining: null
+      }],
+      batteries: [{ id, name: 'Battery', voltage: null, current: null, power: null }],
+      bankDisplayModels: {
+        [id]: {
+          id,
+          titleText: 'Bank',
+          currentText: this.formatCurrent(null),
+          powerText: this.formatPower(null),
+          socText: this.formatSoc(null),
+          remainingTimeText: '',
+          remainingCapacityText: '',
+          gaugeValuePath: this.buildSemiGaugeArcPath(WidgetBmsComponent.BANK_GAUGE_RADIUS, null),
+          gaugeValueColor: widgetColors?.color ?? 'var(--skip-contrast-color)',
+          zoneState: null,
+          zoneColor: null
+        }
+      },
+      batteryDisplayModels: {
+        [id]: {
+          id,
+          titleText: 'Battery',
+          chargeWidth: 0,
+          chargeBarColorCompact: dimmer,
+          chargeBarColorRegular: dim,
+          currentTextColorCompact: dim,
+          currentTextColorRegular: dim,
+          currentText: this.formatCurrent(null),
+          detailLineCompact: this.formatVoltage(null),
+          detailLineRegular: this.formatVoltage(null),
+          socText: this.formatSoc(null),
+          socGlowEnabled: false,
+          remainingCapacityText: '',
+          remainingTimeText: '',
+          iconKey: 'power_available'
+        }
+      }
+    };
+  }
+
   private render(snapshot: BmsRenderSnapshot): void {
     if (!this.bankLayer || !this.batteryLayer) return;
-    const { banks, batteries, bankDisplayModels, batteryDisplayModels, widgetColors } = snapshot;
+    const isPlaceholder = snapshot.banks.length === 0 && snapshot.batteries.length === 0;
+    const { banks, batteries, bankDisplayModels, batteryDisplayModels } = isPlaceholder
+      ? this.placeholderRenderInput(snapshot.widgetColors)
+      : snapshot;
+    const widgetColors = snapshot.widgetColors;
 
     const renderLayout = this.buildRenderLayout(
       banks,
@@ -679,6 +737,7 @@ export class WidgetBmsComponent implements AfterViewInit {
     const viewBoxHeight = Math.max(WidgetBmsComponent.MIN_VIEWBOX_HEIGHT, renderLayout.contentHeight);
     this.svg?.attr('viewBox', `0 0 ${WidgetBmsComponent.VIEWBOX_WIDTH} ${viewBoxHeight}`);
     this.root?.attr('transform', null);
+    this.root?.attr('opacity', isPlaceholder ? WidgetBmsComponent.PLACEHOLDER_OPACITY : null);
 
     const bankSelection = this.bankLayer
       .selectAll<SVGGElement, BmsRenderBank>('g.bank-card')

--- a/src/app/widgets/widget-charger/widget-charger.component.html
+++ b/src/app/widgets/widget-charger/widget-charger.component.html
@@ -2,7 +2,9 @@
 <svg #chargerSvg class="charger-svg" aria-hidden="false"></svg>
 @if (!hasChargers()) {
 <div class="charger-empty">
-  <div class="charger-empty-title">No chargers detected</div>
-  <div class="charger-empty-sub">Check Signal K charger paths or select chargers in widget settings.</div>
+  <div class="charger-empty-panel">
+    <div class="charger-empty-title">No chargers detected</div>
+    <div class="charger-empty-sub">Check Signal K charger paths or select chargers in widget settings.</div>
+  </div>
 </div>
 }

--- a/src/app/widgets/widget-charger/widget-charger.component.scss
+++ b/src/app/widgets/widget-charger/widget-charger.component.scss
@@ -24,13 +24,23 @@
   inset: 0;
   margin: 10px;
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 8px;
   text-align: center;
   color: var(--mat-sys-on-surface);
-  background: color-mix(in srgb, var(--skip-widget-card-background-color) 92%, transparent);
+  pointer-events: none;
+}
+
+// The message gets its own plate rather than a full-bleed scrim, so it stays legible while the
+// placeholder card behind it still reads as the widget it belongs to.
+.charger-empty-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--skip-widget-card-border-color);
+  background: color-mix(in srgb, var(--mat-sys-surface-container-high) 88%, transparent);
 }
 
 .charger-empty-title {

--- a/src/app/widgets/widget-charger/widget-charger.component.scss
+++ b/src/app/widgets/widget-charger/widget-charger.component.scss
@@ -28,6 +28,8 @@
   justify-content: center;
   text-align: center;
   color: var(--mat-sys-on-surface);
+  // Above the card SVG, which carries z-index 20.
+  z-index: 30;
   pointer-events: none;
 }
 

--- a/src/app/widgets/widget-charger/widget-charger.component.spec.ts
+++ b/src/app/widgets/widget-charger/widget-charger.component.spec.ts
@@ -620,4 +620,20 @@ describe('WidgetChargerComponent', () => {
       vi.useRealTimers();
     }
   });
+  it('draws one dimmed all-placeholder card while no charger has reported', async () => {
+    // The widget must keep its card shape behind the empty-state message rather than collapsing
+    // to a bare panel carrying a sentence.
+    vi.useFakeTimers();
+    await setup([]);
+    await vi.runAllTimersAsync();
+    fixture.detectChanges();
+    await vi.runAllTimersAsync();
+
+    const host = fixture.nativeElement as HTMLElement;
+    const cards = host.querySelectorAll('g.charger-card');
+    expect(cards.length).toBe(1);
+    expect(cards[0].getAttribute('opacity')).toBe('0.6');
+    expect(host.querySelector('tspan.voltage-metric-value')?.textContent).toBe('--');
+    expect(host.querySelector('tspan.current-metric-value')?.textContent).toBe('--');
+  });
 });

--- a/src/app/widgets/widget-charger/widget-charger.component.ts
+++ b/src/app/widgets/widget-charger/widget-charger.component.ts
@@ -52,6 +52,22 @@ export class WidgetChargerComponent implements AfterViewInit {
   private static readonly CHARGER_DISPLAY_BASE_WIDTH = 145;
   private static readonly CHARGER_DISPLAY_BASE_HEIGHT = 37;
   private static readonly CHARGER_DISPLAY_HORIZONTAL_MARGIN = 40;
+  private static readonly PLACEHOLDER_KEY = '__no-charger-data__';
+  private static readonly PLACEHOLDER_OPACITY = 0.6;
+
+  /** Dimmed all-'--' card shown while no charger has reported. */
+  private static placeholderDisplayModel(): ChargerDisplayModel {
+    return {
+      id: '',
+      titleText: '',
+      modeText: '--',
+      voltageText: '--',
+      currentText: '--',
+      powerText: '--',
+      temperatureText: '--',
+      temperatureUnit: ''
+    };
+  }
 
   public static readonly DEFAULT_CONFIG: IWidgetSvcConfig = {
     color: 'contrast',
@@ -479,12 +495,25 @@ export class WidgetChargerComponent implements AfterViewInit {
     const displayY = compact ? 33 : 60;
 
 
-    const cards = snapshot.chargers.map((charger, index) => ({
-      key: charger.deviceKey ?? charger.id,
-      id: charger.id,
-      charger,
-      y: index * (cardHeight + WidgetChargerComponent.CARD_GAP)
-    }));
+    // With nothing to show, draw one all-'--' card so the widget keeps its shape behind the
+    // empty-state message instead of collapsing to a bare panel and a sentence.
+    const isPlaceholder = snapshot.chargers.length === 0;
+    const models = isPlaceholder
+      ? { [WidgetChargerComponent.PLACEHOLDER_KEY]: WidgetChargerComponent.placeholderDisplayModel() }
+      : snapshot.displayModels;
+    const cards = isPlaceholder
+      ? [{
+          key: WidgetChargerComponent.PLACEHOLDER_KEY,
+          id: '',
+          charger: { id: '' } as ChargerSnapshot,
+          y: 0
+        }]
+      : snapshot.chargers.map((charger, index) => ({
+          key: charger.deviceKey ?? charger.id,
+          id: charger.id,
+          charger,
+          y: index * (cardHeight + WidgetChargerComponent.CARD_GAP)
+        }));
     const contentHeight = cards.length
       ? cards[cards.length - 1].y + cardHeight
       : cardHeight;
@@ -575,6 +604,7 @@ export class WidgetChargerComponent implements AfterViewInit {
     const merged = enter.merge(selection as Selection<SVGGElement, { key: string; id: string; charger: ChargerSnapshot; y: number }, SVGGElement, unknown>);
 
     merged.attr('transform', item => `translate(0, ${item.y})`);
+    merged.attr('opacity', isPlaceholder ? WidgetChargerComponent.PLACEHOLDER_OPACITY : null);
     merged.select('g.charger-display-group')
       .attr('transform', `translate(${displayX}, ${displayY}) scale(${displayScale})`)
       .each((item, _index, nodes) => {
@@ -612,7 +642,7 @@ export class WidgetChargerComponent implements AfterViewInit {
         .attr('y', titleY)
         .attr('font-size', layout.titleFontSize)
         .attr('fill', 'var(--skip-contrast-dim-color)')
-        .text(item => snapshot.displayModels[item.key]?.titleText ?? this.resolveTitleText(item.charger));
+        .text(item => models[item.key]?.titleText ?? this.resolveTitleText(item.charger));
     } else {
       merged.select('text.charger-title').text('');
     }
@@ -626,7 +656,7 @@ export class WidgetChargerComponent implements AfterViewInit {
       .attr('fill', 'var(--skip-contrast-color)');
 
     merged.select('tspan.voltage-metric-value')
-      .text(item => snapshot.displayModels[item.key]?.voltageText ?? '');
+      .text(item => models[item.key]?.voltageText ?? '');
 
     merged.select('tspan.voltage-metric-unit')
       .attr('dx', 1)
@@ -643,7 +673,7 @@ export class WidgetChargerComponent implements AfterViewInit {
       .attr('fill', 'var(--skip-contrast-color)');
 
     merged.select('tspan.current-metric-value')
-      .text(item => snapshot.displayModels[item.key]?.currentText ?? '');
+      .text(item => models[item.key]?.currentText ?? '');
 
     merged.select('tspan.current-metric-unit')
       .attr('dx', 1)
@@ -658,7 +688,7 @@ export class WidgetChargerComponent implements AfterViewInit {
       .attr('font-size', 10);
 
     merged.select('tspan.power-metric-value')
-      .text(item => snapshot.displayModels[item.key]?.powerText ?? '');
+      .text(item => models[item.key]?.powerText ?? '');
 
     merged.select('tspan.power-metric-unit')
       .attr('dx', 1)
@@ -673,20 +703,20 @@ export class WidgetChargerComponent implements AfterViewInit {
       .attr('font-size', 10);
 
     merged.select('tspan.temperature-metric-value')
-      .text(item => snapshot.displayModels[item.key]?.temperatureText ?? '');
+      .text(item => models[item.key]?.temperatureText ?? '');
 
     merged.select('tspan.temperature-metric-unit')
       .attr('dx', 1)
       .attr('font-size', 6)
       .attr('fill', 'var(--skip-contrast-dim-color)')
-      .text(item => snapshot.displayModels[item.key]?.temperatureUnit ?? '');
+      .text(item => models[item.key]?.temperatureUnit ?? '');
 
     merged.select('text.charger-mode')
       .attr('x', 5)
       .attr('y', 46)
       .attr('font-size', 10)
       .attr('fill', 'var(--skip-contrast-dim-color)')
-      .text(item => snapshot.displayModels[item.key]?.modeText ?? '');
+      .text(item => models[item.key]?.modeText ?? '');
 
     selection.exit().remove();
   }

--- a/src/app/widgets/widget-charger/widget-charger.component.ts
+++ b/src/app/widgets/widget-charger/widget-charger.component.ts
@@ -10,7 +10,7 @@ import type { ElectricalCardDisplayMode } from '../../core/contracts/electrical-
 import type { ElectricalTrackedDevice, IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
 import type { ITheme } from '../../core/services/app-service';
 import type { ChargerDisplayModel, ChargerSnapshot } from './widget-charger.types';
-import { ELECTRICAL_DIRECT_CARD_COMPACT_LAYOUT, ELECTRICAL_DIRECT_CARD_FULL_LAYOUT, ELECTRICAL_DIRECT_CARD_GAP, ELECTRICAL_DIRECT_CARD_HEIGHT, ELECTRICAL_DIRECT_CARD_VIEWBOX_WIDTH, ELECTRICAL_DIRECT_COMPACT_CARD_HEIGHT } from '../shared/electrical-card-layout.constants';
+import { ELECTRICAL_DIRECT_CARD_COMPACT_LAYOUT, ELECTRICAL_DIRECT_CARD_FULL_LAYOUT, ELECTRICAL_DIRECT_CARD_GAP, ELECTRICAL_DIRECT_CARD_HEIGHT, ELECTRICAL_DIRECT_CARD_VIEWBOX_WIDTH, ELECTRICAL_DIRECT_COMPACT_CARD_HEIGHT, ELECTRICAL_NO_DATA_OPACITY } from '../shared/electrical-card-layout.constants';
 import { normalizeOptionalString, normalizeTrackedDevices, buildIdToDeviceKeysMap } from '../shared/electrical-config.util';
 import { setValue, setMetricValue, toStringValue, toBoolean, toNumber, resolveMostSevereState } from '../shared/electrical-apply.util';
 import { ElectricalIngestScheduler } from '../shared/electrical-ingest-scheduler';
@@ -53,7 +53,6 @@ export class WidgetChargerComponent implements AfterViewInit {
   private static readonly CHARGER_DISPLAY_BASE_HEIGHT = 37;
   private static readonly CHARGER_DISPLAY_HORIZONTAL_MARGIN = 40;
   private static readonly PLACEHOLDER_KEY = '__no-charger-data__';
-  private static readonly PLACEHOLDER_OPACITY = 0.6;
 
   /** Dimmed all-'--' card shown while no charger has reported. */
   private static placeholderDisplayModel(): ChargerDisplayModel {
@@ -505,7 +504,7 @@ export class WidgetChargerComponent implements AfterViewInit {
       ? [{
           key: WidgetChargerComponent.PLACEHOLDER_KEY,
           id: '',
-          charger: { id: '' } as ChargerSnapshot,
+          charger: { id: '' },
           y: 0
         }]
       : snapshot.chargers.map((charger, index) => ({
@@ -604,7 +603,7 @@ export class WidgetChargerComponent implements AfterViewInit {
     const merged = enter.merge(selection as Selection<SVGGElement, { key: string; id: string; charger: ChargerSnapshot; y: number }, SVGGElement, unknown>);
 
     merged.attr('transform', item => `translate(0, ${item.y})`);
-    merged.attr('opacity', isPlaceholder ? WidgetChargerComponent.PLACEHOLDER_OPACITY : null);
+    merged.attr('opacity', isPlaceholder ? ELECTRICAL_NO_DATA_OPACITY : null);
     merged.select('g.charger-display-group')
       .attr('transform', `translate(${displayX}, ${displayY}) scale(${displayScale})`)
       .each((item, _index, nodes) => {

--- a/src/app/widgets/widget-gauge-ng-compass/widget-gauge-ng-compass.component.html
+++ b/src/app/widgets/widget-gauge-ng-compass/widget-gauge-ng-compass.component.html
@@ -1,4 +1,4 @@
-@if (shouldRenderGauge()) {
+@if (optionsReady()) {
   <radial-gauge
     #compassGauge
     skipResizeObserver

--- a/src/app/widgets/widget-gauge-ng-compass/widget-gauge-ng-compass.component.spec.ts
+++ b/src/app/widgets/widget-gauge-ng-compass/widget-gauge-ng-compass.component.spec.ts
@@ -1,0 +1,99 @@
+import { signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { WidgetGaugeNgCompassComponent } from './widget-gauge-ng-compass.component';
+import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
+import { WidgetStreamsDirective } from '../../core/directives/widget-streams.directive';
+import { UnitsService } from '../../core/services/units.service';
+import { IPathUpdate } from '../../core/services/data.service';
+import { IWidgetSvcConfig, IPathArray } from '../../core/interfaces/widgets-interface';
+
+/**
+ * A compass with no heading must still show its rose, with no needle and a '--' readout — a needle
+ * parked on north is indistinguishable from a real heading of 000.
+ *
+ * Harness follows the radial gauge spec: the host directives are faked and the
+ * @godind/ng-canvas-gauges lib is aliased to a no-op shim in the test build, so the gauge element
+ * renders as a bare canvas and the component's guarded update() calls are no-ops.
+ */
+describe('WidgetGaugeNgCompassComponent no-data state', () => {
+  let fixture: ComponentFixture<WidgetGaugeNgCompassComponent>;
+  let internals: CompassInternals;
+  let capturedNext: ((u: IPathUpdate) => void) | undefined;
+
+  interface CompassInternals {
+    value: () => number | null | undefined;
+    textValue: () => string;
+    dataAvailable: () => boolean;
+    optionsReady: () => boolean;
+    gaugeOptions: { needle?: boolean };
+  }
+
+  const makeConfig = (): IWidgetSvcConfig => {
+    const dflt = WidgetGaugeNgCompassComponent.DEFAULT_CONFIG;
+    const gaugePath = (dflt.paths as IPathArray)['gaugePath'];
+    return {
+      ...dflt,
+      paths: { gaugePath: { ...gaugePath, path: 'self.navigation.headingTrue' } }
+    };
+  };
+
+  const update = (value: unknown): IPathUpdate =>
+    ({ data: { value, timestamp: null }, state: 'normal' }) as unknown as IPathUpdate;
+
+  beforeEach(async () => {
+    capturedNext = undefined;
+    const options = signal<IWidgetSvcConfig | undefined>(makeConfig());
+    const streamsFake = {
+      observe(_pathName: string, next: (u: IPathUpdate) => void) { capturedNext = next; }
+    };
+    const unitsFake = {
+      getUnitDisplaySymbol: (measure: string | null | undefined): string => measure ?? '',
+      convertBetweenMeasures: (_from: string, _to: string, value: number): number => value
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [WidgetGaugeNgCompassComponent],
+      providers: [
+        { provide: WidgetRuntimeDirective, useValue: { options } },
+        { provide: WidgetStreamsDirective, useValue: streamsFake },
+        { provide: UnitsService, useValue: unitsFake }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(WidgetGaugeNgCompassComponent);
+    fixture.componentRef.setInput('id', 'compass-1');
+    fixture.componentRef.setInput('type', 'widget-gauge-ng-compass');
+    fixture.componentRef.setInput('theme', {
+      contrast: 'rgba(255,255,255,1)', contrastDim: 'rgba(200,200,200,1)',
+      contrastDimmer: 'rgba(150,150,150,1)', cardColor: 'rgba(17,17,17,1)',
+      background: 'rgba(0,0,0,1)', zoneAlarm: 'rgba(255,0,0,1)',
+      zoneWarn: 'rgba(255,170,0,1)', zoneAlert: 'rgba(255,0,255,1)',
+      zoneEmergency: 'rgba(255,0,0,1)'
+    });
+    fixture.detectChanges();
+    internals = fixture.componentInstance as unknown as CompassInternals;
+  });
+
+  it('renders the rose before any heading arrives, with no needle', () => {
+    expect(internals.optionsReady()).toBe(true);
+    expect(fixture.nativeElement.querySelector('radial-gauge')).not.toBeNull();
+    expect(internals.dataAvailable()).toBe(false);
+    expect(internals.gaugeOptions.needle).toBe(false);
+    expect(internals.textValue()).toBe('--');
+  });
+
+  it('shows the needle and the heading once one arrives', () => {
+    capturedNext?.(update(142));
+    expect(internals.dataAvailable()).toBe(true);
+    expect(internals.value()).toBe(142);
+    expect(internals.textValue()).toBe('142');
+  });
+
+  it('returns to the placeholder when the heading stops arriving', () => {
+    capturedNext?.(update(142));
+    capturedNext?.(update(null));
+    expect(internals.dataAvailable()).toBe(false);
+    expect(internals.textValue()).toBe('--');
+  });
+});

--- a/src/app/widgets/widget-gauge-ng-compass/widget-gauge-ng-compass.component.ts
+++ b/src/app/widgets/widget-gauge-ng-compass/widget-gauge-ng-compass.component.ts
@@ -104,8 +104,14 @@ export class WidgetGaugeNgCompassComponent implements AfterViewInit {
   // Data/state
   protected textValue = signal('--');
   protected value = signal<number | null | undefined>(undefined);
-  /** True after first datapoint has been received (including zero). */
-  protected shouldRenderGauge = computed(() => this.value() !== undefined);
+  /** True while a non-null datapoint is in hand; the needle is suppressed when false. */
+  protected dataAvailable = signal(false);
+  /**
+   * Gates the gauge element on the first buildGaugeOptions() run. The library builds its geometry
+   * in the constructor and throws on the empty initial options object, so the gauge has to wait for
+   * config and theme — but not for data.
+   */
+  protected optionsReady = signal(false);
   /** True after first non-animated frame has been rendered. */
   private gaugeBootstrapped = signal(false);
   /** Enables smooth transitions only after the first static frame. */
@@ -143,6 +149,7 @@ export class WidgetGaugeNgCompassComponent implements AfterViewInit {
       if (!pCfg?.path) return;
       untracked(() => this.streams.observe('gaugePath', pkt => {
         let raw = (pkt?.data?.value as number) ?? null;
+        this.dataAvailable.set(raw != null);
         if (raw == null) {
           this.value.set(0);
           this.textValue.set('--');
@@ -164,18 +171,29 @@ export class WidgetGaugeNgCompassComponent implements AfterViewInit {
       if (!cfg || !theme) return;
       untracked(() => {
         this.buildGaugeOptions(cfg, theme);
+        this.optionsReady.set(true);
         if (this.viewReady()) {
           try { this.ngGauge()?.update(this.gaugeOptions); } catch { /* ignore */ }
         }
       });
     });
 
-    // Enable the needle animation only after the gauge canvas is first mounted, so
-    // the initial @if render places the needle at the real value without a sweep.
+    // Hide the needle while no datapoint is in hand, so an unfed compass shows its rose and
+    // a '--' readout instead of a needle parked on north as if it were a real heading.
+    effect(() => {
+      const hasData = this.dataAvailable();
+      if (!this.viewReady()) return;
+      untracked(() => {
+        try { this.ngGauge()?.update({ needle: hasData }); } catch { /* ignore */ }
+      });
+    });
+
+    // Enable the needle animation only after the first datapoint has been placed, so the
+    // needle lands on the real value without a sweep from north.
     // The value box tween (animatedValue) stays off on every path — see #222.
     effect(() => {
       const gauge = this.ngGauge();
-      if (!gauge || this.gaugeBootstrapped()) return;
+      if (!gauge || !this.dataAvailable() || this.gaugeBootstrapped()) return;
       untracked(() => {
         try {
           requestAnimationFrame(() => {
@@ -220,7 +238,7 @@ export class WidgetGaugeNgCompassComponent implements AfterViewInit {
     g.ticksAngle = 360; g.startAngle = 180; g.exactTicks = false; g.strokeTicks = '' as unknown as string;
     g.majorTicks = cfg.gauge?.compassUseNumbers ? ['N','30','60','E','120','150','S','210','240','W','300','330','N'] : ['N','NE','E','SE','S','SW','W','NW','N'];
     g.majorTicksDec = 0; g.majorTicksInt = 1; g.numbersMargin = 5; g.fontNumbersSize = 25; g.minorTicks = cfg.gauge?.compassUseNumbers ? 3 : 2;
-    g.needle = true; g.needleType = this.LINE; g.needleStart = this.NEEDLE_START; g.needleEnd = this.NEEDLE_END; g.needleCircleSize = this.NEEDLE_CIRCLE_SIZE; g.needleWidth = 4; g.needleShadow = false; g.needleCircleInner = false; g.needleCircleOuter = false;
+    g.needle = this.dataAvailable(); g.needleType = this.LINE; g.needleStart = this.NEEDLE_START; g.needleEnd = this.NEEDLE_END; g.needleCircleSize = this.NEEDLE_CIRCLE_SIZE; g.needleWidth = 4; g.needleShadow = false; g.needleCircleInner = false; g.needleCircleOuter = false;
     g.borders = true; g.borderOuterWidth = 0; g.borderMiddleWidth = this.BORDER_MIDDLE_WIDTH; g.borderInnerWidth = this.BORDER_INNER_WIDTH; g.borderShadowWidth = 0;
     g.highlights = []; g.highlightsWidth = 0;
     g.fontTitle = 'Roboto'; g.fontTitleWeight = 'normal'; g.fontTitleSize = 25; g.fontUnits = 'Roboto'; g.fontUnitsSize = 25; g.fontUnitsWeight = 'normal';

--- a/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.html
+++ b/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.html
@@ -4,14 +4,14 @@
     <span class="gaugeUnit">{{ unitSymbol() }}</span>
   }
 </div>
-@if (shouldRenderGauge()) {
+@if (optionsReady()) {
   <linear-gauge
     class="linearGauge"
     #linearGauge
     skipResizeObserver
     (resizeChange)="onResized($event)"
     [options]="gaugeOptions"
-    [value]="value() ?? 0"
+    [value]="value() ?? adjustedScale().min"
     [attr.value-text]="textValue()"
   ></linear-gauge>
 }

--- a/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.spec.ts
+++ b/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.spec.ts
@@ -8,6 +8,7 @@ import { WidgetStreamsDirective } from '../../core/directives/widget-streams.dir
 import { WidgetMetadataDirective } from '../../core/directives/widget-metadata.directive';
 import { UnitsService } from '../../core/services/units.service';
 import { IWidgetSvcConfig, IPathArray } from '../../core/interfaces/widgets-interface';
+import { States } from '../../core/interfaces/signalk-interfaces';
 
 /**
  * The label and the unit are rendered by the component as one header row on the card, so the gauge
@@ -28,6 +29,11 @@ describe('WidgetGaugeNgLinearComponent header row and sizing', () => {
 
   interface LinearInternals {
     effectiveUnit: WritableSignal<string>;
+    dataAvailable: WritableSignal<boolean>;
+    currentState: WritableSignal<string>;
+    barColor: (cfg: IWidgetSvcConfig, theme: unknown, state: string) => string;
+    optionsReady: () => boolean;
+    textValue: () => string;
     gaugeOptions: LinearGaugeOptions;
     unitSymbol: () => string;
     buildGaugeOptions: (cfg: IWidgetSvcConfig, theme: unknown, scale: unknown) => void;
@@ -151,5 +157,63 @@ describe('WidgetGaugeNgLinearComponent header row and sizing', () => {
     component.onResized(resizeEntry(0, 0));
 
     expect(sizeUpdates).toEqual([]);
+  });
+  describe('no-data state', () => {
+    it('mounts the gauge before any datapoint, with a placeholder reading', () => {
+      // The whole template used to sit behind a data-dependent @if, so a silent path drew nothing.
+      expect(internals.optionsReady()).toBe(true);
+      expect(fixture.nativeElement.querySelector('linear-gauge')).not.toBeNull();
+      expect(internals.textValue()).toBe('--');
+    });
+
+    it('keeps barProgress on and hides the bar by colour instead', () => {
+      // Switching barProgress off makes the library skip the pass that computes barDimensions,
+      // which every later draw step reads — it throws on construction and kills the canvas.
+      const cfg = makeConfig();
+      internals.dataAvailable.set(false);
+      internals.buildGaugeOptions(cfg, theme, internals.adjustedScale());
+      expect(internals.gaugeOptions.barProgress).toBe(true);
+      expect(internals.gaugeOptions.colorBarProgress).toBe('rgba(0,0,0,0)');
+
+      internals.dataAvailable.set(true);
+      internals.buildGaugeOptions(cfg, theme, internals.adjustedScale());
+      expect(internals.gaugeOptions.barProgress).toBe(true);
+      expect(internals.gaugeOptions.colorBarProgress).not.toBe('rgba(0,0,0,0)');
+    });
+
+    it('suppresses the needle only while no reading is in hand', () => {
+      const cfg = makeConfig();
+      cfg.gauge = { ...cfg.gauge, type: 'ngLinear', enableNeedle: true };
+
+      internals.dataAvailable.set(false);
+      internals.buildGaugeOptions(cfg, theme, internals.adjustedScale());
+      expect(internals.gaugeOptions.needle).toBe(false);
+
+      internals.dataAvailable.set(true);
+      internals.buildGaugeOptions(cfg, theme, internals.adjustedScale());
+      expect(internals.gaugeOptions.needle).toBe(true);
+    });
+
+    it('leaves the bar in the widget palette when zones are ignored', () => {
+      // The zone-state effect returns early under ignoreZones, so a zone colour applied anywhere
+      // else would stick with nothing to correct it.
+      const themed = { ...theme, zoneAlarm: '#f00' };
+      const cfg = makeConfig();
+      internals.dataAvailable.set(true);
+
+      cfg.ignoreZones = true;
+      expect(internals.barColor(cfg, themed, States.Alarm)).not.toBe('#f00');
+
+      cfg.ignoreZones = false;
+      expect(internals.barColor(cfg, themed, States.Alarm)).toBe('#f00');
+    });
+
+    it('paints the bar transparent with no reading, whatever the zone state', () => {
+      const themed = { ...theme, zoneAlarm: '#f00' };
+      const cfg = makeConfig();
+      cfg.ignoreZones = false;
+      internals.dataAvailable.set(false);
+      expect(internals.barColor(cfg, themed, States.Alarm)).toBe('rgba(0,0,0,0)');
+    });
   });
 });

--- a/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.ts
+++ b/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.ts
@@ -86,8 +86,14 @@ export class WidgetGaugeNgLinearComponent implements AfterViewInit {
   // Reactive presentation
   protected textValue = signal('--');
   protected value = signal<number | null | undefined>(undefined);
-  /** True after first datapoint has been received (including zero). */
-  protected shouldRenderGauge = computed(() => this.value() !== undefined);
+  /** True while a non-null datapoint is in hand; needle and progress bar are suppressed when false. */
+  protected dataAvailable = signal(false);
+  /**
+   * Gates the gauge element on the first buildGaugeOptions() run. The library builds its geometry
+   * in the constructor and throws on the empty initial options object, so the gauge has to wait for
+   * config and theme — but not for data.
+   */
+  protected optionsReady = signal(false);
   protected gaugeOptions: LinearGaugeOptions = {} as LinearGaugeOptions;
   private viewReady = signal(false);
   /** True after first non-animated frame has been rendered. */
@@ -98,7 +104,7 @@ export class WidgetGaugeNgLinearComponent implements AfterViewInit {
   /** Measure the incoming value was converted to (server-resolved for this display path). '' = boot placeholder. */
   private effectiveUnit = signal<string>('');
 
-  private adjustedScale = computed<IScale>(() => {
+  protected adjustedScale = computed<IScale>(() => {
     const cfg = this.runtime.options();
     if (!cfg) return { min: 0, max: 100, majorTicks: [] };
     // displayScale bounds are stored in the user-picked convertUnitTo; re-express them in the
@@ -151,6 +157,7 @@ export class WidgetGaugeNgLinearComponent implements AfterViewInit {
           const stored = cfg.paths?.['gaugePath']?.convertUnitTo ?? 'unitless';
           const lower = this.unitsService.convertBetweenMeasures(stored, measure, cfg.displayScale?.lower ?? 0);
           const upper = this.unitsService.convertBetweenMeasures(stored, measure, cfg.displayScale?.upper ?? 100);
+          this.dataAvailable.set(raw != null);
           if (raw == null) {
             this.value.set(lower);
             this.textValue.set('--');
@@ -200,6 +207,7 @@ export class WidgetGaugeNgLinearComponent implements AfterViewInit {
         const cfg = this.runtime.options();
         if (!cfg || !theme) return;
         this.buildGaugeOptions(cfg, theme, scale);
+        this.optionsReady.set(true);
         if (this.viewReady()) {
           try {
             this.ngGauge()?.update(this.gaugeOptions);
@@ -209,10 +217,32 @@ export class WidgetGaugeNgLinearComponent implements AfterViewInit {
       });
     });
 
-    // Enable animation only after the first rendered frame to avoid startup motion.
+    // Hide the needle and progress bar while no datapoint is in hand, so an unfed gauge reads
+    // as "no data" instead of parking both at the scale minimum as if it were a real reading.
+    effect(() => {
+      const hasData = this.dataAvailable();
+      if (!this.viewReady()) return;
+      untracked(() => {
+        const cfg = this.runtime.options();
+        const theme = this.theme();
+        if (!cfg || !theme) return;
+        const enableNeedle = !!cfg.gauge?.enableNeedle;
+        const opt: LinearGaugeOptions = { needle: enableNeedle && hasData } as LinearGaugeOptions;
+        if (!enableNeedle) {
+          const palette = getColors(cfg.color ?? 'contrast', theme);
+          opt.colorBarProgress = this.progressBarColor(this.zoneColor(theme, palette.color, this.currentState()));
+        }
+        try {
+          this.ngGauge()?.update(opt);
+        } catch { /* ignore */ }
+      });
+    });
+
+    // Enable animation only after the first datapoint has been placed, so the bar never
+    // sweeps up from the scale minimum on the first real reading.
     effect(() => {
       const gauge = this.ngGauge();
-      if (!gauge || this.gaugeBootstrapped()) return;
+      if (!gauge || !this.dataAvailable() || this.gaugeBootstrapped()) return;
       untracked(() => {
         try {
           requestAnimationFrame(() => {
@@ -232,51 +262,35 @@ export class WidgetGaugeNgLinearComponent implements AfterViewInit {
         const theme = this.theme();
         if (!cfg || !theme || cfg.ignoreZones) return;
 
-        const opt: LinearGaugeOptions = {};
         const enableNeedle = cfg.gauge?.enableNeedle;
         const palette = getColors(cfg.color ?? 'contrast', theme);
-        switch (state) {
-          case States.Alarm:
-            if (enableNeedle) {
-              opt.colorNeedle = theme.zoneAlarm;
-              opt.colorValueText = theme.zoneAlarm;
-            } else {
-              opt.colorBarProgress = theme.zoneAlarm;
-              opt.colorValueText = theme.zoneAlarm;
-            }
-            break;
-          case States.Warn:
-            if (enableNeedle) {
-              opt.colorNeedle = theme.zoneWarn;
-              opt.colorValueText = theme.zoneWarn;
-            } else {
-              opt.colorBarProgress = theme.zoneWarn;
-              opt.colorValueText = theme.zoneWarn;
-            }
-            break;
-          case States.Alert:
-            if (enableNeedle) {
-              opt.colorNeedle = theme.zoneAlert;
-              opt.colorValueText = theme.zoneAlert;
-            } else {
-              opt.colorBarProgress = theme.zoneAlert;
-              opt.colorValueText = theme.zoneAlert;
-            }
-            break;
-          default:
-            if (enableNeedle) {
-              opt.colorNeedle = palette.color;
-              opt.colorValueText = palette.color;
-            } else {
-              opt.colorBarProgress = palette.color;
-              opt.colorValueText = palette.color;
-            }
+        const stateColor = this.zoneColor(theme, palette.color, state);
+        const opt: LinearGaugeOptions = { colorValueText: stateColor } as LinearGaugeOptions;
+        if (enableNeedle) {
+          opt.colorNeedle = stateColor;
+        } else {
+          opt.colorBarProgress = this.progressBarColor(stateColor);
         }
         try {
           this.ngGauge()?.update(opt);
         } catch { /* ignore */ }
       });
     });
+  }
+
+  /** The bar's colour, or fully transparent while no datapoint is in hand. */
+  private progressBarColor(color: string): string {
+    return this.dataAvailable() ? color : 'rgba(0,0,0,0)';
+  }
+
+  /** Zone colour for the indicator and value text, falling back to the widget's own palette. */
+  private zoneColor(theme: ITheme, paletteColor: string, state: string): string {
+    switch (state) {
+      case States.Alarm: return theme.zoneAlarm;
+      case States.Warn: return theme.zoneWarn;
+      case States.Alert: return theme.zoneAlert;
+      default: return paletteColor;
+    }
   }
 
   private buildGaugeOptions(cfg: IWidgetSvcConfig, theme: ITheme, scale: IScale) {
@@ -292,9 +306,12 @@ export class WidgetGaugeNgLinearComponent implements AfterViewInit {
     // Bar geometry (match legacy defaults)
     opt.barLength = isVertical ? 80 : 90;
     opt.barWidth = ticks ? (enableNeedle ? 0 : 30) : 60;
+    // barProgress stays on even with no data: the library computes the bar geometry every other
+    // draw step reads (barDimensions) inside the progress-bar pass, so switching it off throws.
+    // The bar is hidden by painting it transparent instead — see progressBarColor().
     opt.barProgress = true; opt.barBeginCircle = 0; opt.barStrokeWidth = 0; opt.barShadow = 0;
     // Needle geometry
-    opt.needle = !!enableNeedle; opt.needleType = enableNeedle ? 'arrow' : 'line';
+    opt.needle = !!enableNeedle && this.dataAvailable(); opt.needleType = enableNeedle ? 'arrow' : 'line';
     opt.needleStart = enableNeedle ? (isVertical ? 200 : 155) : -45;
     opt.needleEnd = enableNeedle ? (isVertical ? 175 : 180) : 55;
     opt.needleShadow = true; opt.needleSide = 'both';
@@ -312,7 +329,7 @@ export class WidgetGaugeNgLinearComponent implements AfterViewInit {
       opt.colorNeedle = palette.color; opt.colorNeedleEnd = palette.color; opt.needleWidth = 45;
       opt.colorNeedleShadowUp = palette.color; opt.colorNeedleShadowDown = palette.color;
     } else {
-      opt.colorBarProgress = palette.color; opt.colorBarProgressEnd = ''; opt.needleWidth = 0;
+      opt.colorBarProgress = this.progressBarColor(palette.color); opt.colorBarProgressEnd = ''; opt.needleWidth = 0;
     }
     opt.colorPlate = theme.cardColor; opt.colorBar = theme.background; opt.colorBarEnd = ''; opt.colorBarStroke = '0';
     opt.colorMajorTicks = getColors('contrast', theme).dim; opt.colorMinorTicks = getColors('contrast', theme).dim; opt.colorNumbers = getColors('contrast', theme).dim;

--- a/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.ts
+++ b/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.ts
@@ -227,10 +227,9 @@ export class WidgetGaugeNgLinearComponent implements AfterViewInit {
         const theme = this.theme();
         if (!cfg || !theme) return;
         const enableNeedle = !!cfg.gauge?.enableNeedle;
-        const opt: LinearGaugeOptions = { needle: enableNeedle && hasData } as LinearGaugeOptions;
+        const opt: LinearGaugeOptions = { needle: enableNeedle && hasData };
         if (!enableNeedle) {
-          const palette = getColors(cfg.color ?? 'contrast', theme);
-          opt.colorBarProgress = this.progressBarColor(this.zoneColor(theme, palette.color, this.currentState()));
+          opt.colorBarProgress = this.barColor(cfg, theme, this.currentState());
         }
         try {
           this.ngGauge()?.update(opt);
@@ -265,11 +264,11 @@ export class WidgetGaugeNgLinearComponent implements AfterViewInit {
         const enableNeedle = cfg.gauge?.enableNeedle;
         const palette = getColors(cfg.color ?? 'contrast', theme);
         const stateColor = this.zoneColor(theme, palette.color, state);
-        const opt: LinearGaugeOptions = { colorValueText: stateColor } as LinearGaugeOptions;
+        const opt: LinearGaugeOptions = { colorValueText: stateColor };
         if (enableNeedle) {
           opt.colorNeedle = stateColor;
         } else {
-          opt.colorBarProgress = this.progressBarColor(stateColor);
+          opt.colorBarProgress = this.barColor(cfg, theme, state);
         }
         try {
           this.ngGauge()?.update(opt);
@@ -278,9 +277,18 @@ export class WidgetGaugeNgLinearComponent implements AfterViewInit {
     });
   }
 
-  /** The bar's colour, or fully transparent while no datapoint is in hand. */
-  private progressBarColor(color: string): string {
-    return this.dataAvailable() ? color : 'rgba(0,0,0,0)';
+  /**
+   * The single decision about what colour the bar is painted, shared by the no-data effect, the
+   * zone-state effect and the option builder so they cannot disagree. Transparent stands in for
+   * "hidden": switching barProgress off makes the library skip the pass that computes
+   * barDimensions, which every later draw step reads, so it throws on construction.
+   */
+  private barColor(cfg: IWidgetSvcConfig, theme: ITheme, state: string): string {
+    if (!this.dataAvailable()) return 'rgba(0,0,0,0)';
+    const palette = getColors(cfg.color ?? 'contrast', theme);
+    // The zone-state effect returns early under ignoreZones, so a zone colour written anywhere
+    // else would stick with nothing to correct it.
+    return cfg.ignoreZones ? palette.color : this.zoneColor(theme, palette.color, state);
   }
 
   /** Zone colour for the indicator and value text, falling back to the widget's own palette. */
@@ -306,9 +314,9 @@ export class WidgetGaugeNgLinearComponent implements AfterViewInit {
     // Bar geometry (match legacy defaults)
     opt.barLength = isVertical ? 80 : 90;
     opt.barWidth = ticks ? (enableNeedle ? 0 : 30) : 60;
-    // barProgress stays on even with no data: the library computes the bar geometry every other
-    // draw step reads (barDimensions) inside the progress-bar pass, so switching it off throws.
-    // The bar is hidden by painting it transparent instead — see progressBarColor().
+    // barProgress stays on even with no data. The library computes barDimensions inside the
+    // progress-bar pass, and every later draw step reads it, so switching barProgress off throws
+    // on construction. The bar is hidden by painting it transparent instead — see barColor().
     opt.barProgress = true; opt.barBeginCircle = 0; opt.barStrokeWidth = 0; opt.barShadow = 0;
     // Needle geometry
     opt.needle = !!enableNeedle && this.dataAvailable(); opt.needleType = enableNeedle ? 'arrow' : 'line';
@@ -329,7 +337,7 @@ export class WidgetGaugeNgLinearComponent implements AfterViewInit {
       opt.colorNeedle = palette.color; opt.colorNeedleEnd = palette.color; opt.needleWidth = 45;
       opt.colorNeedleShadowUp = palette.color; opt.colorNeedleShadowDown = palette.color;
     } else {
-      opt.colorBarProgress = this.progressBarColor(palette.color); opt.colorBarProgressEnd = ''; opt.needleWidth = 0;
+      opt.colorBarProgress = this.barColor(cfg, theme, this.currentState()); opt.colorBarProgressEnd = ''; opt.needleWidth = 0;
     }
     opt.colorPlate = theme.cardColor; opt.colorBar = theme.background; opt.colorBarEnd = ''; opt.colorBarStroke = '0';
     opt.colorMajorTicks = getColors('contrast', theme).dim; opt.colorMinorTicks = getColors('contrast', theme).dim; opt.colorNumbers = getColors('contrast', theme).dim;

--- a/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.html
+++ b/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.html
@@ -1,9 +1,9 @@
-@if (shouldRenderGauge()) {
+@if (optionsReady()) {
   <radial-gauge
     #radialGauge
     skipResizeObserver
     [options]="gaugeOptions"
-    [value]="value() ?? 0"
+    [value]="value() ?? adjustedScale().min"
     [attr.value-text]="textValue()"
     (resizeChange)="onResized($event)"
   ></radial-gauge>

--- a/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.spec.ts
+++ b/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.spec.ts
@@ -39,6 +39,8 @@ describe('WidgetGaugeNgRadialComponent displayScale reinterpretation (P2b flip)'
     adjustedScale: () => IScale;
     value: () => number | null | undefined;
     textValue: () => string;
+    dataAvailable: () => boolean;
+    optionsReady: () => boolean;
   }
 
   // convertUnitTo is the stored authoring unit; a tagged measure that differs is the flip target.
@@ -99,8 +101,8 @@ describe('WidgetGaugeNgRadialComponent displayScale reinterpretation (P2b flip)'
       contrast: '#fff', contrastDim: '#ccc', contrastDimmer: '#999',
       cardColor: '#111', background: '#000'
     });
-    // Runs the data-subscription effect, capturing the stream callback (value still undefined here, so
-    // the @if never renders the gauge and no lib code runs).
+    // Runs the data-subscription and option-building effects, capturing the stream callback. The gauge
+    // element renders as soon as the options exist (the lib is a no-op shim here), before any data.
     fixture.detectChanges();
     internals = fixture.componentInstance as unknown as GaugeInternals;
   });
@@ -120,6 +122,27 @@ describe('WidgetGaugeNgRadialComponent displayScale reinterpretation (P2b flip)'
     // effectiveUnit '' (boot) -> fall back to convertUnitTo ('ratio'), identity conversion.
     internals.effectiveUnit.set('');
     expect(internals.adjustedScale()).toEqual({ min: 10, max: 100, majorTicks: [] });
+  });
+
+  it('renders the gauge before any datapoint arrives, with no needle and a placeholder reading', () => {
+    // The widget must show its dial rather than a blank card while its path is silent.
+    expect(internals.optionsReady()).toBe(true);
+    expect(fixture.nativeElement.querySelector('radial-gauge')).not.toBeNull();
+    expect(internals.dataAvailable()).toBe(false);
+    expect(internals.textValue()).toBe('--');
+  });
+
+  it('marks data available once a non-null value arrives and blanks the placeholder text', () => {
+    capturedNext?.(update(42, 'percent'));
+    expect(internals.dataAvailable()).toBe(true);
+    expect(internals.textValue()).toBe('');
+  });
+
+  it('drops back to the placeholder when a later datapoint is null', () => {
+    capturedNext?.(update(42, 'percent'));
+    capturedNext?.(update(null, 'percent'));
+    expect(internals.dataAvailable()).toBe(false);
+    expect(internals.textValue()).toBe('--');
   });
 
   it('sets the value to the reinterpreted lower bound on a null (first/placeholder) datapoint', () => {

--- a/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
+++ b/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
@@ -87,9 +87,16 @@ export class WidgetGaugeNgRadialComponent implements AfterViewInit {
 
   // Reactive state
   protected value = signal<number | null | undefined>(undefined);
-  /** True after first datapoint has been received (including zero). */
-  protected shouldRenderGauge = computed(() => this.value() !== undefined);
-  protected textValue = signal('--');
+  /** True while a non-null datapoint is in hand; needle and progress bar are suppressed when false. */
+  protected dataAvailable = signal(false);
+  /**
+   * Gates the gauge element on the first buildGaugeOptions() run. The library builds its geometry
+   * in the constructor, so mounting it against the empty initial options object throws — the gauge
+   * has to wait for config and theme, but not for data.
+   */
+  protected optionsReady = signal(false);
+  /** '--' with no reading; blank once one arrives, which lets the gauge print its own value. */
+  protected textValue = computed(() => this.dataAvailable() ? '' : '--');
   protected colorStrokeTicks = signal('');
   /** True after first non-animated frame has been rendered. */
   private gaugeBootstrapped = signal(false);
@@ -101,7 +108,7 @@ export class WidgetGaugeNgRadialComponent implements AfterViewInit {
   private effectiveMeasure = computed<string>(() =>
     this.effectiveUnit() || (this.runtime.options()?.paths?.['gaugePath']?.convertUnitTo ?? 'unitless')
   );
-  private adjustedScale = computed<IScale>(() => {
+  protected adjustedScale = computed<IScale>(() => {
     const cfg = this.runtime.options();
     if (!cfg) return { min: 0, max: 100, majorTicks: [] };
     const fromUnit = cfg.paths?.['gaugePath']?.convertUnitTo ?? 'unitless';
@@ -158,14 +165,12 @@ export class WidgetGaugeNgRadialComponent implements AfterViewInit {
         const upper = this.unitsService.convertBetweenMeasures(fromUnit, toMeasure, cfg.displayScale?.upper ?? 100);
 
         const raw = (path?.data?.value as number) ?? null;
+        this.dataAvailable.set(raw != null);
         if (raw == null) {
           this.value.set(lower);
-          this.textValue.set('--');
         } else {
           // clamp
-          const clamped = Math.min(Math.max(raw, lower), upper);
-          this.value.set(clamped);
-          if (this.textValue() === '--') this.textValue.set('');
+          this.value.set(Math.min(Math.max(raw, lower), upper));
         }
       }));
     });
@@ -205,6 +210,7 @@ export class WidgetGaugeNgRadialComponent implements AfterViewInit {
         const cfg = this.runtime.options();
         if (!cfg || !theme) return;
         this.buildGaugeOptions(cfg, theme, scale);
+        this.optionsReady.set(true);
         if (this.viewReady()) {
           try {
             this.ngGauge()?.update(this.gaugeOptions);
@@ -213,10 +219,28 @@ export class WidgetGaugeNgRadialComponent implements AfterViewInit {
       });
     });
 
-    // Enable animation only after the first rendered frame to avoid startup motion.
+    // Hide the needle and progress bar while no datapoint is in hand, so an unfed gauge reads
+    // as "no data" instead of parking both at the scale minimum as if it were a real reading.
+    effect(() => {
+      const hasData = this.dataAvailable();
+      if (!this.viewReady()) return;
+      untracked(() => {
+        const cfg = this.runtime.options();
+        if (!cfg) return;
+        try {
+          this.ngGauge()?.update({
+            needle: !!cfg.gauge?.enableNeedle && hasData,
+            barProgress: !!cfg.gauge?.enableProgressbar && hasData
+          });
+        } catch { /* ignore */ }
+      });
+    });
+
+    // Enable animation only after the first datapoint has been placed, so the needle never
+    // sweeps up from the scale minimum on the first real reading.
     effect(() => {
       const gauge = this.ngGauge();
-      if (!gauge || this.gaugeBootstrapped()) return;
+      if (!gauge || !this.dataAvailable() || this.gaugeBootstrapped()) return;
       untracked(() => {
         try {
           requestAnimationFrame(() => {
@@ -323,7 +347,7 @@ export class WidgetGaugeNgRadialComponent implements AfterViewInit {
     g.colorBorderShadow = false; g.colorBorderOuter = theme.cardColor; g.colorBorderOuterEnd = ''; g.colorBorderMiddle = theme.cardColor; g.colorBorderMiddleEnd = '';
     g.colorPlate = g.colorPlateEnd = theme.cardColor; g.colorBar = theme.background;
 
-    g.barProgress = cfg.gauge?.enableProgressbar; g.colorBarProgress = getColors(cfg.color ?? 'contrast', theme).color;
+    g.barProgress = !!cfg.gauge?.enableProgressbar && this.dataAvailable(); g.colorBarProgress = getColors(cfg.color ?? 'contrast', theme).color;
     g.colorNeedle = getColors(cfg.color ?? 'contrast', theme).color; g.colorNeedleEnd = getColors(cfg.color ?? 'contrast', theme).color;
     g.needleShadow = true; g.colorNeedleShadowUp = "black"; g.colorNeedleShadowDown = "black";
     g.colorNeedleCircleInner = g.colorPlate; g.colorNeedleCircleInnerEnd = g.colorPlate; g.colorNeedleCircleOuter = g.colorPlate; g.colorNeedleCircleOuterEnd = g.colorPlate;
@@ -339,14 +363,14 @@ export class WidgetGaugeNgRadialComponent implements AfterViewInit {
       g.colorMajorTicks = g.colorPlate; g.colorNumbers = g.colorMinorTicks = '' as unknown as string;
 
       g.barWidth = 20; g.colorBarProgress = getColors(cfg.color ?? 'contrast', theme).dim;
-      g.needle = cfg.gauge.enableNeedle; g.needleType = this.LINE; g.needleWidth = 2; g.needleStart = 75; g.needleEnd = 95; g.needleCircleSize = 1; g.needleCircleInner = false; g.needleCircleOuter = false;
+      g.needle = !!cfg.gauge.enableNeedle && this.dataAvailable(); g.needleType = this.LINE; g.needleWidth = 2; g.needleStart = 75; g.needleEnd = 95; g.needleCircleSize = 1; g.needleCircleInner = false; g.needleCircleOuter = false;
       g.ticksAngle = 360; g.startAngle = (cfg.gauge?.scaleStart as number) || 180; g.majorTicks = 0 as unknown as string[]; g.exactTicks = true; g.strokeTicks = false; g.minorTicks = 0; g.numbersMargin = 0; g.fontNumbersSize = 0;
       g.borders = true; g.borderOuterWidth = 2; g.borderMiddleWidth = 1; g.borderInnerWidth = 0; g.borderShadowWidth = 0;
 
     } else { // measuring
       g.fontTitleSize = 24;
       g.barWidth = 15; g.valueBox = true; g.fontValueSize = 60; g.valueBoxWidth = 100; g.valueBoxBorderRadius = 0; g.valueBoxStroke = 0; g.colorValueBoxBackground = '';
-      g.needle = cfg.gauge?.enableNeedle; g.needleType = this.LINE; g.needleWidth = 2; g.needleStart = 0; g.needleEnd = 95; g.needleCircleSize = 10; g.needleCircleInner = false; g.needleCircleOuter = false;
+      g.needle = !!cfg.gauge?.enableNeedle && this.dataAvailable(); g.needleType = this.LINE; g.needleWidth = 2; g.needleStart = 0; g.needleEnd = 95; g.needleCircleSize = 10; g.needleCircleInner = false; g.needleCircleOuter = false;
       g.ticksAngle = 270; g.startAngle = 45; g.barStartPosition = cfg.gauge?.barStartPosition || 'left';
       if (cfg.gauge?.enableTicks) {
         g.strokeTicks = true; g.majorTicks = scale.majorTicks as unknown as string[]; g.minorTicks = 2; g.exactTicks = false; g.numbersMargin = 3; g.fontNumbersSize = 15;

--- a/src/app/widgets/widget-inverter/widget-inverter.component.html
+++ b/src/app/widgets/widget-inverter/widget-inverter.component.html
@@ -2,7 +2,9 @@
 <svg #inverterSvg class="inverter-svg" aria-hidden="false"></svg>
 @if (!hasInverters()) {
 <div class="inverter-empty">
-  <div class="inverter-empty-title">No inverters detected</div>
-  <div class="inverter-empty-sub">Check Signal K inverter paths or select inverters in widget settings.</div>
+  <div class="inverter-empty-panel">
+    <div class="inverter-empty-title">No inverters detected</div>
+    <div class="inverter-empty-sub">Check Signal K inverter paths or select inverters in widget settings.</div>
+  </div>
 </div>
 }

--- a/src/app/widgets/widget-inverter/widget-inverter.component.scss
+++ b/src/app/widgets/widget-inverter/widget-inverter.component.scss
@@ -24,13 +24,23 @@
   inset: 0;
   margin: 10px;
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 8px;
   text-align: center;
   color: var(--mat-sys-on-surface);
-  background: color-mix(in srgb, var(--skip-widget-card-background-color) 92%, transparent);
+  pointer-events: none;
+}
+
+// The message gets its own plate rather than a full-bleed scrim, so it stays legible while the
+// placeholder card behind it still reads as the widget it belongs to.
+.inverter-empty-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--skip-widget-card-border-color);
+  background: color-mix(in srgb, var(--mat-sys-surface-container-high) 88%, transparent);
 }
 
 .inverter-empty-title {

--- a/src/app/widgets/widget-inverter/widget-inverter.component.scss
+++ b/src/app/widgets/widget-inverter/widget-inverter.component.scss
@@ -28,6 +28,8 @@
   justify-content: center;
   text-align: center;
   color: var(--mat-sys-on-surface);
+  // Above the card SVG, which carries z-index 20.
+  z-index: 30;
   pointer-events: none;
 }
 

--- a/src/app/widgets/widget-inverter/widget-inverter.component.spec.ts
+++ b/src/app/widgets/widget-inverter/widget-inverter.component.spec.ts
@@ -331,4 +331,19 @@ describe('WidgetInverterComponent', () => {
     const normalized = (svg?.outerHTML ?? '').replace(/ _ng(content|host)-[a-z0-9-]+=""/g, '');
     expect(normalized).toMatchSnapshot();
   });
+  it('draws one dimmed all-placeholder card while no inverter has reported', async () => {
+    // The widget must keep its card shape behind the empty-state message rather than collapsing
+    // to a bare panel carrying a sentence.
+    vi.useFakeTimers();
+    await setup([]);
+    await vi.runAllTimersAsync();
+    fixture.detectChanges();
+    await vi.runAllTimersAsync();
+
+    const host = fixture.nativeElement as HTMLElement;
+    const cards = host.querySelectorAll('g.inverter-card');
+    expect(cards.length).toBe(1);
+    expect(cards[0].getAttribute('opacity')).toBe('0.6');
+    expect(host.querySelector('text.inverter-metrics-1')?.textContent).toBe('--');
+  });
 });

--- a/src/app/widgets/widget-position/widget-position.component.spec.ts
+++ b/src/app/widgets/widget-position/widget-position.component.spec.ts
@@ -101,7 +101,7 @@ describe('WidgetPositionComponent', () => {
       expect(drawn).toContain('longitudeMin:22.5');
     });
 
-    it('renders blank coordinates when no position value is present', async () => {
+    it('renders a placeholder for both coordinates when no position value is present', async () => {
       await setup();
       const callback = streamsMock.observe.mock.calls[0][1] as (u: IPathUpdate) => void;
       drawText.mockReset();
@@ -109,7 +109,8 @@ describe('WidgetPositionComponent', () => {
       callback({ data: { value: null } } as unknown as IPathUpdate);
 
       const drawn = drawText.mock.calls.map(c => c[1]);
-      expect(drawn).toContain('');
+      // Both coordinates read '--' so the widget still shows its label and two value rows.
+      expect(drawn.filter(s => s === '--')).toHaveLength(2);
       expect(drawn.some(s => typeof s === 'string' && s.includes(':'))).toBe(false);
     });
 
@@ -122,12 +123,12 @@ describe('WidgetPositionComponent', () => {
 
       const drawn = drawText.mock.calls.map(c => c[1]);
       expect(drawn).toContain('latitudeMin:59.5');
-      // The absent longitude must blank, never render 'undefined'/'NaN' text.
-      expect(drawn).toContain('');
+      // The absent longitude reads '--', never 'undefined'/'NaN' text.
+      expect(drawn).toContain('--');
       expect(drawn.some(s => typeof s === 'string' && s.startsWith('longitudeMin'))).toBe(false);
     });
 
-    it('blanks a non-finite coordinate rather than formatting NaN', async () => {
+    it('shows a placeholder for a non-finite coordinate rather than formatting NaN', async () => {
       await setup();
       const callback = streamsMock.observe.mock.calls[0][1] as (u: IPathUpdate) => void;
       drawText.mockReset();
@@ -136,10 +137,11 @@ describe('WidgetPositionComponent', () => {
 
       const drawn = drawText.mock.calls.map(c => c[1]);
       expect(drawn).toContain('longitudeMin:22.5');
+      expect(drawn).toContain('--');
       expect(drawn.some(s => typeof s === 'string' && s.startsWith('latitudeMin'))).toBe(false);
     });
 
-    it('blanks both coordinates for a non-object scalar value (guards against +value coercion)', async () => {
+    it('shows a placeholder for both coordinates on a non-object scalar value (guards against +value coercion)', async () => {
       await setup();
       const callback = streamsMock.observe.mock.calls[0][1] as (u: IPathUpdate) => void;
       drawText.mockReset();

--- a/src/app/widgets/widget-position/widget-position.component.spec.ts
+++ b/src/app/widgets/widget-position/widget-position.component.spec.ts
@@ -149,6 +149,7 @@ describe('WidgetPositionComponent', () => {
       callback({ data: { value: 42 } } as unknown as IPathUpdate);
 
       const drawn = drawText.mock.calls.map(c => c[1]);
+      expect(drawn.filter(s => s === '--')).toHaveLength(2);
       expect(drawn.some(s => typeof s === 'string' && s.includes(':'))).toBe(false);
     });
   });

--- a/src/app/widgets/widget-position/widget-position.component.ts
+++ b/src/app/widgets/widget-position/widget-position.component.ts
@@ -44,9 +44,18 @@ export class WidgetPositionComponent implements AfterViewInit, OnDestroy {
   private center = 0;
   private fontSizeOffset = 0;
 
+  /** Shown for either coordinate until a finite value arrives, matching widget-numeric. */
+  private static readonly NO_VALUE = '--';
+  /**
+   * A formatted coordinate of typical length. drawText sizes text to fill its box, so a bare '--'
+   * would render several times larger than the real reading it stands in for; this bounds the
+   * placeholder to the size an actual coordinate gets.
+   */
+  private static readonly REFERENCE_COORDINATE = "60° 10.12' N";
+
   // Value state
-  private latPos = '';
-  private longPos = '';
+  private latPos = WidgetPositionComponent.NO_VALUE;
+  private longPos = WidgetPositionComponent.NO_VALUE;
   protected labelColor = signal<string>('');
   private valueColor = '';
 
@@ -104,10 +113,10 @@ export class WidgetPositionComponent implements AfterViewInit, OnDestroy {
   }
 
   private formatCoordinate(measure: 'latitudeMin' | 'longitudeMin', value: number | null | undefined): string {
-    if (value === null || value === undefined || !Number.isFinite(value)) return '';
+    if (value === null || value === undefined || !Number.isFinite(value)) return WidgetPositionComponent.NO_VALUE;
     // The latitudeMin/longitudeMin conversions return a preformatted DMS string despite convertToUnit's
     // number|null signature, so the String() coercion is load-bearing — do not drop it or reformat here.
-    return String(this.units.convertToUnit(measure, value) ?? '');
+    return String(this.units.convertToUnit(measure, value) ?? WidgetPositionComponent.NO_VALUE);
   }
 
   // Canvas lifecycle
@@ -142,6 +151,20 @@ export class WidgetPositionComponent implements AfterViewInit, OnDestroy {
     }
   }
 
+  private valueTextHeight(text: string): number {
+    if (text !== WidgetPositionComponent.NO_VALUE || !this.ctx) return this.maxTextHeight;
+    return Math.min(
+      this.maxTextHeight,
+      this.canvas.calculateOptimalFontSize(
+        this.ctx,
+        WidgetPositionComponent.REFERENCE_COORDINATE,
+        this.maxTextWidth,
+        this.maxTextHeight,
+        'bold'
+      )
+    );
+  }
+
   private draw(): void {
     if (!this.ctx || !this.canvasElement) return;
     const cfg = this.runtime.options();
@@ -168,7 +191,7 @@ export class WidgetPositionComponent implements AfterViewInit, OnDestroy {
       this.center,
       this.middle - this.fontSizeOffset,
       this.maxTextWidth,
-      this.maxTextHeight,
+      this.valueTextHeight(this.latPos),
       'bold',
       this.valueColor,
       'center',
@@ -181,7 +204,7 @@ export class WidgetPositionComponent implements AfterViewInit, OnDestroy {
       this.center,
       this.middle + this.fontSizeOffset,
       this.maxTextWidth,
-      this.maxTextHeight,
+      this.valueTextHeight(this.longPos),
       'bold',
       this.valueColor,
       'center',

--- a/src/app/widgets/widget-solar-charger/widget-solar-charger.component.html
+++ b/src/app/widgets/widget-solar-charger/widget-solar-charger.component.html
@@ -2,7 +2,9 @@
 <svg #solarSvg class="solar-svg" aria-hidden="false"></svg>
 @if (!hasChargers()) {
   <div class="solar-empty">
-    <div class="solar-empty-title">No solar chargers detected</div>
-    <div class="solar-empty-sub">Check Signal K solar paths or select chargers in widget settings.</div>
+    <div class="solar-empty-panel">
+      <div class="solar-empty-title">No solar chargers detected</div>
+      <div class="solar-empty-sub">Check Signal K solar paths or select chargers in widget settings.</div>
+    </div>
   </div>
 }

--- a/src/app/widgets/widget-solar-charger/widget-solar-charger.component.scss
+++ b/src/app/widgets/widget-solar-charger/widget-solar-charger.component.scss
@@ -25,13 +25,24 @@
   inset: 0;
   margin: 10px;
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 8px;
   text-align: center;
   color: var(--mat-sys-on-surface);
-  background: color-mix(in srgb, var(--skip-widget-card-background-color) 92%, transparent);
+  z-index: 30;
+  pointer-events: none;
+}
+
+// The message gets its own translucent panel rather than a full-bleed scrim, so it stays legible
+// while the placeholder card behind it still reads as a solar charger with no data.
+.solar-empty-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--skip-widget-card-border-color);
+  background: color-mix(in srgb, var(--mat-sys-surface-container-high) 88%, transparent);
 }
 
 .solar-empty-title {

--- a/src/app/widgets/widget-solar-charger/widget-solar-charger.component.spec.ts
+++ b/src/app/widgets/widget-solar-charger/widget-solar-charger.component.spec.ts
@@ -424,6 +424,51 @@ describe('WidgetSolarChargerComponent', () => {
     expect(tspans.length).toBe(2);
   });
 
+  it('draws one dimmed all-placeholder card while no charger has reported', () => {
+    // The widget must keep the shape of a charger card behind its empty-state message rather than
+    // collapsing to a bare panel carrying a sentence.
+    dataServiceMock.subscribePathTreeWithInitial.mockReturnValue({
+      initial: [],
+      live$: liveSubject.asObservable()
+    });
+
+    // The scheduler subscribes when the component is constructed, so the empty tree has to be in
+    // place before createComponent.
+    fixture = TestBed.createComponent(WidgetSolarChargerComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('id', 'w-solar-empty');
+    fixture.componentRef.setInput('type', 'widget-solar-charger');
+    fixture.componentRef.setInput('theme', themeMock);
+    fixture.detectChanges();
+
+    const testApi = component as unknown as {
+      buildRenderSnapshot: () => unknown;
+      render: (snapshot: unknown) => void;
+    };
+    testApi.render(testApi.buildRenderSnapshot());
+
+    const host = fixture.nativeElement as HTMLElement;
+    const cards = host.querySelectorAll('g.solar-card');
+    expect(cards.length).toBe(1);
+    expect(cards[0].getAttribute('opacity')).toBe('0.6');
+    expect(host.querySelector('tspan.current-metric-value')?.textContent).toBe('--');
+    expect(host.querySelector('text.solar-yield-today')?.textContent).toBe('--');
+  });
+
+  it('leaves live cards at full opacity', () => {
+    fixture.detectChanges();
+
+    const testApi = component as unknown as {
+      buildRenderSnapshot: () => unknown;
+      render: (snapshot: unknown) => void;
+    };
+    testApi.render(testApi.buildRenderSnapshot());
+
+    const cards = (fixture.nativeElement as HTMLElement).querySelectorAll('g.solar-card');
+    expect(cards.length).toBe(2);
+    expect(cards[0].getAttribute('opacity')).toBeNull();
+  });
+
   it('normalizes compact card mode from widget config', () => {
     runtimeOptions.solarCharger = {
       trackedDevices: [{ id: 'sc1', source: 'default', key: 'sc1||default' }],

--- a/src/app/widgets/widget-solar-charger/widget-solar-charger.component.ts
+++ b/src/app/widgets/widget-solar-charger/widget-solar-charger.component.ts
@@ -10,7 +10,7 @@ import type { IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
 import type { ElectricalCardModeConfig, ElectricalTrackedDevice, SolarChargerDisplayModel, SolarChargerSnapshot, SolarOptionConfig, SolarWidgetConfig } from './widget.solar-charger.types';
 import { getElectricalWidgetFamilyDescriptor } from '../../core/contracts/electrical-widget-family.contract';
 import type { ElectricalCardDisplayMode } from '../../core/contracts/electrical-topology-card.contract';
-import { ELECTRICAL_DIRECT_CARD_GAP, ELECTRICAL_DIRECT_CARD_HEIGHT, ELECTRICAL_DIRECT_CARD_VIEWBOX_WIDTH, ELECTRICAL_DIRECT_CARD_FULL_LAYOUT } from '../shared/electrical-card-layout.constants';
+import { ELECTRICAL_DIRECT_CARD_GAP, ELECTRICAL_DIRECT_CARD_HEIGHT, ELECTRICAL_DIRECT_CARD_VIEWBOX_WIDTH, ELECTRICAL_DIRECT_CARD_FULL_LAYOUT, ELECTRICAL_NO_DATA_OPACITY } from '../shared/electrical-card-layout.constants';
 import { normalizeOptionalString, normalizeStringList, normalizeTrackedDevices } from '../shared/electrical-config.util';
 import { setValue, toNumber, resolveMostSevereState } from '../shared/electrical-apply.util';
 import { ElectricalIngestScheduler } from '../shared/electrical-ingest-scheduler';
@@ -58,7 +58,6 @@ export class WidgetSolarChargerComponent implements AfterViewInit {
   };
 
   private static readonly PLACEHOLDER_KEY = '__no-solar-data__';
-  private static readonly PLACEHOLDER_OPACITY = 0.6;
 
   /** Dimmed all-'--' card shown while no charger has reported. */
   private static placeholderDisplayModel(): SolarChargerDisplayModel {
@@ -778,7 +777,7 @@ export class WidgetSolarChargerComponent implements AfterViewInit {
     const merged = enter.merge(selection as Selection<SVGGElement, { key: string; model: SolarChargerDisplayModel; y: number }, SVGGElement, unknown>);
 
     merged.attr('transform', item => `translate(0, ${item.y})`);
-    merged.attr('opacity', isPlaceholder ? WidgetSolarChargerComponent.PLACEHOLDER_OPACITY : null);
+    merged.attr('opacity', isPlaceholder ? ELECTRICAL_NO_DATA_OPACITY : null);
 
     if (snapshot.solarUnits.length > 1) {
       merged.select('text.solar-charger-title')

--- a/src/app/widgets/widget-solar-charger/widget-solar-charger.component.ts
+++ b/src/app/widgets/widget-solar-charger/widget-solar-charger.component.ts
@@ -57,6 +57,36 @@ export class WidgetSolarChargerComponent implements AfterViewInit {
     }
   };
 
+  private static readonly PLACEHOLDER_KEY = '__no-solar-data__';
+  private static readonly PLACEHOLDER_OPACITY = 0.6;
+
+  /** Dimmed all-'--' card shown while no charger has reported. */
+  private static placeholderDisplayModel(): SolarChargerDisplayModel {
+    const dim = 'var(--skip-contrast-dim-color)';
+    return {
+      id: '',
+      titleText: '',
+      panelPowerText: '--',
+      panelPowerUnitText: 'W',
+      panelPowerColor: 'var(--skip-contrast-dimmer-color)',
+      panelPowerGlowEnabled: false,
+      chargerCurrentTextColor: dim,
+      chargerMetaTextColor: dim,
+      panelValuesTextColor: dim,
+      panelValuesGlowEnabled: false,
+      gaugeProgress: 0,
+      gaugeSectionText: '--',
+      yieldTodayText: '--',
+      yieldYesterdayText: '--',
+      chargerMode: '--',
+      chargerSectionCurrent: '--',
+      chargerSectionMetadata: '--',
+      relaySectionVisible: true,
+      relaySectionText: '--',
+      relayValuesTextColor: dim
+    };
+  }
+
   // Getters, not fields: read the shared layout constants at access time. A
   // class-def-time capture reads undefined in combined test bundles (#360).
   private static get VIEWBOX_WIDTH(): number { return ELECTRICAL_DIRECT_CARD_VIEWBOX_WIDTH; }
@@ -667,11 +697,20 @@ export class WidgetSolarChargerComponent implements AfterViewInit {
     const compact = this.isCompactCardMode();
     // Compact mode is wired, but solar intentionally reuses the full-card geometry until a dedicated layout exists.
     const layout = compact ? ELECTRICAL_DIRECT_CARD_FULL_LAYOUT : ELECTRICAL_DIRECT_CARD_FULL_LAYOUT;
-    const cards = snapshot.solarUnits.map((solar, index) => ({
-      key: solar.deviceKey ?? solar.id,
-      model: snapshot.displayModels[solar.deviceKey ?? solar.id],
-      y: index * (WidgetSolarChargerComponent.CARD_HEIGHT + WidgetSolarChargerComponent.CARD_GAP)
-    }));
+    // With nothing to show, draw one all-'--' card so the widget keeps its shape behind the
+    // empty-state message instead of collapsing to a bare panel and a sentence.
+    const isPlaceholder = snapshot.solarUnits.length === 0;
+    const cards = isPlaceholder
+      ? [{
+          key: WidgetSolarChargerComponent.PLACEHOLDER_KEY,
+          model: WidgetSolarChargerComponent.placeholderDisplayModel(),
+          y: 0
+        }]
+      : snapshot.solarUnits.map((solar, index) => ({
+          key: solar.deviceKey ?? solar.id,
+          model: snapshot.displayModels[solar.deviceKey ?? solar.id],
+          y: index * (WidgetSolarChargerComponent.CARD_HEIGHT + WidgetSolarChargerComponent.CARD_GAP)
+        }));
 
     const contentHeight = cards.length
       ? cards[cards.length - 1].y + WidgetSolarChargerComponent.CARD_HEIGHT
@@ -739,6 +778,7 @@ export class WidgetSolarChargerComponent implements AfterViewInit {
     const merged = enter.merge(selection as Selection<SVGGElement, { key: string; model: SolarChargerDisplayModel; y: number }, SVGGElement, unknown>);
 
     merged.attr('transform', item => `translate(0, ${item.y})`);
+    merged.attr('opacity', isPlaceholder ? WidgetSolarChargerComponent.PLACEHOLDER_OPACITY : null);
 
     if (snapshot.solarUnits.length > 1) {
       merged.select('text.solar-charger-title')


### PR DESCRIPTION
Widgets whose Signal K path never reports went blank or near-blank. A radial gauge on an
absent RPM path drew nothing at all — a white (or black) rectangle where an instrument
should be. This makes every affected widget degrade to something a helm can read: the
instrument is still there, and the missing reading says `--`.

## Why the gauges were blank

`gaugePath` sets `suppressBootstrapNull: true`, so the stream never emits for a path with
no data, so `value()` never left `undefined`, so the `@if (shouldRenderGauge())` wrapping
the entire template never became true. The three ng-canvas gauges (radial, linear,
compass) now mount as soon as config and theme are known and convey "no reading" by
suppressing the needle and progress bar, with `--` in the value box.

One trap worth recording: the linear gauge cannot express that by turning `barProgress`
off. canvas-gauges computes the bar geometry (`barDimensions`) inside the progress-bar
pass, and every later draw step reads it, so `barProgress: false` at construction makes
`ngOnInit` throw `Cannot read properties of undefined (reading 'isVertical')` and the
gauge renders as a dead canvas — with data as well as without. The bar is painted
transparent instead.

## The rest

- **Position** printed an empty string per coordinate, so an unfed widget was its label
  and nothing else. Now `--`, bounded to the size a real coordinate gets (`drawText`
  otherwise sizes two dashes to fill the card).
- **Autopilot** gated every control row on a real mode, so an off-line or unconfigured
  pilot collapsed to two buttons over an opaque panel. The rows stay laid out and
  disabled; the message sits on a bordered plate over a transparent layer so the AP screen
  reads through; heading, wind angle and target stay `null` rather than being coerced to
  `0`, so the screen shows `--` instead of a fabricated north. The message also used
  `--mat-sys-error-container` — a *background* token, pale pink — as text colour directly
  on the grey overlay; it now uses `--mat-sys-error` on the plate (measured ≈8.9:1 dark,
  ≈5.3:1 light). Engage is disabled while an error is showing: the v2 branch returned
  "enabled" unconditionally, leaving a live Engage button on a widget whose own message
  said it was not configured.
- **All six electrical widgets** (solar, BMS, alternator, inverter, AC, charger) covered
  themselves with a 92%-opaque scrim over an empty SVG. Each now draws one dimmed all-`--`
  card behind a translucent message plate. Alternator, inverter and AC share
  `drawDirectCards`, so that placeholder lives there once; solar, BMS and charger have
  their own renders and their own.

## Verification

Reproduced and re-checked against the perf-harness mock with streaming off, plus a
streaming run to confirm nothing regressed when data *is* present — that second run is
what caught the linear-gauge crash above. `npm run ci` passes at 1938 tests; nine are new,
covering the no-data render for the radial gauge, the position placeholder, the autopilot
control rows and engage guard, and the placeholder card in each of the six electrical
widgets. Deployed to a test device and exercised there.

The full-suite run intermittently fails `minichart.component.spec.ts`; that reproduces on
`main` with this branch stashed and passes in isolation. Issue #469 covers it — not
addressed here.
