### PR TITLE
Darken the light theme page background

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -258,6 +258,12 @@ body {
   touch-action: none;
 }
 
+// The generated M3 light surface is near-white, so white widget cards vanish
+// into it. Use the theme's own backdrop tone instead.
+body.light-theme {
+  background: var(--mat-sys-background);
+}
+
 #app-filter-wrapper {
   filter: brightness(var(--skip-nightModeBrightness)) var(--skip-nightModeFilters);
   backdrop-filter: brightness(var(--skip-nightModeBrightness));

--- a/src/themes/_m3light.scss
+++ b/src/themes/_m3light.scss
@@ -5,7 +5,7 @@
 @use '@angular/material' as mat;
 
 $_widget-card-background-color: #ffffff;
-$_background: #e1e4ec;
+$_background: #e0e0e0;
 
 $skip-light-color: (
   blue: #005bb5, blue-dim: #005bb5b6, blue-dimmer: #005bb578,


### PR DESCRIPTION
The light theme painted the page from `--mat-sys-surface`, which `mat.theme()` generates as `#fcf8fd` — near-white with a magenta cast. Widget cards are `#ffffff`, so they had a 3/255 step against the backdrop and effectively no edge; the only thing separating a card from the page was its elevation shadow.

The theme already defined a backdrop tone (`$_background` in `_m3light.scss`) that nothing painted the page with. This points `body.light-theme` at it and makes it a neutral `#e0e0e0`, giving cards a 31/255 step.

Scoped to the light theme deliberately: `body` still paints `--mat-sys-surface` for dark and night, which look right today, and `--mat-sys-surface` itself is untouched so the two in-card consumers (the autopilot menu box fill, the data-chart overlay) stay light.

`--mat-sys-background` is also the recessed fill inside the charger/BMS/windsteer widgets, so those shift `#e1e4ec` → `#e0e0e0` — consistent with how the dark theme uses the same token for the same purpose.

Verified against a real production build driven in headless Chromium: `getComputedStyle(document.body).backgroundColor` is `rgb(224, 224, 224)`. `npm run ci` passes (176 test files / 1925 tests, plus 7 files / 33 tests for the MCP schema).

No `VERSION` bump: `VERSION` is already 1.3.1 against the latest stable release v1.3.0+2, so a prior PR opened this patch cycle and this is a patch-level change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)