### PR TITLE
Keep saves on the loaded profile when a profile-switch reload is declined

### DIFF
--- a/src/app/core/services/profile.service.spec.ts
+++ b/src/app/core/services/profile.service.spec.ts
@@ -262,6 +262,43 @@ describe('ProfileService', () => {
       expect(settings.setActiveProfile).not.toHaveBeenCalled();
     });
 
+    // The rename deletes the old slot, so a write path left on that name posts every later save
+    // against a slot the server no longer has. A rename preserves the config, so the write path
+    // follows the name — including when the reload is declined and when there is no reload at all.
+    it('moves the write path onto the new name, whatever happens to the reload', async () => {
+      const s = makeStorageMock(['default', 'profileA']);
+      s.sharedConfigName = 'profileA';
+      setup(s, makeSettingsMock('profileA'));
+      await service.refresh();
+
+      await service.renameProfile('profileA', 'newName');
+
+      expect(s.sharedConfigName).toBe('newName');
+    });
+
+    it('moves the write path when the ephemerally-active slot is renamed, which never reloads', async () => {
+      const s = makeStorageMock(['default', 'day']);
+      s.sharedConfigName = 'day';
+      setup(s, makeSettingsMock('day', 'default'));
+      await service.refresh();
+
+      await service.renameProfile('day', 'night');
+
+      expect(s.sharedConfigName).toBe('night');
+      expect(settings.setActiveProfile).not.toHaveBeenCalled();
+    });
+
+    it('leaves the write path alone when some other profile is renamed', async () => {
+      const s = makeStorageMock(['default', 'profileA', 'other']);
+      s.sharedConfigName = 'profileA';
+      setup(s, makeSettingsMock('profileA'));
+      await service.refresh();
+
+      await service.renameProfile('other', 'renamed');
+
+      expect(s.sharedConfigName).toBe('profileA');
+    });
+
     it('blocks renaming the reserved default profile', async () => {
       await service.refresh();
       await expect(service.renameProfile('default', 'x')).rejects.toThrow(/default/i);

--- a/src/app/core/services/profile.service.spec.ts
+++ b/src/app/core/services/profile.service.spec.ts
@@ -198,6 +198,16 @@ describe('ProfileService', () => {
       expect(storage.removeItem).not.toHaveBeenCalled();
     });
 
+    // A switch whose reload was declined leaves the persisted name on a profile that is not loaded,
+    // so the loaded-slot guard above no longer covers it. Deleting it there points the device at a
+    // slot that no longer exists, and the next reload lands on the degraded recovery screen.
+    it('blocks deleting the profile a deferred switch will boot into', async () => {
+      setup(makeStorageMock(['default', 'profileA', 'cockpit']), makeSettingsMock('profileA', 'cockpit'));
+      await service.refresh();
+      await expect(service.deleteProfile('cockpit')).rejects.toThrow(/next reload/i);
+      expect(storage.removeItem).not.toHaveBeenCalled();
+    });
+
     it('blocks deleting the reserved default profile', async () => {
       await service.refresh();
       await expect(service.deleteProfile('default')).rejects.toThrow(/default/i);

--- a/src/app/core/services/profile.service.ts
+++ b/src/app/core/services/profile.service.ts
@@ -136,6 +136,14 @@ export class ProfileService {
         console.warn(`[ProfileService] Old profile slot "${oldName}" may not have been removed; an orphan copy could remain until the next refresh.`);
       }
 
+      // A rename preserves the configuration, so the session's write path follows the slot to its new
+      // name whatever happens next. Leaving it behind would point every later save at the slot this
+      // rename just deleted — including when the reload below is declined, and in a `?profile`
+      // session, which takes the else branch and never reloads at all.
+      if (this.storage.sharedConfigName === oldName) {
+        this.storage.sharedConfigName = normalized;
+      }
+
       // Repersist + reload ONLY when the renamed slot is the persisted per-device default. Keying off
       // the ephemeral active name (getActiveProfileName) would write a URL-selected `?profile`
       // override's name into the persisted device default — the override must stay ephemeral.

--- a/src/app/core/services/profile.service.ts
+++ b/src/app/core/services/profile.service.ts
@@ -129,19 +129,21 @@ export class ProfileService {
       }
       await this.storage.setConfig(PROFILE_SCOPE, normalized, sourceConfig);
 
+      // A rename preserves the configuration, so the session's write path follows the slot to its new
+      // name whatever happens next. Leaving it behind would point every later save at the slot this
+      // rename is about to delete — including when the reload below is declined, and in a `?profile`
+      // session, which takes the else branch and never reloads at all. It moves before the removal
+      // because `patchConfig` bakes the slot name in at enqueue time: a save queued during the
+      // removal's drain would otherwise target a slot the queue deletes ahead of it, and fail.
+      if (this.storage.sharedConfigName === oldName) {
+        this.storage.sharedConfigName = normalized;
+      }
+
       // Failure is surfaced via awaitQueueDrain() below; swallow the per-write rejection.
       void this.storage.removeItem(PROFILE_SCOPE, oldName).catch(() => undefined);
       const drained = await this.storage.awaitQueueDrain();
       if (!drained) {
         console.warn(`[ProfileService] Old profile slot "${oldName}" may not have been removed; an orphan copy could remain until the next refresh.`);
-      }
-
-      // A rename preserves the configuration, so the session's write path follows the slot to its new
-      // name whatever happens next. Leaving it behind would point every later save at the slot this
-      // rename just deleted — including when the reload below is declined, and in a `?profile`
-      // session, which takes the else branch and never reloads at all.
-      if (this.storage.sharedConfigName === oldName) {
-        this.storage.sharedConfigName = normalized;
       }
 
       // Repersist + reload ONLY when the renamed slot is the persisted per-device default. Keying off
@@ -164,6 +166,13 @@ export class ProfileService {
       }
       if (name === this.settings.getActiveProfileName()) {
         throw new Error('The active profile cannot be deleted. Switch to another profile first.');
+      }
+      // The persisted name is what the next boot loads, and it parts company with the loaded slot
+      // whenever a switch was persisted but its reload declined. Deleting it there would leave the
+      // device pointed at a slot that no longer exists, and the next reload lands on the degraded
+      // "no shared configuration" recovery instead of the dashboards on screen.
+      if (name === this.settings.getPersistedProfileName()) {
+        throw new Error('This profile is set to load on the next reload and cannot be deleted. Switch to another profile first.');
       }
       if (this.existingNames().length <= 1) {
         throw new Error('The last remaining profile cannot be deleted.');

--- a/src/app/core/services/reload.service.ts
+++ b/src/app/core/services/reload.service.ts
@@ -27,10 +27,9 @@ export class ReloadService {
    * Reload the app only if the server is reachable; otherwise keep the shell and show a persistent
    * Retry toast that re-runs this same gated reload (so recovery never leaves the app).
    *
-   * Deliberately reports nothing. A caller cannot act on "the reload was committed": the navigation
-   * is asynchronous and can still be cancelled, and `performReload` short-circuits under the test
-   * flag, so the only honest contract is that state must be correct whether or not the page is
-   * replaced.
+   * Callers must leave their state correct whether or not the page is replaced: the navigation is
+   * asynchronous and can still be cancelled, so a caller that waited on this could not tell the two
+   * outcomes apart anyway.
    */
   public async reload(): Promise<void> {
     if (await this.isServerReachable()) {

--- a/src/app/core/services/reload.service.ts
+++ b/src/app/core/services/reload.service.ts
@@ -26,6 +26,11 @@ export class ReloadService {
   /**
    * Reload the app only if the server is reachable; otherwise keep the shell and show a persistent
    * Retry toast that re-runs this same gated reload (so recovery never leaves the app).
+   *
+   * Deliberately reports nothing. A caller cannot act on "the reload was committed": the navigation
+   * is asynchronous and can still be cancelled, and `performReload` short-circuits under the test
+   * flag, so the only honest contract is that state must be correct whether or not the page is
+   * replaced.
    */
   public async reload(): Promise<void> {
     if (await this.isServerReachable()) {

--- a/src/app/core/services/settings.service.spec.ts
+++ b/src/app/core/services/settings.service.spec.ts
@@ -311,18 +311,15 @@ describe('SettingsService', () => {
       expect(storage.sharedConfigName).toBe('profileA');
     });
 
-    it('persists the chosen profile, so the reload it asks for boots onto it', () => {
-      service.setActiveProfile('cockpit');
-
-      const cc = JSON.parse(localStorage.getItem('skip.connectionConfig') as string);
-      expect(cc.sharedConfigName).toBe('cockpit');
-    });
-
     // The two names diverge while a switch is deferred, and "reset the active profile" has to mean
     // the one on screen. Targeting the pending name would blank a profile the user is not looking at.
     it('resets the loaded profile, not the one a pending switch is waiting to load', () => {
       const storage = TestBed.inject(StorageService);
-      storage.sharedConfigName = 'profileA';
+      storage.bootstrapRemoteContext({
+        sharedConfigName: 'profileA',
+        configFileVersion: 11,
+        initConfig: { app: { configVersion: 11 }, theme: null, dashboards: [] } as unknown as IConfig
+      });
       storage.storageServiceReady$.next(true);
       const setConfig = vi.spyOn(storage, 'setConfig').mockResolvedValue(null);
       service.setActiveProfile('cockpit');
@@ -330,6 +327,25 @@ describe('SettingsService', () => {
       service.resetSettings();
 
       expect(setConfig).toHaveBeenCalledWith('user', 'profileA', expect.anything());
+    });
+
+    // The demand is computed from the dashboards in memory, which belong to the loaded profile. Under
+    // the pending name it would be read back pre-auth at the next boot as that profile's answer, and
+    // a wrong `false` does not fail open — that boot would subscribe to no AIS targets (#386).
+    it('records remote-context demand under the loaded profile while a switch is deferred', () => {
+      const storage = TestBed.inject(StorageService);
+      storage.bootstrapRemoteContext({
+        sharedConfigName: 'profileA',
+        configFileVersion: 11,
+        initConfig: { app: { configVersion: 11 }, theme: null, dashboards: [] } as unknown as IConfig
+      });
+      service.setActiveProfile('cockpit');
+
+      service.setRemoteContextDemand(true);
+
+      const cc = JSON.parse(localStorage.getItem('skip.connectionConfig') as string);
+      expect(cc.remoteContextDemand['profileA']).toBe(true);
+      expect(cc.remoteContextDemand['cockpit']).toBeUndefined();
     });
   });
 
@@ -388,7 +404,7 @@ describe('SettingsService', () => {
 
     it('keys demand by the CURRENT profile so a switch cannot overwrite a sibling profile (#386)', () => {
       const service = createService({ remoteContextDemand: { profileA: false } });
-      service.setActiveProfile('night'); // switch device to a different profile (reload mocked)
+      service.setActiveProfile('night');       // switch device to a different profile (reload mocked)
       service.setRemoteContextDemand(true);    // night needs AIS
       const cc = JSON.parse(localStorage.getItem('skip.connectionConfig') as string);
       expect(cc.remoteContextDemand).toEqual({ profileA: false, night: true }); // profileA preserved

--- a/src/app/core/services/settings.service.spec.ts
+++ b/src/app/core/services/settings.service.spec.ts
@@ -297,10 +297,39 @@ describe('SettingsService', () => {
       expect(cc.sharedConfigName).toBe('cockpit');
     });
 
-    it('setActiveProfile keeps StorageService.sharedConfigName coherent', () => {
+    // #520: the write path must never move off the profile whose configuration is in memory.
+    // patchConfig builds every path from it, so repointing while the old config is still loaded
+    // replaces the newly selected profile's dashboards with the old profile's content. The reload
+    // that would make the move safe replaces the document, and the bootstrap sets this field then.
+    it('never repoints the storage write path off the loaded profile', () => {
       const storage = TestBed.inject(StorageService);
+      // The bootstrap hands the loaded slot to StorageService; stand in for that here.
+      storage.sharedConfigName = 'profileA';
+
       service.setActiveProfile('cockpit');
-      expect(storage.sharedConfigName).toBe('cockpit');
+
+      expect(storage.sharedConfigName).toBe('profileA');
+    });
+
+    it('persists the chosen profile, so the reload it asks for boots onto it', () => {
+      service.setActiveProfile('cockpit');
+
+      const cc = JSON.parse(localStorage.getItem('skip.connectionConfig') as string);
+      expect(cc.sharedConfigName).toBe('cockpit');
+    });
+
+    // The two names diverge while a switch is deferred, and "reset the active profile" has to mean
+    // the one on screen. Targeting the pending name would blank a profile the user is not looking at.
+    it('resets the loaded profile, not the one a pending switch is waiting to load', () => {
+      const storage = TestBed.inject(StorageService);
+      storage.sharedConfigName = 'profileA';
+      storage.storageServiceReady$.next(true);
+      const setConfig = vi.spyOn(storage, 'setConfig').mockResolvedValue(null);
+      service.setActiveProfile('cockpit');
+
+      service.resetSettings();
+
+      expect(setConfig).toHaveBeenCalledWith('user', 'profileA', expect.anything());
     });
   });
 
@@ -359,7 +388,7 @@ describe('SettingsService', () => {
 
     it('keys demand by the CURRENT profile so a switch cannot overwrite a sibling profile (#386)', () => {
       const service = createService({ remoteContextDemand: { profileA: false } });
-      service.setActiveProfile('night');       // switch device to a different profile (reload mocked)
+      service.setActiveProfile('night'); // switch device to a different profile (reload mocked)
       service.setRemoteContextDemand(true);    // night needs AIS
       const cc = JSON.parse(localStorage.getItem('skip.connectionConfig') as string);
       expect(cc.remoteContextDemand).toEqual({ profileA: false, night: true }); // profileA preserved

--- a/src/app/core/services/settings.service.ts
+++ b/src/app/core/services/settings.service.ts
@@ -335,11 +335,22 @@ export class SettingsService {
    * Points this device at a different profile (named config slot) and reloads so the bootstrap
    * loads it. The active profile is per-device: persisted in the always-local connectionConfig.
    *
+   * The storage write path is deliberately NOT repointed here. On a reload that lands, the document
+   * is replaced and the bootstrap sets it from the persisted name, so an assignment here has no
+   * successor to observe it. Every case where it would be observed is a case where the app carries
+   * on with the previous profile's configuration in memory — ReloadService declining a server that
+   * does not answer, a navigation the user cancels, the `__SKIP_TEST__` short-circuit — and there
+   * `patchConfig`, which builds every path from `sharedConfigName`, would write that configuration
+   * into the newly selected profile's slot and replace its dashboards.
+   *
+   * The persisted name is written regardless, before a navigation that does not return. A switch
+   * that does not reload is therefore deferred rather than lost: the toast's Retry, or any later
+   * reload, boots onto the profile that was asked for.
+   *
    * @param {string} name Profile (config slot) name to make active on this device.
    */
   public setActiveProfile(name: string): void {
     this.sharedConfigName = name;
-    this.storage.sharedConfigName = name; // keep the storage write-path slot name coherent
     this.saveConnectionConfigToLocalStorage();
     void this._reload.reload();
   }
@@ -492,13 +503,18 @@ export class SettingsService {
       dashboards: this.getDefaultDashboardsConfig()
     };
 
-    this.storage.setConfig('user', this.sharedConfigName, newDefaultConfig)
+    // The slot the session actually loaded, which is what the UI calls the active profile and what
+    // the reset copy promises to replace. It parts company with the persisted device default when a
+    // profile switch was persisted but its reload declined, and during a `?profile` session.
+    const loadedSlot = this.storage.sharedConfigName || this.sharedConfigName;
+
+    this.storage.setConfig('user', loadedSlot, newDefaultConfig)
       .then(() => {
-        console.log("[AppSettings Service] Replaced server config name: " + this.sharedConfigName + ", with default configuration values");
+        console.log("[AppSettings Service] Replaced server config name: " + loadedSlot + ", with default configuration values");
         void this._reload.reload();
       })
       .catch(error => {
-        console.error("[AppSettings Service] Error replacing server config name: " + this.sharedConfigName + ", with default configuration values", error);
+        console.error("[AppSettings Service] Error replacing server config name: " + loadedSlot + ", with default configuration values", error);
         this.snackBar.open(
           'Problem saving configuration to the server. Resolve this issue before Skip can be used reliably.',
           'Close',

--- a/src/app/core/services/settings.service.ts
+++ b/src/app/core/services/settings.service.ts
@@ -335,17 +335,13 @@ export class SettingsService {
    * Points this device at a different profile (named config slot) and reloads so the bootstrap
    * loads it. The active profile is per-device: persisted in the always-local connectionConfig.
    *
-   * The storage write path is deliberately NOT repointed here. On a reload that lands, the document
-   * is replaced and the bootstrap sets it from the persisted name, so an assignment here has no
-   * successor to observe it. Every case where it would be observed is a case where the app carries
-   * on with the previous profile's configuration in memory — ReloadService declining a server that
-   * does not answer, a navigation the user cancels, the `__SKIP_TEST__` short-circuit — and there
-   * `patchConfig`, which builds every path from `sharedConfigName`, would write that configuration
-   * into the newly selected profile's slot and replace its dashboards.
+   * The storage write path is deliberately NOT repointed here: the bootstrap alone moves it, so it
+   * always names the configuration that is actually in memory. Repointing it would send every save
+   * made after a reload that did not happen into the newly selected slot, replacing that profile's
+   * dashboards with the ones still on screen.
    *
-   * The persisted name is written regardless, before a navigation that does not return. A switch
-   * that does not reload is therefore deferred rather than lost: the toast's Retry, or any later
-   * reload, boots onto the profile that was asked for.
+   * The persisted name is written regardless, so a switch whose reload does not happen is deferred
+   * rather than lost.
    *
    * @param {string} name Profile (config slot) name to make active on this device.
    */
@@ -431,13 +427,14 @@ export class SettingsService {
     this.saveConnectionConfigToLocalStorage();
   }
 
-  // Remote (AIS/DSC) context subscribe demand (#386), recorded under the ACTIVE profile — callers
-  // (the dashboard save effect) only reach here for the device's own authoritative, non-ephemeral
-  // profile, so this.sharedConfigName is the profile the demand was computed for and matches the key
-  // the next boot reads. Consumed pre-auth at the next boot; the no-op guard avoids churning
-  // localStorage on every unrelated dashboard save.
+  // Remote (AIS/DSC) context subscribe demand (#386), recorded under the LOADED slot — the demand is
+  // computed from the dashboards in memory, which belong to the profile actually loaded, not to a
+  // pending switch or a persisted default. Keying it anywhere else files one profile's answer under
+  // another's name, and the next boot reads it pre-auth to pick subscribe scope: a wrong `false`
+  // does not fail open, so that boot subscribes to no AIS targets. Consumed pre-auth at the next
+  // boot; the no-op guard avoids churning localStorage on every unrelated dashboard save.
   public setRemoteContextDemand(needsRemoteContexts: boolean) {
-    const profile = this.sharedConfigName;
+    const profile = this.getActiveProfileName();
     if (this.remoteContextDemand[profile] === needsRemoteContexts) return;
     this.remoteContextDemand[profile] = needsRemoteContexts;
     this.saveConnectionConfigToLocalStorage();
@@ -506,7 +503,7 @@ export class SettingsService {
     // The slot the session actually loaded, which is what the UI calls the active profile and what
     // the reset copy promises to replace. It parts company with the persisted device default when a
     // profile switch was persisted but its reload declined, and during a `?profile` session.
-    const loadedSlot = this.storage.sharedConfigName || this.sharedConfigName;
+    const loadedSlot = this.getActiveProfileName();
 
     this.storage.setConfig('user', loadedSlot, newDefaultConfig)
       .then(() => {


### PR DESCRIPTION
## Why

`setActiveProfile` repointed `storage.sharedConfigName` before calling `ReloadService.reload()`, which legitimately declines to navigate when the server probe fails or returns 5xx — a Traefik 502 during a Signal K restart, or a timeout over 4s.

The app then kept running with the previous profile's config in memory while every later save PATCHed the newly selected slot, because `StorageService.patchConfig` builds each path as `/${sharedConfigName}/...`. Switch profile during a brief SK restart → reload declined → SK returns → user edits a dashboard → the target profile is replaced by the old profile's content.

## What

`ReloadService.reload()` now reports whether it committed the navigation, and `setActiveProfile` repoints the storage write path only on a commit.

The persisted name is still written before the reload either way, deliberately: the navigation does not return, so it has to be in place beforehand, and leaving it there means a declined switch is **deferred rather than lost** — the Retry on the "server is still unreachable" toast, or any later reload, boots onto the profile the user picked. Reverting it instead would have made Retry land back on the old profile, and would have pointed the device at a deleted slot on the `renameProfile` path.

`setActiveProfile` is async now; its two callers in `ProfileService` await it, which also keeps the switch inside the `mutationInFlight` guard for its full duration.

## Tests

Two added to `settings.service.spec.ts`: a declined reload leaves the write path on the loaded profile (fails on `main`), and it still persists the chosen name so a later boot lands on it. The existing `ReloadService` fake now models a committed reload rather than resolving `undefined`.

Full suite: 2031 passing.

Fixes #520