### PR TITLE
Add the mass and area conversion groups

### DIFF
--- a/src/app/core/services/units.service.spec.ts
+++ b/src/app/core/services/units.service.spec.ts
@@ -196,7 +196,7 @@ describe('UnitsService', () => {
     it('resolves the identity target of every group Skip supports (the server`s `base` category)', () => {
       // `base` is always-valid on the server and emits targetUnit === the path's own SI unit, so it
       // reaches Skip for any path — a second route into the resolver that no preset exercises.
-      for (const unit of ['m/s', 'K', 'Pa', 'm', 'rad', 'rad/s', 'm3', 'V', 'A', 'W', 'ratio', 'Hz', 's', 'C', 'm3/s', 'J']) {
+      for (const unit of ['m/s', 'K', 'Pa', 'm', 'rad', 'rad/s', 'm3', 'V', 'A', 'W', 'ratio', 'Hz', 's', 'C', 'm3/s', 'J', 'kg', 'm2']) {
         const service = setupWithData(unit, { targetUnit: unit });
         expect(service.getConversionsForPath('self.some.path').base, `base target ${unit}`).toBe(unit);
       }
@@ -209,6 +209,10 @@ describe('UnitsService', () => {
         ['m3/s', 'L/min', 'l/min'], ['m', 'meter', 'm'], ['rad', 'radian', 'rad'],
         ['rad', 'gradian', 'grad'], ['Hz', 'hertz', 'Hz'], ['W', 'watt', 'W'],
         ['s', 'second', 's'], ['s', 'minute', 'Minutes'], ['s', 'day', 'Days'],
+        // The definitions file has no `kg` conversion key, so `kilogram` is the metric mass option
+        // the admin Data Browser actually offers — the preset path reaches `kg` only through the
+        // server's targetUnit === siUnit shortcut.
+        ['kg', 'kilogram', 'kg'],
       ];
       for (const [unit, target, measure] of cases) {
         const service = setupWithData(unit, { targetUnit: target });
@@ -318,6 +322,20 @@ describe('UnitsService', () => {
       expect(service.getUnitDisplaySymbol('gal-imp/h')).toBe('imp gal/h');
       expect(service.getUnitDisplaySymbol('gallon-imp')).toBe('imp gal');
       expect(service.getUnitDisplaySymbol('btu')).toBe('BTU');
+    });
+
+    it('converts and labels the mass and area targets', () => {
+      const service = setup();
+      // js-quantities accepts `sqft` as a unit name of its own, so `swiftConverter('m^2','sqft')`
+      // is the identity rather than an error — the plausible spelling would ship every area 10.76x
+      // too small with nothing failing. Same shape for a mass unit one row away in the library.
+      expect(service.convertToUnit('lbs', 1) as number).toBeCloseTo(2.2046226, 5);
+      expect(service.convertToUnit('sqft', 1) as number).toBeCloseTo(10.7639104, 5);
+      expect(service.convertToUnit('kg', 1) as number).toBe(1);
+      expect(service.convertToUnit('m2', 1) as number).toBe(1);
+      expect(service.getUnitDisplaySymbol('lbs')).toBe('lb');
+      expect(service.getUnitDisplaySymbol('sqft')).toBe('ft²');
+      expect(service.getUnitDisplaySymbol('m2')).toBe('m²');
     });
 
     it('keeps the label-matches-conversion invariant for every aliased category (symbol + working conversion)', () => {

--- a/src/app/core/services/units.service.spec.ts
+++ b/src/app/core/services/units.service.spec.ts
@@ -148,6 +148,28 @@ describe('UnitsService', () => {
       expect(service.getConversionsForPath('self.environment.outside.pressure').base).toBe('mbar');
     });
 
+    // #570: getConversionsForPath filters _conversionList for a group holding the path's SI unit, so
+    // a unit in no group came back empty and the path degraded to 'unitless' — a displacement or a
+    // sail area rendered as a raw number with no label, on every preset including metric.
+    it('resolves a mass path to its own group rather than degrading it to unitless', () => {
+      const service = setupWithData('kg', { targetUnit: 'kg' });
+      const resolved = service.getConversionsForPath('self.design.displacement');
+      expect(resolved.base).toBe('kg');
+      expect(resolved.conversions.some(g => g.group === 'Mass')).toBe(true);
+    });
+
+    it('resolves an area path to its own group rather than degrading it to unitless', () => {
+      const service = setupWithData('m2', { targetUnit: 'm2' });
+      const resolved = service.getConversionsForPath('self.sails.inventory.main.area');
+      expect(resolved.base).toBe('m2');
+      expect(resolved.conversions.some(g => g.group === 'Area')).toBe(true);
+    });
+
+    it('honours the imperial mass and area targets the server presets ask for', () => {
+      expect(setupWithData('kg', { targetUnit: 'pound' }).getConversionsForPath('self.design.displacement').base).toBe('lbs');
+      expect(setupWithData('m2', { targetUnit: 'sqft' }).getConversionsForPath('self.sails.inventory.main.area').base).toBe('sqft');
+    });
+
     it('falls back to unitless when the path has no server displayUnits', () => {
       const service = setupWithData('m/s', undefined);
       expect(service.getConversionsForPath('self.navigation.speedOverGround').base).toBe('unitless');
@@ -224,10 +246,9 @@ describe('UnitsService', () => {
     // logs nothing for an unmappable target — which is what #536 reported for fuel rate: the metric
     // presets emit volumeRate 'L/h' and Skip's Flow measure is 'l/h'.
     //
-    // Categories deliberately absent: mass (kg) and area (m2) have no Skip conversion group at all, so
-    // even their identity target fails (#570); dataSize, dateTime and boolean are not Signal K numeric
-    // units; and angleDegrees (baseUnit 'deg') is left out because Skip's only 'deg' measure converts
-    // FROM radians, so honouring it would scale an already-degrees value by 57.3 (#574).
+    // Categories deliberately absent: dataSize, dateTime and boolean are not Signal K numeric units;
+    // and angleDegrees (baseUnit 'deg') is left out because Skip's only 'deg' measure converts FROM
+    // radians, so honouring it would scale an already-degrees value by 57.3 (#574).
     const PRESET_TARGET_VOCABULARY: { category: string; unit: string; target: string; measure: string }[] = [
       { category: 'angle', unit: 'rad', target: 'degree', measure: 'deg' },
       { category: 'angularVelocity', unit: 'rad/s', target: 'deg/s', measure: 'deg/s' },
@@ -243,6 +264,10 @@ describe('UnitsService', () => {
       { category: 'frequency', unit: 'Hz', target: 'rpm', measure: 'rpm' },
       { category: 'length', unit: 'm', target: 'm', measure: 'm' },
       { category: 'length', unit: 'm', target: 'foot', measure: 'feet' },
+      { category: 'area', unit: 'm2', target: 'm2', measure: 'm2' },
+      { category: 'area', unit: 'm2', target: 'sqft', measure: 'sqft' },
+      { category: 'mass', unit: 'kg', target: 'kg', measure: 'kg' },
+      { category: 'mass', unit: 'kg', target: 'pound', measure: 'lbs' },
       { category: 'percentage', unit: 'ratio', target: 'percent', measure: 'percent' },
       { category: 'power', unit: 'W', target: 'W', measure: 'W' },
       { category: 'pressure', unit: 'Pa', target: 'mbar', measure: 'mbar' },

--- a/src/app/core/services/units.service.ts
+++ b/src/app/core/services/units.service.ts
@@ -106,8 +106,9 @@ type UnitConverter = (v: any) => any;
  * A target with no entry that is not a measure of the path's own group degrades to 'unitless': the
  * raw SI value with no label. That is how #536 surfaced — the metric presets emit `L/h` where Skip's
  * measure is `l/h`. Targets Skip genuinely has no conversion for (kW, horsepower, Wh, mAh, atm, torr,
- * Bf, fps, the duration formats, and every dataSize target) belong in that fallback and are
- * deliberately absent here. A units.service.spec case pins this table against the full built-in
+ * Bf, fps, the duration formats, every dataSize target, and the mass and area targets outside the
+ * kilogram/pound and square-metre/square-foot pairs — gram, ounce, stone, acre, hectare and the
+ * rest) belong in that fallback and are deliberately absent here. A units.service.spec case pins this table against the full built-in
  * preset vocabulary; extend both together.
  */
 const SERVER_TARGET_UNIT_ALIASES: Record<string, string> = {
@@ -119,6 +120,7 @@ const SERVER_TARGET_UNIT_ALIASES: Record<string, string> = {
   mile: 'mi',
   foot: 'feet',
   pound: 'lbs',
+  kilogram: 'kg',
   degree: 'deg',
   radian: 'rad',
   gradian: 'grad',

--- a/src/app/core/services/units.service.ts
+++ b/src/app/core/services/units.service.ts
@@ -106,9 +106,9 @@ type UnitConverter = (v: any) => any;
  * A target with no entry that is not a measure of the path's own group degrades to 'unitless': the
  * raw SI value with no label. That is how #536 surfaced — the metric presets emit `L/h` where Skip's
  * measure is `l/h`. Targets Skip genuinely has no conversion for (kW, horsepower, Wh, mAh, atm, torr,
- * Bf, fps, the duration formats, and every mass/area/dataSize target — halos-org/skip#570) belong in
- * that fallback and are deliberately absent here. A units.service.spec case pins this table against
- * the full built-in preset vocabulary; extend both together.
+ * Bf, fps, the duration formats, and every dataSize target) belong in that fallback and are
+ * deliberately absent here. A units.service.spec case pins this table against the full built-in
+ * preset vocabulary; extend both together.
  */
 const SERVER_TARGET_UNIT_ALIASES: Record<string, string> = {
   kn: 'knots',
@@ -118,6 +118,7 @@ const SERVER_TARGET_UNIT_ALIASES: Record<string, string> = {
   meter: 'm',
   mile: 'mi',
   foot: 'feet',
+  pound: 'lbs',
   degree: 'deg',
   radian: 'rad',
   gradian: 'grad',
@@ -233,6 +234,14 @@ export class UnitsService {
       { measure: 'psi', description: "psi" },
       { measure: 'mmHg', description: "mmHg" },
       { measure: 'inHg', description: "inHg" },
+    ] },
+    { group: 'Mass', units: [
+      { measure: 'kg', description: "Kilograms (base)"},
+      { measure: 'lbs', symbol: 'lb', description: "Pounds"},
+    ] },
+    { group: 'Area', units: [
+      { measure: 'm2', symbol: 'm²', description: "Square Meters (base)"},
+      { measure: 'sqft', symbol: 'ft²', description: "Square Feet"},
     ] },
     { group: 'Density', units: [ { measure: 'kg/m3', description: "Air density - kg/cubic meter (base)"} ] },
     { group: 'Time', units: [
@@ -496,6 +505,12 @@ export class UnitsService {
     'kph': Qty.swiftConverter("m/s", "kph"),
     'm/s': function(v) { return v; },
     'mph': Qty.swiftConverter("m/s", "mph"),
+// mass
+    'kg': function(v) { return v; },
+    'lbs': Qty.swiftConverter('kg', 'lbs'),
+// area
+    'm2': function(v) { return v; },
+    'sqft': Qty.swiftConverter('m^2', 'ft^2'),
 // volume
     "liter": Qty.swiftConverter('m^3', 'liter'),
     "gallon": Qty.swiftConverter('m^3', 'gallon'),

--- a/src/assets/skip-dashboard-schema.json
+++ b/src/assets/skip-dashboard-schema.json
@@ -415,6 +415,32 @@
         ]
       },
       {
+        "group": "Mass",
+        "measures": [
+          {
+            "description": "Kilograms (base)",
+            "measure": "kg"
+          },
+          {
+            "description": "Pounds",
+            "measure": "lbs"
+          }
+        ]
+      },
+      {
+        "group": "Area",
+        "measures": [
+          {
+            "description": "Square Meters (base)",
+            "measure": "m2"
+          },
+          {
+            "description": "Square Feet",
+            "measure": "sqft"
+          }
+        ]
+      },
+      {
         "group": "Density",
         "measures": [
           {


### PR DESCRIPTION
Replaces [#580](https://github.com/halos-org/skip/pull/580), which GitHub closed automatically when its base branch (`fix/server-unit-preference-vocabulary`, now merged as [#571](https://github.com/halos-org/skip/pull/571)) was deleted. Same branch, same commit, rebased onto `main`.

## Why

`getConversionsForPath` filters `_conversionList` for a group containing a measure equal to the path's SI unit. No group contained `kg` or `m2`, so the filter came back empty and the path degraded to `unitless` — even for the identity target, and on every preset including metric. `design.displacement` and a sail area rendered a raw number with no label.

This was split out of the #536 fix, which could not complete these two categories because the gap is not an alias: Skip had no conversion group for them at all.

## What

| category | SI base | targets |
| --- | --- | --- |
| Mass | `kg` | `kg`, `lbs` |
| Area | `m2` | `m2`, `sqft` |

Plus the matching `unitConversionFunctions` entries (js-quantities handles `kg -> lbs` and `m^2 -> ft^2`), and one alias — the server preset names its imperial mass target `pound`, following the same shape as the existing `foot: 'feet'`. `sqft` needs none; the server's target name and Skip's measure agree.

`skBaseUnits` already listed both `kg` (Mass) and `m2` (Area) as valid Signal K units, so the type surface expected them; only the conversion table was missing.

Both categories move out of the "deliberately absent" notes in `SERVER_TARGET_UNIT_ALIASES` and in the spec's preset-vocabulary table, and into that table as four new rows.

`src/assets/skip-dashboard-schema.json` is the regenerated artifact; re-running `npm run gen:mcp-schema` after the rebase produces no further change.

## Tests

Three added, plus the four new vocabulary rows. All four cases fail without the groups (the existing preset-vocabulary test included). Suite: 2039 passing on `main`.

Fixes #570

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for mass and area measurements.
  - Added conversions between kilograms and pounds.
  - Added conversions between square meters and square feet.
  - Added display symbols and dashboard schema support for the new measurement groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->