### PR TITLE
fix(gauge-steel): seed a freshly built gauge with its value

### DIFF
--- a/src/app/widgets/gauge-steel/gauge-steel.component.spec.ts
+++ b/src/app/widgets/gauge-steel/gauge-steel.component.spec.ts
@@ -146,4 +146,62 @@ describe('GaugeSteelComponent', () => {
     // rather than staying collapsed/off-scale from the boot-time '' unit.
     expect(internals.gaugeOptions.section).toEqual([{ lower: 11.5, upper: 12.5, color: 'red' }]);
   });
+  // #556: the gauge only ever learns a value through ngOnChanges, which drops every change that
+  // lands before the canvas exists (and the first change always). A path a previously-visited page
+  // already subscribed emits on subscribe -- before the canvas is built -- so with a constant
+  // reading no further change ever arrives and the needle stayed at zero for good.
+  interface FakeGauge { setValue: (v: number) => void; setValueAnimated: (v: number) => void }
+
+  const stubRadial = (seeded: number[]): void => {
+    const steel = (globalThis as unknown as { steelseries: Record<string, unknown> }).steelseries;
+    steel.Radial = vi.fn(function (this: FakeGauge) {
+      this.setValue = (v: number) => { seeded.push(v); };
+      this.setValueAnimated = vi.fn();
+    });
+  };
+
+  it('seeds a freshly built gauge with the value it already holds', () => {
+    const seeded: number[] = [];
+    stubRadial(seeded);
+
+    fixture.componentRef.setInput('widgetUUID', 'uuid-warm-path');
+    fixture.componentRef.setInput('subType', 'radial');
+    fixture.componentRef.setInput('minValue', 0);
+    fixture.componentRef.setInput('maxValue', 3600);
+    // The value arrives before the gauge is built, which is the whole point.
+    fixture.componentRef.setInput('value', 1800);
+
+    (component as unknown as { startGauge: (f?: boolean) => void }).startGauge(true);
+
+    expect(seeded).toEqual([1800]);
+  });
+
+  it('re-seeds the value on a rebuild, so a resize or zone change does not blank the needle', () => {
+    const seeded: number[] = [];
+    stubRadial(seeded);
+
+    fixture.componentRef.setInput('widgetUUID', 'uuid-rebuild');
+    fixture.componentRef.setInput('subType', 'radial');
+    fixture.componentRef.setInput('minValue', 0);
+    fixture.componentRef.setInput('maxValue', 3600);
+    fixture.componentRef.setInput('value', 1800);
+
+    const internals = component as unknown as { startGauge: (f?: boolean) => void };
+    internals.startGauge(true);
+    internals.startGauge(true); // a resize or zone rebuild replaces the gauge object
+
+    expect(seeded).toEqual([1800, 1800]);
+  });
+
+  it('leaves a gauge unseeded when no value has arrived yet', () => {
+    const seeded: number[] = [];
+    stubRadial(seeded);
+
+    fixture.componentRef.setInput('widgetUUID', 'uuid-no-value');
+    fixture.componentRef.setInput('subType', 'radial');
+
+    (component as unknown as { startGauge: (f?: boolean) => void }).startGauge(true);
+
+    expect(seeded).toEqual([]);
+  });
 });

--- a/src/app/widgets/gauge-steel/gauge-steel.component.spec.ts
+++ b/src/app/widgets/gauge-steel/gauge-steel.component.spec.ts
@@ -204,4 +204,67 @@ describe('GaugeSteelComponent', () => {
 
     expect(seeded).toEqual([]);
   });
