### PR TITLE
Draw Realtime Data Plot scale ticks inside the plot area

### DIFF
--- a/src/app/widget-config/dataset-chart-options/dataset-chart-options.component.html
+++ b/src/app/widget-config/dataset-chart-options/dataset-chart-options.component.html
@@ -63,7 +63,7 @@
     </div>
   </div>
   @if (datachartAngleRange(); as angleRangeCtrl) {
-    <mat-form-field class="full-width">
+    <mat-form-field class="full-width" style="margin-top: 10px;">
       <mat-label>Angle display range</mat-label>
       <mat-select [formControl]="angleRangeCtrl" name="datachartAngleRange">
         <mat-option [value]="null">Automatic (based on path)</mat-option>

--- a/src/app/widgets/widget-data-chart/widget-data-chart.component.spec.ts
+++ b/src/app/widgets/widget-data-chart/widget-data-chart.component.spec.ts
@@ -29,6 +29,7 @@ vi.mock('chartjs-plugin-annotation', () => ({ default: {} }));
 vi.mock('chartjs-adapter-date-fns', () => ({}));
 vi.mock('@aziham/chartjs-plugin-streaming', () => ({ default: {} }));
 
+import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { EMPTY, Subject } from 'rxjs';
 import { WidgetDataChartComponent } from './widget-data-chart.component';
@@ -53,13 +54,17 @@ const makeConfig = (overrides: Partial<IWidgetSvcConfig> = {}): IWidgetSvcConfig
 describe('WidgetDataChartComponent', () => {
   let fixture: ComponentFixture<WidgetDataChartComponent>;
 
-  const runtimeMock = { options: vi.fn() };
+  // A real signal, not a vi.fn: the component tracks runtime.options() inside computed/effect, so a
+  // config edit only reaches the rebuild path when the source is reactive — which is what the live
+  // WidgetRuntimeDirective provides.
+  const options = signal<IWidgetSvcConfig | undefined>(undefined);
+  const runtimeMock = { options };
   const historyMock = { getBackfillThenLive: vi.fn() };
   const unitsMock = { convertToUnit: (_unit: string, value: number) => value, getUnitDisplaySymbol: (measure: string) => measure, resolvePathMeasure: () => 'knots' };
   const canvasMock = { releaseCanvas: vi.fn() };
 
   const setup = async (config: IWidgetSvcConfig): Promise<void> => {
-    runtimeMock.options.mockReturnValue(config);
+    options.set(config);
 
     await TestBed.configureTestingModule({
       imports: [WidgetDataChartComponent],
@@ -83,7 +88,7 @@ describe('WidgetDataChartComponent', () => {
   beforeEach(() => {
     vi.spyOn(HTMLCanvasElement.prototype, 'getContext')
       .mockReturnValue({} as unknown as CanvasRenderingContext2D);
-    runtimeMock.options.mockReset();
+    options.set(undefined);
     historyMock.getBackfillThenLive.mockReset().mockReturnValue(EMPTY);
   });
 
@@ -192,6 +197,7 @@ describe('WidgetDataChartComponent', () => {
     }).subtitle;
 
   interface AxisState {
+    type?: string;
     ticks?: { mirror?: boolean; padding?: number; textStrokeColor?: string; textStrokeWidth?: number; color?: string };
     grid?: { display?: boolean; drawTicks?: boolean };
     title?: { display?: boolean };
@@ -243,6 +249,29 @@ describe('WidgetDataChartComponent', () => {
       expect(axis?.grid?.display).toBe(true);
       expect(axis?.grid?.drawTicks).toBe(false);
     }
+  });
+
+  it('rebuilds the chart when the orientation is toggled', async () => {
+    const emissions$ = new Subject<IDatasetServiceDatapoint>();
+    historyMock.getBackfillThenLive.mockReturnValue(emissions$);
+
+    await setup(makeConfig({ verticalChart: false, showTimeScale: true, showYScale: true }));
+    emissions$.next({ timestamp: 1000, data: { value: 5 } });
+
+    expect(readAxis('x')?.type).toBe('realtime');
+    expect(fixture.componentInstance.lineChartData.datasets[0].data.length).toBeGreaterThan(0);
+    const streamsBefore = historyMock.getBackfillThenLive.mock.calls.length;
+
+    options.set(makeConfig({ verticalChart: true, showTimeScale: true, showYScale: true }));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    // Swapping the orientation swaps which axis carries time. transformDatasetRows only transposes
+    // rows as they arrive, so anything already buffered plots as garbage — up to a 365-day window —
+    // unless the toggle goes through the full rebuild rather than an in-place options update.
+    expect(readAxis('y')?.type).toBe('realtime');
+    expect(fixture.componentInstance.lineChartData.datasets[0].data.length).toBe(0);
+    expect(historyMock.getBackfillThenLive.mock.calls.length).toBeGreaterThan(streamsBefore);
   });
 
   it('keeps the per-axis tick colour when the shared inside-tick options are applied', async () => {

--- a/src/app/widgets/widget-data-chart/widget-data-chart.component.spec.ts
+++ b/src/app/widgets/widget-data-chart/widget-data-chart.component.spec.ts
@@ -185,6 +185,81 @@ describe('WidgetDataChartComponent', () => {
     expect(title).not.toContain('celsius');
   });
 
+  interface SubtitleState { display?: boolean; text?: string }
+  const readSubtitle = (): SubtitleState | undefined =>
+    (fixture.componentInstance.lineChartOptions.plugins as unknown as {
+      subtitle?: SubtitleState;
+    }).subtitle;
+
+  interface AxisState {
+    ticks?: { mirror?: boolean; padding?: number; textStrokeColor?: string; textStrokeWidth?: number; color?: string };
+    grid?: { display?: boolean; drawTicks?: boolean };
+    title?: { display?: boolean };
+  }
+  const readAxis = (id: 'x' | 'y'): AxisState | undefined =>
+    (fixture.componentInstance.lineChartOptions.scales as unknown as Record<string, AxisState>)[id];
+
+  it('states the plot window on the widget label, not on a time-axis title', async () => {
+    await setup(makeConfig({ displayName: 'SOG', timeScale: 'second', period: 30, showTimeScale: true }));
+
+    // The axis title cost the plot a whole row to say this; the label says it in four characters.
+    // Nothing else carries the window, so the suffix is the only indicator the user has left.
+    expect(readSubtitle()?.text).toContain('SOG (30 s)');
+    expect(readAxis('x')?.title?.display ?? false).toBe(false);
+  });
+
+  it('keeps the plot window on screen when the widget label is hidden', async () => {
+    // The removed axis title rendered independently of Show Label, so hiding the name must not
+    // take the window with it.
+    await setup(makeConfig({ displayName: 'SOG', timeScale: 'minute', period: 10, showLabel: false }));
+
+    const subtitle = readSubtitle();
+    expect(subtitle?.display).toBe(true);
+    expect(subtitle?.text?.trim()).toBe('(10 min)');
+    expect(subtitle?.text).not.toContain('SOG');
+  });
+
+  it('falls back to the bare label for a legacy time scale with no abbreviation', async () => {
+    // Stored configs can still carry the pre-migration TimeScaleFormat members. A full Record or a
+    // `?? format` default would render "SOG (30 Last 30 Minutes)" on those.
+    await setup(makeConfig({ displayName: 'SOG', timeScale: 'Last 30 Minutes', period: 30 }));
+
+    expect(readSubtitle()?.text?.trim()).toBe('SOG');
+  });
+
+  it.each([
+    { orientation: 'horizontal', verticalChart: false },
+    { orientation: 'vertical', verticalChart: true }
+  ])('draws both axes\' ticks inside the plot in the $orientation layout', async ({ verticalChart }) => {
+    // The same options are spread into four separate axis blocks, two per orientation. One block
+    // losing them reintroduces the label gutter for that orientation alone, which no dashboard
+    // review would catch until someone opens a chart in that layout.
+    await setup(makeConfig({ verticalChart, showTimeScale: true, showYScale: true }));
+
+    for (const axis of [readAxis('x'), readAxis('y')]) {
+      expect(axis?.ticks?.mirror).toBe(true);
+      expect(axis?.ticks?.textStrokeColor).toBeTruthy();
+      expect(axis?.ticks?.textStrokeWidth).toBeGreaterThan(0);
+      expect(axis?.grid?.display).toBe(true);
+      expect(axis?.grid?.drawTicks).toBe(false);
+    }
+  });
+
+  it('keeps the per-axis tick colour when the shared inside-tick options are applied', async () => {
+    // The shared options carry text-styling keys and are spread first, so a later `color` or `font`
+    // added to them cannot silently win over the per-axis value in four places. A theme that names
+    // each key separates the two: the ink is the axis colour, the halo is the card colour.
+    await setup(makeConfig({ showTimeScale: true, showYScale: true }));
+    fixture.componentRef.setInput('theme', new Proxy({}, { get: (_t, key) => String(key) }) as unknown as ITheme);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    for (const axis of [readAxis('x'), readAxis('y')]) {
+      expect(axis?.ticks?.color).toBe('contrastDim');
+      expect(axis?.ticks?.textStrokeColor).toBe('cardColor');
+    }
+  });
+
   it('draws the value line with a hair of tension so it avoids the fast pixel-bucketing path', async () => {
     await setup(makeConfig());
 

--- a/src/app/widgets/widget-data-chart/widget-data-chart.component.ts
+++ b/src/app/widgets/widget-data-chart/widget-data-chart.component.ts
@@ -271,7 +271,9 @@ export class WidgetDataChartComponent implements OnDestroy {
     };
     const insideGrid = { display: true, drawTicks: false, color: theme.contrastDimmer };
     // The plot window rides on the widget label instead of a time-axis title, which would cost the
-    // plot a whole row to say what the label can say in four characters.
+    // plot a whole row to say what the label can say in four characters. The axis title rendered
+    // independently of the label toggle, so the subtitle carries the window on its own when the
+    // label is off rather than taking it down with the name.
     const suffix = TIME_SCALE_SUFFIX[datasetConfig.timeScaleFormat];
     const windowSuffix = suffix ? ` (${datasetConfig.period} ${suffix})` : '';
 
@@ -280,7 +282,7 @@ export class WidgetDataChartComponent implements OnDestroy {
         y: {
           type: "realtime",
           display: cfg.showTimeScale,
-          position: cfg.verticalChart ? "right" : "left",
+          position: "right",
           suggestedMin: "",
           suggestedMax: "",
           time: {
@@ -297,41 +299,35 @@ export class WidgetDataChartComponent implements OnDestroy {
             },
           },
           ticks: {
+            ...insideTicks,
             autoSkip: true,
             color: this.getThemeColors().averageChartLine,
             major: {
               enabled: true
-            },
-            ...insideTicks
+            }
           },
-          grid: insideGrid
+          grid: { ...insideGrid }
         },
         x: {
           type: "linear",
           display: cfg.showYScale,
-          position: cfg.verticalChart ? "top" : "bottom",
+          position: "top",
           suggestedMin: cfg.enableMinMaxScaleLimit ? undefined : cfg.yScaleSuggestedMin,
           suggestedMax: cfg.enableMinMaxScaleLimit ? undefined : cfg.yScaleSuggestedMax,
           min: cfg.enableMinMaxScaleLimit ? cfg.yScaleMin : undefined,
           max: cfg.enableMinMaxScaleLimit ? cfg.yScaleMax : undefined,
           beginAtZero: cfg.startScaleAtZero,
           reverse: cfg.inverseYAxis,
-          title: {
-            display: false,
-            text: "Value Axis",
-            align: "center",
-            color: this.getThemeColors().averageChartLine
-          },
           ticks: {
+            ...insideTicks,
             maxTicksLimit: 8,
             precision: cfg.numDecimal,
             color: this.getThemeColors().averageChartLine,
             major: {
               enabled: true,
-            },
-            ...insideTicks
+            }
           },
-          grid: insideGrid
+          grid: { ...insideGrid }
         }
       }
     } else {
@@ -353,14 +349,14 @@ export class WidgetDataChartComponent implements OnDestroy {
             },
           },
           ticks: {
+            ...insideTicks,
             autoSkip: true,
             color: this.getThemeColors().averageChartLine,
             major: {
               enabled: true
-            },
-            ...insideTicks
+            }
           },
-          grid: insideGrid
+          grid: { ...insideGrid }
         },
         y: {
           display: cfg.showYScale,
@@ -371,22 +367,16 @@ export class WidgetDataChartComponent implements OnDestroy {
           max: cfg.enableMinMaxScaleLimit ? cfg.yScaleMax : undefined,
           beginAtZero: cfg.startScaleAtZero,
           reverse: cfg.inverseYAxis,
-          title: {
-            display: false,
-            text: "Value Axis",
-            align: "center",
-            color: this.getThemeColors().averageChartLine
-          },
           ticks: {
+            ...insideTicks,
             maxTicksLimit: 8,
             precision: cfg.numDecimal,
             color: this.getThemeColors().averageChartLine,
             major: {
               enabled: true,
-            },
-            ...insideTicks
+            }
           },
-          grid: insideGrid
+          grid: { ...insideGrid }
         }
       }
     }
@@ -406,13 +396,13 @@ export class WidgetDataChartComponent implements OnDestroy {
         color: this.getThemeColors().chartValue
       },
       subtitle: {
-        display: cfg.showLabel,
+        display: cfg.showLabel || !!windowSuffix,
         align: "start",
         padding: {
           top: -35,
           bottom: 20
         },
-        text: `  ${cfg.displayName}${windowSuffix}`,
+        text: `  ${cfg.showLabel ? `${cfg.displayName}${windowSuffix}` : windowSuffix.trimStart()}`,
         font: {
           size: 22,
         },

--- a/src/app/widgets/widget-data-chart/widget-data-chart.component.ts
+++ b/src/app/widgets/widget-data-chart/widget-data-chart.component.ts
@@ -119,7 +119,6 @@ export class WidgetDataChartComponent implements OnDestroy {
   private streamSub: Subscription | null = null;
   private datasetConfig: IDatasetServiceDatasetConfig | null = null;
   private dataSourceInfo: IDatasetServiceDataSourceInfo | null = null;
-  private lastVerticalChart: boolean | null | undefined = null;
   // Latest finite annotation values; NaN until real data arrives, which keeps the
   // min/max/average lines and their labels hidden instead of drawing at a placeholder 0.
   private lastAverageValue = NaN;
@@ -151,7 +150,11 @@ export class WidgetDataChartComponent implements OnDestroy {
     if (!cfg?.datachartPath) {
       return undefined;
     }
-    return [cfg.datachartPath, this.pathMeasure(), cfg.datachartSource, cfg.timeScale, cfg.period, cfg.datachartAngleRange].join('|');
+    // verticalChart belongs here rather than in the display effect: swapping the orientation swaps
+    // which axis carries time, so every buffered point is transposed and the realtime scale changes
+    // type. Only a full rebuild re-maps the data and destroys the outgoing scale — an in-place
+    // options update leaves the old scale's refresh interval running against the live chart.
+    return [cfg.datachartPath, this.pathMeasure(), cfg.datachartSource, cfg.timeScale, cfg.period, cfg.datachartAngleRange, cfg.verticalChart].join('|');
   });
   private previousPathSignature: string | undefined = undefined;
 
@@ -178,21 +181,16 @@ export class WidgetDataChartComponent implements OnDestroy {
       const theme = this.theme();
       if (!cfg || !theme) return;
       untracked(() => {
-        const verticalChanged = this.lastVerticalChart !== null && this.lastVerticalChart !== cfg.verticalChart;
-        if (verticalChanged) {
-          this.lastVerticalChart = cfg.verticalChart;
-          this.rebuildForDataset(cfg);
-        } else if (this.chart) {
-          // Styling / axis / annotation toggles / showAverageData. setChartOptions rebuilds the
-          // annotation plugin wholesale, so annotation visibility is re-applied after it — otherwise
-          // an already-enabled avg/min/max line is reset to hidden until the next stream emission.
-          this.ensureAverageDatasetPresence();
-          this.applyDynamicTrackAverageStyling();
-          this.setChartOptions(cfg);
-          this.updateAnnotationVisibility();
-          this.setDatasetsColors();
-          this.ngZone.runOutsideAngular(() => this.chart?.update('none'));
-        }
+        if (!this.chart) return;
+        // Styling / axis / annotation toggles / showAverageData. setChartOptions rebuilds the
+        // annotation plugin wholesale, so annotation visibility is re-applied after it — otherwise
+        // an already-enabled avg/min/max line is reset to hidden until the next stream emission.
+        this.ensureAverageDatasetPresence();
+        this.applyDynamicTrackAverageStyling();
+        this.setChartOptions(cfg);
+        this.updateAnnotationVisibility();
+        this.setDatasetsColors();
+        this.ngZone.runOutsideAngular(() => this.chart?.update('none'));
       });
     });
 

--- a/src/app/widgets/widget-data-chart/widget-data-chart.component.ts
+++ b/src/app/widgets/widget-data-chart/widget-data-chart.component.ts
@@ -48,6 +48,15 @@ interface IDataSetRow { x: number | null, y: number | null }
 // below a pixel from the vertices, so the rendered line is indistinguishable from straight segments.
 const NON_FAST_PATH_TENSION = 1e-6;
 
+// Compact plot-window suffix for the widget label ("SOG (30 s)"). The legacy TimeScaleFormat members
+// have no abbreviation, so a config still carrying one gets the bare label.
+const TIME_SCALE_SUFFIX: Partial<Record<TimeScaleFormat, string>> = {
+  day: 'd',
+  hour: 'h',
+  minute: 'min',
+  second: 's'
+};
+
 @Component({
   selector: 'widget-data-chart',
   templateUrl: './widget-data-chart.component.html',
@@ -250,6 +259,22 @@ export class WidgetDataChartComponent implements OnDestroy {
     this.lineChartOptions.animation = false;
     this.lineChartOptions.indexAxis = cfg.verticalChart ? 'y' : 'x';
 
+    // Ticks drawn inside the plot area: an enabled axis then costs the plot the padding alone
+    // instead of a label gutter. Chart.js draws tick labels above the grid but below the datasets,
+    // so the card-coloured outline — the Numeric widget's halo — keeps a label legible over the
+    // grid lines behind it while the value line still crosses in front.
+    const insideTicks = {
+      mirror: true,
+      padding: 4,
+      textStrokeColor: theme.cardColor,
+      textStrokeWidth: 3
+    };
+    const insideGrid = { display: true, drawTicks: false, color: theme.contrastDimmer };
+    // The plot window rides on the widget label instead of a time-axis title, which would cost the
+    // plot a whole row to say what the label can say in four characters.
+    const suffix = TIME_SCALE_SUFFIX[datasetConfig.timeScaleFormat];
+    const windowSuffix = suffix ? ` (${datasetConfig.period} ${suffix})` : '';
+
     if (cfg.verticalChart) {
       this.lineChartOptions.scales = {
         y: {
@@ -258,12 +283,6 @@ export class WidgetDataChartComponent implements OnDestroy {
           position: cfg.verticalChart ? "right" : "left",
           suggestedMin: "",
           suggestedMax: "",
-          title: {
-            display: true,
-            text: `Last ${datasetConfig.period} ${datasetConfig.timeScaleFormat}`,
-            align: "center",
-            color: this.getThemeColors().averageChartLine
-          },
           time: {
             unit: datasetConfig.timeScaleFormat as TimeUnit,
             minUnit: "second",
@@ -282,12 +301,10 @@ export class WidgetDataChartComponent implements OnDestroy {
             color: this.getThemeColors().averageChartLine,
             major: {
               enabled: true
-            }
+            },
+            ...insideTicks
           },
-          grid: {
-            display: true,
-            color: theme.contrastDimmer
-          }
+          grid: insideGrid
         },
         x: {
           type: "linear",
@@ -311,12 +328,10 @@ export class WidgetDataChartComponent implements OnDestroy {
             color: this.getThemeColors().averageChartLine,
             major: {
               enabled: true,
-            }
+            },
+            ...insideTicks
           },
-          grid: {
-            display: true,
-            color: theme.contrastDimmer,
-          }
+          grid: insideGrid
         }
       }
     } else {
@@ -324,12 +339,6 @@ export class WidgetDataChartComponent implements OnDestroy {
         x: {
           type: "realtime",
           display: cfg.showTimeScale,
-          title: {
-            display: true,
-            text: `Last ${datasetConfig.period} ${datasetConfig.timeScaleFormat}`,
-            align: "center",
-            color: this.getThemeColors().averageChartLine
-          },
           time: {
             unit: datasetConfig.timeScaleFormat as TimeUnit,
             minUnit: "second",
@@ -348,12 +357,10 @@ export class WidgetDataChartComponent implements OnDestroy {
             color: this.getThemeColors().averageChartLine,
             major: {
               enabled: true
-            }
+            },
+            ...insideTicks
           },
-          grid: {
-            display: true,
-            color: theme.contrastDimmer
-          }
+          grid: insideGrid
         },
         y: {
           display: cfg.showYScale,
@@ -376,12 +383,10 @@ export class WidgetDataChartComponent implements OnDestroy {
             color: this.getThemeColors().averageChartLine,
             major: {
               enabled: true,
-            }
+            },
+            ...insideTicks
           },
-          grid: {
-            display: true,
-            color: theme.contrastDimmer,
-          }
+          grid: insideGrid
         }
       }
     }
@@ -407,7 +412,7 @@ export class WidgetDataChartComponent implements OnDestroy {
           top: -35,
           bottom: 20
         },
-        text: `  ${cfg.displayName}`,
+        text: `  ${cfg.displayName}${windowSuffix}`,
         font: {
           size: 22,
         },


### PR DESCRIPTION
## Why

Turning on either scale in the Realtime Data Plot cost a lot of the plot. The value axis reserved a
label gutter, and the time axis reserved a label row *plus* a title row for "Last 30 second" — on a
small tile that left the trace squeezed into a band. Separately, in the widget settings the Source
and "Angle display range" select boxes shared a border, because the angle field sits outside the
`.flex-container` blocks that carry the form's 10px rhythm and `subscriptSizing` is `dynamic`
app-wide, so a field with no hint reserves nothing below it.

## How

Chart.js 4.5.1 does all of this natively — no plugin, no custom draw pass:

- `ticks.mirror` draws the labels inside the grid **and** makes `Scale.fit()` reserve zero space for
  them. The docs call it vertical-only; the implementation applies it to horizontal axes too, and it
  works on the bottom time axis.
- Tick labels are layer `z=0`, grid is `z=-1`, and everything at `z<=0` draws before the datasets —
  so labels land above the grid and below the plot lines with no extra work.
- `ticks.textStrokeColor` / `textStrokeWidth` stroke behind the fill, giving the Numeric widget's
  card-coloured halo: it knocks out the grid line behind the glyphs without hiding the value line
  that crosses in front.
- `grid.drawTicks: false` drops the 8px tick-mark gutter.

The plot window moves off the axis title onto the widget label as a compact suffix — `SOG (30 s)`.
Legacy `TimeScaleFormat` members have no abbreviation, so a config still carrying one gets the bare
label rather than a wrong one.

## Verified

Rendered before/after in the perf-harness mock server across all three tile shapes (wide, vertical,
small); the grid now runs to the tile edge in each. `npm run lint`, `npm run snc` and the full suite
(178 files, 1952 tests) pass.

## Known, not introduced here

On narrow tiles the large value readout is drawn over the widget label — the `title` and `subtitle`
plugins are overlaid on one row (`subtitle.padding.top: -35`) with no width negotiation. That
already happened with the bare label; the `(30 s)` suffix makes it start on wider tiles too.

Two smaller rough edges from the mirrored layout: the last time label and the bottom value label can
nearly touch in the corner (two axes, no cross-axis collision avoidance), and a `position: 'right'`
value axis cannot be fully inset because its label anchor is `scale.left + ticks.padding`, which
pushes outward.


## Merged in from #543

Fixes #539 — toggling Vertical Data Graph never rebuilt the chart. `lastVerticalChart` was
initialized to `null` and assigned only inside the branch that required it non-null, and
`verticalChart` was absent from `pathSignature`, so an orientation change swapped the scale blocks
in place: buffered points kept the old x/y mapping and plotted transposed until the window scrolled
out, and the replaced realtime scale was dropped without `destroy()`, leaving its refresh interval
and rAF loop running. `cfg.verticalChart` now sits in `pathSignature` and the dead flag is gone.

That work landed here rather than in its own PR to `main` because it touches the same component and
was stacked on this branch.
