### PR TITLE
feat(profiles): activate a profile the moment it is created

### DIFF
--- a/src/app/core/components/settings/configuration/config.component.spec.ts
+++ b/src/app/core/components/settings/configuration/config.component.spec.ts
@@ -140,6 +140,19 @@ describe('SettingsConfigComponent', () => {
     expect(data.description).toMatch(/shipped with this version/i);
   });
 
+  it('warns that creating a profile switches onto it and reloads', () => {
+    component['createProfile']();
+    const [data] = dialogMock.openNameDialog.mock.calls.at(-1) as [{ description?: string }];
+    expect(data.description).toMatch(/reloads/i);
+  });
+
+  it('warns that duplicating switches onto the copy and reloads, naming the untouched source', () => {
+    component['duplicateProfile']('cockpit');
+    const [data] = dialogMock.openNameDialog.mock.calls.at(-1) as [{ description?: string }];
+    expect(data.description).toMatch(/"cockpit"/);
+    expect(data.description).toMatch(/reloads/i);
+  });
+
   it('offers no such description when renaming, which starts from nothing', () => {
     component['renameProfile']('cockpit');
     const [data] = dialogMock.openNameDialog.mock.calls.at(-1) as [{ description?: string }];

--- a/src/app/core/components/settings/configuration/config.component.spec.ts
+++ b/src/app/core/components/settings/configuration/config.component.spec.ts
@@ -143,6 +143,7 @@ describe('SettingsConfigComponent', () => {
   it('warns that creating a profile switches onto it and reloads', () => {
     component['createProfile']();
     const [data] = dialogMock.openNameDialog.mock.calls.at(-1) as [{ description?: string }];
+    expect(data.description).toMatch(/switches to it/i);
     expect(data.description).toMatch(/reloads/i);
   });
 
@@ -150,6 +151,8 @@ describe('SettingsConfigComponent', () => {
     component['duplicateProfile']('cockpit');
     const [data] = dialogMock.openNameDialog.mock.calls.at(-1) as [{ description?: string }];
     expect(data.description).toMatch(/"cockpit"/);
+    expect(data.description).toMatch(/left untouched/i);
+    expect(data.description).toMatch(/switches to the copy/i);
     expect(data.description).toMatch(/reloads/i);
   });
 

--- a/src/app/core/components/settings/configuration/config.component.ts
+++ b/src/app/core/components/settings/configuration/config.component.ts
@@ -75,7 +75,7 @@ export class SettingsConfigComponent {
       .openNameDialog({
         title: 'New profile',
         name: '',
-        description: 'The profile starts from the pages shipped with this version of Skip. You can change everything in it afterwards.',
+        description: 'The profile starts from the pages shipped with this version of Skip. Skip switches to it and reloads; you can change everything in it afterwards.',
         confirmBtnText: 'Create',
         cancelBtnText: 'Cancel'
       })
@@ -110,7 +110,13 @@ export class SettingsConfigComponent {
 
   protected duplicateProfile(name: string): void {
     this.dialog
-      .openNameDialog({ title: 'Duplicate profile', name: `${name} copy`, confirmBtnText: 'Duplicate', cancelBtnText: 'Cancel' })
+      .openNameDialog({
+        title: 'Duplicate profile',
+        name: `${name} copy`,
+        description: `The copy starts as an exact copy of "${name}", which is left untouched. Skip switches to the copy and reloads.`,
+        confirmBtnText: 'Duplicate',
+        cancelBtnText: 'Cancel'
+      })
       .afterClosed()
       .subscribe(async (result) => {
         if (!result?.name) {

--- a/src/app/core/services/profile.service.spec.ts
+++ b/src/app/core/services/profile.service.spec.ts
@@ -30,6 +30,13 @@ function makeStorageMock(userNames: string[] = ['default', 'profileA']) {
   };
 }
 
+/** A promise plus its resolver, for tests that need to hold an async step open and release it. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => { resolve = r; });
+  return { promise, resolve };
+}
+
 function makeSettingsMock(active = 'profileA', persisted = active) {
   return {
     getActiveProfileName: vi.fn(() => active),
@@ -59,6 +66,22 @@ describe('ProfileService', () => {
   }
 
   beforeEach(() => setup());
+
+  /**
+   * Make the server's listing reflect the slots written so far, so a test can assert what the user
+   * would see in the profile list. The default mock returns a fixed listing, under which a created
+   * profile is invisible however the service refreshes.
+   */
+  function listConfigsReflectsWrites(): void {
+    const base = [{ scope: 'user', name: 'default' }, { scope: 'user', name: 'profileA' }];
+    storage.listConfigs.mockImplementation(() =>
+      Promise.resolve([
+        ...base,
+        ...storage.setConfig.mock.calls.map(([scope, name]) => ({ scope, name })),
+        { scope: 'global', name: 'sharedThing' }
+      ])
+    );
+  }
 
   it('should be created', () => {
     expect(service).toBeTruthy();
@@ -119,26 +142,33 @@ describe('ProfileService', () => {
     });
 
     it('waits for the drain to settle before activating, not merely calling it', async () => {
-      // A deferred drain: call order alone would also pass for code that fires awaitQueueDrain()
-      // and activates without awaiting it. Holding the promise open is what distinguishes them.
-      let releaseDrain!: (drained: boolean) => void;
-      storage.awaitQueueDrain.mockReturnValueOnce(new Promise<boolean>((resolve) => { releaseDrain = resolve; }));
+      // Code that fires awaitQueueDrain() without awaiting it activates anyway, and both call-order
+      // and a fixed microtask flush would still pass — the flush lands while createProfile is inside
+      // its first refresh(), long before the drain. Gate on the mock being entered, hold the drain
+      // open across a full macrotask, and only then assert nothing has activated.
+      const drain = deferred<boolean>();
+      const entered = deferred<void>();
+      storage.awaitQueueDrain.mockImplementationOnce(() => { entered.resolve(); return drain.promise; });
       await service.refresh();
       const pending = service.createProfile('cockpit');
-      await Promise.resolve();
+      await entered.promise;
+      await new Promise((resolve) => setTimeout(resolve, 0));
       expect(settings.setActiveProfile).not.toHaveBeenCalled();
-      releaseDrain(true);
+      drain.resolve(true);
       await pending;
       expect(settings.setActiveProfile).toHaveBeenCalledWith('cockpit');
     });
 
     it('does not activate when the queue did not drain — the reload would abandon the pending write', async () => {
+      listConfigsReflectsWrites();
       storage.awaitQueueDrain.mockResolvedValueOnce(false);
       await service.refresh();
       await expect(service.createProfile('cockpit')).rejects.toThrow(/could not be saved/i);
       expect(settings.setActiveProfile).not.toHaveBeenCalled();
-      // The slot itself was written before the drain failed, so it must survive as an inactive profile.
+      // The slot is written before the drain runs, so the cancellation has to leave the user a
+      // profile they can see and switch to by hand — not a write with nothing on screen to show it.
       expect(storage.setConfig).toHaveBeenCalledWith('user', 'cockpit', expect.anything());
+      expect(service.profiles()).toContainEqual({ name: 'cockpit', isActive: false });
     });
 
     it.each(['', '   ', 'default', 'profileA', 'bad/name', 'bad.name', 'a~b', 'a::b'])(
@@ -187,10 +217,12 @@ describe('ProfileService', () => {
     });
 
     it('does not activate the copy when the queue did not drain', async () => {
+      listConfigsReflectsWrites();
       storage.awaitQueueDrain.mockResolvedValueOnce(false);
       await service.refresh();
       await expect(service.duplicateProfile('profileA', 'profileB')).rejects.toThrow(/could not be saved/i);
       expect(settings.setActiveProfile).not.toHaveBeenCalled();
+      expect(service.profiles()).toContainEqual({ name: 'profileB', isActive: false });
     });
   });
 

--- a/src/app/core/services/profile.service.spec.ts
+++ b/src/app/core/services/profile.service.spec.ts
@@ -84,6 +84,12 @@ describe('ProfileService', () => {
       await expect(service.switchProfile('ghost')).rejects.toThrow(/no longer exists/i);
       expect(settings.setActiveProfile).not.toHaveBeenCalled();
     });
+
+    it('refuses to switch when the queue did not drain, rather than reloading over the pending write', async () => {
+      storage.awaitQueueDrain.mockResolvedValueOnce(false);
+      await expect(service.switchProfile('default')).rejects.toThrow(/could not be saved/i);
+      expect(settings.setActiveProfile).not.toHaveBeenCalled();
+    });
   });
 
   describe('create', () => {
@@ -112,12 +118,27 @@ describe('ProfileService', () => {
       expect(settings.setActiveProfile).toHaveBeenCalledWith('cockpit');
     });
 
-    it('drains the write queue before activating, so a save queued against the old profile is not lost', async () => {
+    it('waits for the drain to settle before activating, not merely calling it', async () => {
+      // A deferred drain: call order alone would also pass for code that fires awaitQueueDrain()
+      // and activates without awaiting it. Holding the promise open is what distinguishes them.
+      let releaseDrain!: (drained: boolean) => void;
+      storage.awaitQueueDrain.mockReturnValueOnce(new Promise<boolean>((resolve) => { releaseDrain = resolve; }));
       await service.refresh();
-      await service.createProfile('cockpit');
-      const drained = storage.awaitQueueDrain.mock.invocationCallOrder[0];
-      const activated = settings.setActiveProfile.mock.invocationCallOrder[0];
-      expect(drained).toBeLessThan(activated);
+      const pending = service.createProfile('cockpit');
+      await Promise.resolve();
+      expect(settings.setActiveProfile).not.toHaveBeenCalled();
+      releaseDrain(true);
+      await pending;
+      expect(settings.setActiveProfile).toHaveBeenCalledWith('cockpit');
+    });
+
+    it('does not activate when the queue did not drain — the reload would abandon the pending write', async () => {
+      storage.awaitQueueDrain.mockResolvedValueOnce(false);
+      await service.refresh();
+      await expect(service.createProfile('cockpit')).rejects.toThrow(/could not be saved/i);
+      expect(settings.setActiveProfile).not.toHaveBeenCalled();
+      // The slot itself was written before the drain failed, so it must survive as an inactive profile.
+      expect(storage.setConfig).toHaveBeenCalledWith('user', 'cockpit', expect.anything());
     });
 
     it.each(['', '   ', 'default', 'profileA', 'bad/name', 'bad.name', 'a~b', 'a::b'])(
@@ -162,6 +183,13 @@ describe('ProfileService', () => {
       await service.refresh();
       storage.setConfig.mockRejectedValueOnce(new Error('500'));
       await expect(service.duplicateProfile('profileA', 'profileB')).rejects.toThrow();
+      expect(settings.setActiveProfile).not.toHaveBeenCalled();
+    });
+
+    it('does not activate the copy when the queue did not drain', async () => {
+      storage.awaitQueueDrain.mockResolvedValueOnce(false);
+      await service.refresh();
+      await expect(service.duplicateProfile('profileA', 'profileB')).rejects.toThrow(/could not be saved/i);
       expect(settings.setActiveProfile).not.toHaveBeenCalled();
     });
   });

--- a/src/app/core/services/profile.service.spec.ts
+++ b/src/app/core/services/profile.service.spec.ts
@@ -106,10 +106,18 @@ describe('ProfileService', () => {
       config.dashboards.forEach((d, i) => expect(d.id).not.toBe(DefaultDashboard[i].id));
     });
 
-    it('does not auto-switch into the created profile', async () => {
+    it('activates the created profile', async () => {
       await service.refresh();
       await service.createProfile('cockpit');
-      expect(settings.setActiveProfile).not.toHaveBeenCalled();
+      expect(settings.setActiveProfile).toHaveBeenCalledWith('cockpit');
+    });
+
+    it('drains the write queue before activating, so a save queued against the old profile is not lost', async () => {
+      await service.refresh();
+      await service.createProfile('cockpit');
+      const drained = storage.awaitQueueDrain.mock.invocationCallOrder[0];
+      const activated = settings.setActiveProfile.mock.invocationCallOrder[0];
+      expect(drained).toBeLessThan(activated);
     });
 
     it.each(['', '   ', 'default', 'profileA', 'bad/name', 'bad.name', 'a~b', 'a::b'])(
@@ -142,6 +150,19 @@ describe('ProfileService', () => {
       await service.refresh();
       await expect(service.duplicateProfile('profileA', 'profileB')).rejects.toThrow(/no usable configuration/i);
       expect(storage.setConfig).not.toHaveBeenCalled();
+    });
+
+    it('activates the copy, not the source', async () => {
+      await service.refresh();
+      await service.duplicateProfile('profileA', 'profileB');
+      expect(settings.setActiveProfile).toHaveBeenCalledWith('profileB');
+    });
+
+    it('surfaces a storage failure and never activates', async () => {
+      await service.refresh();
+      storage.setConfig.mockRejectedValueOnce(new Error('500'));
+      await expect(service.duplicateProfile('profileA', 'profileB')).rejects.toThrow();
+      expect(settings.setActiveProfile).not.toHaveBeenCalled();
     });
   });
 

--- a/src/app/core/services/profile.service.ts
+++ b/src/app/core/services/profile.service.ts
@@ -50,7 +50,7 @@ export class ProfileService {
     );
   }
 
-  /** Make a profile active on this device. Verifies the slot still exists, drains pending writes, then persists + reloads. */
+  /** Make a profile active on this device. Verifies the slot still exists, drains pending writes (rejecting if they do not land), then persists + reloads. */
   public async switchProfile(name: string): Promise<void> {
     return this.exclusive(async () => {
       await this.refresh();
@@ -69,11 +69,17 @@ export class ProfileService {
    * abandoned by the reload. A freshly written slot needs no existence check — the write that
    * created it was awaited — so only `switchProfile`, which targets a slot it did not write,
    * verifies the name first.
+   *
+   * A drain that reports failure (a patch failed, or the wait timed out) cancels the switch rather
+   * than reloading over the pending write. The loss is silent and unrecoverable otherwise: the
+   * reload discards the queue, and the user sees the new profile with no sign that the last edits
+   * to the old one never landed. `deleteProfile` already treats the same signal as an error. A
+   * created slot survives the cancellation as an inactive profile, which the refreshed list shows.
    */
   private async activate(name: string): Promise<void> {
     const drained = await this.storage.awaitQueueDrain();
     if (!drained) {
-      console.warn('[ProfileService] Pending changes to the previous profile may not have been saved before switching.');
+      throw new Error('Pending changes to the current profile could not be saved, so the switch was cancelled. Retry once the connection recovers.');
     }
     this.settings.setActiveProfile(name);
   }

--- a/src/app/core/services/profile.service.ts
+++ b/src/app/core/services/profile.service.ts
@@ -57,21 +57,35 @@ export class ProfileService {
       if (!this.existingNames().includes(name)) {
         throw new Error(`Profile "${name}" no longer exists — it may have been deleted on another device.`);
       }
-      const drained = await this.storage.awaitQueueDrain();
-      if (!drained) {
-        console.warn('[ProfileService] Pending changes to the previous profile may not have been saved before switching.');
-      }
-      this.settings.setActiveProfile(name);
+      await this.activate(name);
     });
   }
 
-  /** Create a new profile from a blank default config. Does not switch. */
+  /**
+   * Drain the write queue, then point the device at `name` (which persists and reloads).
+   * Callers hold the mutation lock already, so this never re-enters `exclusive`.
+   *
+   * The drain is what keeps a save that is still queued against the outgoing profile from being
+   * abandoned by the reload. A freshly written slot needs no existence check — the write that
+   * created it was awaited — so only `switchProfile`, which targets a slot it did not write,
+   * verifies the name first.
+   */
+  private async activate(name: string): Promise<void> {
+    const drained = await this.storage.awaitQueueDrain();
+    if (!drained) {
+      console.warn('[ProfileService] Pending changes to the previous profile may not have been saved before switching.');
+    }
+    this.settings.setActiveProfile(name);
+  }
+
+  /** Create a new profile from a blank default config, then switch onto it (which reloads). */
   public async createProfile(name: string): Promise<void> {
     return this.exclusive(async () => {
       await this.refresh();
       const normalized = this.validateNewName(name);
       await this.storage.setConfig(PROFILE_SCOPE, normalized, buildDefaultConfig());
       await this.refresh();
+      await this.activate(normalized);
     });
   }
 
@@ -97,7 +111,7 @@ export class ProfileService {
     });
   }
 
-  /** Copy an existing profile's config under a new name. */
+  /** Copy an existing profile's config under a new name, then switch onto the copy (which reloads). */
   public async duplicateProfile(sourceName: string, newName: string): Promise<void> {
     return this.exclusive(async () => {
       await this.refresh();
@@ -108,6 +122,7 @@ export class ProfileService {
       }
       await this.storage.setConfig(PROFILE_SCOPE, normalized, sourceConfig);
       await this.refresh();
+      await this.activate(normalized);
     });
   }
 


### PR DESCRIPTION
Creating a profile left the device on the old one. `ProfileService.createProfile` said so in its own doc comment — "Does not switch" — and `duplicateProfile` did the same, so the new profile appeared greyed out in the list and reaching it took a Switch click plus a second confirmation dialog. Both actions mean "use this profile now": you create a profile to set it up, and you duplicate one to experiment on the copy without touching the original.

Activation is routed through the drain-then-persist path an explicit switch already uses, extracted as a private `activate()` because `exclusive()` throws on re-entry and both callers are already inside it. The drain matters more here than the extra dialog it replaces: neither create path drained before, so a save still queued against the outgoing profile could be abandoned by the reload.

`switchProfile` keeps its existence check and the create paths do not get one — a freshly written slot needs no probe, since the write that created it was awaited, and asking the server "does this exist" immediately after writing it invites a confusing "no longer exists" from a lagging list.

Import is deliberately unchanged. Its doc comment records that decision, and importing to archive a config is a real use.

## On the deferred-switch hole

[#582](https://github.com/halos-org/skip/issues/582) describes what happens when `ReloadService` declines the reload: the switch is deferred with nothing durable recording it. That does not meaningfully apply here. The profile write has to succeed before the reload probe runs, so the server would have to die between two adjacent requests — and an explicit Switch already carries the same exposure. This is not gated on #582.

The New and Duplicate buttons are both `[disabled]="!canWriteUserData()"`, so a read-only session never reaches this path.

## Verification

`npm run ci` clean: lint, strict-null gate, 2100 unit tests (up from 2098), 34 schema tests.

Five new tests, written before the change and confirmed failing against the old behaviour:

- create activates the new profile
- create drains the write queue *before* activating, asserted on `invocationCallOrder` rather than on both calls merely having happened
- duplicate activates the copy, not the source
- a storage failure during duplicate never activates
- both dialogs tell the user Skip will reload, and the duplicate dialog names the source it leaves untouched

The existing "does not auto-switch into the created profile" test is replaced rather than deleted; the import test asserting the same property is untouched and now guards the deliberate difference.

Not exercised on a device: the reload itself. The activation path is the one an explicit switch already takes in production.

Closes #589


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Creating or duplicating a profile activates the new profile and reloads the application.
- The activation path drains pending writes before switching to preserve changes to the outgoing profile.
- Duplication leaves the source profile unchanged and activates the copied profile.
- Importing a profile does not activate it.
- If storage draining fails, activation does not proceed.
- Name dialogs explain that Skip reloads the application onto the new profile.
- Tests cover activation, write-queue ordering, duplication, storage failures, and dialog messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->