+  // A rebuild replaces the gauge object, but the library cannot cancel a tween: the discarded
+  // instance keeps repainting the same canvas with its stale scale and wins the last frame. So a
+  // batch that both changes the value and forces a rebuild must not animate the outgoing gauge --
+  // the rebuild's seed paints the value instead. This is the ordinary boot batch, where the
+  // server-resolved measure lands together with the value it re-converted.
+  it('does not animate a gauge that a rebuild in the same batch is about to discard', () => {
+    const seeded: number[] = [];
+    const animated: number[] = [];
+    const steel = (globalThis as unknown as { steelseries: Record<string, unknown> }).steelseries;
+    steel.Radial = vi.fn(function (this: FakeGauge) {
+      this.setValue = (v: number) => { seeded.push(v); };
+      this.setValueAnimated = (v: number) => { animated.push(v); };
+    });
+
+    fixture.componentRef.setInput('widgetUUID', 'uuid-batch');
+    fixture.componentRef.setInput('subType', 'radial');
+    fixture.componentRef.setInput('minValue', 0);
+    fixture.componentRef.setInput('maxValue', 3600);
+    fixture.componentRef.setInput('value', 900);
+
+    const internals = component as unknown as {
+      startGauge: (f?: boolean) => void;
+      ngOnChanges: (c: Record<string, SimpleChange>) => void;
+    };
+    internals.startGauge(true);
+    seeded.length = 0;
+
+    fixture.componentRef.setInput('value', 1800);
+    fixture.componentRef.setInput('maxValue', 4000);
+    internals.ngOnChanges({
+      value: new SimpleChange(900, 1800, false),
+      maxValue: new SimpleChange(3600, 4000, false),
+    });
+
+    expect(animated).toEqual([]);
+    expect(seeded).toEqual([1800]);
+  });
+
+  it('still animates a value change that stands alone', () => {
+    const animated: number[] = [];
+    const steel = (globalThis as unknown as { steelseries: Record<string, unknown> }).steelseries;
+    steel.Radial = vi.fn(function (this: FakeGauge) {
+      this.setValue = vi.fn();
+      this.setValueAnimated = (v: number) => { animated.push(v); };
+    });
+
+    fixture.componentRef.setInput('widgetUUID', 'uuid-solo');
+    fixture.componentRef.setInput('subType', 'radial');
+    fixture.componentRef.setInput('minValue', 0);
+    fixture.componentRef.setInput('maxValue', 3600);
+    fixture.componentRef.setInput('value', 900);
+
+    const internals = component as unknown as {
+      startGauge: (f?: boolean) => void;
+      ngOnChanges: (c: Record<string, SimpleChange>) => void;
+    };
+    internals.startGauge(true);
+
+    fixture.componentRef.setInput('value', 1800);
+    internals.ngOnChanges({ value: new SimpleChange(900, 1800, false) });
+
+    expect(animated).toEqual([1800]);
+  });
 });

--- a/src/app/widgets/gauge-steel/gauge-steel.component.ts
+++ b/src/app/widgets/gauge-steel/gauge-steel.component.ts
@@ -257,6 +257,18 @@ export class GaugeSteelComponent implements OnInit, OnChanges, OnDestroy {
         this.gauge = new steelseries.Linear(id, this.gaugeOptions);
       }
     }
