### PR TITLE
Show the Angle display range setting only for angular paths

### DIFF
--- a/src/app/widget-config/graph-data-options/graph-data-options.component.html
+++ b/src/app/widget-config/graph-data-options/graph-data-options.component.html
@@ -62,7 +62,7 @@
       </mat-form-field>
     </div>
   </div>
-  @if (datachartAngleRange(); as angleRangeCtrl) {
+  @if (angleRangeControl(); as angleRangeCtrl) {
     <mat-form-field class="full-width" style="margin-top: 10px;">
       <mat-label>Angle display range</mat-label>
       <mat-select [formControl]="angleRangeCtrl" name="datachartAngleRange">
@@ -70,7 +70,7 @@
         <mat-option value="signed">Signed (-180&deg; to 180&deg;)</mat-option>
         <mat-option value="direction">Compass (0&deg; to 360&deg;)</mat-option>
       </mat-select>
-      <mat-hint>For angular paths. Choose Signed for values that go negative (e.g. wind shift).</mat-hint>
+      <mat-hint>Choose Signed for values that go negative (e.g. wind shift).</mat-hint>
     </mat-form-field>
   }
   <br />

--- a/src/app/widget-config/graph-data-options/graph-data-options.component.spec.ts
+++ b/src/app/widget-config/graph-data-options/graph-data-options.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { UntypedFormControl } from '@angular/forms';
+import { FormControl, UntypedFormControl } from '@angular/forms';
 import { GraphDataOptionsComponent } from './graph-data-options.component';
 import { DataService } from '../../core/services/data.service';
 import { UnitsService } from '../../core/services/units.service';
@@ -13,9 +13,11 @@ describe('GraphDataOptionsComponent', () => {
   let component: GraphDataOptionsComponent;
   let fixture: ComponentFixture<GraphDataOptionsComponent>;
   let pathObject: Partial<ISkPathData> | null;
+  let pathUnits: Record<string, string>;
 
   beforeEach(async () => {
     pathObject = null;
+    pathUnits = {};
     await TestBed.configureTestingModule({
       imports: [GraphDataOptionsComponent],
       providers: [
@@ -24,6 +26,7 @@ describe('GraphDataOptionsComponent', () => {
           useValue: {
             getPathsAndMetaByType: () => [],
             getPathObject: () => pathObject,
+            getPathUnitType: (path: string) => pathUnits[path] ?? null,
           },
         },
         {
@@ -168,6 +171,55 @@ describe('GraphDataOptionsComponent', () => {
       pathControl.setValue('self.propulsion.port.temperature');
       await vi.advanceTimersByTimeAsync(400);
       expect(sourceControl.value).toBe('default');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  const mountWithAngleRange = (path: string) => {
+    const fx = TestBed.createComponent(GraphDataOptionsComponent);
+    const set = fx.componentRef.setInput.bind(fx.componentRef) as (k: string, v: unknown) => void;
+    set('filterSelfPaths', new UntypedFormControl(false));
+    set('datachartPath', new UntypedFormControl(path));
+    set('datachartSource', new UntypedFormControl({ value: '', disabled: true }));
+    set('datachartAngleRange', new FormControl<'signed' | 'direction' | null>(null));
+    set('timeScale', new UntypedFormControl(''));
+    set('period', new UntypedFormControl(''));
+    fx.detectChanges();
+    return fx;
+  };
+
+  const showsAngleRange = (fx: ComponentFixture<GraphDataOptionsComponent>) =>
+    ((fx.nativeElement as HTMLElement).textContent ?? '').includes('Angle display range');
+
+  it('hides the angle range for a path with a non-angular unit (#368)', () => {
+    pathUnits['self.propulsion.port.temperature'] = 'K';
+    expect(showsAngleRange(mountWithAngleRange('self.propulsion.port.temperature'))).toBe(false);
+  });
+
+  it('offers the angle range for a radian path (#368)', () => {
+    pathUnits['self.environment.wind.angleApparent'] = 'rad';
+    expect(showsAngleRange(mountWithAngleRange('self.environment.wind.angleApparent'))).toBe(true);
+  });
+
+  it('offers the angle range while the path publishes no unit (#368)', () => {
+    // An idle instrument publishes no metadata, and the override is then the only way to keep a
+    // graph angular — see resolveAngleDomain.
+    expect(showsAngleRange(mountWithAngleRange('self.environment.wind.angleApparent'))).toBe(true);
+  });
+
+  it('hides the angle range once the path changes to a non-angular one (#368)', async () => {
+    vi.useFakeTimers();
+    try {
+      pathUnits['self.environment.wind.angleApparent'] = 'rad';
+      pathUnits['self.propulsion.port.temperature'] = 'K';
+      const fx = mountWithAngleRange('self.environment.wind.angleApparent');
+      expect(showsAngleRange(fx)).toBe(true);
+
+      fx.componentInstance.datachartPath().setValue('self.propulsion.port.temperature');
+      await vi.advanceTimersByTimeAsync(400);
+      fx.detectChanges();
+      expect(showsAngleRange(fx)).toBe(false);
     } finally {
       vi.useRealTimers();
     }

--- a/src/app/widget-config/graph-data-options/graph-data-options.component.spec.ts
+++ b/src/app/widget-config/graph-data-options/graph-data-options.component.spec.ts
@@ -208,7 +208,9 @@ describe('GraphDataOptionsComponent', () => {
     expect(showsAngleRange(mountWithAngleRange('self.environment.wind.angleApparent'))).toBe(true);
   });
 
-  it('hides the angle range once the path changes to a non-angular one (#368)', async () => {
+  it('hides the angle range as soon as the path changes to a non-angular one (#368)', async () => {
+    // Behind the 300 ms path debounce the control would stay editable for a path it does not
+    // belong to.
     vi.useFakeTimers();
     try {
       pathUnits['self.environment.wind.angleApparent'] = 'rad';
@@ -217,6 +219,9 @@ describe('GraphDataOptionsComponent', () => {
       expect(showsAngleRange(fx)).toBe(true);
 
       fx.componentInstance.datachartPath().setValue('self.propulsion.port.temperature');
+      fx.detectChanges();
+      expect(showsAngleRange(fx)).toBe(false);
+
       await vi.advanceTimersByTimeAsync(400);
       fx.detectChanges();
       expect(showsAngleRange(fx)).toBe(false);

--- a/src/app/widget-config/graph-data-options/graph-data-options.component.ts
+++ b/src/app/widget-config/graph-data-options/graph-data-options.component.ts
@@ -10,7 +10,7 @@ import { DataService } from '../../core/services/data.service';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatInputModule } from '@angular/material/input';
 import { IPathMetaData, ISkPathData } from '../../core/interfaces/app-interfaces';
-import { debounceTime } from 'rxjs';
+import { debounceTime, tap } from 'rxjs';
 import { RouterLink } from '@angular/router';
 import { pathRequiredValidator, pathSlotWarning } from '../../core/utils/path-validators.util';
 
@@ -58,7 +58,13 @@ export class GraphDataOptionsComponent implements OnInit {
     this.refreshNumericPaths();
     this.filteredNumericPaths.set(this.numericPaths());
 
-    this.datachartPath().valueChanges.pipe(debounceTime(300), takeUntilDestroyed(this._destroyRef)).subscribe(value => {
+    // The unit gates whether the angle range is shown at all, so it is read ahead of the debounce:
+    // behind it the control stays editable for 300 ms on a path it does not belong to.
+    this.datachartPath().valueChanges.pipe(
+      tap(value => this.refreshPathUnit(value)),
+      debounceTime(300),
+      takeUntilDestroyed(this._destroyRef)
+    ).subscribe(value => {
       this.refreshNumericPaths();
       const term = (value || '').toLowerCase().trim();
       if (!term) {
@@ -67,7 +73,6 @@ export class GraphDataOptionsComponent implements OnInit {
         this.filteredNumericPaths.set(this.numericPaths().filter(p => p.path.toLowerCase().includes(term)));
       }
       this.refreshPathWarning(value);
-      this.refreshPathUnit(value);
       // An unoffered path never appears in the autocomplete, so typing is the only way to enter one
       // and (optionSelected) never fires. Re-derive here too, or the previous path's concrete source
       // stays pinned to a path that will never fill it.

--- a/src/app/widget-config/graph-data-options/graph-data-options.component.ts
+++ b/src/app/widget-config/graph-data-options/graph-data-options.component.ts
@@ -38,7 +38,21 @@ export class GraphDataOptionsComponent implements OnInit {
   protected pathWarning = signal<string | null>(null);
   /** The path `pathSources` was last built for, so re-deriving needs a real path change. */
   private _sourcesForPath: string | null = null;
+  /** Base unit of the selected path, or null when the server publishes none for it. */
+  private pathUnit = signal<string | null>(null);
   protected maxDuration = computed<number>(() => this.timeScale().value === 'day' ? 365 : 60);
+  /**
+   * The angle range only changes how radian values are read, so it is offered for radian paths and
+   * withheld from every path with another unit. An unknown unit keeps it: metadata is missing while
+   * the producing instrument is idle, and the override is then the only way to keep the graph
+   * angular (see `resolveAngleDomain`).
+   */
+  protected angleRangeControl = computed<FormControl<'signed' | 'direction' | null> | undefined>(() => {
+    const control = this.datachartAngleRange();
+    if (!control) return undefined;
+    const unit = this.pathUnit();
+    return unit === null || unit === 'rad' ? control : undefined;
+  });
 
   ngOnInit(): void {
     this.refreshNumericPaths();
@@ -53,6 +67,7 @@ export class GraphDataOptionsComponent implements OnInit {
         this.filteredNumericPaths.set(this.numericPaths().filter(p => p.path.toLowerCase().includes(term)));
       }
       this.refreshPathWarning(value);
+      this.refreshPathUnit(value);
       // An unoffered path never appears in the autocomplete, so typing is the only way to enter one
       // and (optionSelected) never fires. Re-derive here too, or the previous path's concrete source
       // stays pinned to a path that will never fill it.
@@ -66,6 +81,7 @@ export class GraphDataOptionsComponent implements OnInit {
     this.datachartPath().updateValueAndValidity({ emitEvent: false });
     const currentPath = this.datachartPath()?.value;
     this.refreshPathWarning(currentPath);
+    this.refreshPathUnit(currentPath);
     this.setPathSourcesFor(currentPath);
     this.setInitFormState();
   }
@@ -78,6 +94,10 @@ export class GraphDataOptionsComponent implements OnInit {
     this.pathWarning.set(pathSlotWarning(path, path ? this.data.getPathObject(path) : null, {
       pathType: 'number', supportsPutOnly: false, zonesOnly: false, selfOnly: this.filterSelfPaths().value
     }));
+  }
+
+  private refreshPathUnit(path: string | null): void {
+    this.pathUnit.set(path ? this.data.getPathUnitType(path) : null);
   }
 
   /**


### PR DESCRIPTION
The Data Graph config screen always offered **Angle display range**, even for a temperature or a speed path where the setting does nothing — `resolveAngleDomain` returns `scalar` for any positively non-radian unit, override or not.

The control now renders only when the selected path's Signal K unit is `rad`, or when the server publishes no unit for it. The unknown-unit case is deliberate: metadata is often absent while the producing instrument is idle, and the override is then the only way to keep the graph angular (the case `resolveAngleDomain` documents). Visibility follows the path control, so it appears and disappears as the path is edited.

The unit comes from `DataService.getPathUnitType`, the same source `HistoryGraphStreamService` feeds to `resolveAngleDomain`, so the UI and the runtime agree on what counts as angular. A stored override on a now-hidden control stays in the config and stays inert.

Verified with four new specs asserting the rendered control's presence (rad, unknown, non-rad, and a path switch), plus the full `npm run ci` gate: lint, snc, 2107 tests, MCP schema.

Closes halos-org/skip#368

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Shows the **Angle display range** control for paths with a `rad` or unknown Signal K unit.
- Hides the control for non-radian paths and updates visibility immediately when the selected path changes.
- Keeps stored angle-range overrides in configuration while they are inactive.
- Adds coverage for radian, unitless, non-radian, and path-switch scenarios.
- Verifies the full `npm run ci` gate, including 2,107 tests and MCP schema validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->