### PR TITLE
Shorten the dashboard page transition to a slide-and-fade

### DIFF
--- a/src/app/core/components/dashboard/dashboard.component.spec.ts
+++ b/src/app/core/components/dashboard/dashboard.component.spec.ts
@@ -482,13 +482,14 @@ describe('DashboardComponent', () => {
         interface RunPageChangeApi {
             runPageChange: () => Promise<void>;
             animatePhase: (el: HTMLElement, from: SlidePose, to: SlidePose, easing: string) => Promise<void>;
+            ngOnDestroy?: () => void;
             loadDashboard: (dashboardId: number) => void;
             prefersReducedMotion: () => boolean;
         }
 
         // Drive the sequence without real Web Animations: record phase/load ordering
         // (load carries the index) and stub loadDashboard so it does not touch the grid.
-        function instrument(): { api: RunPageChangeApi; order: string[]; animate: Mock } {
+        function instrument(): { api: RunPageChangeApi; order: string[]; animate: Mock; slide: HTMLElement } {
             const api = component as unknown as RunPageChangeApi;
             const order: string[] = [];
             const slide = document.createElement('div');
@@ -499,7 +500,7 @@ describe('DashboardComponent', () => {
                 return Promise.resolve();
             }) as unknown as Mock;
             vi.spyOn(api, 'loadDashboard').mockImplementation((id) => { order.push(`load:${id}`); });
-            return { api, order, animate };
+            return { api, order, animate, slide };
         }
 
         function deferred(): { promise: Promise<void>; resolve: () => void } {
@@ -508,17 +509,30 @@ describe('DashboardComponent', () => {
             return { promise, resolve };
         }
 
-        it('slides out then in, loading the current page off-screen at the midpoint, for next', async () => {
+        it('slides out then in, loading the current page while transparent at the midpoint, for next', async () => {
             mockDashboardService.activeDashboard.set(1);
             (mockDashboardService.consumePendingPageDirection as Mock).mockReturnValue('next');
-            const { api, order } = instrument();
+            const { api, order, slide } = instrument();
+            let pointerEventsDuringExit: string | undefined;
+            (api.animatePhase as unknown as Mock).mockImplementationOnce((el, from, to) => {
+                order.push(`animate:${from.pct}@${from.opacity}->${to.pct}@${to.opacity}`);
+                pointerEventsDuringExit = (el as HTMLElement).style.pointerEvents;
+                return Promise.resolve();
+            });
 
             await api.runPageChange();
 
+            // A transparent page is still hit-testable and, at this travel, still inside the host's
+            // clip box: input must be off for the whole transition or a tap reaches an unseen control.
+            expect(pointerEventsDuringExit).toBe('none');
             // The exit must end fully transparent: opacity, not distance, is what hides the swap.
             expect(order).toEqual(['animate:0@1->-15@0', 'load:1', 'animate:15@0->0@1']);
             expect(mockDashboardService.beginPageTransition).toHaveBeenCalledTimes(1);
             expect(mockDashboardService.endPageTransition).toHaveBeenCalledTimes(1);
+            // A missed restore now leaves the dashboard invisible and deaf to taps, not just displaced.
+            expect(slide.style.opacity).toBe('');
+            expect(slide.style.transform).toBe('');
+            expect(slide.style.pointerEvents).toBe('');
         });
 
         it('mirrors the slide direction for a previous navigation', async () => {
@@ -528,6 +542,82 @@ describe('DashboardComponent', () => {
             await api.runPageChange();
 
             expect(order).toEqual(['animate:0@1->15@0', 'load:0', 'animate:-15@0->0@1']);
+        });
+
+        it('animates transform and opacity together, and persists the end pose before dropping the fill', async () => {
+            // jsdom has no Element.animate, so every other test in this block stubs animatePhase and
+            // its body never runs. Dropping the opacity keyframes, or persisting the end pose after
+            // the cancel instead of before it, would leave the wrapper opaque while the grid swaps —
+            // the half-loaded flash this transition exists to prevent — with the rest of the suite green.
+            const api = component as unknown as RunPageChangeApi;
+            let opacityAtCancel: string | undefined;
+            let keyframes: Keyframe[] | undefined;
+            let options: KeyframeAnimationOptions | undefined;
+            const el = { style: {} as CSSStyleDeclaration } as HTMLElement;
+            (el as unknown as { animate: Mock }).animate = vi.fn((kf: Keyframe[], opt: KeyframeAnimationOptions) => {
+                keyframes = kf;
+                options = opt;
+                return {
+                    finished: Promise.resolve(),
+                    cancel: () => { opacityAtCancel = el.style.opacity; }
+                };
+            }) as unknown as Mock;
+
+            await api.animatePhase(el, { pct: 0, opacity: 1 }, { pct: -15, opacity: 0 }, 'ease-in');
+
+            expect(keyframes).toEqual([
+                { transform: 'translateX(0%)', opacity: 1 },
+                { transform: 'translateX(-15%)', opacity: 0 }
+            ]);
+            expect(options).toMatchObject({ easing: 'ease-in', fill: 'forwards' });
+            expect(options?.duration).toBeGreaterThan(0);
+            expect(opacityAtCancel).toBe('0');
+            expect(el.style.transform).toBe('translateX(-15%)');
+        });
+
+        it('restores the wrapper when the component is destroyed mid-transition', async () => {
+            (mockDashboardService.consumePendingPageDirection as Mock).mockReturnValue('next');
+            const { api, order, slide } = instrument();
+            const exit = deferred();
+            (api.animatePhase as unknown as Mock).mockImplementationOnce(() => exit.promise);
+
+            // ngOnDestroy is stubbed for the rest of the suite; this test needs the real teardown.
+            (vi.mocked(component.ngOnDestroy) as unknown as { mockRestore: () => void }).mockRestore();
+
+            const run = api.runPageChange();
+            component.ngOnDestroy();
+            exit.resolve();
+            await run;
+
+            // The teardown guard must not skip the restore: a slide abandoned at opacity 0 leaves a
+            // blank dashboard behind, and loadDashboard re-queues itself forever against a dead grid.
+            expect(order).not.toContain('load:0');
+            expect(slide.style.opacity).toBe('');
+            expect(slide.style.pointerEvents).toBe('');
+            // Once from the teardown, once from the finally — the flag must not be left set either way.
+            expect(mockDashboardService.endPageTransition).toHaveBeenCalledTimes(2);
+        });
+
+        it('reads the reduced-motion preference from the real media query', async () => {
+            // The other reduced-motion test stubs the predicate, so the query string itself is never
+            // evaluated; a typo there would animate for users who asked not to be.
+            (mockDashboardService.consumePendingPageDirection as Mock).mockReturnValue('next');
+            const { api, order } = instrument();
+            // src/test.ts defines matchMedia without a setter, so it is replaced through its
+            // descriptor. Restored immediately: this spec has no afterEach, and a leak would send
+            // every later test down the reduced-motion path.
+            const spy = vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => ({
+                matches: query === '(prefers-reduced-motion: reduce)'
+            }) as unknown as MediaQueryList);
+
+            try {
+                await api.runPageChange();
+            } finally {
+                spy.mockRestore();
+            }
+
+            expect(order).toEqual(['load:0']);
+            expect(api.animatePhase).not.toHaveBeenCalled();
         });
 
         it('swaps instantly without animating when no travel direction is pending', async () => {

--- a/src/app/core/components/dashboard/dashboard.component.spec.ts
+++ b/src/app/core/components/dashboard/dashboard.component.spec.ts
@@ -478,9 +478,10 @@ describe('DashboardComponent', () => {
     });
 
     describe('runPageChange (page transition)', () => {
+        interface SlidePose { pct: number; opacity: number }
         interface RunPageChangeApi {
             runPageChange: () => Promise<void>;
-            animatePhase: (el: HTMLElement, from: number, to: number, easing: string) => Promise<void>;
+            animatePhase: (el: HTMLElement, from: SlidePose, to: SlidePose, easing: string) => Promise<void>;
             loadDashboard: (dashboardId: number) => void;
             prefersReducedMotion: () => boolean;
         }
@@ -494,7 +495,7 @@ describe('DashboardComponent', () => {
             vi.spyOn(component as unknown as { _pageSlide: () => unknown }, '_pageSlide')
                 .mockReturnValue({ nativeElement: slide });
             const animate = vi.spyOn(api, 'animatePhase').mockImplementation((_el, from, to) => {
-                order.push(`animate:${from}->${to}`);
+                order.push(`animate:${from.pct}@${from.opacity}->${to.pct}@${to.opacity}`);
                 return Promise.resolve();
             }) as unknown as Mock;
             vi.spyOn(api, 'loadDashboard').mockImplementation((id) => { order.push(`load:${id}`); });
@@ -514,7 +515,8 @@ describe('DashboardComponent', () => {
 
             await api.runPageChange();
 
-            expect(order).toEqual(['animate:0->-100', 'load:1', 'animate:100->0']);
+            // The exit must end fully transparent: opacity, not distance, is what hides the swap.
+            expect(order).toEqual(['animate:0@1->-15@0', 'load:1', 'animate:15@0->0@1']);
             expect(mockDashboardService.beginPageTransition).toHaveBeenCalledTimes(1);
             expect(mockDashboardService.endPageTransition).toHaveBeenCalledTimes(1);
         });
@@ -525,7 +527,7 @@ describe('DashboardComponent', () => {
 
             await api.runPageChange();
 
-            expect(order).toEqual(['animate:0->100', 'load:0', 'animate:-100->0']);
+            expect(order).toEqual(['animate:0@1->15@0', 'load:0', 'animate:-15@0->0@1']);
         });
 
         it('swaps instantly without animating when no travel direction is pending', async () => {

--- a/src/app/core/components/dashboard/dashboard.component.ts
+++ b/src/app/core/components/dashboard/dashboard.component.ts
@@ -28,9 +28,13 @@ const PAGE_SLIDE_PHASE_MS = 150;
 const PAGE_SLIDE_EXIT_EASING = 'ease-in';
 const PAGE_SLIDE_ENTER_EASING = 'ease-out';
 /**
- * How far a page travels, as a fraction of the wrapper's own width. Short on purpose: the page is
- * transparent well before it gets far, so the swap hides behind opacity rather than behind the
- * viewport edge, and no full-width empty sweep is ever exposed between the two phases.
+ * How far a page travels, as a fraction of the wrapper's own width. Short on purpose: what hides the
+ * grid swap is the exit phase ending at opacity 0, not the page clearing the viewport, so the travel
+ * only has to suggest a direction. A short hop also keeps a full-width empty sweep off screen.
+ *
+ * The fade does not lead the motion — `animatePhase` passes one effect easing, so opacity and
+ * transform ride the same curve and opacity only reaches 0 at the end of the phase. Extending the
+ * travel on the assumption that the page is already invisible partway would expose the swap.
  */
 const PAGE_SLIDE_TRAVEL_PCT = 15;
 
@@ -312,17 +316,23 @@ export class DashboardComponent implements AfterViewInit, OnDestroy {
       return;
     }
 
-    const exitTo = direction === 'next' ? -PAGE_SLIDE_TRAVEL_PCT : PAGE_SLIDE_TRAVEL_PCT;
-    const enterFrom = -exitTo;
+    const exitPose: SlidePose = { pct: direction === 'next' ? -PAGE_SLIDE_TRAVEL_PCT : PAGE_SLIDE_TRAVEL_PCT, opacity: 0 };
+    // Seeded inline and then declared as the enter phase's start: one binding so the two cannot
+    // disagree, which would start the enter with a visible jump.
+    const enterPose: SlidePose = { pct: -exitPose.pct, opacity: 0 };
     this._slideInFlight = true;
+    // A transparent page is still hit-testable, and at this travel it stays inside the host's clip
+    // box — without this a tap mid-transition reaches a control the user cannot see, on the page
+    // they have not seen yet. Widgets do not consult the transition flag themselves.
+    slide.style.pointerEvents = 'none';
     this.dashboard.beginPageTransition();
     try {
-      await this.animatePhase(slide, PAGE_SLIDE_RESTING, { pct: exitTo, opacity: 0 }, PAGE_SLIDE_EXIT_EASING);
+      await this.animatePhase(slide, PAGE_SLIDE_RESTING, exitPose, PAGE_SLIDE_EXIT_EASING);
       if (this._destroyed) return;
       let target = this.dashboard.activeDashboard();
       this.loadDashboard(target);
-      this.setSlidePose(slide, { pct: enterFrom, opacity: 0 }); // jump to the opposite side, still invisible
-      await this.animatePhase(slide, { pct: enterFrom, opacity: 0 }, PAGE_SLIDE_RESTING, PAGE_SLIDE_ENTER_EASING);
+      this.setSlidePose(slide, enterPose); // jump to the opposite side, still invisible
+      await this.animatePhase(slide, enterPose, PAGE_SLIDE_RESTING, PAGE_SLIDE_ENTER_EASING);
       if (this._destroyed) return;
       // A change that landed during the slide bypassed the guard; settle on it now.
       if (this.dashboard.activeDashboard() !== target) {
@@ -330,9 +340,10 @@ export class DashboardComponent implements AfterViewInit, OnDestroy {
         this.loadDashboard(target);
       }
     } finally {
-      // Restores opacity as well as position: an aborted transition must never leave the page
-      // displaced or invisible.
+      // Restores opacity and input as well as position: an aborted transition must never leave the
+      // page displaced, invisible, or deaf to taps.
       this.setSlidePose(slide, PAGE_SLIDE_RESTING);
+      slide.style.pointerEvents = '';
       this._slideInFlight = false;
       this.dashboard.endPageTransition();
     }

--- a/src/app/core/components/dashboard/dashboard.component.ts
+++ b/src/app/core/components/dashboard/dashboard.component.ts
@@ -23,12 +23,23 @@ import { PluginConfigClientService } from '../../services/plugin-config-client.s
 import { EmbedModeService } from '../../services/embed-mode.service';
 
 /** Per-phase duration (ms) of the page-transition slide; two phases run back to back. */
-const PAGE_SLIDE_PHASE_MS = 180;
+const PAGE_SLIDE_PHASE_MS = 150;
 /** Exit accelerates out, enter decelerates in, so the two phases read as one motion. */
 const PAGE_SLIDE_EXIT_EASING = 'ease-in';
 const PAGE_SLIDE_ENTER_EASING = 'ease-out';
-/** Distance a page travels to fully clear the viewport (100% of the wrapper's own width). */
-const PAGE_SLIDE_OFFSCREEN_PCT = 100;
+/**
+ * How far a page travels, as a fraction of the wrapper's own width. Short on purpose: the page is
+ * transparent well before it gets far, so the swap hides behind opacity rather than behind the
+ * viewport edge, and no full-width empty sweep is ever exposed between the two phases.
+ */
+const PAGE_SLIDE_TRAVEL_PCT = 15;
+
+/** Where a page sits mid-transition: displaced by {@link SlidePose.pct} and faded to its opacity. */
+interface SlidePose {
+  pct: number;
+  opacity: number;
+}
+const PAGE_SLIDE_RESTING: SlidePose = { pct: 0, opacity: 1 };
 
 interface PressGestureDetail { x?: number; y?: number; center?: { x: number; y: number }; }
 interface GridApi {
@@ -278,10 +289,11 @@ export class DashboardComponent implements AfterViewInit, OnDestroy {
   }
 
   /**
-   * Applies an active-dashboard change: a horizontal slide when the change was
-   * initiated by a navigate* call (a travel direction is pending) and motion is
-   * allowed, otherwise an instant swap. The incoming page loads while the wrapper
-   * is off-screen, so no partially-loaded page is ever visible mid-slide.
+   * Applies an active-dashboard change: a short horizontal slide with a fade when the change was
+   * initiated by a navigate* call (a travel direction is pending) and motion is allowed, otherwise
+   * an instant swap. The incoming page loads while the wrapper is fully transparent, so no
+   * partially-loaded page is ever visible mid-transition — opacity is what hides the swap here, not
+   * distance, so the exit phase must always end at opacity 0.
    *
    * Always loads the *current* activeDashboard rather than a captured index, and
    * ignores re-entrant calls (a router-driven change — browser back/forward —
@@ -300,17 +312,17 @@ export class DashboardComponent implements AfterViewInit, OnDestroy {
       return;
     }
 
-    const exitTo = direction === 'next' ? -PAGE_SLIDE_OFFSCREEN_PCT : PAGE_SLIDE_OFFSCREEN_PCT;
+    const exitTo = direction === 'next' ? -PAGE_SLIDE_TRAVEL_PCT : PAGE_SLIDE_TRAVEL_PCT;
     const enterFrom = -exitTo;
     this._slideInFlight = true;
     this.dashboard.beginPageTransition();
     try {
-      await this.animatePhase(slide, 0, exitTo, PAGE_SLIDE_EXIT_EASING);
+      await this.animatePhase(slide, PAGE_SLIDE_RESTING, { pct: exitTo, opacity: 0 }, PAGE_SLIDE_EXIT_EASING);
       if (this._destroyed) return;
       let target = this.dashboard.activeDashboard();
       this.loadDashboard(target);
-      this.setSlideOffset(slide, enterFrom); // jump to the opposite edge, still off-screen
-      await this.animatePhase(slide, enterFrom, 0, PAGE_SLIDE_ENTER_EASING);
+      this.setSlidePose(slide, { pct: enterFrom, opacity: 0 }); // jump to the opposite side, still invisible
+      await this.animatePhase(slide, { pct: enterFrom, opacity: 0 }, PAGE_SLIDE_RESTING, PAGE_SLIDE_ENTER_EASING);
       if (this._destroyed) return;
       // A change that landed during the slide bypassed the guard; settle on it now.
       if (this.dashboard.activeDashboard() !== target) {
@@ -318,30 +330,36 @@ export class DashboardComponent implements AfterViewInit, OnDestroy {
         this.loadDashboard(target);
       }
     } finally {
-      this.setSlideOffset(slide, 0);
+      // Restores opacity as well as position: an aborted transition must never leave the page
+      // displaced or invisible.
+      this.setSlidePose(slide, PAGE_SLIDE_RESTING);
       this._slideInFlight = false;
       this.dashboard.endPageTransition();
     }
   }
 
-  /** Runs one transform-only slide phase. Overridable so specs can drive the sequence without real Web Animations. */
-  protected animatePhase(el: HTMLElement, fromPct: number, toPct: number, easing: string): Promise<void> {
+  /** Runs one slide-and-fade phase. Overridable so specs can drive the sequence without real Web Animations. */
+  protected animatePhase(el: HTMLElement, from: SlidePose, to: SlidePose, easing: string): Promise<void> {
     const animation = el.animate(
-      [{ transform: `translateX(${fromPct}%)` }, { transform: `translateX(${toPct}%)` }],
+      [
+        { transform: `translateX(${from.pct}%)`, opacity: from.opacity },
+        { transform: `translateX(${to.pct}%)`, opacity: to.opacity }
+      ],
       { duration: PAGE_SLIDE_PHASE_MS, easing, fill: 'forwards' }
     );
     this._currentAnimation = animation;
     return animation.finished
       .catch(() => undefined)
       .then(() => {
-        this.setSlideOffset(el, toPct); // persist the end position as the inline base
+        this.setSlidePose(el, to); // persist the end pose as the inline base
         animation.cancel(); // drop the forwards fill so the inline style wins
         if (this._currentAnimation === animation) this._currentAnimation = null;
       });
   }
 
-  private setSlideOffset(el: HTMLElement, pct: number): void {
-    el.style.transform = pct === 0 ? '' : `translateX(${pct}%)`;
+  private setSlidePose(el: HTMLElement, pose: SlidePose): void {
+    el.style.transform = pose.pct === 0 ? '' : `translateX(${pose.pct}%)`;
+    el.style.opacity = pose.opacity === 1 ? '' : String(pose.opacity);
   }
 
   private prefersReducedMotion(): boolean {


### PR DESCRIPTION
## Why

The page transition read as page → slide → blank → slide → page. The blank was structural, not
stylistic: there is one `<gridstack>` inside one `.page-slide` wrapper, so `runPageChange()` has to
slide that single wrapper fully off-screen, reload the same grid with the next page's widgets, and
slide it back. Travelling 100% of the wrapper's width is what hid the swap, and it exposed an empty
viewport twice on the way.

## How

Travel drops to 15% and both phases animate opacity, so the page is transparent well before it gets
far. The swap now hides behind opacity 0 rather than behind the viewport edge, and no empty sweep is
ever shown. Per-phase duration drops 180 ms → 150 ms to match the shorter distance.

That moves the load-bearing invariant, which is the part worth reviewing: **the exit phase must end
at opacity 0.** If a later change drops the fade and keeps the short travel, a half-loaded page
flashes in place mid-transition. The method comment says so and the spec asserts the opacity
endpoints alongside the phase ordering, so that regression fails a test rather than shipping.

A direct page → slide → page transition was considered and rejected: it needs two live grids, which
puts the incoming page's widget mount inside the animation window — trading a clean blank for jank
on exactly the frames being improved, on Pi-class hardware.

## How this variant was chosen

Two candidates were built and deployed to a HALPI2 for side-by-side judgement:

- this one — 15% travel, both phases fade, 150 ms each
- slide the outgoing page fully off-screen, fade the incoming one up in place

The second still shows the full-width empty sweep on the way out. This one was preferred after
testing both on the device.

## Verified

`npm run lint`, `npm run snc`, and the dashboard spec (38 tests). Deployed to a HALPI2 and exercised
by swipe and by arrow keys.

Note: the full suite currently trips the known minichart flake (#544), which is unrelated to this
change — it touches only `dashboard.component.ts` and its spec.

`VERSION` stays at 1.3.1: the cycle is already open (latest stable is `v1.3.0+2`) and this is a
transition-style change, not new functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
