### PR TITLE
fix(bootstrap): scope an anonymous session's subscription to what it renders

### DIFF
--- a/src/app/core/services/app-initNetwork.service.spec.ts
+++ b/src/app/core/services/app-initNetwork.service.spec.ts
@@ -31,7 +31,8 @@ describe('AppNetworkInitService', () => {
     const state$ = new BehaviorSubject<ConnectionState>(ConnectionState.Disconnected);
 
     const mockConnection = {
-        initializeConnection: vi.fn().mockResolvedValue(undefined)
+        initializeConnection: vi.fn().mockResolvedValue(undefined),
+        setSubscribeAll: vi.fn()
     };
 
     const mockAuth = {
@@ -86,6 +87,7 @@ describe('AppNetworkInitService', () => {
         mockStorage.getConfig.mockReset().mockResolvedValue(validRemoteConfig());
         mockStorage.listConfigs.mockReset().mockResolvedValue([]);
         mockStorage.bootstrapRemoteContext.mockClear();
+        mockConnection.setSubscribeAll.mockClear();
         mockEmbed.embed.mockClear().mockReturnValue(false);
         mockEmbed.profile.mockClear().mockReturnValue(null);
         mockAuth.loginStatusValue = null;
@@ -456,6 +458,17 @@ describe('AppNetworkInitService', () => {
     // A session-less visitor has no user-scope slot to load, so the dashboards come from the shared
     // global scope, falling back to the dashboards shipped in this release (#551).
     describe('anonymous bootstrap config source (#551)', () => {
+        // The pre-auth scope comes from the stored per-device demand map, so these tests have to seed
+        // localStorage rather than the in-memory config: initNetworkServices reloads it on entry.
+        const storeAnonConn = (remoteContextDemand: Record<string, boolean>): void => {
+            localStorage.setItem('skip.connectionConfig', JSON.stringify({
+                configVersion: 13, skipUUID: 'test-uuid', signalKUrl: 'http://localhost',
+                proxyEnabled: false, signalKSubscribeAll: false, sharedConfigName: 'default',
+                isRemoteControl: false, instanceName: '', remoteContextDemand
+            }));
+            mockConnection.initializeConnection.mockClear();
+        };
+
         beforeEach(() => {
             mockAuth.refreshLoginStatus.mockResolvedValue({
                 status: 'notLoggedIn', authenticationRequired: true, readOnlyAccess: true
@@ -473,6 +486,37 @@ describe('AppNetworkInitService', () => {
                 expect.objectContaining({ initConfig: published, readOnly: true })
             );
             expect(latestStatus()).toBe('ready');
+        });
+
+        // The subscribe scope is picked pre-auth from the device's OWN profile demand, which describes
+        // dashboards this session is not rendering (#561). A device whose profile needs no remote
+        // contexts must not starve a shared dashboard's AIS widgets.
+        it('widens the subscribe scope when the published dashboard needs remote contexts', async () => {
+            storeAnonConn({ default: false });
+            mockStorage.getConfig.mockResolvedValue({
+                app: { configVersion: 11 },
+                theme: null,
+                dashboards: [{ configuration: [{ input: { widgetProperties: { type: 'widget-ais-radar' } } }] }]
+            } as unknown as IConfig);
+
+            await service.initNetworkServices();
+
+            expect(mockConnection.initializeConnection).toHaveBeenCalledWith(expect.anything(), true, false);
+            expect(mockConnection.setSubscribeAll).toHaveBeenCalledWith(true);
+        });
+
+        it('narrows the subscribe scope when the published dashboard needs none', async () => {
+            storeAnonConn({ default: true });
+            mockStorage.getConfig.mockResolvedValue({
+                app: { configVersion: 11 },
+                theme: null,
+                dashboards: [{ configuration: [{ input: { widgetProperties: { type: 'widget-numeric' } } }] }]
+            } as unknown as IConfig);
+
+            await service.initNetworkServices();
+
+            expect(mockConnection.initializeConnection).toHaveBeenCalledWith(expect.anything(), true, true);
+            expect(mockConnection.setSubscribeAll).toHaveBeenCalledWith(false);
         });
 
         it('falls back to the shipped dashboards when the server publishes none', async () => {

--- a/src/app/core/services/app-initNetwork.service.ts
+++ b/src/app/core/services/app-initNetwork.service.ts
@@ -14,6 +14,7 @@ import { SsoRedirectService } from './sso-redirect.service';
 import { DefaultConnectionConfig } from '../../../default-config/config.blank.const';
 import { buildDefaultConfig } from '../../../default-config/config.default.factory';
 import { isValidConfigShape } from '../utils/config-shape.util';
+import { dashboardsRequireRemoteContexts } from '../utils/remote-context-demand.util';
 import { cloneDeep } from 'lodash-es';
 import { BehaviorSubject, Observable, Subscription } from 'rxjs';
 import { DataService } from './data.service';
@@ -326,10 +327,17 @@ export class AppNetworkInitService implements OnDestroy {
     if (!storageReady) {
       throw new Error('[AppInit Network Service] StorageService did not become ready in time. Cannot bootstrap anonymous configuration.');
     }
+    const initConfig = await this.loadAnonymousConfig();
+    // The subscribe scope was chosen before the session was known, from a demand value computed for
+    // this device's own profile (#386). An anonymous visitor renders someone else's configuration, so
+    // that value describes the wrong dashboards: a device whose own profile needs no remote contexts
+    // would leave a shared dashboard's AIS and DSC widgets empty for the life of the page, with no
+    // error anywhere. Recompute from what is actually being rendered — the socket is still closed.
+    this.connection.setSubscribeAll(dashboardsRequireRemoteContexts(initConfig.dashboards));
     this.storage.bootstrapRemoteContext({
       sharedConfigName: ANONYMOUS_CONFIG_NAME,
       configFileVersion: REMOTE_CONFIG_FILE_VERSION,
-      initConfig: await this.loadAnonymousConfig(),
+      initConfig,
       readOnly: true
     });
   }

--- a/src/app/core/services/signalk-connection.service.spec.ts
+++ b/src/app/core/services/signalk-connection.service.spec.ts
@@ -51,4 +51,35 @@ describe('SignalKConnectionService', () => {
       expect(() => parseEndpoint(noWs)).toThrow();
     });
   });
+
+  describe('setSubscribeAll', () => {
+    it('re-emits the current endpoint with the new scope', () => {
+      const seen: (boolean | undefined)[] = [];
+      const sub = service.serverServiceEndpoint$.subscribe(e => seen.push(e.subscribeAll));
+
+      service.setSubscribeAll(true);
+
+      expect(seen).toEqual([undefined, true]);
+      expect(service.serverServiceEndpoint$.getValue().state).toBe(EndpointStatus.Disconnected);
+      sub.unsubscribe();
+    });
+
+    it('does not re-emit when the scope already matches', () => {
+      service.setSubscribeAll(true);
+      const seen: boolean[] = [];
+      const sub = service.serverServiceEndpoint$.subscribe(e => seen.push(!!e.subscribeAll));
+
+      service.setSubscribeAll(true);
+
+      expect(seen).toEqual([true]); // the BehaviorSubject's current value only
+      sub.unsubscribe();
+    });
+
+    // An HTTP retry rebuilds the endpoint from currentSubscribeAll, so a scope set here has to
+    // survive it — otherwise a retry silently reverts to the pre-auth scope.
+    it('is the scope an HTTP retry rebuilds from', () => {
+      service.setSubscribeAll(true);
+      expect((service as unknown as { currentSubscribeAll?: boolean }).currentSubscribeAll).toBe(true);
+    });
+  });
 });

--- a/src/app/core/services/signalk-connection.service.ts
+++ b/src/app/core/services/signalk-connection.service.ts
@@ -95,6 +95,24 @@ export class SignalKConnectionService {
    * @return {Promise<void>} - A promise that resolves when the operation is complete.
    * @memberof SignalKConnectionService
    */
+  /**
+   * Re-scopes the WebSocket subscription. The scope is picked before the bootstrap knows whose
+   * configuration it will render, so a boot that ends up rendering a different one corrects it here.
+   * The delta service reads the flag when the socket opens, so this only takes effect while the
+   * socket is still closed; it also survives an HTTP retry, which re-emits from currentSubscribeAll.
+   *
+   * @param {boolean} subscribeAll - True to subscribe to every context, false for `self` only.
+   * @memberof SignalKConnectionService
+   */
+  public setSubscribeAll(subscribeAll: boolean): void {
+    this.currentSubscribeAll = subscribeAll;
+    const current = this.serverServiceEndpoint$.getValue();
+    if (current.subscribeAll === subscribeAll) {
+      return;
+    }
+    this.serverServiceEndpoint$.next({ ...current, subscribeAll });
+  }
+
   public async initializeConnection(skUrl: ISignalKUrl, proxyEnabled?: boolean, subscribeAll?: boolean): Promise<void> {
     if (!skUrl.url) {
       console.log("[Connection Service] Connection initialization called with null or empty URL value");


### PR DESCRIPTION
## Why

The WebSocket subscribe scope is decided before `refreshLoginStatus()` runs, from `remoteContextDemand[sharedConfigName]` — a value computed for *this device's own* profile ([#386](https://github.com/halos-org/skip/issues/386)). An anonymous visitor renders someone else's configuration, so that value describes dashboards this session is not showing.

The failure: a browser that last ran Skip signed in on a profile with no AIS widgets has `remoteContextDemand['default'] === false` persisted. The session expires, the visitor reloads into the shared read-only dashboard, and that dashboard *does* carry an AIS radar. The socket subscribes `self` only and those widgets stay empty for the life of the page, with nothing logged anywhere.

The code already recognises this shape for embed and ephemeral-`?profile` sessions and fails open to `all` there. The anonymous session is the same situation and was missed because the auth outcome is not known at the decision point.

## How

The scope is only consumed when the socket opens (`SignalKDeltaService` reads `subscribeAll` off the endpoint status to build the WS URL), and the socket opens in `initNetworkServices`' `finally` — after `bootstrapAnonymousConfig()`. So it can be corrected in place rather than re-initialising the connection, which is what made this look like a connection-lifecycle change when it was deferred from [#560](https://github.com/halos-org/skip/pull/560).

`SignalKConnectionService.setSubscribeAll` re-emits the current endpoint with the new value and stores it as `currentSubscribeAll`, so an HTTP retry rebuilds from the corrected scope rather than reverting to the pre-auth one. Every `serverServiceEndpoint$` subscriber (delta, storage, history client, the two video components) is idempotent in the fields this leaves untouched.

The bootstrap then computes the scope from the config it actually loaded, using the same `dashboardsRequireRemoteContexts` helper the dashboard save path uses. Of the issue's two shapes, this is the exact one rather than failing open to `all`: the helper scans every string in a widget's config and over-matches by construction, so a narrow result means the rendered dashboards genuinely need nothing remote. It is also a pure util with no DI edge — relevant here, since injecting a service into this bootstrap is what broke 20 specs in [#560](https://github.com/halos-org/skip/pull/560).

## Verification

`npm run ci` clean: lint, strict-null gate, 2023 unit tests (up from 2019), 33 schema tests.

Both new bootstrap tests are mutation-checked — removing the `setSubscribeAll` call makes them fail and leaves the rest of the suite green, which is the property the old code lacked. The widening test seeds exactly the issue's scenario: persisted demand `false`, published dashboard with a `widget-ais-radar`, asserting the pre-auth call still passes `false` and the correction then asks for `all`. The narrowing test is its mirror.

Not exercised against a live server with a published shared dashboard; the AIS-targets-arrive half of the issue's "done when" is a device check.

Closes #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)