### PR TITLE
Rebuild the Data Plot when the chart orientation is toggled

### DIFF
--- a/src/app/widgets/widget-data-chart/widget-data-chart.component.spec.ts
+++ b/src/app/widgets/widget-data-chart/widget-data-chart.component.spec.ts
@@ -29,6 +29,7 @@ vi.mock('chartjs-plugin-annotation', () => ({ default: {} }));
 vi.mock('chartjs-adapter-date-fns', () => ({}));
 vi.mock('@aziham/chartjs-plugin-streaming', () => ({ default: {} }));
 
+import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { EMPTY, Subject } from 'rxjs';
 import { WidgetDataChartComponent } from './widget-data-chart.component';
@@ -53,13 +54,17 @@ const makeConfig = (overrides: Partial<IWidgetSvcConfig> = {}): IWidgetSvcConfig
 describe('WidgetDataChartComponent', () => {
   let fixture: ComponentFixture<WidgetDataChartComponent>;
 
-  const runtimeMock = { options: vi.fn() };
+  // A real signal, not a vi.fn: the component tracks runtime.options() inside computed/effect, so a
+  // config edit only reaches the rebuild path when the source is reactive — which is what the live
+  // WidgetRuntimeDirective provides.
+  const options = signal<IWidgetSvcConfig | undefined>(undefined);
+  const runtimeMock = { options };
   const historyMock = { getBackfillThenLive: vi.fn() };
   const unitsMock = { convertToUnit: (_unit: string, value: number) => value, getUnitDisplaySymbol: (measure: string) => measure, resolvePathMeasure: () => 'knots' };
   const canvasMock = { releaseCanvas: vi.fn() };
 
   const setup = async (config: IWidgetSvcConfig): Promise<void> => {
-    runtimeMock.options.mockReturnValue(config);
+    options.set(config);
 
     await TestBed.configureTestingModule({
       imports: [WidgetDataChartComponent],
@@ -83,7 +88,7 @@ describe('WidgetDataChartComponent', () => {
   beforeEach(() => {
     vi.spyOn(HTMLCanvasElement.prototype, 'getContext')
       .mockReturnValue({} as unknown as CanvasRenderingContext2D);
-    runtimeMock.options.mockReset();
+    options.set(undefined);
     historyMock.getBackfillThenLive.mockReset().mockReturnValue(EMPTY);
   });
 
@@ -192,6 +197,7 @@ describe('WidgetDataChartComponent', () => {
     }).subtitle;
 
   interface AxisState {
+    type?: string;
     ticks?: { mirror?: boolean; padding?: number; textStrokeColor?: string; textStrokeWidth?: number; color?: string };
     grid?: { display?: boolean; drawTicks?: boolean };
     title?: { display?: boolean };
@@ -243,6 +249,29 @@ describe('WidgetDataChartComponent', () => {
       expect(axis?.grid?.display).toBe(true);
       expect(axis?.grid?.drawTicks).toBe(false);
     }
+  });
+
+  it('rebuilds the chart when the orientation is toggled', async () => {
+    const emissions$ = new Subject<IDatasetServiceDatapoint>();
+    historyMock.getBackfillThenLive.mockReturnValue(emissions$);
+
+    await setup(makeConfig({ verticalChart: false, showTimeScale: true, showYScale: true }));
+    emissions$.next({ timestamp: 1000, data: { value: 5 } });
+
+    expect(readAxis('x')?.type).toBe('realtime');
+    expect(fixture.componentInstance.lineChartData.datasets[0].data.length).toBeGreaterThan(0);
+    const streamsBefore = historyMock.getBackfillThenLive.mock.calls.length;
+
+    options.set(makeConfig({ verticalChart: true, showTimeScale: true, showYScale: true }));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    // Swapping the orientation swaps which axis carries time. transformDatasetRows only transposes
+    // rows as they arrive, so anything already buffered plots as garbage — up to a 365-day window —
+    // unless the toggle goes through the full rebuild rather than an in-place options update.
+    expect(readAxis('y')?.type).toBe('realtime');
+    expect(fixture.componentInstance.lineChartData.datasets[0].data.length).toBe(0);
+    expect(historyMock.getBackfillThenLive.mock.calls.length).toBeGreaterThan(streamsBefore);
   });
 
   it('keeps the per-axis tick colour when the shared inside-tick options are applied', async () => {

--- a/src/app/widgets/widget-data-chart/widget-data-chart.component.ts
+++ b/src/app/widgets/widget-data-chart/widget-data-chart.component.ts
@@ -119,7 +119,6 @@ export class WidgetDataChartComponent implements OnDestroy {
   private streamSub: Subscription | null = null;
   private datasetConfig: IDatasetServiceDatasetConfig | null = null;
   private dataSourceInfo: IDatasetServiceDataSourceInfo | null = null;
-  private lastVerticalChart: boolean | null | undefined = null;
   // Latest finite annotation values; NaN until real data arrives, which keeps the
   // min/max/average lines and their labels hidden instead of drawing at a placeholder 0.
   private lastAverageValue = NaN;
@@ -151,7 +150,11 @@ export class WidgetDataChartComponent implements OnDestroy {
     if (!cfg?.datachartPath) {
       return undefined;
     }
-    return [cfg.datachartPath, this.pathMeasure(), cfg.datachartSource, cfg.timeScale, cfg.period, cfg.datachartAngleRange].join('|');
+    // verticalChart belongs here rather than in the display effect: swapping the orientation swaps
+    // which axis carries time, so every buffered point is transposed and the realtime scale changes
+    // type. Only a full rebuild re-maps the data and destroys the outgoing scale — an in-place
+    // options update leaves the old scale's refresh interval running against the live chart.
+    return [cfg.datachartPath, this.pathMeasure(), cfg.datachartSource, cfg.timeScale, cfg.period, cfg.datachartAngleRange, cfg.verticalChart].join('|');
   });
   private previousPathSignature: string | undefined = undefined;
 
@@ -178,21 +181,16 @@ export class WidgetDataChartComponent implements OnDestroy {
       const theme = this.theme();
       if (!cfg || !theme) return;
       untracked(() => {
-        const verticalChanged = this.lastVerticalChart !== null && this.lastVerticalChart !== cfg.verticalChart;
-        if (verticalChanged) {
-          this.lastVerticalChart = cfg.verticalChart;
-          this.rebuildForDataset(cfg);
-        } else if (this.chart) {
-          // Styling / axis / annotation toggles / showAverageData. setChartOptions rebuilds the
-          // annotation plugin wholesale, so annotation visibility is re-applied after it — otherwise
-          // an already-enabled avg/min/max line is reset to hidden until the next stream emission.
-          this.ensureAverageDatasetPresence();
-          this.applyDynamicTrackAverageStyling();
-          this.setChartOptions(cfg);
-          this.updateAnnotationVisibility();
-          this.setDatasetsColors();
-          this.ngZone.runOutsideAngular(() => this.chart?.update('none'));
-        }
+        if (!this.chart) return;
+        // Styling / axis / annotation toggles / showAverageData. setChartOptions rebuilds the
+        // annotation plugin wholesale, so annotation visibility is re-applied after it — otherwise
+        // an already-enabled avg/min/max line is reset to hidden until the next stream emission.
+        this.ensureAverageDatasetPresence();
+        this.applyDynamicTrackAverageStyling();
+        this.setChartOptions(cfg);
+        this.updateAnnotationVisibility();
+        this.setDatasetsColors();
+        this.ngZone.runOutsideAngular(() => this.chart?.update('none'));
       });
     });
 


### PR DESCRIPTION
Fixes #539.

## Why

`lastVerticalChart` was initialized to `null` and its only assignment sat inside the branch that
required it to already be non-null, so the orientation check evaluated false for the component's
whole lifetime. `verticalChart` was not part of `pathSignature` either, so neither rebuild path
fired on an orientation change.

Toggling **Vertical Data Graph** on a live widget therefore swapped the two scale blocks in place
via `setChartOptions()` + `update('none')`:

- `transformDatasetRows()` picks `{x: value, y: timestamp}` or `{x: timestamp, y: value}` per row as
  rows arrive, and buffered points are never re-mapped — they plot transposed until the whole window
  scrolls out, up to 365 days on a day-scale config.
- The realtime scale changes `type` between the two blocks. Chart.js replaces a scale whose type
  changed and overwrites `scales[id]` without destroying the old one, and `RealTimeScale.destroy()`
  is what cancels the streaming plugin's `setInterval` and `requestAnimationFrame` loop.

Config edits reach the widget in place (`widget-host2` `applyRuntimeConfig` / `reconfigure`), so
this is the normal path.

## How

`cfg.verticalChart` joins `pathSignature`, so the orientation takes the same full-rebuild path as
every other structural change, and the dead flag and its branch are deleted.

The spec's runtime mock becomes a real `signal` instead of a `vi.fn`. The component tracks
`runtime.options()` inside a `computed`/`effect`, so a config edit only reaches the rebuild path
when the source is reactive — which is what the live `WidgetRuntimeDirective` provides. Without
that, no test could drive a config change at all.

## Verified

New spec case flips the orientation on a live component and asserts the time axis moved, the
buffered point was cleared, and the stream was re-subscribed. Mutation-checked: dropping
`cfg.verticalChart` from the signature fails it on the buffered-point assertion — the transposed-data
symptom itself. `npm run lint`, `npm run snc` and the full suite (178 files, 1959 tests) pass.

## Landing order

Stacked on `feat/chart-ticks-inside-plot` (#538), which touches the same component. Merge #538
first without deleting its branch, retarget this PR to `main`, then delete it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