+
+    // A steelseries gauge is born at its own default, and ngOnChanges is the only thing
+    // that ever feeds it a value — yet it drops every change that lands before the canvas
+    // exists, and the first change always. So seed the fresh gauge from the value we
+    // already hold. Without this the needle sticks at zero whenever no further change
+    // arrives: a path a previously-visited page already subscribed emits on subscribe,
+    // before this runs, and a constant reading never changes again (#556). Rebuilds from
+    // resize and zone changes land in the same hole.
+    const current = this.value();
+    if (current != null && this.gauge?.setValue) {
+      this.gauge.setValue(current);
+    }
   }
 
   onResized(event: ResizeObserverEntry):void {

--- a/src/app/widgets/gauge-steel/gauge-steel.component.ts
+++ b/src/app/widgets/gauge-steel/gauge-steel.component.ts
@@ -84,7 +84,9 @@ export class GaugeSteelComponent implements OnInit, OnChanges, OnDestroy {
   readonly zones = input<ISkZone[]>();
   readonly title = input<string>();
   readonly units = input<string>();
-  readonly value = input<number>();
+  // null until the first packet, so a gauge built before any data keeps the library's
+  // start-at-minimum face instead of being seeded with a fabricated zero.
+  readonly value = input<number | null>();
   // eslint-disable-next-line @angular-eslint/no-input-rename
   readonly theme = input<ITheme | null>(null, { alias: "themeColors" });
 
@@ -296,7 +298,14 @@ export class GaugeSteelComponent implements OnInit, OnChanges, OnDestroy {
 
   ngOnChanges(changes: SimpleChanges) {
     if (!this.gaugeStarted) { return; }
-    if (changes.value && !changes.value.firstChange) {
+    // A structural change replaces the gauge object further down, and the replacement is seeded
+    // with the current value. Animating the outgoing one first is not merely wasted: the library
+    // offers no way to cancel a tween, so the discarded gauge keeps repainting the same canvas —
+    // with its own now-stale scale, sections and size — and wins the last frame. Under a steady
+    // reading nothing repaints afterwards, leaving the old face on screen for good. The server's
+    // measure resolving after the first value delivers exactly this batch on an ordinary boot.
+    const rebuilding = !!(changes.zones || changes.radialSize || changes.units || changes.minValue || changes.maxValue);
+    if (changes.value && !changes.value.firstChange && !rebuilding) {
         this.gauge.setValueAnimated(changes.value.currentValue);
     }
     if (changes.zones) {
@@ -334,11 +343,14 @@ export class GaugeSteelComponent implements OnInit, OnChanges, OnDestroy {
       this.resizeTimer = null;
     }
 
-    // Stop any running animations before cleanup
+    // Park the needle on its current reading. This does NOT stop a running setValueAnimated tween —
+    // the library exposes no cancel, and only a later setValueAnimated on the same instance stops the
+    // previous one — so an animation in flight keeps repainting until it finishes on its own.
     if (this.gauge && this.gauge.setValue) {
-      // Call setValue to stop any running setValueAnimated animations
       const currentValue = this.gauge.getValue ? this.gauge.getValue() : this.value();
-      this.gauge.setValue(currentValue);
+      if (currentValue != null) {
+        this.gauge.setValue(currentValue);
+      }
     }
 
     // Steelseries draws into the canvas with id widgetUUID(). Release it to free GPU memory.

--- a/src/app/widgets/widget-gauge-steel/widget-gauge-steel.component.ts
+++ b/src/app/widgets/widget-gauge-steel/widget-gauge-steel.component.ts
@@ -62,7 +62,9 @@ export class WidgetSteelGaugeComponent {
   };
 
   // Reactive state
-  protected readonly dataValue = signal<number>(0);
+  /** null until the first packet: a gauge built before any data arrives must not be seeded with a
+   *  zero that reads as a live measurement on a scale whose minimum is negative. */
+  protected readonly dataValue = signal<number | null>(null);
   protected readonly zones = signal<ISkZone[]>([]);
   protected readonly displayName = computed(() => this.runtime.options()?.displayName || 'Gauge Label');
 


### PR DESCRIPTION
Closes #556.

## The bug

A steelseries gauge only ever learned a value through `ngOnChanges`, and that handler drops two classes of change:

```
if (!this.gaugeStarted) { return; }                  // every change before the canvas exists
if (changes.value && !changes.value.firstChange)     // and the first change, always
```

Meanwhile `startGauge()` constructed `new steelseries.Radial(...)` and never applied the value the component already held, so a fresh gauge started at the library default and waited for a *subsequent* change to paint.

While a reading moves that is invisible — the next change lands a moment later and paints the right number. It sticks when no further change ever arrives, which is exactly what a steady reading produces. A path that a previously-visited page already subscribed emits its cached value on subscribe, i.e. before the canvas is built, so that one emission was dropped and nothing followed it. The needle stayed at zero indefinitely while every other widget on the page read correctly.

Rebuilds fell into the same hole: `onResized` and a zone change both call `startGauge(true)`, replacing the gauge object, and the new one was equally unseeded.

## Reproduction

Two pages, same Signal K path, one radial gauge and one steel gauge, streaming a constant value:

| Navigation | Before | After |
|---|---|---|
| direct to the steel page | 1800.00 | 1800.00 |
| via the radial page first | **0.00** | 1800.00 |

Both the constant value and the prior subscriber are required. An oscillating value masks it completely, which is why a first minimal reproduction attempt with a moving value did not show it.

## The fix

Seed the gauge from `this.value()` right after constructing it. That covers the initial build and every rebuild, and it needs no change to the two `ngOnChanges` guards — whatever they drop, the next build re-reads the current value.

## Verification

`npm run ci` passes: lint, `snc`, 1965 tests across 178 files, 33 MCP-schema tests.

Three regression tests in `gauge-steel.component.spec.ts`. The two that assert seeding fail against the unfixed component with `expected [] to deeply equal [ 1800 ]`; the third asserts a gauge with no value yet is left alone, and passes either way so it cannot mask a regression. Confirmed end-to-end in a real browser against the production bundle with the reproduction above.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: one widget's initial paint, no service, endpoint, or persistence behavior involved.

Worth an eye on the first device that takes this build: open a dashboard with a Classic Steel gauge on a path another page also shows, navigate between them, and confirm the needle tracks rather than sitting at zero.
